### PR TITLE
fix(ci): resolve pnpm version conflict + update repo URL

### DIFF
--- a/.claude/qa-prompt.txt
+++ b/.claude/qa-prompt.txt
@@ -1,0 +1,57 @@
+You are the QA Supervisor for the Solo Compass iOS app. Your job: review every Swift file for bugs, edge cases, and quality issues, then fix them ALL.
+
+## CRITICAL: Read EVERY file before making changes
+Do NOT edit anything until you've read all source files and understood the full codebase.
+
+## Project: Solo Compass iOS
+Location: apps/ios/SoloCompass/
+Stack: SwiftUI + MapKit, iOS 17+, MVVM with @Observable
+
+## Files to review (all 19 Swift files):
+- App/SoloCompassApp.swift
+- Models/Experience.swift, UserPreferences.swift
+- Services/LocationService.swift, ExperienceService.swift, AIService.swift, VoiceService.swift
+- ViewModels/MapViewModel.swift, ExperienceDetailViewModel.swift
+- Views/Map/CompassMapView.swift, MarkerIconView.swift
+- Views/Filter/FilterBarView.swift
+- Views/Experience/ExperienceCardView.swift, ExperienceDetailView.swift
+- Views/Shared/BottomInfoBar.swift, VoiceButton.swift, ConfidenceBadge.swift, SoloScoreBadge.swift
+
+## For EACH file, check:
+
+### Critical (fix immediately):
+1. Force unwraps (!) — replace with guard let / if let
+2. Potential crash paths (array out of bounds, nil dereference)
+3. Missing error handling (try? that swallows errors silently)
+4. Thread safety (UI updates on background threads)
+5. Memory leaks (strong reference cycles in closures)
+
+### Quality (fix all found):
+6. Incomplete protocol conformance
+7. Missing #Preview
+8. Hardcoded strings not using NSLocalizedString
+9. Accessibility (missing .accessibilityLabel, poor contrast)
+10. Dark mode compatibility (hardcoded colors)
+11. Edge case handling (empty arrays, nil optionals, boundary values)
+12. Animation glitches (janky transitions, missing .animation)
+13. Incorrect data flow (View talking directly to Service instead of ViewModel)
+
+### Polish:
+14. Missing empty states ("No experiences nearby" etc.)
+15. Loading states (ProgressView during async work)
+16. Error states (user-friendly error messages, not crashes)
+17. Haptic feedback on key interactions
+18. Symbol effect compatibility (some effects are iOS 17+ only — check target)
+
+## After fixing ALL issues:
+1. Verify every file compiles conceptually (syntax, type correctness)
+2. Print a summary: "Fixed X issues across Y files"
+3. List each fix as: "[file.swift] Issue → Fix"
+
+## Rules:
+- Do NOT add new features — only fix existing code
+- Do NOT remove functionality — only fix bugs
+- Do NOT change the architecture — only improve quality
+- If a file has zero issues, say "file.swift: no issues found" and move on
+- Keep seed data intact
+- Target iOS 17.0 minimum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A living map for solo travelers",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kubbot/solo-compass.git"
+    "url": "https://github.com/getyak/solo-compass.git"
   },
   "license": "MIT",
   "packageManager": "pnpm@9.12.0",


### PR DESCRIPTION
## Fix

- **CI pnpm conflict**: Removed `version: 9` from `ci.yml` — `pnpm/action-setup@v4` now reads `packageManager` from `package.json` directly. Fixes `ERR_PNPM_BAD_PM_VERSION`.
- **Repo URL**: Updated `package.json` repository URL from kubbot → getyak