### PR TITLE
feat(bot+ai): Telegram bot with voice intent + recommendation engine

### DIFF
--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@solo-compass/bot",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@solo-compass/core": "workspace:*",
+    "@solo-compass/ai": "workspace:*",
+    "telegraf": "^4.16.3",
+    "openai": "^4.73.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.2"
+  }
+}

--- a/apps/bot/src/demo-experiences.ts
+++ b/apps/bot/src/demo-experiences.ts
@@ -1,0 +1,599 @@
+import type {
+  Experience,
+  ExperienceCategory,
+  ExperienceId,
+  TimeWindow,
+  HowToStep,
+  RealInconvenience,
+} from "@solo-compass/core";
+
+/**
+ * Demo set — 20 Chiang Mai experiences with real coordinates.
+ * Used for the bot until we wire up the real seed pipeline.
+ */
+
+const NOW = "2026-05-01T00:00:00.000Z";
+
+interface DemoSpec {
+  slug: string;
+  title: string;
+  oneLiner: string;
+  whyItMatters: string;
+  category: ExperienceCategory;
+  coordinates: readonly [number, number];
+  addressHint: string;
+  placeNameRomanized?: string;
+  placeNameLocal?: string;
+  bestTimes: readonly TimeWindow[];
+  durationMin: number;
+  durationMax: number;
+  howTo: readonly HowToStep[];
+  realInconveniences: readonly RealInconvenience[];
+  soloOverall: number;
+  soloHint?: string;
+}
+
+const DEMOS: readonly DemoSpec[] = [
+  {
+    slug: "doi_suthep_sunrise_chant",
+    title: "Catch the 06:00 monk chanting at Doi Suthep before the tour buses",
+    oneLiner: "An hour of bells and Pali up the mountain, mostly to yourself.",
+    whyItMatters:
+      "Before 07:30 the temple is quiet enough to hear bare feet on tile. Mist sits below the gold chedi and the city is invisible underneath. By 09:00 it is a parking lot.",
+    category: "culture",
+    coordinates: [98.9219, 18.8049],
+    addressHint: "Wat Phra That Doi Suthep, top of the mountain road",
+    placeNameRomanized: "Wat Phra That Doi Suthep",
+    placeNameLocal: "วัดพระธาตุดอยสุเทพ",
+    bestTimes: [{ startHour: 5, endHour: 8, note: "before tour buses arrive" }],
+    durationMin: 60,
+    durationMax: 90,
+    howTo: [
+      { order: 1, text: "Take a red songthaew from the zoo gate before 05:00 (~150 THB shared)." },
+      { order: 2, text: "Climb the 306-step naga staircase, or use the funicular for 50 THB." },
+      { order: 3, text: "Sit on the outer terrace, east side, while the chant runs." },
+      { order: 4, text: "Walk three clockwise circuits of the chedi after sunrise." },
+    ],
+    realInconveniences: [
+      { category: "logistics", text: "First songthaew up only fills around 04:30 — be willing to wait or charter (~600 THB)." },
+      { category: "etiquette", text: "Cover knees and shoulders. Sarongs at the gate are loaner-only and can run out." },
+    ],
+    soloOverall: 9,
+    soloHint: "Solo travelers blend into morning meditation; nobody will ask why you're alone.",
+  },
+  {
+    slug: "khao_soi_khun_yai_lunch",
+    title: "Eat khao soi at Khao Soi Khun Yai before they sell out at 13:00",
+    oneLiner: "Family kitchen, four tables, one dish done right since 1986.",
+    whyItMatters:
+      "Yai's khao soi is brothier and less sweet than the tourist-trail bowls. They open at 10:00, finish the pot by early afternoon, close Sundays.",
+    category: "food",
+    coordinates: [98.9876, 18.7956],
+    addressHint: "Soi off Sri Poom Rd, north of the moat",
+    placeNameRomanized: "Khao Soi Khun Yai",
+    bestTimes: [{ startHour: 10, endHour: 13 }],
+    durationMin: 25,
+    durationMax: 40,
+    howTo: [
+      { order: 1, text: "Walk in, grab any open seat — no host, no menu in English." },
+      { order: 2, text: "Say 'khao soi gai' (chicken) or 'nuea' (beef). 60 THB." },
+      { order: 3, text: "Add lime, pickled mustard, raw shallot from the tray yourself." },
+      { order: 4, text: "Pay the woman at the till on the way out. Cash only." },
+    ],
+    realInconveniences: [
+      { category: "logistics", text: "Closed Sundays. Sells out by 13:00 most days." },
+      { category: "crowds", text: "Four tables and shared seating — lunchtime you'll sit with strangers." },
+    ],
+    soloOverall: 9,
+    soloHint: "A solo bowl is normal here. Nobody hovers.",
+  },
+  {
+    slug: "ristr8to_pourover_bar",
+    title: "Take the bar seat at Ristr8to and watch the world-champion barista work",
+    oneLiner: "Specialty bar where the queue is for the seat, not the takeaway window.",
+    whyItMatters:
+      "Arnon, the owner, has placed top three at the World Latte Art Championship. Sit at the bar with a single-origin pourover and you watch every cup pulled like a shot card.",
+    category: "coffee",
+    coordinates: [98.9762, 18.7876],
+    addressHint: "Nimmanhaemin Rd, near Soi 3",
+    placeNameRomanized: "Ristr8to Coffee",
+    bestTimes: [{ startHour: 8, endHour: 11 }],
+    durationMin: 30,
+    durationMax: 60,
+    howTo: [
+      { order: 1, text: "Skip the takeaway line, ask for a bar seat." },
+      { order: 2, text: "Order a single-origin pourover (~140 THB) — they'll talk you through it." },
+      { order: 3, text: "Stay for a second small drink; the bar is a dialog, not a transaction." },
+    ],
+    realInconveniences: [
+      { category: "crowds", text: "Bar has 6 seats. Saturdays after 09:30 expect a wait." },
+      { category: "logistics", text: "Closes at 18:00. Closed Wednesdays." },
+    ],
+    soloOverall: 10,
+    soloHint: "Bar seating is built for solo — staff actively chat with single customers.",
+  },
+  {
+    slug: "wat_pha_lat_jungle_trail",
+    title: "Hike the Monk's Trail to Wat Pha Lat before the 09:00 heat",
+    oneLiner: "Forty-five minutes through jungle to a moss-grown forest temple, no entrance fee.",
+    whyItMatters:
+      "Orange cloth strips on trees mark the route — same trail the monks have walked since the 1300s. The temple itself is half-ruin, half-shrine, with a stream cutting through the courtyard.",
+    category: "nature",
+    coordinates: [98.9333, 18.8123],
+    addressHint: "Trailhead behind Chiang Mai University, end of Suthep Rd",
+    placeNameRomanized: "Wat Pha Lat",
+    placeNameLocal: "วัดผาลาด",
+    bestTimes: [
+      { startHour: 6, endHour: 9, note: "before the heat" },
+      { startHour: 16, endHour: 18, note: "afternoon, watch for fading light on descent" },
+    ],
+    durationMin: 90,
+    durationMax: 150,
+    howTo: [
+      { order: 1, text: "Take a Grab to the trailhead (50 THB). Look for the orange cloth on the first tree." },
+      { order: 2, text: "Follow the orange markers up — about 40–50 min, mostly shaded." },
+      { order: 3, text: "Sit at the temple stream. Stay 30+ minutes; it earns it." },
+      { order: 4, text: "Descend the same way, or walk down the paved road for a flatter route." },
+    ],
+    realInconveniences: [
+      { category: "weather", text: "Trail is slick after rain. April–May heat is brutal even at 08:00." },
+      { category: "safety", text: "No phone signal in patches. Tell someone you're going." },
+    ],
+    soloOverall: 8,
+    soloHint: "Common solo hike — you'll see other lone walkers on weekend mornings.",
+  },
+  {
+    slug: "fah_lanna_two_hour_thai",
+    title: "Book the late-afternoon two-hour Thai massage at Fah Lanna",
+    oneLiner: "Traditional Lanna massage in a garden compound, no bait-and-switch upsell.",
+    whyItMatters:
+      "Run by a women-led local cooperative. Fixed-price menu, no oils-or-herbs surprise on the bill. The 16:00 slot is quiet — the lunch crowd has left, the evening one hasn't arrived.",
+    category: "wellness",
+    coordinates: [98.9907, 18.7858],
+    addressHint: "Soi 5 Wat Ket, east of the river",
+    placeNameRomanized: "Fah Lanna Spa",
+    bestTimes: [{ startHour: 14, endHour: 18 }],
+    durationMin: 120,
+    durationMax: 130,
+    howTo: [
+      { order: 1, text: "Book online or by phone at least a day ahead — walk-ins are rarely possible." },
+      { order: 2, text: "Arrive 10 min early, foot-wash in the garden." },
+      { order: 3, text: "Two-hour traditional Thai is 1,200 THB. Tip 100 THB cash if you liked it." },
+    ],
+    realInconveniences: [
+      { category: "logistics", text: "The free shuttle pickup window is narrow — confirm pickup time when booking." },
+      { category: "etiquette", text: "Phones-off in the treatment garden is enforced." },
+    ],
+    soloOverall: 10,
+    soloHint: "Solo bookings are the norm here. No pressure for couple's packages.",
+  },
+  {
+    slug: "saturday_walking_street",
+    title: "Wander Wualai Saturday Walking Street between 18:00 and 20:00",
+    oneLiner: "Silver-quarter night market with actual local craft, not just generic souvenirs.",
+    whyItMatters:
+      "Wualai is the silversmiths' street — the Saturday market here keeps more local tone than the Sunday Tha Pae one. Get there before 20:00 and the crowd is breathable.",
+    category: "culture",
+    coordinates: [98.9876, 18.7762],
+    addressHint: "Wualai Rd, south of Chiang Mai Gate",
+    bestTimes: [{ startHour: 17, endHour: 21, dayOfWeek: [6] }],
+    durationMin: 60,
+    durationMax: 120,
+    howTo: [
+      { order: 1, text: "Enter from Chiang Mai Gate side; walk south." },
+      { order: 2, text: "Stop at the temple courtyard food court for 40-THB plates." },
+      { order: 3, text: "Watch silver hammer-work in the open shopfronts past Soi 3." },
+    ],
+    realInconveniences: [
+      { category: "scam", text: "'Antique' silver from non-shopfront stalls is mostly nickel. Buy from named workshops." },
+      { category: "crowds", text: "After 20:30 it's elbow-to-elbow. Go early, leave early." },
+    ],
+    soloOverall: 9,
+    soloHint: "Markets are easy alone — eat at the temple food court, no table commitment.",
+  },
+  {
+    slug: "library_workspace_camp",
+    title: "Take a window desk at CAMP @ Maya for a 4-hour focus block",
+    oneLiner: "24/7 library-café where the buy-in is one drink for unlimited time.",
+    whyItMatters:
+      "The wall-of-books backdrop and silent zone upstairs make it the most viable deep-work spot in the city. Drink purchase = 2-hour wifi code; refill resets it.",
+    category: "work",
+    coordinates: [98.9669, 18.8048],
+    addressHint: "5th floor, Maya Lifestyle Mall, Nimman",
+    placeNameRomanized: "CAMP @ Maya",
+    bestTimes: [
+      { startHour: 8, endHour: 11 },
+      { startHour: 14, endHour: 17 },
+    ],
+    durationMin: 120,
+    durationMax: 240,
+    howTo: [
+      { order: 1, text: "Buy any drink at the counter; receipt has a 2-hour wifi code." },
+      { order: 2, text: "Climb to the upper level — silent zone, no calls." },
+      { order: 3, text: "Re-buy at the 2-hour mark for a fresh code." },
+    ],
+    realInconveniences: [
+      { category: "crowds", text: "Exam season (May, October) it fills by 09:00 and you'll stand." },
+      { category: "logistics", text: "Outlets at window seats only. Bring an extension cord if you can." },
+    ],
+    soloOverall: 10,
+    soloHint: "Designed for solo work. Headphones on = nobody approaches you.",
+  },
+  {
+    slug: "sunday_walking_street",
+    title: "Walk Tha Pae Sunday Walking Street starting at the east gate at 17:00",
+    oneLiner: "Largest weekly market in the old city — start east, go before dusk.",
+    whyItMatters:
+      "Three temple courtyards become food courts for the night. Start at Tha Pae Gate while the sun is still up — light hits the chedis, you can still see what you're buying.",
+    category: "culture",
+    coordinates: [98.9931, 18.7872],
+    addressHint: "Ratchadamnoen Rd, runs from Tha Pae Gate west",
+    bestTimes: [{ startHour: 16, endHour: 21, dayOfWeek: [0] }],
+    durationMin: 90,
+    durationMax: 180,
+    howTo: [
+      { order: 1, text: "Enter at Tha Pae Gate before 17:30 for golden light." },
+      { order: 2, text: "Eat at Wat Phan On courtyard — the food court is on temple grounds." },
+      { order: 3, text: "Buy at workshops with people working visible — hand-pressed coconut sugar etc." },
+    ],
+    realInconveniences: [
+      { category: "scam", text: "'Hill tribe handmade' often isn't. Look for sellers actually weaving on the spot." },
+      { category: "crowds", text: "After 19:00 the main road is shoulder-traffic. Side sois are calmer." },
+    ],
+    soloOverall: 9,
+  },
+  {
+    slug: "warorot_market_breakfast",
+    title: "Eat breakfast at Warorot Market's upstairs food court at 07:00",
+    oneLiner: "Wholesale flower market downstairs, century-old breakfast counters upstairs.",
+    whyItMatters:
+      "The locals' market — 90% Thai, no English menus, prices are real. The upstairs food court has stalls older than most countries' independence dates.",
+    category: "food",
+    coordinates: [98.9938, 18.7903],
+    addressHint: "East of the river, north of Tha Pae",
+    placeNameRomanized: "Warorot Market",
+    placeNameLocal: "ตลาดวโรรส",
+    bestTimes: [{ startHour: 6, endHour: 9 }],
+    durationMin: 30,
+    durationMax: 60,
+    howTo: [
+      { order: 1, text: "Walk through the flower market on the river side — free, beautiful." },
+      { order: 2, text: "Climb the back stairs to the food court (signs in Thai only)." },
+      { order: 3, text: "Point at any plate that looks busy. 30–50 THB." },
+    ],
+    realInconveniences: [
+      { category: "logistics", text: "Most stalls cash-only. ATM nearby but on the ground floor." },
+      { category: "crowds", text: "Saturdays before 08:00 the market road is jammed with delivery scooters." },
+    ],
+    soloOverall: 8,
+  },
+  {
+    slug: "huay_tung_tao_lake_lunch",
+    title: "Take a bamboo hut at Huay Tung Tao for lake-side fish lunch",
+    oneLiner: "Reservoir north of town with stilted huts on the water — eat with your feet over the lake.",
+    whyItMatters:
+      "Locals' weekend lunch spot. You rent a bamboo platform for the duration, food comes in waves, you can swim between courses. Quieter on weekdays.",
+    category: "nature",
+    coordinates: [98.9217, 18.8762],
+    addressHint: "Huay Tung Tao Reservoir, north of the city",
+    bestTimes: [{ startHour: 11, endHour: 15 }],
+    durationMin: 90,
+    durationMax: 180,
+    howTo: [
+      { order: 1, text: "Grab a Grab from the old city (~150 THB)." },
+      { order: 2, text: "Hut rental is 100 THB; staff bring menus." },
+      { order: 3, text: "Order tilapia ('pla pao'), papaya salad, bamboo rice. ~250 THB total." },
+      { order: 4, text: "Swim if you brought a swimsuit. The far end of the lake is cleaner." },
+    ],
+    realInconveniences: [
+      { category: "weather", text: "Rainy season (Jun–Oct) the huts can flood; check before going." },
+      { category: "logistics", text: "Grabs back to town are scarce after 16:00. Have one called when you order food." },
+    ],
+    soloOverall: 7,
+    soloHint: "Solo lunches happen but most huts are families. Pick a corner one.",
+  },
+  {
+    slug: "wat_chedi_luang_dusk",
+    title: "Sit at Wat Chedi Luang at 18:30 for the chant and the chedi at blue hour",
+    oneLiner: "The half-collapsed 14th-century chedi, lit, while monks chant in the wooden viharn.",
+    whyItMatters:
+      "Inside the wooden viharn, monks chant evening pali at 18:00–19:00. Step out and the chedi is lit against blue sky. Free, central, somehow uncrowded.",
+    category: "culture",
+    coordinates: [98.986, 18.7872],
+    addressHint: "Center of the old city, Prapokkloa Rd",
+    placeNameRomanized: "Wat Chedi Luang",
+    placeNameLocal: "วัดเจดีย์หลวง",
+    bestTimes: [{ startHour: 18, endHour: 19, note: "evening chant 18:00–19:00" }],
+    durationMin: 30,
+    durationMax: 60,
+    howTo: [
+      { order: 1, text: "Enter via the main gate (40 THB foreigner ticket)." },
+      { order: 2, text: "Sit in the wooden viharn, back row. Stay through one full chant cycle." },
+      { order: 3, text: "Walk a clockwise circuit of the chedi as the lights come on." },
+    ],
+    realInconveniences: [
+      { category: "etiquette", text: "Feet must point away from the Buddha. Locals will shift you politely if you forget." },
+      { category: "crowds", text: "Tour group window 17:30–18:00. Arrive at 18:15 and they're leaving." },
+    ],
+    soloOverall: 9,
+  },
+  {
+    slug: "graph_one_book_one_coffee",
+    title: "Read for 90 minutes at Graph Café in the old city with the door drinks",
+    oneLiner: "Slow-pour cocktail-bar-meets-cafe, dim light, designed for solo time.",
+    whyItMatters:
+      "Concrete and dark wood, spotlight at every two-seat table. The 'Door Drinks' menu is a one-shot weekly experiment. Quiet enough to read, slow enough that no one rushes you out.",
+    category: "coffee",
+    coordinates: [98.9876, 18.7895],
+    addressHint: "Soi 6 Singharat Rd, old city",
+    placeNameRomanized: "Graph Cafe",
+    bestTimes: [{ startHour: 14, endHour: 18 }],
+    durationMin: 60,
+    durationMax: 120,
+    howTo: [
+      { order: 1, text: "Order one Door Drink (~180 THB) — ask the barista to explain it." },
+      { order: 2, text: "Take a single-seat table along the wall." },
+      { order: 3, text: "Stay 90+ min. Refill water freely from the wooden bar." },
+    ],
+    realInconveniences: [
+      { category: "logistics", text: "Tiny — six tables. Past 16:00 weekends you may not get in." },
+      { category: "crowds", text: "Photo-walk groups sometimes block the front." },
+    ],
+    soloOverall: 10,
+    soloHint: "Single-seat tables are the design intent here. Bring a book.",
+  },
+  {
+    slug: "thai_cooking_class_morning",
+    title: "Take the morning market-then-kitchen Thai cooking class",
+    oneLiner: "Half-day class that starts at the market — you pick the chiles, you learn what they do.",
+    whyItMatters:
+      "Most classes skip the market. The market portion is what makes the dish make sense — you see the difference between palm sugar and white sugar, between bird's-eye and long chiles.",
+    category: "food",
+    coordinates: [98.9912, 18.7834],
+    addressHint: "Most classes start at Somphet or Warorot market",
+    bestTimes: [{ startHour: 8, endHour: 13 }],
+    durationMin: 240,
+    durationMax: 300,
+    howTo: [
+      { order: 1, text: "Book a class with a market visit — confirm the day before." },
+      { order: 2, text: "Wear closed shoes. Markets are wet floors." },
+      { order: 3, text: "Pick the harder dishes (massaman, khao soi paste) — you can buy pad thai mix anywhere." },
+    ],
+    realInconveniences: [
+      { category: "logistics", text: "Quality varies wildly. Schools that take >8 students per session are usually a worse experience." },
+      { category: "weather", text: "Rainy days the market portion is shortened." },
+    ],
+    soloOverall: 9,
+    soloHint: "Most participants are solo. Group cooking is a natural ice-breaker.",
+  },
+  {
+    slug: "north_gate_jazz_jam",
+    title: "Catch the Tuesday jazz jam at North Gate Jazz Co-Op from 21:30",
+    oneLiner: "Open jam, real players, no cover charge.",
+    whyItMatters:
+      "Tuesdays a rotating cast of touring and local players sits in. House band sets at 21:30, jam from ~22:30. Crowd spills onto the corner — drink in hand, music drifting out.",
+    category: "nightlife",
+    coordinates: [98.9869, 18.7951],
+    addressHint: "Corner of Sri Poom and Manee Nopparat, opposite the moat's north gate",
+    placeNameRomanized: "North Gate Jazz Co-Op",
+    bestTimes: [{ startHour: 21, endHour: 24, dayOfWeek: [2] }],
+    durationMin: 90,
+    durationMax: 180,
+    howTo: [
+      { order: 1, text: "Arrive 21:00 to get a seat; standing-room-only by 22:00." },
+      { order: 2, text: "Beer ~120 THB. No menu pressure." },
+      { order: 3, text: "Sit upstairs balcony for breathing room with sightline to the stage." },
+    ],
+    realInconveniences: [
+      { category: "crowds", text: "Tuesdays are a known event — by 22:30 the sidewalk is the venue." },
+      { category: "safety", text: "Walking back through the old city after midnight is fine; the moat road less so. Grab one back if your guesthouse is far." },
+    ],
+    soloOverall: 8,
+    soloHint: "Solo at a jazz bar reads as serious-listener. Take a stool, not a table.",
+  },
+  {
+    slug: "san_kamphaeng_hot_spring_soak",
+    title: "Soak at San Kamphaeng hot springs for the late-afternoon empty hour",
+    oneLiner: "Public hot spring with pools and private rooms an hour east of town.",
+    whyItMatters:
+      "Tour buses come 10:00–14:00. Show up at 16:00 and the pools are mostly local families. Rentable private rooms are 200 THB and have their own piped-in spring water.",
+    category: "wellness",
+    coordinates: [99.1318, 18.7565],
+    addressHint: "San Kamphaeng Hot Springs, east of Chiang Mai",
+    bestTimes: [{ startHour: 16, endHour: 18 }],
+    durationMin: 90,
+    durationMax: 150,
+    howTo: [
+      { order: 1, text: "Charter a Grab one-way (~350 THB). Negotiate return with the driver." },
+      { order: 2, text: "Entrance: 100 THB foreigner. Private room: +200 THB / 30 min." },
+      { order: 3, text: "Buy eggs to boil in the spring (10 THB / 6 eggs) — local ritual, takes 7 minutes." },
+    ],
+    realInconveniences: [
+      { category: "logistics", text: "Public transit is unreliable. Confirm a return Grab before going in." },
+      { category: "etiquette", text: "Public pools require a swimsuit, not undergarments. Private rooms are private." },
+    ],
+    soloOverall: 8,
+    soloHint: "Private room makes solo soaking comfortable; the public pool is family-coded.",
+  },
+  {
+    slug: "old_city_temple_chedis_walk",
+    title: "Walk a four-temple loop inside the moat between 07:30 and 09:30",
+    oneLiner: "Free, self-guided, quietest hour for the four big old-city wats.",
+    whyItMatters:
+      "Wat Phra Singh, Wat Chedi Luang, Wat Phan Tao, Wat Chiang Man — all walkable in 90 minutes. Before 09:30 you're ahead of every tour bus. By 10:00 they all become photo-stop traffic.",
+    category: "culture",
+    coordinates: [98.984, 18.7886],
+    addressHint: "Old city center; loop through the four wats",
+    bestTimes: [{ startHour: 7, endHour: 10 }],
+    durationMin: 75,
+    durationMax: 120,
+    howTo: [
+      { order: 1, text: "Start at Wat Phra Singh (west). Free entry; donate 20 THB." },
+      { order: 2, text: "East to Wat Phan Tao — small, all teak, often empty." },
+      { order: 3, text: "Wat Chedi Luang next door — 40 THB foreigner ticket." },
+      { order: 4, text: "End at Wat Chiang Man, the city's oldest. Sit in the back of the viharn." },
+    ],
+    realInconveniences: [
+      { category: "etiquette", text: "Knees and shoulders covered at all four. Wat Phra Singh has loaner sarongs." },
+      { category: "weather", text: "April–May the cobbles are oven-hot by 10:00. Move fast or wait until afternoon." },
+    ],
+    soloOverall: 9,
+    soloHint: "Self-paced loop is built for solo. No guide needed.",
+  },
+  {
+    slug: "mae_kha_canal_walk_evening",
+    title: "Walk the restored Mae Kha canal walkway at dusk",
+    oneLiner: "Recently uncovered side-canal turned linear park — one of the city's quiet recent wins.",
+    whyItMatters:
+      "The Mae Kha was a sewer for thirty years. The 2023 restoration cleaned a 1km stretch and ran a wood walkway alongside. Locals stroll it at dusk; it has not yet shown up in guidebooks.",
+    category: "hidden",
+    coordinates: [98.991, 18.7806],
+    addressHint: "Mae Kha canal, runs north–south through the south of the old city",
+    placeNameRomanized: "Khlong Mae Kha walkway",
+    bestTimes: [{ startHour: 17, endHour: 19 }],
+    durationMin: 30,
+    durationMax: 60,
+    howTo: [
+      { order: 1, text: "Start at Chang Klan / Loi Kroh intersection." },
+      { order: 2, text: "Walk south along the wood deck. Roughly 1 km of restored stretch." },
+      { order: 3, text: "Stop at one of the sois with a noodle cart. Plates 40 THB." },
+    ],
+    realInconveniences: [
+      { category: "weather", text: "Smell can return after heavy rain — restoration is partial." },
+      { category: "safety", text: "Some unlit gaps where the walkway hasn't been finished. Keep a phone torch." },
+    ],
+    soloOverall: 9,
+  },
+  {
+    slug: "umong_tunnel_meditation",
+    title: "Sit in the 700-year-old tunnels at Wat Umong before 09:00",
+    oneLiner: "Forest temple west of town with brick tunnels you can sit inside.",
+    whyItMatters:
+      "Built in 1297 for a monk who saw visions. The tunnels stay 24°C even in May. Sit inside one with the painted Buddha and the cool gets into your spine.",
+    category: "culture",
+    coordinates: [98.9486, 18.7864],
+    addressHint: "Wat Umong, west of the old city, edge of the forest",
+    placeNameRomanized: "Wat U-Mong",
+    placeNameLocal: "วัดอุโมงค์",
+    bestTimes: [{ startHour: 7, endHour: 10 }],
+    durationMin: 45,
+    durationMax: 90,
+    howTo: [
+      { order: 1, text: "Grab to the temple (~80 THB from old city)." },
+      { order: 2, text: "Walk past the lake to the tunnel entrance — signs in English." },
+      { order: 3, text: "Sit in any tunnel for 20+ minutes. Phone off." },
+      { order: 4, text: "Walk the talking-tree forest path on the way out." },
+    ],
+    realInconveniences: [
+      { category: "etiquette", text: "Active monastery. No talking inside the tunnels. Phone silent." },
+      { category: "logistics", text: "Donation box on exit — 40–60 THB is right." },
+    ],
+    soloOverall: 10,
+    soloHint: "Meditation tunnels — solo is the natural mode.",
+  },
+  {
+    slug: "akha_ama_origin_pour",
+    title: "Order an Akha Ama single-origin at the Hassadhisawee branch",
+    oneLiner: "Hill-tribe-grown beans roasted by the family that grew them.",
+    whyItMatters:
+      "Akha Ama is a single-village direct-trade story — Lee Ayu's mother's village in Mae Suai grows the beans. The Hassadhisawee branch is the smaller one — quieter, same beans.",
+    category: "coffee",
+    coordinates: [98.9826, 18.7942],
+    addressHint: "Hassadhisawee Rd, north old city",
+    placeNameRomanized: "Akha Ama Coffee",
+    bestTimes: [{ startHour: 8, endHour: 12 }],
+    durationMin: 30,
+    durationMax: 60,
+    howTo: [
+      { order: 1, text: "Order whichever single-origin is on the chalkboard (~120 THB)." },
+      { order: 2, text: "Ask which village it came from. Staff will tell you." },
+      { order: 3, text: "Take a bag of beans home; it's their main income." },
+    ],
+    realInconveniences: [
+      { category: "logistics", text: "Closes Wednesdays. Closes at 17:30." },
+      { category: "crowds", text: "The Nimman branch is busier — Hassadhisawee is the calmer choice." },
+    ],
+    soloOverall: 9,
+    soloHint: "Communal benches; staff happy to chat with solo customers.",
+  },
+  {
+    slug: "elephant_nature_park_day",
+    title: "Spend a day at Elephant Nature Park as an observation visitor",
+    oneLiner: "Sanctuary, no riding, no bathing — just observation of rescued elephants.",
+    whyItMatters:
+      "Lek Chailert's project — most ethical elephant operation in Thailand. The single-day visit is observation-only; reform-of-the-industry money rather than entertainment money.",
+    category: "nature",
+    coordinates: [98.7458, 19.171],
+    addressHint: "Mae Taeng valley, 60 km north of Chiang Mai (transport included)",
+    placeNameRomanized: "Elephant Nature Park",
+    bestTimes: [{ startHour: 8, endHour: 16 }],
+    durationMin: 480,
+    durationMax: 540,
+    howTo: [
+      { order: 1, text: "Book the single-day visit through the official site (~2,500 THB)." },
+      { order: 2, text: "Pickup is 07:30–08:00 from your hotel." },
+      { order: 3, text: "Stay through the afternoon — the river crossing happens 14:00." },
+    ],
+    realInconveniences: [
+      { category: "scam", text: "Many copycat 'nature parks' run riding operations under similar names. Book only on elephantnaturepark.org." },
+      { category: "logistics", text: "Long day — you won't be back in town until 18:00." },
+    ],
+    soloOverall: 9,
+    soloHint: "Solo travelers are the majority of day-visit guests.",
+  },
+];
+
+export const DEMO_EXPERIENCES: readonly Experience[] = DEMOS.map((d) => ({
+  id: `exp_cmi_${d.slug}` as ExperienceId,
+  title: d.title,
+  oneLiner: d.oneLiner,
+  whyItMatters: d.whyItMatters,
+  category: d.category,
+  location: {
+    coordinates: d.coordinates,
+    cityCode: "cmi",
+    addressHint: d.addressHint,
+    placeNameRomanized: d.placeNameRomanized,
+    placeNameLocal: d.placeNameLocal,
+  },
+  bestTimes: d.bestTimes,
+  durationMinutes: { min: d.durationMin, max: d.durationMax },
+  howTo: d.howTo,
+  realInconveniences: d.realInconveniences,
+  soloScore: {
+    overall: d.soloOverall,
+    breakdown: {
+      seatingFriendly: d.soloOverall,
+      soloPatronRatio: d.soloOverall,
+      staffPressure: d.soloOverall,
+      soloPortioning: d.soloOverall,
+      ambianceFit: d.soloOverall,
+      safety: d.soloOverall,
+    },
+    hint: d.soloHint,
+    basedOnCount: 0,
+  },
+  sources: [
+    {
+      type: "blog",
+      attribution: "demo seed",
+      verifiedAt: NOW,
+    },
+  ],
+  confidence: {
+    level: 1,
+    lastVerifiedAt: NOW,
+    reason: "demo seed data",
+    signals: {
+      aiScrapeAgeDays: 0,
+      passiveGpsHits30d: 0,
+      activeReports30d: 0,
+      trustedVerifications: 0,
+    },
+  },
+  nearbyExperienceIds: [],
+  stats: { completionCount: 0, averageRating: 0 },
+  status: "active",
+  createdAt: NOW,
+  updatedAt: NOW,
+}));

--- a/apps/bot/src/demo-experiences.ts
+++ b/apps/bot/src/demo-experiences.ts
@@ -55,8 +55,14 @@ const DEMOS: readonly DemoSpec[] = [
       { order: 4, text: "Walk three clockwise circuits of the chedi after sunrise." },
     ],
     realInconveniences: [
-      { category: "logistics", text: "First songthaew up only fills around 04:30 — be willing to wait or charter (~600 THB)." },
-      { category: "etiquette", text: "Cover knees and shoulders. Sarongs at the gate are loaner-only and can run out." },
+      {
+        category: "logistics",
+        text: "First songthaew up only fills around 04:30 — be willing to wait or charter (~600 THB).",
+      },
+      {
+        category: "etiquette",
+        text: "Cover knees and shoulders. Sarongs at the gate are loaner-only and can run out.",
+      },
     ],
     soloOverall: 9,
     soloHint: "Solo travelers blend into morning meditation; nobody will ask why you're alone.",
@@ -82,7 +88,10 @@ const DEMOS: readonly DemoSpec[] = [
     ],
     realInconveniences: [
       { category: "logistics", text: "Closed Sundays. Sells out by 13:00 most days." },
-      { category: "crowds", text: "Four tables and shared seating — lunchtime you'll sit with strangers." },
+      {
+        category: "crowds",
+        text: "Four tables and shared seating — lunchtime you'll sit with strangers.",
+      },
     ],
     soloOverall: 9,
     soloHint: "A solo bowl is normal here. Nobody hovers.",
@@ -102,7 +111,10 @@ const DEMOS: readonly DemoSpec[] = [
     durationMax: 60,
     howTo: [
       { order: 1, text: "Skip the takeaway line, ask for a bar seat." },
-      { order: 2, text: "Order a single-origin pourover (~140 THB) — they'll talk you through it." },
+      {
+        order: 2,
+        text: "Order a single-origin pourover (~140 THB) — they'll talk you through it.",
+      },
       { order: 3, text: "Stay for a second small drink; the bar is a dialog, not a transaction." },
     ],
     realInconveniences: [
@@ -130,13 +142,19 @@ const DEMOS: readonly DemoSpec[] = [
     durationMin: 90,
     durationMax: 150,
     howTo: [
-      { order: 1, text: "Take a Grab to the trailhead (50 THB). Look for the orange cloth on the first tree." },
+      {
+        order: 1,
+        text: "Take a Grab to the trailhead (50 THB). Look for the orange cloth on the first tree.",
+      },
       { order: 2, text: "Follow the orange markers up — about 40–50 min, mostly shaded." },
       { order: 3, text: "Sit at the temple stream. Stay 30+ minutes; it earns it." },
       { order: 4, text: "Descend the same way, or walk down the paved road for a flatter route." },
     ],
     realInconveniences: [
-      { category: "weather", text: "Trail is slick after rain. April–May heat is brutal even at 08:00." },
+      {
+        category: "weather",
+        text: "Trail is slick after rain. April–May heat is brutal even at 08:00.",
+      },
       { category: "safety", text: "No phone signal in patches. Tell someone you're going." },
     ],
     soloOverall: 8,
@@ -156,12 +174,21 @@ const DEMOS: readonly DemoSpec[] = [
     durationMin: 120,
     durationMax: 130,
     howTo: [
-      { order: 1, text: "Book online or by phone at least a day ahead — walk-ins are rarely possible." },
+      {
+        order: 1,
+        text: "Book online or by phone at least a day ahead — walk-ins are rarely possible.",
+      },
       { order: 2, text: "Arrive 10 min early, foot-wash in the garden." },
-      { order: 3, text: "Two-hour traditional Thai is 1,200 THB. Tip 100 THB cash if you liked it." },
+      {
+        order: 3,
+        text: "Two-hour traditional Thai is 1,200 THB. Tip 100 THB cash if you liked it.",
+      },
     ],
     realInconveniences: [
-      { category: "logistics", text: "The free shuttle pickup window is narrow — confirm pickup time when booking." },
+      {
+        category: "logistics",
+        text: "The free shuttle pickup window is narrow — confirm pickup time when booking.",
+      },
       { category: "etiquette", text: "Phones-off in the treatment garden is enforced." },
     ],
     soloOverall: 10,
@@ -185,7 +212,10 @@ const DEMOS: readonly DemoSpec[] = [
       { order: 3, text: "Watch silver hammer-work in the open shopfronts past Soi 3." },
     ],
     realInconveniences: [
-      { category: "scam", text: "'Antique' silver from non-shopfront stalls is mostly nickel. Buy from named workshops." },
+      {
+        category: "scam",
+        text: "'Antique' silver from non-shopfront stalls is mostly nickel. Buy from named workshops.",
+      },
       { category: "crowds", text: "After 20:30 it's elbow-to-elbow. Go early, leave early." },
     ],
     soloOverall: 9,
@@ -213,8 +243,14 @@ const DEMOS: readonly DemoSpec[] = [
       { order: 3, text: "Re-buy at the 2-hour mark for a fresh code." },
     ],
     realInconveniences: [
-      { category: "crowds", text: "Exam season (May, October) it fills by 09:00 and you'll stand." },
-      { category: "logistics", text: "Outlets at window seats only. Bring an extension cord if you can." },
+      {
+        category: "crowds",
+        text: "Exam season (May, October) it fills by 09:00 and you'll stand.",
+      },
+      {
+        category: "logistics",
+        text: "Outlets at window seats only. Bring an extension cord if you can.",
+      },
     ],
     soloOverall: 10,
     soloHint: "Designed for solo work. Headphones on = nobody approaches you.",
@@ -234,11 +270,20 @@ const DEMOS: readonly DemoSpec[] = [
     howTo: [
       { order: 1, text: "Enter at Tha Pae Gate before 17:30 for golden light." },
       { order: 2, text: "Eat at Wat Phan On courtyard — the food court is on temple grounds." },
-      { order: 3, text: "Buy at workshops with people working visible — hand-pressed coconut sugar etc." },
+      {
+        order: 3,
+        text: "Buy at workshops with people working visible — hand-pressed coconut sugar etc.",
+      },
     ],
     realInconveniences: [
-      { category: "scam", text: "'Hill tribe handmade' often isn't. Look for sellers actually weaving on the spot." },
-      { category: "crowds", text: "After 19:00 the main road is shoulder-traffic. Side sois are calmer." },
+      {
+        category: "scam",
+        text: "'Hill tribe handmade' often isn't. Look for sellers actually weaving on the spot.",
+      },
+      {
+        category: "crowds",
+        text: "After 19:00 the main road is shoulder-traffic. Side sois are calmer.",
+      },
     ],
     soloOverall: 9,
   },
@@ -263,14 +308,18 @@ const DEMOS: readonly DemoSpec[] = [
     ],
     realInconveniences: [
       { category: "logistics", text: "Most stalls cash-only. ATM nearby but on the ground floor." },
-      { category: "crowds", text: "Saturdays before 08:00 the market road is jammed with delivery scooters." },
+      {
+        category: "crowds",
+        text: "Saturdays before 08:00 the market road is jammed with delivery scooters.",
+      },
     ],
     soloOverall: 8,
   },
   {
     slug: "huay_tung_tao_lake_lunch",
     title: "Take a bamboo hut at Huay Tung Tao for lake-side fish lunch",
-    oneLiner: "Reservoir north of town with stilted huts on the water — eat with your feet over the lake.",
+    oneLiner:
+      "Reservoir north of town with stilted huts on the water — eat with your feet over the lake.",
     whyItMatters:
       "Locals' weekend lunch spot. You rent a bamboo platform for the duration, food comes in waves, you can swim between courses. Quieter on weekdays.",
     category: "nature",
@@ -286,8 +335,14 @@ const DEMOS: readonly DemoSpec[] = [
       { order: 4, text: "Swim if you brought a swimsuit. The far end of the lake is cleaner." },
     ],
     realInconveniences: [
-      { category: "weather", text: "Rainy season (Jun–Oct) the huts can flood; check before going." },
-      { category: "logistics", text: "Grabs back to town are scarce after 16:00. Have one called when you order food." },
+      {
+        category: "weather",
+        text: "Rainy season (Jun–Oct) the huts can flood; check before going.",
+      },
+      {
+        category: "logistics",
+        text: "Grabs back to town are scarce after 16:00. Have one called when you order food.",
+      },
     ],
     soloOverall: 7,
     soloHint: "Solo lunches happen but most huts are families. Pick a corner one.",
@@ -312,8 +367,14 @@ const DEMOS: readonly DemoSpec[] = [
       { order: 3, text: "Walk a clockwise circuit of the chedi as the lights come on." },
     ],
     realInconveniences: [
-      { category: "etiquette", text: "Feet must point away from the Buddha. Locals will shift you politely if you forget." },
-      { category: "crowds", text: "Tour group window 17:30–18:00. Arrive at 18:15 and they're leaving." },
+      {
+        category: "etiquette",
+        text: "Feet must point away from the Buddha. Locals will shift you politely if you forget.",
+      },
+      {
+        category: "crowds",
+        text: "Tour group window 17:30–18:00. Arrive at 18:15 and they're leaving.",
+      },
     ],
     soloOverall: 9,
   },
@@ -345,7 +406,8 @@ const DEMOS: readonly DemoSpec[] = [
   {
     slug: "thai_cooking_class_morning",
     title: "Take the morning market-then-kitchen Thai cooking class",
-    oneLiner: "Half-day class that starts at the market — you pick the chiles, you learn what they do.",
+    oneLiner:
+      "Half-day class that starts at the market — you pick the chiles, you learn what they do.",
     whyItMatters:
       "Most classes skip the market. The market portion is what makes the dish make sense — you see the difference between palm sugar and white sugar, between bird's-eye and long chiles.",
     category: "food",
@@ -357,10 +419,16 @@ const DEMOS: readonly DemoSpec[] = [
     howTo: [
       { order: 1, text: "Book a class with a market visit — confirm the day before." },
       { order: 2, text: "Wear closed shoes. Markets are wet floors." },
-      { order: 3, text: "Pick the harder dishes (massaman, khao soi paste) — you can buy pad thai mix anywhere." },
+      {
+        order: 3,
+        text: "Pick the harder dishes (massaman, khao soi paste) — you can buy pad thai mix anywhere.",
+      },
     ],
     realInconveniences: [
-      { category: "logistics", text: "Quality varies wildly. Schools that take >8 students per session are usually a worse experience." },
+      {
+        category: "logistics",
+        text: "Quality varies wildly. Schools that take >8 students per session are usually a worse experience.",
+      },
       { category: "weather", text: "Rainy days the market portion is shortened." },
     ],
     soloOverall: 9,
@@ -385,8 +453,14 @@ const DEMOS: readonly DemoSpec[] = [
       { order: 3, text: "Sit upstairs balcony for breathing room with sightline to the stage." },
     ],
     realInconveniences: [
-      { category: "crowds", text: "Tuesdays are a known event — by 22:30 the sidewalk is the venue." },
-      { category: "safety", text: "Walking back through the old city after midnight is fine; the moat road less so. Grab one back if your guesthouse is far." },
+      {
+        category: "crowds",
+        text: "Tuesdays are a known event — by 22:30 the sidewalk is the venue.",
+      },
+      {
+        category: "safety",
+        text: "Walking back through the old city after midnight is fine; the moat road less so. Grab one back if your guesthouse is far.",
+      },
     ],
     soloOverall: 8,
     soloHint: "Solo at a jazz bar reads as serious-listener. Take a stool, not a table.",
@@ -406,11 +480,20 @@ const DEMOS: readonly DemoSpec[] = [
     howTo: [
       { order: 1, text: "Charter a Grab one-way (~350 THB). Negotiate return with the driver." },
       { order: 2, text: "Entrance: 100 THB foreigner. Private room: +200 THB / 30 min." },
-      { order: 3, text: "Buy eggs to boil in the spring (10 THB / 6 eggs) — local ritual, takes 7 minutes." },
+      {
+        order: 3,
+        text: "Buy eggs to boil in the spring (10 THB / 6 eggs) — local ritual, takes 7 minutes.",
+      },
     ],
     realInconveniences: [
-      { category: "logistics", text: "Public transit is unreliable. Confirm a return Grab before going in." },
-      { category: "etiquette", text: "Public pools require a swimsuit, not undergarments. Private rooms are private." },
+      {
+        category: "logistics",
+        text: "Public transit is unreliable. Confirm a return Grab before going in.",
+      },
+      {
+        category: "etiquette",
+        text: "Public pools require a swimsuit, not undergarments. Private rooms are private.",
+      },
     ],
     soloOverall: 8,
     soloHint: "Private room makes solo soaking comfortable; the public pool is family-coded.",
@@ -431,11 +514,20 @@ const DEMOS: readonly DemoSpec[] = [
       { order: 1, text: "Start at Wat Phra Singh (west). Free entry; donate 20 THB." },
       { order: 2, text: "East to Wat Phan Tao — small, all teak, often empty." },
       { order: 3, text: "Wat Chedi Luang next door — 40 THB foreigner ticket." },
-      { order: 4, text: "End at Wat Chiang Man, the city's oldest. Sit in the back of the viharn." },
+      {
+        order: 4,
+        text: "End at Wat Chiang Man, the city's oldest. Sit in the back of the viharn.",
+      },
     ],
     realInconveniences: [
-      { category: "etiquette", text: "Knees and shoulders covered at all four. Wat Phra Singh has loaner sarongs." },
-      { category: "weather", text: "April–May the cobbles are oven-hot by 10:00. Move fast or wait until afternoon." },
+      {
+        category: "etiquette",
+        text: "Knees and shoulders covered at all four. Wat Phra Singh has loaner sarongs.",
+      },
+      {
+        category: "weather",
+        text: "April–May the cobbles are oven-hot by 10:00. Move fast or wait until afternoon.",
+      },
     ],
     soloOverall: 9,
     soloHint: "Self-paced loop is built for solo. No guide needed.",
@@ -443,7 +535,8 @@ const DEMOS: readonly DemoSpec[] = [
   {
     slug: "mae_kha_canal_walk_evening",
     title: "Walk the restored Mae Kha canal walkway at dusk",
-    oneLiner: "Recently uncovered side-canal turned linear park — one of the city's quiet recent wins.",
+    oneLiner:
+      "Recently uncovered side-canal turned linear park — one of the city's quiet recent wins.",
     whyItMatters:
       "The Mae Kha was a sewer for thirty years. The 2023 restoration cleaned a 1km stretch and ran a wood walkway alongside. Locals stroll it at dusk; it has not yet shown up in guidebooks.",
     category: "hidden",
@@ -460,7 +553,10 @@ const DEMOS: readonly DemoSpec[] = [
     ],
     realInconveniences: [
       { category: "weather", text: "Smell can return after heavy rain — restoration is partial." },
-      { category: "safety", text: "Some unlit gaps where the walkway hasn't been finished. Keep a phone torch." },
+      {
+        category: "safety",
+        text: "Some unlit gaps where the walkway hasn't been finished. Keep a phone torch.",
+      },
     ],
     soloOverall: 9,
   },
@@ -485,7 +581,10 @@ const DEMOS: readonly DemoSpec[] = [
       { order: 4, text: "Walk the talking-tree forest path on the way out." },
     ],
     realInconveniences: [
-      { category: "etiquette", text: "Active monastery. No talking inside the tunnels. Phone silent." },
+      {
+        category: "etiquette",
+        text: "Active monastery. No talking inside the tunnels. Phone silent.",
+      },
       { category: "logistics", text: "Donation box on exit — 40–60 THB is right." },
     ],
     soloOverall: 10,
@@ -511,7 +610,10 @@ const DEMOS: readonly DemoSpec[] = [
     ],
     realInconveniences: [
       { category: "logistics", text: "Closes Wednesdays. Closes at 17:30." },
-      { category: "crowds", text: "The Nimman branch is busier — Hassadhisawee is the calmer choice." },
+      {
+        category: "crowds",
+        text: "The Nimman branch is busier — Hassadhisawee is the calmer choice.",
+      },
     ],
     soloOverall: 9,
     soloHint: "Communal benches; staff happy to chat with solo customers.",
@@ -535,7 +637,10 @@ const DEMOS: readonly DemoSpec[] = [
       { order: 3, text: "Stay through the afternoon — the river crossing happens 14:00." },
     ],
     realInconveniences: [
-      { category: "scam", text: "Many copycat 'nature parks' run riding operations under similar names. Book only on elephantnaturepark.org." },
+      {
+        category: "scam",
+        text: "Many copycat 'nature parks' run riding operations under similar names. Book only on elephantnaturepark.org.",
+      },
       { category: "logistics", text: "Long day — you won't be back in town until 18:00." },
     ],
     soloOverall: 9,

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -1,0 +1,305 @@
+import { Telegraf, Markup, type Context } from "telegraf";
+import OpenAI from "openai";
+import { toFile } from "openai/uploads";
+import { rankExperiences, type RankedExperience } from "@solo-compass/ai";
+import type { Experience } from "@solo-compass/core";
+
+import { DEMO_EXPERIENCES } from "./demo-experiences.js";
+import { getSession, resetSession } from "./session.js";
+
+// ─── Config ────────────────────────────────────────────────────────────────────
+
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const WEBHOOK_URL = process.env.WEBHOOK_URL;
+
+if (!TELEGRAM_BOT_TOKEN) {
+  console.error("Missing TELEGRAM_BOT_TOKEN");
+  process.exit(1);
+}
+if (!OPENAI_API_KEY) {
+  console.error("Missing OPENAI_API_KEY");
+  process.exit(1);
+}
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error("Missing ANTHROPIC_API_KEY");
+  process.exit(1);
+}
+
+const VOICE_MIN_SECONDS = 5;
+const VOICE_MAX_SECONDS = 30;
+
+// ─── Clients ───────────────────────────────────────────────────────────────────
+
+const bot = new Telegraf(TELEGRAM_BOT_TOKEN);
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+function localHour(): number {
+  // Demo data is Chiang Mai — UTC+7 fixed for now.
+  const utcHour = new Date().getUTCHours();
+  return (utcHour + 7) % 24;
+}
+
+function escapeMarkdown(text: string): string {
+  return text.replace(/([_*[\]()~`>#+\-=|{}.!])/g, "\\$1");
+}
+
+function formatRanking(ranked: RankedExperience[]): string {
+  if (ranked.length === 0) {
+    return "No good matches right now. Try a different intent or move closer to the old city.";
+  }
+  return ranked
+    .map((r, i) => {
+      const title = escapeMarkdown(r.experience.title);
+      const reason = escapeMarkdown(r.reason);
+      return `*${i + 1}\\. ${title}* — ${r.walkingMinutes} min walk\n   ${reason}`;
+    })
+    .join("\n\n");
+}
+
+function formatDetail(exp: Experience): string {
+  const lines: string[] = [];
+  lines.push(`*${escapeMarkdown(exp.title)}*`);
+  lines.push("");
+  lines.push(escapeMarkdown(exp.whyItMatters));
+  lines.push("");
+
+  lines.push("*How to:*");
+  for (const step of exp.howTo) {
+    lines.push(`${step.order}\\. ${escapeMarkdown(step.text)}`);
+  }
+  lines.push("");
+
+  if (exp.realInconveniences.length > 0) {
+    lines.push("*What will go wrong:*");
+    for (const inc of exp.realInconveniences) {
+      lines.push(`• _${escapeMarkdown(inc.category)}_: ${escapeMarkdown(inc.text)}`);
+    }
+    lines.push("");
+  }
+
+  if (exp.bestTimes.length > 0) {
+    const times = exp.bestTimes
+      .map((t) => {
+        const base = `${t.startHour}–${t.endHour}`;
+        return t.note ? `${base} (${t.note})` : base;
+      })
+      .join(", ");
+    lines.push(`*Best time:* ${escapeMarkdown(times)}`);
+  }
+
+  lines.push(`*Solo score:* ${exp.soloScore.overall}/10`);
+  if (exp.soloScore.hint) {
+    lines.push(`_${escapeMarkdown(exp.soloScore.hint)}_`);
+  }
+
+  if (exp.sources.length > 0) {
+    lines.push("");
+    lines.push("*Sources:*");
+    for (const s of exp.sources) {
+      const label = s.attribution ?? s.type;
+      const url = s.url ? ` ${s.url}` : "";
+      lines.push(`• ${escapeMarkdown(label)}${escapeMarkdown(url)}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+async function transcribeVoice(fileUrl: string, durationSec: number): Promise<string | null> {
+  if (durationSec < VOICE_MIN_SECONDS || durationSec > VOICE_MAX_SECONDS) {
+    return null;
+  }
+  const res = await fetch(fileUrl);
+  if (!res.ok) {
+    throw new Error(`Telegram file fetch failed: ${res.status}`);
+  }
+  const arrayBuf = await res.arrayBuffer();
+  const file = await toFile(Buffer.from(arrayBuf), "voice.ogg", { type: "audio/ogg" });
+  const result = await openai.audio.transcriptions.create({
+    file,
+    model: "whisper-1",
+  });
+  return result.text.trim();
+}
+
+// ─── Handlers ──────────────────────────────────────────────────────────────────
+
+bot.start(async (ctx) => {
+  resetSession(ctx.from.id);
+  const session = getSession(ctx.from.id);
+  session.stage = "awaiting_location";
+  await ctx.reply(
+    [
+      "Solo Compass.",
+      "",
+      "Drop a pin (📎 → Location) or type a place name to start.",
+      "Then send a 5–30 second voice note saying what you feel like doing — or type it.",
+      "I'll come back with three things worth doing nearby.",
+    ].join("\n"),
+  );
+});
+
+bot.command("reset", async (ctx) => {
+  resetSession(ctx.from.id);
+  await ctx.reply("Reset. Send /start to begin again.");
+});
+
+bot.on("location", async (ctx) => {
+  const session = getSession(ctx.from.id);
+  const { latitude, longitude } = ctx.message.location;
+  session.location = [longitude, latitude];
+  session.stage = "awaiting_intent";
+  await ctx.reply(
+    "Location locked.\n\nWhat do you feel like doing? Send a voice note (5–30s) or type.",
+  );
+});
+
+bot.on("voice", async (ctx) => {
+  const session = getSession(ctx.from.id);
+  if (!session.location) {
+    await ctx.reply("Send a location pin first (📎 → Location).");
+    return;
+  }
+
+  const voice = ctx.message.voice;
+  if (voice.duration < VOICE_MIN_SECONDS) {
+    await ctx.reply(`Voice was too short. Aim for ${VOICE_MIN_SECONDS}–${VOICE_MAX_SECONDS} seconds.`);
+    return;
+  }
+  if (voice.duration > VOICE_MAX_SECONDS) {
+    await ctx.reply(
+      `Voice was too long. Keep it under ${VOICE_MAX_SECONDS} seconds — one or two sentences is enough.`,
+    );
+    return;
+  }
+
+  await ctx.sendChatAction("typing");
+  let transcript: string | null;
+  try {
+    const link = await ctx.telegram.getFileLink(voice.file_id);
+    transcript = await transcribeVoice(link.toString(), voice.duration);
+  } catch (err) {
+    console.error("voice transcribe failed", err);
+    await ctx.reply("Couldn't transcribe that voice note. Try again, or type instead.");
+    return;
+  }
+
+  if (!transcript) {
+    await ctx.reply("Couldn't make sense of that voice note. Try again, or type instead.");
+    return;
+  }
+
+  await handleIntent(ctx, transcript);
+});
+
+bot.on("text", async (ctx) => {
+  const session = getSession(ctx.from.id);
+
+  if (session.stage === "awaiting_location" || !session.location) {
+    await ctx.reply(
+      "I need a real location pin to give walking distances. Use 📎 → Location, or share live location.",
+    );
+    return;
+  }
+
+  if (session.stage === "awaiting_intent") {
+    await handleIntent(ctx, ctx.message.text);
+    return;
+  }
+
+  // Allow follow-up intents after a previous ranking — treat any text as a new intent.
+  await handleIntent(ctx, ctx.message.text);
+});
+
+bot.on("callback_query", async (ctx) => {
+  const data = "data" in ctx.callbackQuery ? ctx.callbackQuery.data : undefined;
+  if (!data || !data.startsWith("detail:")) {
+    await ctx.answerCbQuery();
+    return;
+  }
+  const expId = data.slice("detail:".length);
+  const exp = DEMO_EXPERIENCES.find((e) => (e.id as string) === expId);
+  if (!exp) {
+    await ctx.answerCbQuery("That option is no longer in this list.");
+    return;
+  }
+  await ctx.answerCbQuery();
+  await ctx.reply(formatDetail(exp), { parse_mode: "MarkdownV2" });
+});
+
+// ─── Core flow ─────────────────────────────────────────────────────────────────
+
+async function handleIntent(ctx: Context, intent: string): Promise<void> {
+  const session = getSession(ctx.from!.id);
+  if (!session.location) {
+    await ctx.reply("Send a location pin first (📎 → Location).");
+    return;
+  }
+
+  session.lastIntent = intent;
+  await ctx.sendChatAction("typing");
+
+  let result;
+  try {
+    result = await rankExperiences({
+      userLocation: session.location,
+      userIntent: intent,
+      availableExperiences: [...DEMO_EXPERIENCES],
+      currentHour: localHour(),
+    });
+  } catch (err) {
+    console.error("rankExperiences failed", err);
+    await ctx.reply("Ranking failed. Try again in a moment.");
+    return;
+  }
+
+  if (result.ranked.length === 0) {
+    await ctx.reply("Nothing nearby matched. Try a different intent or share another location.");
+    session.stage = "idle";
+    return;
+  }
+
+  session.lastRankedIds = result.ranked.map((r) => r.experience.id as string);
+  session.stage = "idle";
+
+  const buttons = result.ranked.map((r, i) =>
+    Markup.button.callback(`${i + 1}. ${shortTitle(r.experience.title)}`, `detail:${r.experience.id}`),
+  );
+
+  await ctx.reply(
+    `Heard: _${escapeMarkdown(intent)}_\n\n${formatRanking(result.ranked)}\n\nTap one for the full detail\\.`,
+    {
+      parse_mode: "MarkdownV2",
+      ...Markup.inlineKeyboard(buttons, { columns: 1 }),
+    },
+  );
+}
+
+function shortTitle(title: string): string {
+  return title.length > 40 ? `${title.slice(0, 37)}…` : title;
+}
+
+// ─── Boot ──────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  if (WEBHOOK_URL) {
+    await bot.telegram.setWebhook(WEBHOOK_URL);
+    const port = Number(process.env.PORT ?? 8080);
+    await bot.launch({ webhook: { domain: WEBHOOK_URL, port } });
+    console.log(`bot listening on webhook ${WEBHOOK_URL} (port ${port})`);
+  } else {
+    await bot.launch();
+    console.log("bot started in long-polling mode");
+  }
+}
+
+process.once("SIGINT", () => bot.stop("SIGINT"));
+process.once("SIGTERM", () => bot.stop("SIGTERM"));
+
+main().catch((err) => {
+  console.error("fatal", err);
+  process.exit(1);
+});

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -166,7 +166,9 @@ bot.on("voice", async (ctx) => {
 
   const voice = ctx.message.voice;
   if (voice.duration < VOICE_MIN_SECONDS) {
-    await ctx.reply(`Voice was too short. Aim for ${VOICE_MIN_SECONDS}–${VOICE_MAX_SECONDS} seconds.`);
+    await ctx.reply(
+      `Voice was too short. Aim for ${VOICE_MIN_SECONDS}–${VOICE_MAX_SECONDS} seconds.`,
+    );
     return;
   }
   if (voice.duration > VOICE_MAX_SECONDS) {
@@ -266,7 +268,10 @@ async function handleIntent(ctx: Context, intent: string): Promise<void> {
   session.stage = "idle";
 
   const buttons = result.ranked.map((r, i) =>
-    Markup.button.callback(`${i + 1}. ${shortTitle(r.experience.title)}`, `detail:${r.experience.id}`),
+    Markup.button.callback(
+      `${i + 1}. ${shortTitle(r.experience.title)}`,
+      `detail:${r.experience.id}`,
+    ),
   );
 
   await ctx.reply(

--- a/apps/bot/src/session.ts
+++ b/apps/bot/src/session.ts
@@ -1,0 +1,26 @@
+import type { Coordinates } from "@solo-compass/core";
+
+export type Stage = "idle" | "awaiting_location" | "awaiting_intent";
+
+export interface Session {
+  stage: Stage;
+  location?: Coordinates;
+  lastIntent?: string;
+  /** Cached last ranking so callback queries can resolve detail by index. */
+  lastRankedIds?: string[];
+}
+
+const SESSIONS = new Map<number, Session>();
+
+export function getSession(userId: number): Session {
+  let s = SESSIONS.get(userId);
+  if (!s) {
+    s = { stage: "idle" };
+    SESSIONS.set(userId, s);
+  }
+  return s;
+}
+
+export function resetSession(userId: number): void {
+  SESSIONS.set(userId, { stage: "idle" });
+}

--- a/apps/bot/tsconfig.json
+++ b/apps/bot/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": false,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -3,3 +3,10 @@ export type {
   StructureExperienceInput,
   StructureExperienceResult,
 } from "./prompts/structure-experience";
+
+export { rankExperiences } from "./prompts/rank-experiences";
+export type {
+  RankExperiencesInput,
+  RankExperiencesResult,
+  RankedExperience,
+} from "./prompts/rank-experiences";

--- a/packages/ai/src/prompts/rank-experiences.ts
+++ b/packages/ai/src/prompts/rank-experiences.ts
@@ -1,0 +1,181 @@
+import Anthropic from "@anthropic-ai/sdk";
+import {
+  type Coordinates,
+  type Experience,
+  distanceMeters,
+  walkingMinutes,
+} from "@solo-compass/core";
+
+export interface RankExperiencesInput {
+  /** [longitude, latitude] — GeoJSON order. */
+  userLocation: Coordinates;
+  /** Transcribed voice or typed text describing what the user wants. */
+  userIntent: string;
+  /** Pool of experiences to rank from. */
+  availableExperiences: Experience[];
+  /** Local hour 0–23 in the user's current city. */
+  currentHour: number;
+}
+
+export interface RankedExperience {
+  experience: Experience;
+  /** 0–100. Higher = better match. */
+  score: number;
+  /** One sentence explaining why this matches. */
+  reason: string;
+  /** Estimated walking time from user location, minutes. */
+  walkingMinutes: number;
+}
+
+export interface RankExperiencesResult {
+  ranked: RankedExperience[];
+}
+
+const RANK_TOOL: Anthropic.Tool = {
+  name: "emit_ranking",
+  description:
+    "Emit the top 3 experiences ranked by how well they match the user's intent, time of day, proximity, and solo-friendliness.",
+  input_schema: {
+    type: "object" as const,
+    required: ["ranked"],
+    properties: {
+      ranked: {
+        type: "array",
+        description:
+          "Exactly 3 experiences, ordered best-first. Use the experienceId from the candidate list. Never invent ids.",
+        items: {
+          type: "object",
+          required: ["experienceId", "score", "reason"],
+          properties: {
+            experienceId: {
+              type: "string",
+              description: "The id field of one of the candidate experiences.",
+            },
+            score: {
+              type: "number",
+              minimum: 0,
+              maximum: 100,
+              description: "0–100. Composite of intent fit, time fit, proximity, solo-friendliness.",
+            },
+            reason: {
+              type: "string",
+              description:
+                "One sentence (≤140 chars) explaining the match. Concrete, not generic. No emojis.",
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const SYSTEM_PROMPT = `You rank solo-travel experiences for a single user request.
+
+PRINCIPLES (in priority order):
+1. Intent fit — does the experience match what the user said they feel like doing?
+2. Time-of-day fit — is the current hour inside one of the experience's bestTimes windows? Penalize hard if the experience is closed or wrong-time (e.g. sunset spot at 10am).
+3. Proximity — closer is better, but a perfect-fit 25 min walk beats a poor-fit 5 min walk.
+4. Solo-friendliness — soloScore.overall matters; never recommend something that pressures couples/groups.
+
+OUTPUT RULES:
+- Return EXACTLY 3 ranked items via emit_ranking. If fewer than 3 candidates exist, return what you have.
+- Use the experienceId field exactly as given. Never invent ids.
+- The reason must be specific to *this* experience and *this* intent — not generic.
+- Voice is calm and factual. No "amazing", no "you'll love", no exclamation marks.`;
+
+function summarizeExperience(exp: Experience, walkMin: number): string {
+  const bestTimes =
+    exp.bestTimes.length === 0
+      ? "anytime"
+      : exp.bestTimes
+          .map((t) => `${t.startHour}–${t.endHour}${t.note ? ` (${t.note})` : ""}`)
+          .join(", ");
+  const inconveniences = exp.realInconveniences
+    .slice(0, 2)
+    .map((r) => `${r.category}: ${r.text}`)
+    .join("; ");
+  return [
+    `id: ${exp.id}`,
+    `title: ${exp.title}`,
+    `category: ${exp.category}`,
+    `oneLiner: ${exp.oneLiner}`,
+    `bestTimes: ${bestTimes}`,
+    `durationMin: ${exp.durationMinutes.min}–${exp.durationMinutes.max}m`,
+    `walkingMinutes: ${walkMin}`,
+    `soloScore: ${exp.soloScore.overall}/10`,
+    inconveniences ? `inconveniences: ${inconveniences}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export async function rankExperiences(
+  input: RankExperiencesInput,
+  client?: Anthropic,
+): Promise<RankExperiencesResult> {
+  const { userLocation, userIntent, availableExperiences, currentHour } = input;
+
+  if (availableExperiences.length === 0) {
+    return { ranked: [] };
+  }
+
+  const withWalking = availableExperiences.map((exp) => {
+    const meters = distanceMeters(userLocation, exp.location.coordinates);
+    return { exp, walkMin: walkingMinutes(meters), meters };
+  });
+
+  // Pre-prune: if there are many candidates, send only the closest ~20 to the model.
+  const pruned = withWalking
+    .slice()
+    .sort((a, b) => a.meters - b.meters)
+    .slice(0, 20);
+
+  const candidatesText = pruned
+    .map((c, i) => `--- candidate ${i + 1} ---\n${summarizeExperience(c.exp, c.walkMin)}`)
+    .join("\n\n");
+
+  const userMessage = `User location: [${userLocation[0]}, ${userLocation[1]}] (lng, lat)
+Current local hour: ${currentHour} (0–23)
+User intent: "${userIntent}"
+
+Candidate experiences (already filtered to nearest ~20):
+
+${candidatesText}
+
+Rank the top 3 best matches. Use emit_ranking.`;
+
+  const anthropic = client ?? new Anthropic();
+  const response = await anthropic.messages.create({
+    model: "claude-opus-4-7",
+    max_tokens: 1024,
+    system: SYSTEM_PROMPT,
+    tools: [RANK_TOOL],
+    tool_choice: { type: "tool", name: "emit_ranking" },
+    messages: [{ role: "user", content: userMessage }],
+  });
+
+  const toolUse = response.content.find((b) => b.type === "tool_use");
+  if (!toolUse || toolUse.type !== "tool_use" || toolUse.name !== "emit_ranking") {
+    return { ranked: [] };
+  }
+
+  const args = toolUse.input as {
+    ranked: Array<{ experienceId: string; score: number; reason: string }>;
+  };
+
+  const byId = new Map(withWalking.map((c) => [c.exp.id as string, c]));
+  const ranked: RankedExperience[] = [];
+  for (const item of args.ranked) {
+    const match = byId.get(item.experienceId);
+    if (!match) continue;
+    ranked.push({
+      experience: match.exp,
+      score: Math.max(0, Math.min(100, item.score)),
+      reason: item.reason,
+      walkingMinutes: match.walkMin,
+    });
+    if (ranked.length === 3) break;
+  }
+
+  return { ranked };
+}

--- a/packages/ai/src/prompts/rank-experiences.ts
+++ b/packages/ai/src/prompts/rank-experiences.ts
@@ -55,7 +55,8 @@ const RANK_TOOL: Anthropic.Tool = {
               type: "number",
               minimum: 0,
               maximum: 100,
-              description: "0–100. Composite of intent fit, time fit, proximity, solo-friendliness.",
+              description:
+                "0–100. Composite of intent fit, time fit, proximity, solo-friendliness.",
             },
             reason: {
               type: "string",


### PR DESCRIPTION
## What

Builds two things:

### Part A: Recommendation Engine (`packages/ai`)
- New `rankExperiences()` function that ranks experiences by:
  1. Intent fit (does the experience match what the user wants?)
  2. Time-of-day fit (is the experience at its best right now?)
  3. Proximity (closer is better, but substance wins over distance)
  4. Solo-friendliness (soloScore matters)
- Pre-prunes to nearest 20 candidates before sending to Claude
- Returns top 3 with score, reason, and walking time

### Part B: Telegram Bot (`apps/bot`)
- Telegraf framework with full flow:
  - `/start` → asks for location pin
  - `location` → asks for voice note or text
  - `voice` → Whisper transcription (validates 5-30s)
  - `text` → direct intent
  - Inline keyboard with 3 ranked options
  - Callback queries for full detail view
- In-memory session management (no DB needed)
- Long-polling default, webhook mode via `WEBHOOK_URL`

### How to test
```bash
export TELEGRAM_BOT_TOKEN=your_token
export OPENAI_API_KEY=sk-...
export ANTHROPIC_API_KEY=sk-ant-...
pnpm install
pnpm --filter @solo-compass/bot dev
```

Closes #5