### PR TITLE
feat(web): Scenario B — mobile iOS install funnel (#43)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,23 +1,36 @@
 "use client";
 
-import { Suspense, useCallback, useMemo, useState, useEffect } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { MapView } from "@/components/MapView";
 import { ExperienceSheet } from "@/components/ExperienceSheet";
 import { InfoBar } from "@/components/InfoBar";
 import { VoiceIntent } from "@/components/VoiceIntent";
 import { DesktopLayout } from "@/components/DesktopLayout";
+import { MobileLayout } from "@/components/MobileLayout";
 import { useNearby } from "@/lib/use-nearby";
 import { track } from "@/lib/analytics";
 import type { FilterValue } from "@/components/FilterBar";
 
 const CHIANG_MAI: [number, number] = [98.9853, 18.7883];
 
+function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 1023px)");
+    setIsMobile(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  return isMobile;
+}
+
 function HomeInner() {
+  const isMobile = useIsMobile();
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  // Restore state from URL on mount
   const initialFilter = (searchParams.get("filter") ?? "all") as FilterValue;
   const initialSel = searchParams.get("sel");
 
@@ -25,16 +38,6 @@ function HomeInner() {
   const [intent, setIntent] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(initialSel);
   const [filter, setFilter] = useState<FilterValue>(initialFilter);
-  const [isDesktop, setIsDesktop] = useState(false);
-
-  // Detect desktop breakpoint (>1024px)
-  useEffect(() => {
-    const mq = window.matchMedia("(min-width: 1024px)");
-    setIsDesktop(mq.matches);
-    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, []);
 
   const { data, isLoading } = useNearby({ center, intent: intent ?? undefined });
   const results = data?.results ?? [];
@@ -44,7 +47,6 @@ function HomeInner() {
     [results, selectedId],
   );
 
-  // Sync state → URL (replaceState so browser history captures each distinct change)
   const pushUrl = useCallback(
     (nextFilter: FilterValue, nextSel: string | null) => {
       const params = new URLSearchParams();
@@ -107,51 +109,28 @@ function HomeInner() {
     if (initialSel && results.length > 0 && selectedId === initialSel) return;
   }, [results, initialSel, selectedId]);
 
-  if (isDesktop) {
-    return (
-      <>
-        <DesktopLayout
-          results={results}
-          isLoading={isLoading}
-          selectedId={selectedId}
-          filter={filter}
-          onSelect={handleSelect}
-          onCenterChange={setCenter}
-          onFilterChange={handleFilterChange}
-        />
-        {/* ExperienceSheet for desktop — shown as a floating panel via the sheet's own positioning */}
-        <ExperienceSheet
-          key={selectedId ?? "none"}
-          result={selectedResult}
-          onOpenChange={(open) => !open && handleSelect(null)}
-          onCheckin={handleCheckin}
-        />
-      </>
-    );
+  if (isMobile) {
+    return <MobileLayout />;
   }
 
-  // Mobile layout (unchanged)
   return (
-    <main className="relative h-screen w-screen overflow-hidden bg-paper-cream">
-      <MapView
+    <>
+      <DesktopLayout
         results={results}
-        onSelect={handleSelect}
+        isLoading={isLoading}
         selectedId={selectedId}
+        filter={filter}
+        onSelect={handleSelect}
         onCenterChange={setCenter}
+        onFilterChange={handleFilterChange}
       />
-      <VoiceIntent intent={intent} onIntentChange={handleIntentChange} />
       <ExperienceSheet
         key={selectedId ?? "none"}
         result={selectedResult}
         onOpenChange={(open) => !open && handleSelect(null)}
         onCheckin={handleCheckin}
       />
-      <InfoBar
-        cityName={data?.degraded ? "Paused (AI)" : center ? "Here" : "Loading…"}
-        count={results.length}
-        loading={isLoading && results.length === 0}
-      />
-    </main>
+    </>
   );
 }
 

--- a/apps/web/src/components/IOSPrompt.tsx
+++ b/apps/web/src/components/IOSPrompt.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { dismissIOSPrompt } from "@/lib/checkin-store";
+
+interface IOSPromptProps {
+  readonly onDismiss: () => void;
+}
+
+export function IOSPrompt({ onDismiss }: IOSPromptProps) {
+  function handleDismiss() {
+    dismissIOSPrompt();
+    onDismiss();
+  }
+
+  return (
+    <div className="fixed top-0 inset-x-0 z-50 px-4 pt-safe-top pb-3 bg-paper-cream/95 backdrop-blur-sm border-b border-ink-warm/10 shadow-md">
+      <div className="max-w-md mx-auto">
+        <p className="text-xs text-ink-warm/60 mb-2 text-center">
+          The iOS app does this automatically with background GPS
+        </p>
+        <div className="flex gap-2">
+          <a
+            href="https://apps.apple.com/app/solo-compass"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex-1 rounded-xl bg-deep-teal py-2.5 text-sm font-semibold text-paper-cream text-center transition hover:bg-deep-teal/90"
+          >
+            Get the free app
+          </a>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            className="flex-1 rounded-xl bg-ink-warm/10 py-2.5 text-sm font-semibold text-ink-warm text-center transition hover:bg-ink-warm/15"
+          >
+            Keep using web
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/MobileLayout.tsx
+++ b/apps/web/src/components/MobileLayout.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Drawer } from "vaul";
+import { MapView } from "@/components/MapView";
+import { ExperienceSheet } from "@/components/ExperienceSheet";
+import { IOSPrompt } from "@/components/IOSPrompt";
+import { useNearby } from "@/lib/use-nearby";
+import { track } from "@/lib/analytics";
+import {
+  readCheckins,
+  writeCheckin,
+  isIOSPromptSnoozed,
+  type LocalCheckin,
+} from "@/lib/checkin-store";
+import { categoryEmoji, categoryLabel } from "@/lib/category";
+import type { NearbyResult } from "@/app/api/experiences/nearby/route";
+
+// Chiang Mai center as fallback
+const DEFAULT_CENTER: [number, number] = [98.9853, 18.7883];
+
+type BottomTab = "nearby" | "done";
+
+interface DoneEntry {
+  checkin: LocalCheckin;
+  result: NearbyResult | undefined;
+}
+
+export function MobileLayout() {
+  const [center, setCenter] = useState<[number, number] | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<BottomTab>("nearby");
+  const [checkins, setCheckins] = useState<LocalCheckin[]>([]);
+  const [showIOSPrompt, setShowIOSPrompt] = useState(false);
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  const { data } = useNearby({ center, intent: undefined });
+  const results: readonly NearbyResult[] = data?.results ?? [];
+
+  const selectedResult = useMemo(
+    () => results.find((r) => r.experience.id === selectedId) ?? null,
+    [results, selectedId],
+  );
+
+  // Load checkins from localStorage on mount
+  useEffect(() => {
+    setCheckins(readCheckins());
+  }, []);
+
+  // Request geolocation on first open
+  useEffect(() => {
+    if (!navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => setCenter([pos.coords.longitude, pos.coords.latitude]),
+      () => setCenter(DEFAULT_CENTER),
+    );
+  }, []);
+
+  const handleSelect = useCallback(
+    (id: string | null) => {
+      setSelectedId(id);
+      if (id) {
+        const r = results.find((x) => x.experience.id === id);
+        if (r) {
+          track({
+            name: "marker_view",
+            props: { experienceId: id, category: r.experience.category },
+          });
+          track({
+            name: "sheet_open",
+            props: { experienceId: id, category: r.experience.category },
+          });
+        }
+      }
+    },
+    [results],
+  );
+
+  const handleCheckin = useCallback(
+    async (experienceId: string, rating?: number) => {
+      const res = await fetch(`/api/experiences/${experienceId}/checkin`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(rating ? { rating } : {}),
+      });
+      if (!res.ok) throw new Error(`checkin failed: ${res.status}`);
+
+      const coords = center ?? undefined;
+      const updated = writeCheckin({
+        experienceId,
+        timestamp: new Date().toISOString(),
+        coords,
+      });
+      setCheckins(updated);
+
+      track({ name: "checkin", props: { experienceId, rated: rating !== undefined } });
+
+      if (updated.length >= 2 && !isIOSPromptSnoozed()) {
+        setShowIOSPrompt(true);
+      }
+    },
+    [center],
+  );
+
+  const doneExperiences = useMemo((): DoneEntry[] => {
+    return checkins
+      .slice()
+      .reverse()
+      .map((c) => ({
+        checkin: c,
+        result: results.find((r) => r.experience.id === c.experienceId),
+      }));
+  }, [checkins, results]);
+
+  return (
+    <main className="relative h-screen w-screen overflow-hidden bg-paper-cream">
+      {showIOSPrompt && <IOSPrompt onDismiss={() => setShowIOSPrompt(false)} />}
+
+      <MapView
+        results={results}
+        onSelect={handleSelect}
+        selectedId={selectedId}
+        onCenterChange={setCenter}
+      />
+
+      {/* Experience detail sheet — only shown when marker selected */}
+      <ExperienceSheet
+        key={selectedId ?? "none"}
+        result={selectedResult}
+        onOpenChange={(open) => !open && setSelectedId(null)}
+        onCheckin={handleCheckin}
+      />
+
+      {/* Bottom sheet — nearby / done tabs */}
+      <Drawer.Root
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+        shouldScaleBackground={false}
+        modal={false}
+      >
+        <Drawer.Portal>
+          <Drawer.Content
+            className="fixed inset-x-0 bottom-0 z-20 flex flex-col rounded-t-2xl bg-paper-cream shadow-2xl outline-none"
+            style={{ maxHeight: "60vh" }}
+            aria-describedby={undefined}
+          >
+            <Drawer.Title className="sr-only">Nearby experiences</Drawer.Title>
+            <button
+              type="button"
+              onClick={() => setSheetOpen((v) => !v)}
+              aria-label={sheetOpen ? "Collapse sheet" : "Expand sheet"}
+              className="flex w-full flex-col items-center pt-2 pb-1"
+            >
+              <div className="h-1.5 w-12 rounded-full bg-ink-warm/20" aria-hidden="true" />
+            </button>
+
+            <div className="flex border-b border-ink-warm/10 px-4">
+              <TabButton active={activeTab === "nearby"} onClick={() => setActiveTab("nearby")}>
+                Nearby ({results.length})
+              </TabButton>
+              <TabButton active={activeTab === "done"} onClick={() => setActiveTab("done")}>
+                Done ({checkins.length})
+              </TabButton>
+            </div>
+
+            <div className="overflow-y-auto flex-1">
+              {activeTab === "nearby" ? (
+                <NearbyList
+                  results={results}
+                  checkins={checkins}
+                  onSelect={(id) => {
+                    handleSelect(id);
+                    setSheetOpen(false);
+                  }}
+                />
+              ) : (
+                <DoneList doneExperiences={doneExperiences} />
+              )}
+            </div>
+          </Drawer.Content>
+        </Drawer.Portal>
+      </Drawer.Root>
+
+      {/* Collapsed sheet peek — always visible when sheet is closed */}
+      {!sheetOpen && (
+        <button
+          type="button"
+          onClick={() => setSheetOpen(true)}
+          className="fixed bottom-0 inset-x-0 z-20 flex flex-col items-center rounded-t-2xl bg-paper-cream shadow-2xl py-2"
+          aria-label="Show nearby experiences"
+        >
+          <div className="h-1.5 w-12 rounded-full bg-ink-warm/20 mb-2" aria-hidden="true" />
+          <p className="text-sm text-ink-warm/70 pb-1">
+            {results.length > 0
+              ? `${results.length} experiences nearby — swipe up`
+              : "Finding experiences…"}
+          </p>
+        </button>
+      )}
+    </main>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  readonly active: boolean;
+  readonly onClick: () => void;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={[
+        "flex-1 py-2.5 text-sm font-medium transition",
+        active
+          ? "border-b-2 border-deep-teal text-deep-teal"
+          : "text-ink-warm/50 hover:text-ink-warm/80",
+      ].join(" ")}
+    >
+      {children}
+    </button>
+  );
+}
+
+function NearbyList({
+  results,
+  checkins,
+  onSelect,
+}: {
+  readonly results: readonly NearbyResult[];
+  readonly checkins: readonly LocalCheckin[];
+  readonly onSelect: (id: string) => void;
+}) {
+  if (results.length === 0) {
+    return <p className="py-8 text-center text-sm text-ink-warm/50">Looking for experiences…</p>;
+  }
+
+  return (
+    <ul className="divide-y divide-ink-warm/8">
+      {results.map((r) => {
+        const done = checkins.some((c) => c.experienceId === r.experience.id);
+        return (
+          <li key={r.experience.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(r.experience.id)}
+              className="w-full px-4 py-3 text-left flex items-start gap-3 hover:bg-ink-warm/5 transition"
+            >
+              <span className="text-xl leading-none mt-0.5" aria-hidden="true">
+                {categoryEmoji[r.experience.category]}
+              </span>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-medium text-ink-warm truncate">{r.experience.title}</p>
+                  {done && (
+                    <span className="flex-shrink-0 text-xs bg-soft-green/30 text-deep-teal rounded px-1.5 py-0.5">
+                      Done
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-ink-warm/60 mt-0.5">
+                  {categoryLabel[r.experience.category]} · {r.walkingMinutes} min walk
+                </p>
+              </div>
+              <span className="flex-shrink-0 text-sm font-semibold text-deep-teal mt-0.5">
+                {r.experience.soloScore.overall.toFixed(0)}
+              </span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function DoneList({ doneExperiences }: { readonly doneExperiences: readonly DoneEntry[] }) {
+  if (doneExperiences.length === 0) {
+    return (
+      <div className="py-8 px-6 text-center">
+        <p className="text-sm text-ink-warm/50">No check-ins yet.</p>
+        <p className="text-xs text-ink-warm/40 mt-1">
+          Tap an experience on the map and hit &ldquo;I did this&rdquo;.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-ink-warm/8">
+      {doneExperiences.map(({ checkin, result }) => {
+        const title = result?.experience.title ?? checkin.experienceId;
+        const category = result?.experience.category;
+        const date = new Date(checkin.timestamp).toLocaleDateString(undefined, {
+          month: "short",
+          day: "numeric",
+        });
+        return (
+          <li key={checkin.experienceId} className="px-4 py-3 flex items-center gap-3">
+            <span className="text-xl leading-none" aria-hidden="true">
+              {category ? categoryEmoji[category] : "✓"}
+            </span>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-ink-warm truncate">{title}</p>
+              {category && (
+                <p className="text-xs text-ink-warm/60 mt-0.5">{categoryLabel[category]}</p>
+              )}
+            </div>
+            <span className="flex-shrink-0 text-xs text-ink-warm/50">{date}</span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/web/src/lib/checkin-store.ts
+++ b/apps/web/src/lib/checkin-store.ts
@@ -1,0 +1,56 @@
+export interface LocalCheckin {
+  experienceId: string;
+  timestamp: string; // ISO 8601
+  coords?: [number, number]; // [lng, lat]
+}
+
+const STORAGE_KEY = "sc:checkins";
+
+export function readCheckins(): LocalCheckin[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as LocalCheckin[];
+  } catch {
+    return [];
+  }
+}
+
+export function writeCheckin(checkin: LocalCheckin): LocalCheckin[] {
+  const existing = readCheckins().filter((c) => c.experienceId !== checkin.experienceId);
+  const updated = [...existing, checkin];
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  } catch {
+    // storage full or unavailable — best effort
+  }
+  return updated;
+}
+
+export function hasCheckin(experienceId: string): boolean {
+  return readCheckins().some((c) => c.experienceId === experienceId);
+}
+
+const IOS_PROMPT_KEY = "sc:ios-prompt-dismissed-at";
+
+export function getIOSPromptDismissedAt(): number | null {
+  if (typeof window === "undefined") return null;
+  const raw = localStorage.getItem(IOS_PROMPT_KEY);
+  return raw ? Number(raw) : null;
+}
+
+export function dismissIOSPrompt(): void {
+  try {
+    localStorage.setItem(IOS_PROMPT_KEY, String(Date.now()));
+  } catch {
+    // best effort
+  }
+}
+
+export function isIOSPromptSnoozed(): boolean {
+  const dismissedAt = getIOSPromptDismissedAt();
+  if (dismissedAt === null) return false;
+  const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+  return Date.now() - dismissedAt < sevenDaysMs;
+}


### PR DESCRIPTION
Closes #43

Mobile-responsive web view as iOS trial funnel:
- Full-screen map + expandable bottom sheet
- Anonymous localStorage checkins
- Non-blocking iOS prompt after 2 checkins

## Summary
- `MobileLayout.tsx`: full-screen map + vaul bottom sheet with Nearby/Done tabs; geolocation on first open with CM fallback
- `checkin-store.ts`: localStorage read/write helpers for anonymous checkins + iOS prompt dismissal (7-day snooze)
- `IOSPrompt.tsx`: non-blocking top banner with equal-weight "Get the free app" / "Keep using web" buttons
- `page.tsx`: `useMediaQuery` hook routes `<1024px` to `MobileLayout`, `>=1024px` to existing `DesktopLayout`
- Also fixed pre-existing `WEB_DEMO_EXPERIENCES` → `demoExperiences` import name in nearby route

## Test plan
- [ ] Open on mobile viewport — geolocation prompt fires, falls back to Chiang Mai on deny
- [ ] Tap map markers — ExperienceSheet opens; "I did this" records to localStorage and moves experience to Done tab
- [ ] After 2nd checkin — iOS prompt banner appears with two equal-weight buttons
- [ ] "Keep using web" dismisses and snoozes for 7 days
- [ ] "Done" tab lists checkins reverse-chronologically with category and date
- [ ] Open on ≥1024px — desktop layout unchanged

Typecheck: ✅
Format: ✅