### PR TITLE
feat(web): Scenario D — SEO static pages (#45)

### DIFF
--- a/apps/web/src/app/api/experiences/nearby/route.ts
+++ b/apps/web/src/app/api/experiences/nearby/route.ts
@@ -26,7 +26,7 @@ import {
   type HealthStatus,
 } from "@solo-compass/core";
 import { getExperiencesRepo } from "@/lib/repos";
-import { demoExperiences as WEB_DEMO_EXPERIENCES } from "@/data/demo-experiences";
+import { demoExperiences } from "@/data/demo-experiences";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -112,7 +112,7 @@ export async function GET(
     if (process.env.NODE_ENV === "development") {
       // eslint-disable-next-line no-console
       console.warn("Using demo fallback data — Supabase unavailable in dev");
-      candidates = [...WEB_DEMO_EXPERIENCES];
+      candidates = [...demoExperiences];
     } else {
       return NextResponse.json({ error: "experience lookup failed" }, { status: 502 });
     }

--- a/apps/web/src/app/cmi/[slug]/opengraph-image.tsx
+++ b/apps/web/src/app/cmi/[slug]/opengraph-image.tsx
@@ -1,0 +1,157 @@
+import { ImageResponse } from "next/og";
+import { demoExperiences } from "@/data/demo-experiences";
+import { categoryEmoji, categoryLabel } from "@/lib/category";
+import { idFromSlug } from "@/components/SEOExperience";
+
+export const runtime = "edge";
+export const revalidate = 3600;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function Image({ params }: Props) {
+  const { slug } = await params;
+  const id = idFromSlug(slug);
+  const exp = demoExperiences.find((e) => e.id === id);
+
+  const title = exp?.title ?? "Chiang Mai experience";
+  const oneLiner = exp?.oneLiner ?? "";
+  const category = exp?.category ?? "culture";
+  const score = exp?.soloScore.overall ?? 0;
+  const emoji = categoryEmoji[category];
+  const label = categoryLabel[category];
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "1200px",
+        height: "630px",
+        display: "flex",
+        flexDirection: "column",
+        backgroundColor: "#F5F1E8",
+        padding: "64px",
+        fontFamily: "system-ui, sans-serif",
+        position: "relative",
+      }}
+    >
+      {/* Top band */}
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          height: "6px",
+          backgroundColor: "#2F6B6B",
+        }}
+      />
+
+      {/* Category + city */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "12px",
+          marginBottom: "24px",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            backgroundColor: "rgba(47,107,107,0.12)",
+            borderRadius: "999px",
+            padding: "6px 16px",
+            fontSize: "14px",
+            fontWeight: 700,
+            color: "#2F6B6B",
+            textTransform: "uppercase",
+            letterSpacing: "0.08em",
+          }}
+        >
+          <span>{emoji}</span>
+          <span>{label}</span>
+        </div>
+        <span style={{ fontSize: "13px", color: "#2C2A2699", fontWeight: 500 }}>
+          Chiang Mai · Solo Compass
+        </span>
+      </div>
+
+      {/* Title */}
+      <div
+        style={{
+          fontSize: "52px",
+          fontWeight: 800,
+          color: "#2C2A26",
+          lineHeight: 1.15,
+          flex: 1,
+          maxWidth: "900px",
+        }}
+      >
+        {title}
+      </div>
+
+      {/* One-liner */}
+      <div
+        style={{
+          fontSize: "22px",
+          color: "#2C2A26AA",
+          lineHeight: 1.4,
+          maxWidth: "820px",
+          marginBottom: "32px",
+        }}
+      >
+        {oneLiner.length > 100 ? oneLiner.slice(0, 99) + "…" : oneLiner}
+      </div>
+
+      {/* Footer */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <span
+            style={{
+              fontSize: "40px",
+              fontWeight: 800,
+              color: "#2F6B6B",
+            }}
+          >
+            {score}
+          </span>
+          <span style={{ fontSize: "15px", color: "#2C2A2680" }}>/ 10 solo score</span>
+        </div>
+        <div
+          style={{
+            fontSize: "16px",
+            fontWeight: 700,
+            color: "#2F6B6B",
+            letterSpacing: "-0.01em",
+          }}
+        >
+          solocompass.app
+        </div>
+      </div>
+
+      {/* Bottom accent */}
+      <div
+        style={{
+          position: "absolute",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          height: "4px",
+          backgroundColor: "#C68E3F",
+        }}
+      />
+    </div>,
+    { ...size },
+  );
+}

--- a/apps/web/src/app/cmi/[slug]/page.tsx
+++ b/apps/web/src/app/cmi/[slug]/page.tsx
@@ -1,0 +1,147 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { demoExperiences } from "@/data/demo-experiences";
+import {
+  SEOExperience,
+  slugFromId,
+  idFromSlug,
+  experiencePageTitle,
+  truncate,
+} from "@/components/SEOExperience";
+import { categoryLabel } from "@/lib/category";
+
+export const revalidate = 3600;
+
+export function generateStaticParams() {
+  return demoExperiences
+    .filter((e) => e.status === "active")
+    .map((e) => ({ slug: slugFromId(e.id) }));
+}
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const id = idFromSlug(slug);
+  const exp = demoExperiences.find((e) => e.id === id);
+  if (!exp) return { title: "Not found" };
+
+  const title = experiencePageTitle(exp);
+  const description = truncate(exp.oneLiner, 155);
+  const url = `https://solocompass.app/cmi/${slug}`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: "Solo Compass",
+      locale: "en_US",
+      type: "article",
+      images: [{ url: `${url}/opengraph-image`, width: 1200, height: 630, alt: title }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [`${url}/opengraph-image`],
+    },
+    alternates: { canonical: url },
+  };
+}
+
+export default async function ExperiencePage({ params }: Props) {
+  const { slug } = await params;
+  const id = idFromSlug(slug);
+  const exp = demoExperiences.find((e) => e.id === id);
+  if (!exp || exp.status !== "active") notFound();
+
+  const related = exp.nearbyExperienceIds
+    .map((rid) => demoExperiences.find((e) => e.id === rid))
+    .filter((e): e is (typeof demoExperiences)[number] => e !== undefined && e.status === "active");
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "TouristAttraction",
+        "@id": `https://solocompass.app/cmi/${slug}`,
+        name: exp.title,
+        description: exp.whyItMatters,
+        url: `https://solocompass.app/cmi/${slug}`,
+        touristType: "Solo travelers",
+        geo: {
+          "@type": "GeoCoordinates",
+          longitude: exp.location.coordinates[0],
+          latitude: exp.location.coordinates[1],
+        },
+        containedInPlace: {
+          "@type": "Place",
+          name: "Chiang Mai",
+          address: {
+            "@type": "PostalAddress",
+            addressLocality: "Chiang Mai",
+            addressCountry: "TH",
+          },
+        },
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Solo Compass",
+            item: "https://solocompass.app",
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "Chiang Mai",
+            item: "https://solocompass.app/cmi",
+          },
+          {
+            "@type": "ListItem",
+            position: 3,
+            name: categoryLabel[exp.category],
+            item: `https://solocompass.app/cmi/category/${exp.category}`,
+          },
+          {
+            "@type": "ListItem",
+            position: 4,
+            name: exp.title,
+            item: `https://solocompass.app/cmi/${slug}`,
+          },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      {/* Minimal nav */}
+      <nav className="sticky top-0 z-10 border-b border-ink-warm/10 bg-paper-cream/95 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-2xl items-center justify-between px-4 py-3">
+          <a href="/cmi" className="text-sm font-semibold text-deep-teal">
+            ← Chiang Mai
+          </a>
+          <a
+            href="/"
+            className="hidden rounded-lg bg-deep-teal px-4 py-2 text-xs font-semibold text-paper-cream transition hover:bg-deep-teal/90 md:inline-flex"
+          >
+            Plan a trip →
+          </a>
+        </div>
+      </nav>
+      <SEOExperience experience={exp} relatedExperiences={related} />
+    </>
+  );
+}

--- a/apps/web/src/app/cmi/category/[category]/page.tsx
+++ b/apps/web/src/app/cmi/category/[category]/page.tsx
@@ -1,0 +1,244 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import type { ExperienceCategory } from "@solo-compass/core";
+import { demoExperiences } from "@/data/demo-experiences";
+import { categoryEmoji, categoryLabel } from "@/lib/category";
+import { slugFromId, SoloScorePill } from "@/components/SEOExperience";
+
+export const revalidate = 3600;
+
+const VALID_CATEGORIES: ExperienceCategory[] = [
+  "culture",
+  "nature",
+  "food",
+  "coffee",
+  "work",
+  "wellness",
+  "nightlife",
+  "hidden",
+];
+
+export function generateStaticParams() {
+  return VALID_CATEGORIES.map((category) => ({ category }));
+}
+
+interface Props {
+  params: Promise<{ category: string }>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { category } = await params;
+  if (!VALID_CATEGORIES.includes(category as ExperienceCategory)) return { title: "Not found" };
+  const cat = category as ExperienceCategory;
+
+  const count = demoExperiences.filter((e) => e.category === cat && e.status === "active").length;
+
+  const title = `${categoryLabel[cat]} experiences in Chiang Mai for solo travelers · Solo Compass`;
+  const description = `${count} solo-friendly ${categoryLabel[cat].toLowerCase()} experiences in Chiang Mai. Curated with real tips, best times, and honest inconveniences.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: `https://solocompass.app/cmi/category/${cat}`,
+      siteName: "Solo Compass",
+      locale: "en_US",
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+    alternates: { canonical: `https://solocompass.app/cmi/category/${cat}` },
+  };
+}
+
+export default async function CategoryPage({ params }: Props) {
+  const { category } = await params;
+  if (!VALID_CATEGORIES.includes(category as ExperienceCategory)) notFound();
+  const cat = category as ExperienceCategory;
+
+  const experiences = demoExperiences.filter((e) => e.category === cat && e.status === "active");
+  if (experiences.length === 0) notFound();
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "CollectionPage",
+        name: `${categoryLabel[cat]} in Chiang Mai`,
+        description: `Solo-friendly ${categoryLabel[cat].toLowerCase()} experiences in Chiang Mai, Thailand.`,
+        url: `https://solocompass.app/cmi/category/${cat}`,
+        hasPart: experiences.map((exp) => ({
+          "@type": "TouristAttraction",
+          name: exp.title,
+          description: exp.oneLiner,
+          url: `https://solocompass.app/cmi/${slugFromId(exp.id)}`,
+        })),
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Solo Compass",
+            item: "https://solocompass.app",
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "Chiang Mai",
+            item: "https://solocompass.app/cmi",
+          },
+          {
+            "@type": "ListItem",
+            position: 3,
+            name: categoryLabel[cat],
+            item: `https://solocompass.app/cmi/category/${cat}`,
+          },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <nav className="sticky top-0 z-10 border-b border-ink-warm/10 bg-paper-cream/95 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-3">
+          <a href="/cmi" className="text-sm font-semibold text-deep-teal">
+            ← Chiang Mai
+          </a>
+          <a
+            href="/"
+            className="hidden rounded-lg bg-deep-teal px-4 py-2 text-xs font-semibold text-paper-cream transition hover:bg-deep-teal/90 md:inline-flex"
+          >
+            Plan a trip →
+          </a>
+        </div>
+      </nav>
+
+      <div className="min-h-screen bg-paper-cream pb-16">
+        <main className="mx-auto max-w-4xl px-4 py-8">
+          {/* Breadcrumb */}
+          <nav aria-label="Breadcrumb" className="mb-6 text-xs text-ink-warm/50">
+            <ol className="flex flex-wrap items-center gap-1">
+              <li>
+                <a href="/" className="hover:text-deep-teal hover:underline">
+                  Solo Compass
+                </a>
+              </li>
+              <li aria-hidden="true">›</li>
+              <li>
+                <a href="/cmi" className="hover:text-deep-teal hover:underline">
+                  Chiang Mai
+                </a>
+              </li>
+              <li aria-hidden="true">›</li>
+              <li className="text-ink-warm/70">{categoryLabel[cat]}</li>
+            </ol>
+          </nav>
+
+          <header className="mb-8">
+            <div className="mb-2 flex items-center gap-3">
+              <span className="text-4xl" aria-hidden="true">
+                {categoryEmoji[cat]}
+              </span>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-widest text-ink-warm/50">
+                  Chiang Mai · Solo Compass
+                </p>
+                <h1 className="text-2xl font-bold text-ink-warm md:text-3xl">
+                  {categoryLabel[cat]} in Chiang Mai
+                </h1>
+              </div>
+            </div>
+            <p className="max-w-xl text-sm leading-relaxed text-ink-warm/70">
+              {experiences.length} solo-friendly {categoryLabel[cat].toLowerCase()} experience
+              {experiences.length !== 1 ? "s" : ""} — curated with real tips, best times, and honest
+              inconveniences.
+            </p>
+          </header>
+
+          {/* Other category links */}
+          <div className="mb-8 flex flex-wrap gap-2">
+            <a
+              href="/cmi"
+              className="rounded-full bg-ink-warm/8 px-4 py-1.5 text-xs font-semibold text-ink-warm/70 ring-1 ring-ink-warm/10 transition hover:bg-deep-teal/10 hover:text-deep-teal"
+            >
+              All categories
+            </a>
+            {VALID_CATEGORIES.filter((c) => c !== cat).map((c) => (
+              <a
+                key={c}
+                href={`/cmi/category/${c}`}
+                className="rounded-full bg-ink-warm/8 px-4 py-1.5 text-xs font-semibold text-ink-warm/70 ring-1 ring-ink-warm/10 transition hover:bg-deep-teal/10 hover:text-deep-teal"
+              >
+                {categoryEmoji[c]} {categoryLabel[c]}
+              </a>
+            ))}
+          </div>
+
+          <ul className="grid gap-4 sm:grid-cols-2">
+            {experiences.map((exp) => (
+              <li key={exp.id}>
+                <a
+                  href={`/cmi/${slugFromId(exp.id)}`}
+                  className="group flex flex-col gap-2 rounded-2xl bg-white/50 p-4 ring-1 ring-ink-warm/10 transition hover:ring-deep-teal/40 hover:shadow-sm"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <p className="text-sm font-semibold leading-snug text-ink-warm group-hover:text-deep-teal">
+                      {exp.title}
+                    </p>
+                    <SoloScorePill score={exp.soloScore.overall} />
+                  </div>
+                  <p className="text-xs leading-relaxed text-ink-warm/60">{exp.oneLiner}</p>
+                  {exp.bestTimes.length > 0 && exp.bestTimes[0] && (
+                    <p className="text-xs text-ink-warm/50">
+                      🕐{" "}
+                      {`${String(exp.bestTimes[0].startHour).padStart(2, "0")}:00–${String(exp.bestTimes[0].endHour).padStart(2, "0")}:00`}
+                      {exp.bestTimes[0].note ? ` · ${exp.bestTimes[0].note}` : ""}
+                    </p>
+                  )}
+                  <div className="flex flex-wrap gap-2 mt-1">
+                    {exp.realInconveniences.slice(0, 1).map((r, i) => (
+                      <span
+                        key={i}
+                        className="rounded bg-warm-amber/10 px-1.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-warm-amber"
+                      >
+                        {r.category}
+                      </span>
+                    ))}
+                    <span className="text-xs text-ink-warm/50">
+                      {exp.durationMinutes.min === exp.durationMinutes.max
+                        ? `${exp.durationMinutes.min} min`
+                        : `${exp.durationMinutes.min}–${exp.durationMinutes.max} min`}
+                    </span>
+                  </div>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </main>
+      </div>
+
+      {/* Mobile sticky CTA */}
+      <div className="fixed inset-x-0 bottom-0 z-50 flex md:hidden border-t border-ink-warm/10 bg-paper-cream/95 px-4 py-3 backdrop-blur-sm">
+        <button
+          type="button"
+          className="w-full rounded-xl bg-deep-teal py-3 text-sm font-semibold text-paper-cream"
+        >
+          Open in app
+        </button>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/cmi/page.tsx
+++ b/apps/web/src/app/cmi/page.tsx
@@ -1,0 +1,201 @@
+import type { Metadata } from "next";
+import type { ExperienceCategory } from "@solo-compass/core";
+import { demoExperiences } from "@/data/demo-experiences";
+import { categoryEmoji, categoryLabel } from "@/lib/category";
+import { slugFromId, SoloScorePill, CategoryBadge } from "@/components/SEOExperience";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: "Things to do in Chiang Mai for solo travelers · Solo Compass",
+  description:
+    "25 curated, solo-friendly experiences in Chiang Mai: temples at sunset, khao soi, specialty coffee, forest meditation, hidden rooftops. Honest tips, real inconveniences.",
+  openGraph: {
+    title: "Things to do in Chiang Mai for solo travelers",
+    description:
+      "25 curated solo-friendly experiences in Chiang Mai. Temples, food, coffee, wellness, nightlife — with honest solo-travel tips.",
+    url: "https://solocompass.app/cmi",
+    siteName: "Solo Compass",
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Things to do in Chiang Mai for solo travelers · Solo Compass",
+    description:
+      "25 curated solo-friendly experiences in Chiang Mai. Temples, food, coffee, wellness, nightlife.",
+  },
+  alternates: { canonical: "https://solocompass.app/cmi" },
+};
+
+const CATEGORIES: ExperienceCategory[] = [
+  "culture",
+  "nature",
+  "food",
+  "coffee",
+  "work",
+  "wellness",
+  "nightlife",
+  "hidden",
+];
+
+const activeExperiences = demoExperiences.filter((e) => e.status === "active");
+
+export default function ChiangMaiPage() {
+  const byCategory = CATEGORIES.map((cat) => ({
+    cat,
+    items: activeExperiences.filter((e) => e.category === cat),
+  })).filter((g) => g.items.length > 0);
+
+  return (
+    <>
+      {/* Schema.org structured data */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "CollectionPage",
+            name: "Things to do in Chiang Mai for solo travelers",
+            description:
+              "Curated solo-friendly experiences in Chiang Mai, Thailand. Temples, food, coffee, wellness, nightlife, and hidden gems.",
+            url: "https://solocompass.app/cmi",
+            hasPart: activeExperiences.map((exp) => ({
+              "@type": "TouristAttraction",
+              name: exp.title,
+              description: exp.oneLiner,
+              url: `https://solocompass.app/cmi/${slugFromId(exp.id)}`,
+              geo: {
+                "@type": "GeoCoordinates",
+                longitude: exp.location.coordinates[0],
+                latitude: exp.location.coordinates[1],
+              },
+            })),
+            breadcrumb: {
+              "@type": "BreadcrumbList",
+              itemListElement: [
+                {
+                  "@type": "ListItem",
+                  position: 1,
+                  name: "Solo Compass",
+                  item: "https://solocompass.app",
+                },
+                {
+                  "@type": "ListItem",
+                  position: 2,
+                  name: "Chiang Mai",
+                  item: "https://solocompass.app/cmi",
+                },
+              ],
+            },
+          }),
+        }}
+      />
+
+      <div className="min-h-screen bg-paper-cream pb-16">
+        {/* Nav */}
+        <nav className="sticky top-0 z-10 border-b border-ink-warm/10 bg-paper-cream/95 backdrop-blur-sm">
+          <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-3">
+            <a href="/" className="text-sm font-semibold text-deep-teal">
+              Solo Compass
+            </a>
+            <a
+              href="/"
+              className="hidden rounded-lg bg-deep-teal px-4 py-2 text-xs font-semibold text-paper-cream transition hover:bg-deep-teal/90 md:inline-flex"
+            >
+              Plan a trip →
+            </a>
+          </div>
+        </nav>
+
+        <main className="mx-auto max-w-4xl px-4 py-8">
+          {/* Hero */}
+          <header className="mb-10">
+            <div className="mb-2 text-xs font-semibold uppercase tracking-widest text-ink-warm/50">
+              Thailand · Chiang Mai
+            </div>
+            <h1 className="mb-4 text-3xl font-bold leading-tight text-ink-warm md:text-4xl">
+              Things to do in Chiang Mai
+              <br />
+              <span className="text-deep-teal">for solo travelers</span>
+            </h1>
+            <p className="max-w-xl text-base leading-relaxed text-ink-warm/70">
+              {activeExperiences.length} curated experiences — not places, not restaurants, not
+              things to &ldquo;check off&rdquo;. Each one is a concrete, time-bound story worth
+              doing alone.
+            </p>
+
+            {/* Map preview placeholder */}
+            <div className="mt-6 flex h-40 items-center justify-center rounded-2xl bg-muted-road/30 ring-1 ring-ink-warm/10 md:h-56">
+              <a
+                href="/"
+                className="flex flex-col items-center gap-2 text-ink-warm/50 hover:text-deep-teal"
+              >
+                <span className="text-4xl">🗺️</span>
+                <span className="text-sm font-medium">Open interactive map</span>
+              </a>
+            </div>
+          </header>
+
+          {/* Category filter pills */}
+          <div className="mb-8 flex flex-wrap gap-2">
+            <a
+              href="/cmi"
+              className="rounded-full bg-deep-teal px-4 py-1.5 text-xs font-semibold text-paper-cream"
+            >
+              All ({activeExperiences.length})
+            </a>
+            {byCategory.map(({ cat, items }) => (
+              <a
+                key={cat}
+                href={`/cmi/category/${cat}`}
+                className="rounded-full bg-ink-warm/8 px-4 py-1.5 text-xs font-semibold text-ink-warm/70 ring-1 ring-ink-warm/10 transition hover:bg-deep-teal/10 hover:text-deep-teal"
+              >
+                {categoryEmoji[cat]} {categoryLabel[cat]} ({items.length})
+              </a>
+            ))}
+          </div>
+
+          {/* Experience grid by category */}
+          {byCategory.map(({ cat, items }) => (
+            <section key={cat} className="mb-10">
+              <h2 className="mb-4 flex items-center gap-2 text-base font-semibold text-ink-warm">
+                <span className="text-xl" aria-hidden="true">
+                  {categoryEmoji[cat]}
+                </span>
+                {categoryLabel[cat]}
+              </h2>
+              <ul className="grid gap-3 sm:grid-cols-2">
+                {items.map((exp) => (
+                  <li key={exp.id}>
+                    <a
+                      href={`/cmi/${slugFromId(exp.id)}`}
+                      className="group flex flex-col gap-2 rounded-2xl bg-white/50 p-4 ring-1 ring-ink-warm/10 transition hover:ring-deep-teal/40 hover:shadow-sm"
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <p className="text-sm font-semibold leading-snug text-ink-warm group-hover:text-deep-teal">
+                          {exp.title}
+                        </p>
+                        <SoloScorePill score={exp.soloScore.overall} />
+                      </div>
+                      <p className="text-xs leading-relaxed text-ink-warm/60 line-clamp-2">
+                        {exp.oneLiner}
+                      </p>
+                      {exp.bestTimes.length > 0 && exp.bestTimes[0] && (
+                        <p className="text-xs text-ink-warm/50">
+                          🕐{" "}
+                          {`${String(exp.bestTimes[0].startHour).padStart(2, "0")}:00–${String(exp.bestTimes[0].endHour).padStart(2, "0")}:00`}
+                          {exp.bestTimes[0].note ? ` · ${exp.bestTimes[0].note}` : ""}
+                        </p>
+                      )}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </main>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: ["/", "/cmi/"],
+        disallow: ["/u/", "/api/"],
+      },
+    ],
+    sitemap: "https://solocompass.app/sitemap.xml",
+  };
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,52 @@
+import type { MetadataRoute } from "next";
+import type { ExperienceCategory } from "@solo-compass/core";
+import { demoExperiences } from "@/data/demo-experiences";
+import { slugFromId } from "@/components/SEOExperience";
+
+const BASE = "https://solocompass.app";
+
+const CATEGORIES: ExperienceCategory[] = [
+  "culture",
+  "nature",
+  "food",
+  "coffee",
+  "work",
+  "wellness",
+  "nightlife",
+  "hidden",
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const activeExperiences = demoExperiences.filter((e) => e.status === "active");
+
+  const experienceUrls: MetadataRoute.Sitemap = activeExperiences.map((exp) => ({
+    url: `${BASE}/cmi/${slugFromId(exp.id)}`,
+    lastModified: exp.updatedAt,
+    changeFrequency: "weekly",
+    priority: 0.8,
+  }));
+
+  const categoryUrls: MetadataRoute.Sitemap = CATEGORIES.map((cat) => ({
+    url: `${BASE}/cmi/category/${cat}`,
+    lastModified: new Date().toISOString(),
+    changeFrequency: "weekly",
+    priority: 0.7,
+  }));
+
+  return [
+    {
+      url: BASE,
+      lastModified: new Date().toISOString(),
+      changeFrequency: "daily",
+      priority: 1.0,
+    },
+    {
+      url: `${BASE}/cmi`,
+      lastModified: new Date().toISOString(),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    ...categoryUrls,
+    ...experienceUrls,
+  ];
+}

--- a/apps/web/src/components/SEOExperience.tsx
+++ b/apps/web/src/components/SEOExperience.tsx
@@ -1,0 +1,322 @@
+import type { Experience, ExperienceCategory, TimeWindow } from "@solo-compass/core";
+import { categoryEmoji, categoryLabel } from "@/lib/category";
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+export function readingMinutes(exp: Experience): number {
+  const wordCount =
+    (exp.whyItMatters?.split(" ").length ?? 0) +
+    exp.howTo.reduce((n, s) => n + s.text.split(" ").length, 0) +
+    exp.realInconveniences.reduce((n, r) => n + r.text.split(" ").length, 0);
+  return Math.max(1, Math.ceil(wordCount / 200));
+}
+
+export function slugFromId(id: string): string {
+  // exp_cmi_suan_dok_sunset → suan-dok-sunset
+  return id.replace(/^exp_[a-z]+_/, "").replaceAll("_", "-");
+}
+
+export function idFromSlug(slug: string): string {
+  return "exp_cmi_" + slug.replaceAll("-", "_");
+}
+
+export function experiencePageTitle(exp: Experience): string {
+  return `${exp.title} · Chiang Mai · Solo Compass`;
+}
+
+export function truncate(str: string, max: number): string {
+  return str.length <= max ? str : str.slice(0, max - 1) + "…";
+}
+
+function formatTimeWindow(t: TimeWindow): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const window = `${pad(t.startHour)}:00–${pad(t.endHour)}:00`;
+  const days =
+    t.dayOfWeek && t.dayOfWeek.length > 0 ? t.dayOfWeek.map((d) => DAY_NAMES[d]).join(", ") : null;
+  const note = t.note ?? null;
+  return [window, days, note ? `(${note})` : null].filter(Boolean).join(" · ");
+}
+
+// ─── category badge ──────────────────────────────────────────────────────────
+
+export function CategoryBadge({ category }: { readonly category: ExperienceCategory }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-deep-teal/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-deep-teal">
+      <span aria-hidden="true">{categoryEmoji[category]}</span>
+      {categoryLabel[category]}
+    </span>
+  );
+}
+
+// ─── solo score pill ─────────────────────────────────────────────────────────
+
+export function SoloScorePill({ score }: { readonly score: number }) {
+  const color =
+    score >= 9
+      ? "bg-soft-green/30 text-deep-teal"
+      : score >= 7
+        ? "bg-warm-amber/20 text-warm-amber"
+        : "bg-muted-road/40 text-ink-warm/70";
+  return (
+    <span
+      className={`inline-flex items-baseline gap-1 rounded-full px-3 py-1 text-xs font-semibold ${color}`}
+    >
+      <span className="text-sm font-bold">{score}</span>
+      <span className="font-normal opacity-70">/ 10 solo</span>
+    </span>
+  );
+}
+
+// ─── section wrapper ─────────────────────────────────────────────────────────
+
+function Section({
+  title,
+  children,
+}: {
+  readonly title: string;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <section className="mb-6">
+      <h2 className="mb-2 text-xs font-semibold uppercase tracking-widest text-ink-warm/50">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+// ─── when to go widget ───────────────────────────────────────────────────────
+
+function WhenToGo({ bestTimes }: { readonly bestTimes: readonly TimeWindow[] }) {
+  if (bestTimes.length === 0) return null;
+  return (
+    <Section title="When to go">
+      <ul className="space-y-1.5">
+        {bestTimes.map((t, i) => (
+          <li key={i} className="flex items-center gap-2 text-sm text-ink-warm/80">
+            <span className="text-base" aria-hidden="true">
+              🕐
+            </span>
+            {formatTimeWindow(t)}
+          </li>
+        ))}
+      </ul>
+    </Section>
+  );
+}
+
+// ─── main SEO experience page component ────────────────────────────────────
+
+interface SEOExperienceProps {
+  readonly experience: Experience;
+  readonly relatedExperiences?: readonly Experience[];
+}
+
+export function SEOExperience({ experience: exp, relatedExperiences = [] }: SEOExperienceProps) {
+  const mins = readingMinutes(exp);
+
+  return (
+    <article className="mx-auto max-w-2xl px-4 py-8 md:py-12">
+      {/* Breadcrumb */}
+      <nav aria-label="Breadcrumb" className="mb-6 text-xs text-ink-warm/50">
+        <ol className="flex flex-wrap items-center gap-1">
+          <li>
+            <a href="/" className="hover:text-deep-teal hover:underline">
+              Solo Compass
+            </a>
+          </li>
+          <li aria-hidden="true">›</li>
+          <li>
+            <a href="/cmi" className="hover:text-deep-teal hover:underline">
+              Chiang Mai
+            </a>
+          </li>
+          <li aria-hidden="true">›</li>
+          <li>
+            <a
+              href={`/cmi/category/${exp.category}`}
+              className="hover:text-deep-teal hover:underline capitalize"
+            >
+              {categoryLabel[exp.category]}
+            </a>
+          </li>
+          <li aria-hidden="true">›</li>
+          <li className="text-ink-warm/70 truncate max-w-[200px]">{exp.title}</li>
+        </ol>
+      </nav>
+
+      {/* Header */}
+      <header className="mb-8">
+        <div className="mb-3 flex flex-wrap items-center gap-2">
+          <CategoryBadge category={exp.category} />
+          <SoloScorePill score={exp.soloScore.overall} />
+          <span className="text-xs text-ink-warm/50">
+            {exp.durationMinutes.min === exp.durationMinutes.max
+              ? `${exp.durationMinutes.min} min`
+              : `${exp.durationMinutes.min}–${exp.durationMinutes.max} min`}
+          </span>
+          <span className="text-xs text-ink-warm/50">· {mins} min read</span>
+        </div>
+
+        <h1 className="mb-3 text-2xl font-bold leading-snug text-ink-warm md:text-3xl">
+          {exp.title}
+        </h1>
+        <p className="text-base leading-relaxed text-ink-warm/80 md:text-lg">{exp.oneLiner}</p>
+
+        {exp.location.placeNameRomanized && (
+          <p className="mt-2 text-sm text-ink-warm/50">
+            📍 {exp.location.placeNameRomanized}
+            {exp.location.addressHint ? ` · ${exp.location.addressHint}` : ""}
+          </p>
+        )}
+      </header>
+
+      {/* Why it matters */}
+      <Section title="Why it matters">
+        <p className="text-sm leading-relaxed text-ink-warm/80">{exp.whyItMatters}</p>
+      </Section>
+
+      {/* When to go */}
+      <WhenToGo bestTimes={exp.bestTimes} />
+
+      {/* How to */}
+      <Section title="How to do this">
+        <ol className="space-y-3">
+          {exp.howTo.map((step) => (
+            <li key={step.order} className="flex gap-3 text-sm leading-relaxed text-ink-warm/80">
+              <span className="flex-shrink-0 flex h-5 w-5 items-center justify-center rounded-full bg-deep-teal/10 text-xs font-semibold text-deep-teal">
+                {step.order}
+              </span>
+              <span>{step.text}</span>
+            </li>
+          ))}
+        </ol>
+      </Section>
+
+      {/* Real inconveniences */}
+      {exp.realInconveniences.length > 0 && (
+        <Section title="Real inconveniences">
+          <ul className="space-y-2">
+            {exp.realInconveniences.map((r, i) => (
+              <li key={i} className="flex gap-2 text-sm leading-relaxed text-ink-warm/80">
+                <span className="flex-shrink-0 rounded bg-warm-amber/10 px-1.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-warm-amber">
+                  {r.category}
+                </span>
+                <span>{r.text}</span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {/* Solo score breakdown */}
+      <Section title="Solo score">
+        <div className="rounded-xl bg-paper-cream/60 p-4 ring-1 ring-ink-warm/10">
+          <div className="mb-3 flex items-baseline gap-2">
+            <span className="text-3xl font-bold text-ink-warm">{exp.soloScore.overall}</span>
+            <span className="text-sm text-ink-warm/60">
+              / 10 · based on {exp.soloScore.basedOnCount} reports
+            </span>
+          </div>
+          {exp.soloScore.hint && (
+            <p className="mb-3 text-sm italic text-ink-warm/70">{exp.soloScore.hint}</p>
+          )}
+          <dl className="grid grid-cols-2 gap-x-6 gap-y-1.5 text-xs text-ink-warm/70">
+            {(
+              [
+                ["Seating friendly", exp.soloScore.breakdown.seatingFriendly],
+                ["Solo patron ratio", exp.soloScore.breakdown.soloPatronRatio],
+                ["Staff pressure", exp.soloScore.breakdown.staffPressure],
+                ["Solo portioning", exp.soloScore.breakdown.soloPortioning],
+                ["Ambiance fit", exp.soloScore.breakdown.ambianceFit],
+                ["Safety", exp.soloScore.breakdown.safety],
+              ] as const
+            ).map(([label, val]) => (
+              <div key={label} className="flex justify-between gap-2">
+                <dt>{label}</dt>
+                <dd className="font-medium text-ink-warm/90">{val}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </Section>
+
+      {/* Sources */}
+      {exp.sources.length > 0 && (
+        <Section title="Sources">
+          <ul className="space-y-1">
+            {exp.sources.map((s, i) => (
+              <li key={i} className="text-xs text-ink-warm/60">
+                <span className="font-medium capitalize text-ink-warm/80">{s.type}</span>
+                {s.attribution && <> · {s.attribution}</>}
+                {s.url && (
+                  <>
+                    {" · "}
+                    <a
+                      href={s.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-deep-teal hover:underline"
+                    >
+                      source ↗
+                    </a>
+                  </>
+                )}
+                <span className="ml-2 text-ink-warm/40">verified {s.verifiedAt.slice(0, 10)}</span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {/* Related experiences */}
+      {relatedExperiences.length > 0 && (
+        <Section title="Nearby experiences">
+          <ul className="space-y-2">
+            {relatedExperiences.map((r) => (
+              <li key={r.id}>
+                <a
+                  href={`/cmi/${slugFromId(r.id)}`}
+                  className="group flex items-start gap-3 rounded-xl p-3 ring-1 ring-ink-warm/10 transition hover:ring-deep-teal/40"
+                >
+                  <span className="text-xl" aria-hidden="true">
+                    {categoryEmoji[r.category]}
+                  </span>
+                  <div>
+                    <p className="text-sm font-medium text-ink-warm group-hover:text-deep-teal">
+                      {r.title}
+                    </p>
+                    <p className="text-xs text-ink-warm/60">{truncate(r.oneLiner, 80)}</p>
+                  </div>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {/* Desktop CTA */}
+      <div className="hidden md:flex mt-8 justify-end">
+        <a
+          href="/"
+          className="inline-flex items-center gap-2 rounded-xl bg-deep-teal px-5 py-3 text-sm font-semibold text-paper-cream transition hover:bg-deep-teal/90"
+        >
+          Plan a trip to Chiang Mai →
+        </a>
+      </div>
+
+      {/* Mobile sticky CTA */}
+      <div className="fixed inset-x-0 bottom-0 z-50 flex md:hidden border-t border-ink-warm/10 bg-paper-cream/95 px-4 py-3 backdrop-blur-sm">
+        <button
+          type="button"
+          className="w-full rounded-xl bg-deep-teal py-3 text-sm font-semibold text-paper-cream"
+        >
+          Open in app
+        </button>
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
Closes #45

## Summary
- `/cmi` city overview: all active experiences grouped by category, category filter pills, map preview CTA, schema.org `CollectionPage` + `TouristAttraction` + `BreadcrumbList`
- `/cmi/[slug]` experience detail: full content (whyItMatters, howTo, realInconveniences, soloScore breakdown, sources linked), "when to go" widget, related experiences sidebar, reading time, mobile sticky CTA, desktop "Plan a trip" CTA
- `/cmi/category/[category]` category pages: 8 categories statically pre-rendered, each with proper `<h1>`, description, structured data
- `/cmi/[slug]/opengraph-image` auto OG image via `next/og` `ImageResponse` — title + category badge + solo score, brand colours
- `sitemap.ts` — auto-generates all experience + city + category URLs
- `robots.ts` — allows `/`, `/cmi/*`; disallows `/u/*`, `/api/*`
- `SEOExperience.tsx` shared component reused across detail + category pages
- Also fixes pre-existing `WEB_DEMO_EXPERIENCES` → `demoExperiences` import error in nearby route

## Test plan
- [ ] `pnpm typecheck` — ✅
- [ ] `pnpm format` — ✅
- [ ] `/cmi` renders experience grid grouped by category
- [ ] `/cmi/suan-dok-sunset` renders full experience detail with structured data in `<head>`
- [ ] `/cmi/category/culture` renders culture-filtered list
- [ ] `/cmi/suan-dok-sunset/opengraph-image` returns 1200×630 PNG
- [ ] `/sitemap.xml` enumerates all experience + category URLs
- [ ] `/robots.txt` allows cmi, blocks api

🤖 Generated with [Claude Code](https://claude.com/claude-code)