### PR TITLE
feat(web): Scenario C — public trip recap pages (#44)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "clean": "rm -rf .next .turbo"
   },
   "dependencies": {
+    "@vercel/og": "^0.6.8",
     "@sentry/nextjs": "^8.45.0",
     "@solo-compass/ai": "workspace:*",
     "@solo-compass/core": "workspace:*",

--- a/apps/web/src/app/api/experiences/nearby/route.ts
+++ b/apps/web/src/app/api/experiences/nearby/route.ts
@@ -26,7 +26,7 @@ import {
   type HealthStatus,
 } from "@solo-compass/core";
 import { getExperiencesRepo } from "@/lib/repos";
-import { WEB_DEMO_EXPERIENCES } from "@/data/demo-experiences";
+import { demoExperiences as WEB_DEMO_EXPERIENCES } from "@/data/demo-experiences";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";

--- a/apps/web/src/app/u/[handle]/[city]/[expId]/page.tsx
+++ b/apps/web/src/app/u/[handle]/[city]/[expId]/page.tsx
@@ -1,0 +1,245 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getCompletionsRepo, getExperiencesRepo } from "@/lib/repos";
+import { categoryEmoji, categoryLabel } from "@/lib/category";
+import { cityDisplayName } from "@/components/TripRecap";
+
+// ─── Metadata ──────────────────────────────────────────────────────────────────
+
+interface PageParams {
+  readonly handle: string;
+  readonly city: string;
+  readonly expId: string;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<PageParams>;
+}): Promise<Metadata> {
+  const { handle, city, expId } = await params;
+  const experiencesRepo = getExperiencesRepo();
+  const experience = await experiencesRepo.findById(expId);
+  if (!experience) return {};
+
+  const cityName = cityDisplayName(city);
+  const title = `${experience.title} — ${handle} in ${cityName}`;
+
+  return {
+    title,
+    description: experience.oneLiner,
+    openGraph: {
+      title,
+      description: experience.oneLiner,
+      type: "article",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: experience.oneLiner,
+    },
+  };
+}
+
+// ─── Page ──────────────────────────────────────────────────────────────────────
+
+export default async function SingleExperienceRecapPage({
+  params,
+}: {
+  params: Promise<PageParams>;
+}) {
+  const { handle, city, expId } = await params;
+
+  const completionsRepo = getCompletionsRepo();
+  const experiencesRepo = getExperiencesRepo();
+
+  // Check user exists and has a public profile
+  const profile = await completionsRepo.getProfile(handle);
+  if (!profile) notFound();
+
+  if (!profile.publicProfile) {
+    return <PrivateExperiencePage handle={handle} />;
+  }
+
+  const [experience, completions] = await Promise.all([
+    experiencesRepo.findById(expId),
+    completionsRepo.findByHandle(handle, city),
+  ]);
+
+  if (!experience) notFound();
+
+  const completion = completions.find((c) => c.experienceId === expId);
+  if (!completion) notFound();
+
+  const cityName = cityDisplayName(city);
+  const completedDate = new Date(completion.completedAt).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return (
+    <main className="min-h-screen bg-paper-cream">
+      {/* Back link */}
+      <div className="mx-auto max-w-2xl px-4 pt-6">
+        <a
+          href={`/u/${handle}/${city}`}
+          className="inline-flex items-center gap-1.5 text-sm text-deep-teal hover:underline"
+        >
+          ← {handle}'s trip to {cityName}
+        </a>
+      </div>
+
+      {/* Photo placeholder */}
+      <div className="mx-auto mt-4 max-w-2xl px-4">
+        <div className="flex h-52 items-center justify-center rounded-2xl bg-muted-road/30 sm:h-64">
+          <span className="text-6xl" aria-hidden="true">
+            {categoryEmoji[experience.category]}
+          </span>
+        </div>
+      </div>
+
+      {/* Experience detail */}
+      <article className="mx-auto max-w-2xl px-4 py-6">
+        {/* Category + date + rating */}
+        <div className="mb-2 flex flex-wrap items-center gap-2 text-xs font-medium uppercase tracking-wide text-deep-teal">
+          <span>
+            {categoryEmoji[experience.category]} {categoryLabel[experience.category]}
+          </span>
+          <span className="text-ink-warm/30">·</span>
+          <span className="text-ink-warm/50">{completedDate}</span>
+          {completion.rating && (
+            <>
+              <span className="text-ink-warm/30">·</span>
+              <span className="text-warm-amber">{"★".repeat(completion.rating)}</span>
+            </>
+          )}
+        </div>
+
+        <h1 className="mb-3 text-2xl font-bold leading-snug text-ink-warm sm:text-3xl">
+          {experience.title}
+        </h1>
+
+        <p className="mb-6 text-base leading-relaxed text-ink-warm/80">{experience.oneLiner}</p>
+
+        {/* Personal note */}
+        {completion.note && (
+          <blockquote className="mb-6 rounded-xl border-l-4 border-deep-teal/40 bg-white px-5 py-4 text-sm italic leading-relaxed text-ink-warm/80 shadow-sm">
+            "{completion.note}"
+            <footer className="mt-2 text-xs not-italic text-ink-warm/50">— {handle}</footer>
+          </blockquote>
+        )}
+
+        {/* Why it matters */}
+        <Section title="Why it matters">
+          <p className="text-sm leading-relaxed text-ink-warm/80">{experience.whyItMatters}</p>
+        </Section>
+
+        {/* How to */}
+        <Section title="How to do this">
+          <ol className="space-y-2 text-sm leading-relaxed text-ink-warm/80">
+            {experience.howTo.map((step) => (
+              <li key={step.order} className="flex gap-3">
+                <span className="flex-shrink-0 font-mono text-ink-warm/40">{step.order}.</span>
+                <span>{step.text}</span>
+              </li>
+            ))}
+          </ol>
+        </Section>
+
+        {/* Solo score */}
+        <Section title="Solo score">
+          <div className="flex items-baseline gap-2">
+            <span className="text-2xl font-semibold text-ink-warm">
+              {experience.soloScore.overall.toFixed(0)}
+            </span>
+            <span className="text-xs text-ink-warm/60">
+              / 10 · based on {experience.soloScore.basedOnCount} reports
+            </span>
+          </div>
+          {experience.soloScore.hint && (
+            <p className="mt-1 text-sm text-ink-warm/70">{experience.soloScore.hint}</p>
+          )}
+        </Section>
+
+        {/* Real inconveniences */}
+        {experience.realInconveniences.length > 0 && (
+          <Section title="Real inconveniences">
+            <ul className="space-y-1.5 text-sm leading-relaxed text-ink-warm/80">
+              {experience.realInconveniences.map((r, i) => (
+                <li key={i} className="flex gap-2">
+                  <span className="text-ink-warm/40">•</span>
+                  <span>
+                    <span className="text-xs uppercase tracking-wide text-warm-amber">
+                      {r.category}
+                    </span>{" "}
+                    {r.text}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </Section>
+        )}
+
+        {/* CTA */}
+        <div className="mt-8 rounded-2xl bg-ink-warm px-6 py-6 text-center text-paper-cream">
+          <p className="mb-4 text-sm text-paper-cream/70">Want to do this in {cityName}?</p>
+          <a
+            href={`/${city}`}
+            className="inline-flex items-center gap-2 rounded-xl bg-deep-teal px-5 py-2.5 text-sm font-semibold text-paper-cream shadow-sm transition hover:bg-deep-teal/90"
+          >
+            Open map in {cityName} →
+          </a>
+        </div>
+      </article>
+
+      {/* Footer nav */}
+      <footer className="border-t border-ink-warm/10 px-6 py-8 text-center text-sm text-ink-warm/50">
+        <a href={`/u/${handle}/${city}`} className="hover:text-ink-warm hover:underline">
+          ← See all of {handle}'s {cityName} experiences
+        </a>
+      </footer>
+    </main>
+  );
+}
+
+// ─── Private fallback ──────────────────────────────────────────────────────────
+
+function PrivateExperiencePage({ handle }: { readonly handle: string }) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-paper-cream px-6 text-center">
+      <span className="mb-4 text-5xl" aria-hidden="true">
+        🔒
+      </span>
+      <h1 className="mb-2 text-2xl font-bold text-ink-warm">This trip is private</h1>
+      <p className="mb-6 max-w-sm text-sm text-ink-warm/60">
+        {handle} has chosen to keep their experiences private.
+      </p>
+      <a
+        href="/"
+        className="rounded-xl bg-deep-teal px-5 py-2.5 text-sm font-semibold text-paper-cream transition hover:bg-deep-teal/90"
+      >
+        Explore Solo Compass
+      </a>
+    </main>
+  );
+}
+
+// ─── Section ───────────────────────────────────────────────────────────────────
+
+function Section({
+  title,
+  children,
+}: {
+  readonly title: string;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <section className="mb-5">
+      <h2 className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-ink-warm/40">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}

--- a/apps/web/src/app/u/[handle]/[city]/opengraph-image.tsx
+++ b/apps/web/src/app/u/[handle]/[city]/opengraph-image.tsx
@@ -1,0 +1,138 @@
+import { ImageResponse } from "next/og";
+import { getCompletionsRepo } from "@/lib/repos";
+import { cityDisplayName, cityEmoji, countDays, formatTripDateRange } from "@/components/TripRecap";
+
+export const runtime = "edge";
+export const alt = "Solo Compass trip recap";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+interface ImageProps {
+  params: Promise<{ handle: string; city: string }>;
+}
+
+export default async function OgImage({ params }: ImageProps) {
+  const { handle, city } = await params;
+
+  const completionsRepo = getCompletionsRepo();
+  const completions = await completionsRepo.findByHandle(handle, city).catch(() => []);
+
+  const cityName = cityDisplayName(city);
+  const emoji = cityEmoji(city);
+  const dateRange = formatTripDateRange(completions);
+  const days = countDays(completions);
+  const expCount = completions.length;
+
+  return new ImageResponse(
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        height: "100%",
+        backgroundColor: "#2C2A26",
+        padding: "64px",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+      }}
+    >
+      {/* Top label */}
+      <div
+        style={{
+          display: "flex",
+          fontSize: 18,
+          fontWeight: 600,
+          letterSpacing: "0.12em",
+          textTransform: "uppercase",
+          color: "#F5F1E8",
+          opacity: 0.4,
+          marginBottom: 24,
+        }}
+      >
+        Solo Compass · Trip Recap
+      </div>
+
+      {/* City emoji + name */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 20,
+          marginBottom: 16,
+        }}
+      >
+        <span style={{ fontSize: 80 }}>{emoji}</span>
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <span
+            style={{
+              fontSize: 72,
+              fontWeight: 700,
+              color: "#F5F1E8",
+              lineHeight: 1.1,
+            }}
+          >
+            {cityName}
+          </span>
+        </div>
+      </div>
+
+      {/* Handle + dates */}
+      <div
+        style={{
+          display: "flex",
+          fontSize: 28,
+          color: "#F5F1E8",
+          opacity: 0.7,
+          marginBottom: 48,
+        }}
+      >
+        {handle}
+        {dateRange ? ` · ${dateRange}` : ""}
+      </div>
+
+      {/* Stats row */}
+      <div style={{ display: "flex", gap: 48, marginTop: "auto" }}>
+        <StatBox value={expCount} label="Experiences" />
+        <StatBox value={days} label="Days" />
+      </div>
+
+      {/* Brand mark */}
+      <div
+        style={{
+          display: "flex",
+          position: "absolute",
+          bottom: 40,
+          right: 64,
+          fontSize: 20,
+          fontWeight: 600,
+          color: "#2F6B6B",
+        }}
+      >
+        solo-compass.com
+      </div>
+    </div>,
+    { ...size },
+  );
+}
+
+function StatBox({ value, label }: { value: number; label: string }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
+      <span style={{ fontSize: 56, fontWeight: 700, color: "#F5F1E8", lineHeight: 1 }}>
+        {value}
+      </span>
+      <span
+        style={{
+          fontSize: 16,
+          fontWeight: 600,
+          letterSpacing: "0.1em",
+          textTransform: "uppercase",
+          color: "#F5F1E8",
+          opacity: 0.4,
+          marginTop: 4,
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/app/u/[handle]/[city]/page.tsx
+++ b/apps/web/src/app/u/[handle]/[city]/page.tsx
@@ -1,0 +1,209 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getCompletionsRepo, getExperiencesRepo } from "@/lib/repos";
+import {
+  cityDisplayName,
+  cityEmoji,
+  ExperienceRecapCard,
+  formatTripDateRange,
+  type RecapExperience,
+  ShareButton,
+  TripStats,
+} from "@/components/TripRecap";
+
+// ─── Metadata ──────────────────────────────────────────────────────────────────
+
+interface PageParams {
+  readonly handle: string;
+  readonly city: string;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<PageParams>;
+}): Promise<Metadata> {
+  const { handle, city } = await params;
+  const cityName = cityDisplayName(city);
+  const title = `${handle}'s trip to ${cityName}`;
+
+  return {
+    title,
+    description: `${handle} explored ${cityName} with Solo Compass. See the experiences they collected.`,
+    openGraph: {
+      title,
+      description: `${handle}'s solo trip to ${cityName}`,
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: `${handle}'s solo trip to ${cityName}`,
+    },
+  };
+}
+
+// ─── Page ──────────────────────────────────────────────────────────────────────
+
+export default async function CityRecapPage({ params }: { params: Promise<PageParams> }) {
+  const { handle, city } = await params;
+
+  const completionsRepo = getCompletionsRepo();
+  const experiencesRepo = getExperiencesRepo();
+
+  // Check user exists and has a public profile
+  const profile = await completionsRepo.getProfile(handle);
+  if (!profile) notFound();
+
+  if (!profile.publicProfile) {
+    return <PrivateTripPage handle={handle} />;
+  }
+
+  // Fetch completions for this city
+  const completions = await completionsRepo.findByHandle(handle, city);
+  if (completions.length === 0) notFound();
+
+  // Resolve experience details in parallel
+  const experiences = await Promise.all(
+    completions.map((c) => experiencesRepo.findById(c.experienceId)),
+  );
+
+  const items: RecapExperience[] = completions
+    .map((completion, i) => {
+      const experience = experiences[i];
+      if (!experience) return null;
+      return { completion, experience };
+    })
+    .filter((item): item is RecapExperience => item !== null);
+
+  if (items.length === 0) notFound();
+
+  const cityName = cityDisplayName(city);
+  const emoji = cityEmoji(city);
+  const dateRange = formatTripDateRange(items.map((i) => i.completion));
+
+  // Mapbox static image: plot completed experience locations
+  const mapboxToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN ?? "";
+  const staticMapUrl = buildStaticMapUrl(items, mapboxToken, cityName);
+
+  return (
+    <main className="min-h-screen bg-paper-cream">
+      {/* Hero */}
+      <section className="bg-ink-warm px-6 pb-10 pt-12 text-paper-cream">
+        <div className="mx-auto max-w-2xl">
+          <p className="mb-2 text-sm font-medium uppercase tracking-widest text-paper-cream/50">
+            Solo trip recap
+          </p>
+          <h1 className="mb-2 text-4xl font-bold leading-tight">
+            {emoji} {cityName}
+          </h1>
+          <p className="mb-6 text-lg text-paper-cream/70">
+            {handle} · {dateRange}
+          </p>
+          <TripStats items={items} />
+        </div>
+      </section>
+
+      {/* Mini-map */}
+      {staticMapUrl && (
+        <section className="mx-auto max-w-2xl px-4 pt-8">
+          <div className="overflow-hidden rounded-2xl shadow-md">
+            <img
+              src={staticMapUrl}
+              alt={`Map of ${handle}'s experiences in ${cityName}`}
+              width={800}
+              height={320}
+              className="h-[200px] w-full object-cover sm:h-[240px]"
+            />
+          </div>
+        </section>
+      )}
+
+      {/* Experience cards */}
+      <section className="mx-auto max-w-2xl px-4 py-8">
+        <h2 className="mb-5 text-xs font-semibold uppercase tracking-widest text-ink-warm/40">
+          Experiences collected
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {items.map((item) => (
+            <ExperienceRecapCard
+              key={item.experience.id}
+              item={item}
+              handle={handle}
+              cityCode={city}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* Footer CTA */}
+      <footer className="border-t border-ink-warm/10 bg-paper-cream px-6 py-10 text-center">
+        <p className="mb-4 text-sm text-ink-warm/60">Ready to explore {cityName} yourself?</p>
+        <a
+          href={`/${city}`}
+          className="inline-flex items-center gap-2 rounded-xl bg-deep-teal px-6 py-3 text-sm font-semibold text-paper-cream shadow-sm transition hover:bg-deep-teal/90"
+        >
+          Plan your own {cityName} trip →
+        </a>
+        <div className="mt-6 flex justify-center">
+          <ShareButton
+            title={`${handle}'s trip to ${cityName}`}
+            url={typeof window !== "undefined" ? window.location.href : ""}
+          />
+        </div>
+      </footer>
+    </main>
+  );
+}
+
+// ─── Private trip fallback ─────────────────────────────────────────────────────
+
+function PrivateTripPage({ handle }: { readonly handle: string }) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-paper-cream px-6 text-center">
+      <span className="mb-4 text-5xl" aria-hidden="true">
+        🔒
+      </span>
+      <h1 className="mb-2 text-2xl font-bold text-ink-warm">This trip is private</h1>
+      <p className="mb-6 max-w-sm text-sm text-ink-warm/60">
+        {handle} has chosen to keep their experiences private.
+      </p>
+      <a
+        href="/"
+        className="rounded-xl bg-deep-teal px-5 py-2.5 text-sm font-semibold text-paper-cream transition hover:bg-deep-teal/90"
+      >
+        Explore Solo Compass
+      </a>
+    </main>
+  );
+}
+
+// ─── Static Mapbox image ───────────────────────────────────────────────────────
+
+function buildStaticMapUrl(
+  items: readonly RecapExperience[],
+  token: string,
+  _cityName: string,
+): string | null {
+  if (!token || token === "pk.placeholder_token") return null;
+  if (items.length === 0) return null;
+
+  // Pin markers for each experience (max 15 for URL length)
+  const pins = items.slice(0, 15).map((item) => {
+    const [lng, lat] = item.experience.location.coordinates;
+    return `pin-s-circle+2F6B6B(${lng},${lat})`;
+  });
+
+  // Compute bounding box and add padding
+  const lngs = items.map((i) => i.experience.location.coordinates[0]);
+  const lats = items.map((i) => i.experience.location.coordinates[1]);
+  const minLng = Math.min(...lngs) - 0.01;
+  const maxLng = Math.max(...lngs) + 0.01;
+  const minLat = Math.min(...lats) - 0.01;
+  const maxLat = Math.max(...lats) + 0.01;
+
+  const overlay = pins.join(",");
+  const bbox = `[${minLng},${minLat},${maxLng},${maxLat}]`;
+
+  return `https://api.mapbox.com/styles/v1/mapbox/light-v11/static/${overlay}/${bbox}/800x320@2x?access_token=${token}&padding=40`;
+}

--- a/apps/web/src/components/TripRecap.tsx
+++ b/apps/web/src/components/TripRecap.tsx
@@ -1,0 +1,209 @@
+import type { Experience } from "@solo-compass/core";
+import type { CompletionWithExperienceId } from "@solo-compass/data";
+import { categoryEmoji, categoryLabel } from "@/lib/category";
+
+// ─── Types ─────────────────────────────────────────────────────────────────────
+
+export interface RecapExperience {
+  readonly experience: Experience;
+  readonly completion: CompletionWithExperienceId;
+}
+
+interface TripStatsProps {
+  readonly items: readonly RecapExperience[];
+}
+
+interface ExperienceCardProps {
+  readonly item: RecapExperience;
+  readonly handle: string;
+  readonly cityCode: string;
+}
+
+interface ShareButtonProps {
+  readonly title: string;
+  readonly url: string;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+export function formatTripDateRange(completions: readonly CompletionWithExperienceId[]): string {
+  if (completions.length === 0) return "";
+  const dates = completions.map((c) => c.completedAt).sort();
+  const first = new Date(dates[0]!);
+  const last = new Date(dates[dates.length - 1]!);
+  const opts: Intl.DateTimeFormatOptions = { month: "long", day: "numeric" };
+  if (first.getFullYear() !== last.getFullYear()) {
+    return `${first.toLocaleDateString("en-US", { ...opts, year: "numeric" })} – ${last.toLocaleDateString("en-US", { ...opts, year: "numeric" })}`;
+  }
+  if (first.getMonth() !== last.getMonth()) {
+    return `${first.toLocaleDateString("en-US", opts)} – ${last.toLocaleDateString("en-US", opts)}`;
+  }
+  // same month
+  return `${first.toLocaleDateString("en-US", { month: "long" })} ${first.getDate()}–${last.getDate()}`;
+}
+
+export function countDays(completions: readonly CompletionWithExperienceId[]): number {
+  if (completions.length === 0) return 0;
+  const dates = completions.map((c) => c.completedAt.slice(0, 10));
+  return new Set(dates).size;
+}
+
+function uniqueCategories(items: readonly RecapExperience[]): string[] {
+  const seen = new Set<string>();
+  for (const { experience } of items) {
+    seen.add(experience.category);
+  }
+  return [...seen];
+}
+
+// ─── City name & emoji map (extend as cities are seeded) ───────────────────────
+
+const CITY_NAMES: Record<string, string> = {
+  cmi: "Chiang Mai",
+  bkk: "Bangkok",
+  hni: "Hanoi",
+  sgn: "Ho Chi Minh City",
+  dps: "Bali",
+  mel: "Melbourne",
+  lis: "Lisbon",
+  bcn: "Barcelona",
+  mde: "Medellín",
+  oax: "Oaxaca",
+};
+
+const CITY_EMOJI: Record<string, string> = {
+  cmi: "🏯",
+  bkk: "🛕",
+  hni: "🏮",
+  sgn: "🛵",
+  dps: "🌺",
+  mel: "☕",
+  lis: "🚋",
+  bcn: "🌊",
+  mde: "🌸",
+  oax: "🫙",
+};
+
+export function cityDisplayName(cityCode: string): string {
+  return CITY_NAMES[cityCode] ?? cityCode.toUpperCase();
+}
+
+export function cityEmoji(cityCode: string): string {
+  return CITY_EMOJI[cityCode] ?? "🗺️";
+}
+
+// ─── Sub-components ────────────────────────────────────────────────────────────
+
+export function TripStats({ items }: TripStatsProps) {
+  const categories = uniqueCategories(items);
+  const days = countDays(items.map((i) => i.completion));
+
+  return (
+    <div className="flex flex-wrap items-center gap-4 text-sm text-ink-warm/70">
+      <StatPill label="experiences" value={items.length} />
+      <StatPill label="days" value={days} />
+      <div className="flex flex-wrap gap-1.5">
+        {categories.map((cat) => (
+          <span
+            key={cat}
+            className="rounded-full bg-paper-cream px-2.5 py-0.5 text-xs font-medium ring-1 ring-ink-warm/15"
+            title={categoryLabel[cat as keyof typeof categoryLabel]}
+          >
+            {categoryEmoji[cat as keyof typeof categoryEmoji]}{" "}
+            {categoryLabel[cat as keyof typeof categoryLabel]}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StatPill({ label, value }: { readonly label: string; readonly value: number }) {
+  return (
+    <span className="flex items-baseline gap-1">
+      <span className="text-xl font-bold text-ink-warm">{value}</span>
+      <span className="text-xs uppercase tracking-wider text-ink-warm/50">{label}</span>
+    </span>
+  );
+}
+
+export function ExperienceRecapCard({ item, handle, cityCode }: ExperienceCardProps) {
+  const { experience: exp, completion } = item;
+  const date = new Date(completion.completedAt).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+
+  return (
+    <a
+      href={`/u/${handle}/${cityCode}/${exp.id}`}
+      className="block rounded-2xl bg-white shadow-sm ring-1 ring-ink-warm/8 transition hover:shadow-md hover:ring-ink-warm/15"
+    >
+      {/* Photo placeholder */}
+      <div className="flex h-40 items-center justify-center rounded-t-2xl bg-muted-road/30">
+        <span className="text-4xl" aria-hidden="true">
+          {categoryEmoji[exp.category]}
+        </span>
+      </div>
+
+      <div className="p-4">
+        <div className="mb-1 flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-deep-teal">
+          <span>{categoryLabel[exp.category]}</span>
+          <span className="text-ink-warm/30">·</span>
+          <span className="text-ink-warm/50">{date}</span>
+          {completion.rating && (
+            <>
+              <span className="text-ink-warm/30">·</span>
+              <span className="text-warm-amber">{"★".repeat(completion.rating)}</span>
+            </>
+          )}
+        </div>
+
+        <h3 className="mb-1 text-base font-semibold leading-snug text-ink-warm">{exp.title}</h3>
+        <p className="text-sm leading-relaxed text-ink-warm/70 line-clamp-2">{exp.oneLiner}</p>
+
+        {completion.note && (
+          <p className="mt-3 border-l-2 border-deep-teal/30 pl-3 text-sm italic leading-relaxed text-ink-warm/60 line-clamp-2">
+            {completion.note}
+          </p>
+        )}
+      </div>
+    </a>
+  );
+}
+
+export function ShareButton({ title, url }: ShareButtonProps) {
+  return (
+    <button
+      type="button"
+      className="inline-flex items-center gap-2 rounded-xl bg-deep-teal px-5 py-2.5 text-sm font-semibold text-paper-cream shadow-sm transition hover:bg-deep-teal/90 active:scale-95"
+      onClick={() => {
+        if (typeof navigator !== "undefined" && navigator.share) {
+          void navigator.share({ title, url });
+        } else {
+          void navigator.clipboard.writeText(url);
+        }
+      }}
+    >
+      <svg
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <circle cx="18" cy="5" r="3" />
+        <circle cx="6" cy="12" r="3" />
+        <circle cx="18" cy="19" r="3" />
+        <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+        <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+      </svg>
+      Share trip
+    </button>
+  );
+}

--- a/packages/data/src/completions-repo.ts
+++ b/packages/data/src/completions-repo.ts
@@ -7,7 +7,22 @@
  */
 
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Database } from "./db";
+import type { Database, CompletionRow, UserRow } from "./db";
+
+export interface UserProfile {
+  readonly id: string;
+  readonly handle: string;
+  readonly publicProfile: boolean;
+  readonly createdAt: string;
+}
+
+export interface CompletionWithExperienceId {
+  readonly id: string;
+  readonly experienceId: string;
+  readonly completedAt: string;
+  readonly rating: number | null;
+  readonly note: string | null;
+}
 
 export interface RecordCheckinParams {
   /** Opaque cookie ID — never a real identity. */
@@ -59,5 +74,54 @@ export class CompletionsRepo {
     if (insErr) throw new Error(`completion upsert failed: ${insErr.message}`);
 
     return { created: (count ?? 0) > 0 };
+  }
+
+  /** Look up a user by their display handle. Returns null if not found. */
+  async getProfile(handle: string): Promise<UserProfile | null> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (this.client as any)
+      .from("users")
+      .select("id, handle, public_profile, created_at")
+      .eq("handle", handle)
+      .maybeSingle();
+    if (error) throw new Error(`getProfile failed: ${error.message}`);
+    if (!data) return null;
+    const row = data as UserRow;
+    return {
+      id: row.id,
+      handle: row.handle,
+      publicProfile: row.public_profile,
+      createdAt: row.created_at,
+    };
+  }
+
+  /** Fetch all completions for a user, optionally filtered to a city (by experience id prefix). */
+  async findByHandle(handle: string, cityCode?: string): Promise<CompletionWithExperienceId[]> {
+    const profile = await this.getProfile(handle);
+    if (!profile) return [];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let query = (this.client as any)
+      .from("completions")
+      .select("id, experience_id, completed_at, rating, note")
+      .eq("user_id", profile.id)
+      .order("completed_at", { ascending: true });
+
+    if (cityCode) {
+      // Experience IDs follow the pattern exp_<cityCode>_<slug>
+      query = query.like("experience_id", `exp_${cityCode}_%`);
+    }
+
+    const { data, error } = await query;
+    if (error) throw new Error(`findByHandle failed: ${error.message}`);
+    if (!data) return [];
+
+    return (data as CompletionRow[]).map((row) => ({
+      id: row.id,
+      experienceId: row.experience_id,
+      completedAt: row.completed_at,
+      rating: row.rating,
+      note: row.note,
+    }));
   }
 }

--- a/packages/data/src/db.ts
+++ b/packages/data/src/db.ts
@@ -38,6 +38,7 @@ export interface UserRow {
   id: string;
   handle: string;
   created_at: string;
+  public_profile: boolean;
 }
 
 export interface CompletionRow {

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -5,4 +5,9 @@ export { ExperiencesRepo } from "./experiences-repo";
 export type { FindNearbyParams } from "./experiences-repo";
 
 export { CompletionsRepo } from "./completions-repo";
-export type { RecordCheckinParams, RecordCheckinResult } from "./completions-repo";
+export type {
+  RecordCheckinParams,
+  RecordCheckinResult,
+  UserProfile,
+  CompletionWithExperienceId,
+} from "./completions-repo";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.59.0
         version: 5.100.9(react@19.2.5)
+      '@vercel/og':
+        specifier: ^0.6.8
+        version: 0.6.8
       mapbox-gl:
         specifier: ^3.8.0
         version: 3.23.1
@@ -1115,6 +1118,10 @@ packages:
       '@types/react':
         optional: true
 
+  '@resvg/resvg-wasm@2.4.0':
+    resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
+    engines: {node: '>= 10'}
+
   '@rollup/plugin-commonjs@28.0.1':
     resolution: {integrity: sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==}
     engines: {node: '>=16.0.0 || 14 >= 14.17'}
@@ -1247,6 +1254,11 @@ packages:
     engines: {node: '>= 14'}
     peerDependencies:
       webpack: '>=4.40.0'
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
 
   '@supabase/auth-js@2.105.3':
     resolution: {integrity: sha512-hMFuzP++mjRfe0/BUq4/e82CXIDgyjUgg0khLN8waol/gzoM1t2iGmhfJSGvQHQ1dr3XqWpP6ThAw4bLHMot5Q==}
@@ -1388,6 +1400,10 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+  '@vercel/og@0.6.8':
+    resolution: {integrity: sha512-e4kQK9mP8ntpo3dACWirGod/hHv4qO5JMj9a/0a2AZto7b4persj5YP7t1Er372gTtYFTYxNhMx34jRvHooglw==}
+    engines: {node: '>=16'}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -1514,6 +1530,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
   baseline-browser-mapping@2.10.27:
     resolution: {integrity: sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==}
     engines: {node: '>=6.0.0'}
@@ -1554,6 +1574,9 @@ packages:
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
+
+  camelize@1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
 
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
@@ -1605,6 +1628,23 @@ packages:
 
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
+  css-background-parser@0.1.0:
+    resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
+
+  css-box-shadow@1.0.0-3:
+    resolution: {integrity: sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==}
+
+  css-color-keywords@1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+
+  css-gradient-parser@0.0.16:
+    resolution: {integrity: sha512-3O5QdqgFRUbXvK1x5INf1YkBz1UKSWqrd63vWsum8MNHDBYD5urm3QtxZbKU259OrEXNM26lP/MPY3d1IGkBgA==}
+    engines: {node: '>=16'}
+
+  css-to-react-native@3.2.0:
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   csscolorparser@1.0.3:
     resolution: {integrity: sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==}
@@ -1660,6 +1700,9 @@ packages:
   electron-to-chromium@1.5.351:
     resolution: {integrity: sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   enhanced-resolve@5.21.0:
     resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
     engines: {node: '>=10.13.0'}
@@ -1691,6 +1734,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
@@ -1743,6 +1789,9 @@ packages:
 
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+
+  fflate@0.7.4:
+    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1847,6 +1896,10 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hex-rgb@4.3.0:
+    resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
+    engines: {node: '>=6'}
+
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
@@ -1920,6 +1973,9 @@ packages:
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
+
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -2090,6 +2146,12 @@ packages:
   p-timeout@4.1.0:
     resolution: {integrity: sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==}
     engines: {node: '>=10'}
+
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
+  parse-css-color@0.2.1:
+    resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2334,6 +2396,10 @@ packages:
     resolution: {integrity: sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==}
     engines: {node: '>= 0.10'}
 
+  satori@0.12.2:
+    resolution: {integrity: sha512-3C/laIeE6UUe9A+iQ0A48ywPVCCMKCNSTU5Os101Vhgsjd3AAxGNjyq0uAA8kulMPK5n0csn8JlxPN9riXEjLA==}
+    engines: {node: '>=16'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -2374,6 +2440,9 @@ packages:
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
+
+  string.prototype.codepointat@0.2.1:
+    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -2450,6 +2519,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
@@ -2493,6 +2565,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   unplugin@1.0.1:
     resolution: {integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==}
@@ -2598,6 +2673,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoga-wasm-web@0.3.3:
+    resolution: {integrity: sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -3519,6 +3597,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@resvg/resvg-wasm@2.4.0': {}
+
   '@rollup/plugin-commonjs@28.0.1(rollup@3.29.5)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@3.29.5)
@@ -3732,6 +3812,11 @@ snapshots:
       - encoding
       - supports-color
 
+  '@shuding/opentype.js@1.4.0-beta.0':
+    dependencies:
+      fflate: 0.7.4
+      string.prototype.codepointat: 0.2.1
+
   '@supabase/auth-js@2.105.3':
     dependencies:
       tslib: 2.8.1
@@ -3885,6 +3970,12 @@ snapshots:
     dependencies:
       '@types/node': 22.19.17
 
+  '@vercel/og@0.6.8':
+    dependencies:
+      '@resvg/resvg-wasm': 2.4.0
+      satori: 0.12.2
+      yoga-wasm-web: 0.3.3
+
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -4035,6 +4126,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@0.0.8: {}
+
   baseline-browser-mapping@2.10.27: {}
 
   binary-extensions@2.3.0: {}
@@ -4072,6 +4165,8 @@ snapshots:
       function-bind: 1.1.2
 
   camelcase-css@2.0.1: {}
+
+  camelize@1.0.1: {}
 
   caniuse-lite@1.0.30001791: {}
 
@@ -4120,6 +4215,20 @@ snapshots:
 
   core-js@3.49.0: {}
 
+  css-background-parser@0.1.0: {}
+
+  css-box-shadow@1.0.0-3: {}
+
+  css-color-keywords@1.0.0: {}
+
+  css-gradient-parser@0.0.16: {}
+
+  css-to-react-native@3.2.0:
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
+
   csscolorparser@1.0.3: {}
 
   cssesc@3.0.0: {}
@@ -4156,6 +4265,8 @@ snapshots:
   earcut@3.0.2: {}
 
   electron-to-chromium@1.5.351: {}
+
+  emoji-regex@10.6.0: {}
 
   enhanced-resolve@5.21.0:
     dependencies:
@@ -4210,6 +4321,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
@@ -4250,6 +4363,8 @@ snapshots:
       picomatch: 4.0.4
 
   fflate@0.4.8: {}
+
+  fflate@0.7.4: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -4351,6 +4466,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hex-rgb@4.3.0: {}
+
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
@@ -4416,6 +4533,11 @@ snapshots:
   kdbush@4.0.2: {}
 
   lilconfig@3.1.3: {}
+
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
 
   lines-and-columns@1.2.4: {}
 
@@ -4580,6 +4702,13 @@ snapshots:
       p-limit: 3.1.0
 
   p-timeout@4.1.0: {}
+
+  pako@0.2.9: {}
+
+  parse-css-color@0.2.1:
+    dependencies:
+      color-name: 1.1.4
+      hex-rgb: 4.3.0
 
   path-exists@4.0.0: {}
 
@@ -4810,6 +4939,20 @@ snapshots:
 
   sandwich-stream@2.0.2: {}
 
+  satori@0.12.2:
+    dependencies:
+      '@shuding/opentype.js': 1.4.0-beta.0
+      css-background-parser: 0.1.0
+      css-box-shadow: 1.0.0-3
+      css-gradient-parser: 0.0.16
+      css-to-react-native: 3.2.0
+      emoji-regex: 10.6.0
+      escape-html: 1.0.3
+      linebreak: 1.1.0
+      parse-css-color: 0.2.1
+      postcss-value-parser: 4.2.0
+      yoga-wasm-web: 0.3.3
+
   scheduler@0.27.0: {}
 
   schema-utils@4.3.3:
@@ -4871,6 +5014,8 @@ snapshots:
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
+
+  string.prototype.codepointat@0.2.1: {}
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.5):
     dependencies:
@@ -4970,6 +5115,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-inflate@1.0.3: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -5010,6 +5157,11 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   unplugin@1.0.1:
     dependencies:
@@ -5114,5 +5266,7 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  yoga-wasm-web@0.3.3: {}
 
   zod@3.25.76: {}


### PR DESCRIPTION
Closes #44

## Summary

- `/u/[handle]/[city]` — city recap page with dark hero, stat row (experiences · days · category pills), Mapbox static image of visited spots, time-ordered experience cards
- `/u/[handle]/[city]/[expId]` — single experience detail with user note, how-to, solo score, inconveniences, and "Open map" CTA
- `opengraph-image.tsx` — Next.js App Router OG image (1200×630) generated server-side via `next/og`; shows city emoji, name, handle, date range, experience count
- Privacy: `public_profile` boolean on `UserRow`; both pages show a locked fallback when opt-out is set
- `CompletionsRepo` extended with `getProfile()` and `findByHandle()` for public read paths
- `TripRecap.tsx` shared component with `ExperienceRecapCard`, `TripStats`, `ShareButton`, and city name/emoji helpers
- Fixed pre-existing `WEB_DEMO_EXPERIENCES` import name mismatch in nearby route

## Test plan

- [ ] `pnpm typecheck` — ✅ clean
- [ ] `pnpm format` — ✅ no diffs
- [ ] Visit `/u/mia/cmi` with a seeded user → hero, stats, map, cards render
- [ ] Visit `/u/mia/cmi/<exp-id>` → detail page with note and CTA
- [ ] Set `public_profile = false` → both pages show private fallback
- [ ] Check OG image at `/u/mia/cmi/opengraph-image` → city card renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)