### PR TITLE
test(ai): E2E extraction tests with golden replays (#19)

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:live": "LIVE_API=true vitest run",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {

--- a/packages/ai/src/__fixtures__/insufficient-blurb.txt
+++ b/packages/ai/src/__fixtures__/insufficient-blurb.txt
@@ -1,0 +1,1 @@
+Chiang Mai is a great city in northern Thailand with lots of temples and good food. There are many things to do and see. The old city has many interesting places to visit. The food is delicious and the people are friendly. It is worth visiting if you are in Thailand.

--- a/packages/ai/src/__fixtures__/reddit-coffee-thread.md
+++ b/packages/ai/src/__fixtures__/reddit-coffee-thread.md
@@ -1,0 +1,34 @@
+# Reddit thread: r/chiangmai — "Best single-origin pour-over in the city?"
+
+URL: https://www.reddit.com/r/chiangmai/comments/coffee_thread_2024
+
+---
+
+**u/nomad_brews** (OP):
+Been in Chiang Mai 3 weeks. Found Graph Coffee on Nimman but curious if there's anything more hidden. Looking for proper single-origin, not tourist cafés. Preferably with good WiFi so I can work a few hours.
+
+---
+
+**u/AroiMakSikhao** (198 upvotes):
+Go to Ristr8to on Nimman Soi 3. Specifically ask for the "Lab" section downstairs — different menu, all single-origin micro-lots, mostly from the hills north of Chiang Rai. The head barista (Bee) has been competing in national championships for 5 years. Order the natural-processed Doi Chaang and ask him to explain the processing — he genuinely loves talking about it. The espresso is 80 THB, pour-over 120–150 THB depending on origin. No WiFi in the Lab section on purpose — it's a coffee-first space. Upstairs has WiFi.
+
+Best time to go: Tuesday–Saturday, 08:00–11:00 for full menu availability. Some micro-lots sell out by afternoon. They close Sundays and Mondays.
+
+Exact address: 15/3 Nimman Soi 3, Suthep, Chiang Mai. Coordinates roughly 18.7966° N, 98.9665° E.
+
+---
+
+**u/slow_travel_pete** (87 upvotes):
+Second Ristr8to Lab. One tip — the Lab fills up fast after 09:30 and there are only 8 seats. If you arrive after 10:00 on a weekend you'll wait. Go early, claim the window counter seat (seat 3 from the left), and you get natural light for a couple of hours.
+
+The Lab is cash-only. ATM on Nimman Soi 1 about 200m away.
+
+---
+
+**u/CoffeeDrifter_TH** (54 upvotes):
+The downstairs Lab at Ristr8to is genuinely one of the best café experiences in Southeast Asia. For context: I've done specialty coffee in Tokyo, Seoul, Melbourne. This competes. The issue is it's tiny — 8 seats, and baristas notice if you try to set up a laptop. It's for tasting, not working. Budget about 45–60 min for a proper experience (order two drinks, chat with Bee if he's not slammed).
+
+---
+
+**u/nomad_brews** (OP reply):
+Went this morning (Tuesday, 09:00). Lab was at 3/8 capacity. Ordered the natural Doi Chaang and a honey-processed Akha. Bee spent about 10 minutes explaining the altitude difference between the two farms. Best 200 THB I've spent in months. Cash only, confirmed.

--- a/packages/ai/src/__fixtures__/wikivoyage-chiang-mai-suthep.txt
+++ b/packages/ai/src/__fixtures__/wikivoyage-chiang-mai-suthep.txt
@@ -1,0 +1,14 @@
+Source: Wikivoyage — Chiang Mai/Doi Suthep
+URL: https://en.wikivoyage.org/wiki/Chiang_Mai/Doi_Suthep
+
+== Wat Phra That Doi Suthep ==
+
+Wat Phra That Doi Suthep is the most sacred temple in northern Thailand, perched at 1,073 m on the slopes of Doi Suthep mountain, 15 km northwest of Chiang Mai's old city. The temple was founded in 1383 by King Kuena after a white elephant reportedly died on this spot — locals believe it chose the sacred location by circling three times and trumpeting.
+
+The best time to visit is at dawn (around 06:00–07:00) or late afternoon (16:00–17:30, aiming to catch sunset). At sunrise the mist still clings to the valley below and the gilded chedi glows orange-gold in the early light. There are far fewer visitors at this hour, and monks are finishing their morning prayers — the sound of chanting carries across the open courtyard. The main chedi (stupa) is covered in gold-plated copper and rises 24 metres; circumambulate it clockwise three times for luck, following the lotus-petal terrace at the top.
+
+Getting there: Songthaew (red truck taxis) depart from the Chang Puak bus terminal and from near Chiang Mai University — negotiate 50–80 THB per person for the 30–45 minute ride up the mountain road. The more adventurous can hire a bicycle and tackle the 1,685-step Naga staircase from the base (about 1 km of steps flanked by a seven-headed serpent balustrade). The staircase is free; the temple charges a 50 THB entrance fee for foreigners. Remove shoes before entering the main terrace.
+
+Practical notes: The temple is open daily 06:00–20:00. Dress code is strict — shoulders and knees must be covered; free sarongs are available to borrow at the gate if you arrive in shorts. On weekends and Thai public holidays the place is absolutely packed; expect queues of 200+ people waiting to photograph the chedi. Photography of the monks during prayer is considered disrespectful — watch from a distance. The road up is very steep and narrow; tuk-tuks and songthaew drivers sometimes overcharge tourists — agree the price before you board. There is a small food market near the parking area selling khao man gai and mango sticky rice for 40–60 THB.
+
+Coordinates: 18.8048° N, 98.9217° E

--- a/packages/ai/src/__golden__/insufficient-blurb.json
+++ b/packages/ai/src/__golden__/insufficient-blurb.json
@@ -1,0 +1,7 @@
+{
+  "tool": "refuse",
+  "input": {
+    "reason": "Source is a generic tourist-brochure summary (~60 words) with no specific experience, no how-to steps, no sensory details, no inconveniences, and no verifiable coordinates or hours. Extracting an experience would require fabrication."
+  },
+  "usage": { "input_tokens": 310, "output_tokens": 45 }
+}

--- a/packages/ai/src/__golden__/reddit-coffee-thread.json
+++ b/packages/ai/src/__golden__/reddit-coffee-thread.json
@@ -1,0 +1,39 @@
+{
+  "tool": "emit_experience",
+  "input": {
+    "title": "Order single-origin micro-lots in the 8-seat Lab at Ristr8to before stocks run out",
+    "oneLiner": "A basement coffee lab where the barista explains the altitude difference between two Doi Chaang farms while you sip one of the best natural-processed espressos in Southeast Asia.",
+    "whyItMatters": "The Lab is deliberately WiFi-free and seats only eight — a signal that coffee is the point, not ambiance or coworking. Barista Bee has five years of national championship experience and will spend ten minutes explaining processing if you ask. The micro-lot menu sells out by afternoon, so the window is real.",
+    "category": "coffee",
+    "coordinates": { "longitude": 98.9665, "latitude": 18.7966 },
+    "addressHint": "15/3 Nimman Soi 3, Suthep, Chiang Mai — downstairs Lab section",
+    "placeNameRomanized": "Ristr8to Lab",
+    "bestTimes": [
+      { "startHour": 8, "endHour": 11, "note": "Tuesday–Saturday; micro-lots sell out by afternoon" }
+    ],
+    "durationMin": 45,
+    "durationMax": 60,
+    "howTo": [
+      { "order": 1, "text": "Arrive Tuesday–Saturday between 08:00 and 09:30 — the Lab fills to its 8-seat capacity quickly after that." },
+      { "order": 2, "text": "Head downstairs to the Lab section (not the main floor upstairs, which has a different menu and WiFi)." },
+      { "order": 3, "text": "Ask for the single-origin micro-lot menu and order the natural-processed Doi Chaang as your first drink." },
+      { "order": 4, "text": "Ask barista Bee to explain the processing — he will walk you through the altitude and flavour difference if he's not slammed." },
+      { "order": 5, "text": "Pay cash (the Lab is cash-only); the ATM on Nimman Soi 1 is about 200 m away if needed." }
+    ],
+    "realInconveniences": [
+      { "category": "logistics", "text": "Cash only in the Lab — no card payment; nearest ATM is 200 m on Nimman Soi 1." },
+      { "category": "crowds", "text": "Only 8 seats; arrivals after 10:00 on a weekday or any time on a weekend will likely wait." },
+      { "category": "other", "text": "Closed Sundays and Mondays — plan accordingly." }
+    ],
+    "sources": [
+      {
+        "type": "reddit",
+        "url": "https://www.reddit.com/r/chiangmai/comments/coffee_thread_2024",
+        "attribution": "u/AroiMakSikhao, u/slow_travel_pete, u/CoffeeDrifter_TH",
+        "verifiedAt": "2026-05-07T00:00:00Z"
+      }
+    ],
+    "modelConfidence": 0.91
+  },
+  "usage": { "input_tokens": 740, "output_tokens": 530 }
+}

--- a/packages/ai/src/__golden__/wikivoyage-chiang-mai-suthep.json
+++ b/packages/ai/src/__golden__/wikivoyage-chiang-mai-suthep.json
@@ -1,0 +1,41 @@
+{
+  "tool": "emit_experience",
+  "input": {
+    "title": "Watch dawn light the golden chedi at Doi Suthep before the crowds arrive",
+    "oneLiner": "The most sacred moment at northern Thailand's holiest temple belongs to those who arrive at sunrise when mist fills the valley and monks are still chanting.",
+    "whyItMatters": "At 06:00 the gilded 24-metre chedi glows orange-gold against a mist-covered valley — a colour shift you can't manufacture at any other hour. The chanting carries across the open terrace while incense curls around the lotus-petal walkway. By 09:00 the same terrace holds tour buses; this experience only exists in the early window.",
+    "category": "culture",
+    "coordinates": { "longitude": 98.9217, "latitude": 18.8048 },
+    "addressHint": "Doi Suthep mountain, 15 km northwest of Chiang Mai old city",
+    "placeNameLocal": "วัดพระธาตุดอยสุเทพ",
+    "placeNameRomanized": "Wat Phra That Doi Suthep",
+    "bestTimes": [
+      { "startHour": 6, "endHour": 8, "note": "Sunrise — mist in valley, monks chanting, minimal crowds" },
+      { "startHour": 16, "endHour": 18, "note": "Late afternoon light on the chedi before closing" }
+    ],
+    "durationMin": 60,
+    "durationMax": 120,
+    "howTo": [
+      { "order": 1, "text": "Board a songthaew at Chang Puak bus terminal or near Chiang Mai University — negotiate 50–80 THB per person and depart by 05:30 to arrive at dawn." },
+      { "order": 2, "text": "Climb the 1,685-step Naga staircase (free) flanked by the seven-headed serpent balustrade, or take the cable car if legs are tired." },
+      { "order": 3, "text": "Pay the 50 THB foreigners' entrance fee and remove your shoes before stepping onto the main terrace." },
+      { "order": 4, "text": "Circumambulate the golden chedi clockwise three times on the lotus-petal terrace — follow local worshippers for the correct pace." },
+      { "order": 5, "text": "Stand at the eastern viewpoint as the mist clears from the valley below and watch the chedi shift from orange to gold in the strengthening light." },
+      { "order": 6, "text": "Leave before 09:00 to beat the tour-bus wave; pick up khao man gai or mango sticky rice (40–60 THB) from the market near the car park on the way out." }
+    ],
+    "realInconveniences": [
+      { "category": "crowds", "text": "On weekends and Thai public holidays expect 200+ people queuing to photograph the chedi — the dawn window is the only reliable escape." },
+      { "category": "scam", "text": "Songthaew and tuk-tuk drivers routinely overcharge tourists on the mountain road — agree the fare before boarding." },
+      { "category": "etiquette", "text": "Shoulders and knees must be covered; free sarongs are at the gate but enforced strictly — factor this into your outfit." }
+    ],
+    "sources": [
+      {
+        "type": "wikivoyage",
+        "url": "https://en.wikivoyage.org/wiki/Chiang_Mai/Doi_Suthep",
+        "verifiedAt": "2026-05-07T00:00:00Z"
+      }
+    ],
+    "modelConfidence": 0.88
+  },
+  "usage": { "input_tokens": 820, "output_tokens": 610 }
+}

--- a/packages/ai/src/structure-experience.test.ts
+++ b/packages/ai/src/structure-experience.test.ts
@@ -1,0 +1,407 @@
+/**
+ * E2E extraction tests for structureExperience.
+ *
+ * All tests use golden-replay mocks — no ANTHROPIC_API_KEY needed.
+ * Run `pnpm test:live` to re-run against the real API.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import type Anthropic from "@anthropic-ai/sdk";
+import { structureExperience } from "./prompts/structure-experience";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const FIXTURES_DIR = join(__dirname, "__fixtures__");
+const GOLDEN_DIR = join(__dirname, "__golden__");
+
+function loadFixture(name: string): string {
+  return readFileSync(join(FIXTURES_DIR, name), "utf8");
+}
+
+interface GoldenReplay {
+  tool: string;
+  input: Record<string, unknown>;
+  usage: { input_tokens: number; output_tokens: number };
+}
+
+function loadGolden(name: string): GoldenReplay {
+  return JSON.parse(readFileSync(join(GOLDEN_DIR, name), "utf8")) as GoldenReplay;
+}
+
+function makeMockClient(golden: GoldenReplay): Anthropic {
+  return {
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [
+          {
+            type: "tool_use",
+            name: golden.tool,
+            input: golden.input,
+          },
+        ],
+        usage: golden.usage,
+        model: "claude-opus-4-7",
+      }),
+    },
+  } as unknown as Anthropic;
+}
+
+// ─── Fixture 1: Wikivoyage — rich cultural experience ─────────────────────────
+
+describe("structureExperience — Wikivoyage Doi Suthep", () => {
+  const rawText = loadFixture("wikivoyage-chiang-mai-suthep.txt");
+  const golden = loadGolden("wikivoyage-chiang-mai-suthep.json");
+  const SOURCE_URL = "https://en.wikivoyage.org/wiki/Chiang_Mai/Doi_Suthep";
+
+  const INPUT = {
+    rawText,
+    cityCode: "cmi",
+    cityName: "Chiang Mai",
+    sourceUrl: SOURCE_URL,
+    sourceType: "wikivoyage" as const,
+  };
+
+  it("returns a non-null experience", async () => {
+    const mockClient = makeMockClient(golden);
+    const result = await structureExperience(INPUT, mockClient);
+    expect(result.experience).not.toBeNull();
+  });
+
+  it("experience passes full schema validation", async () => {
+    const mockClient = makeMockClient(golden);
+    const { experience } = await structureExperience(INPUT, mockClient);
+    expect(experience).not.toBeNull();
+    if (!experience) return;
+
+    // Required string fields
+    expect(typeof experience.id).toBe("string");
+    expect(experience.id).toMatch(/^exp_cmi_/);
+    expect(typeof experience.title).toBe("string");
+    expect(experience.title.length).toBeGreaterThan(0);
+    expect(typeof experience.oneLiner).toBe("string");
+    expect(typeof experience.whyItMatters).toBe("string");
+
+    // Category enum
+    const validCategories = ["culture", "nature", "food", "coffee", "work", "wellness", "nightlife", "hidden"];
+    expect(validCategories).toContain(experience.category);
+
+    // Location
+    expect(Array.isArray(experience.location.coordinates)).toBe(true);
+    expect(experience.location.coordinates).toHaveLength(2);
+    expect(typeof experience.location.coordinates[0]).toBe("number");
+    expect(typeof experience.location.coordinates[1]).toBe("number");
+    expect(experience.location.cityCode).toBe("cmi");
+
+    // Times
+    expect(Array.isArray(experience.bestTimes)).toBe(true);
+    for (const t of experience.bestTimes) {
+      expect(t.startHour).toBeGreaterThanOrEqual(0);
+      expect(t.startHour).toBeLessThanOrEqual(23);
+      expect(t.endHour).toBeGreaterThanOrEqual(0);
+      expect(t.endHour).toBeLessThanOrEqual(23);
+    }
+
+    // Duration
+    expect(typeof experience.durationMinutes.min).toBe("number");
+    expect(typeof experience.durationMinutes.max).toBe("number");
+    expect(experience.durationMinutes.max).toBeGreaterThanOrEqual(experience.durationMinutes.min);
+
+    // HowTo: 3–7 steps
+    expect(experience.howTo.length).toBeGreaterThanOrEqual(3);
+    expect(experience.howTo.length).toBeLessThanOrEqual(7);
+
+    // realInconveniences: ≥1
+    expect(experience.realInconveniences.length).toBeGreaterThanOrEqual(1);
+    const validIncCategories = ["scam", "crowds", "logistics", "weather", "etiquette", "safety", "other"];
+    for (const inc of experience.realInconveniences) {
+      expect(validIncCategories).toContain(inc.category);
+      expect(typeof inc.text).toBe("string");
+      expect(inc.text.length).toBeGreaterThan(0);
+    }
+
+    // Sources
+    expect(experience.sources.length).toBeGreaterThanOrEqual(1);
+
+    // Status is "candidate" for AI pipeline
+    expect(experience.status).toBe("candidate");
+
+    // Confidence level = 1 (non-negotiable per system prompt)
+    expect(experience.confidence.level).toBe(1);
+  });
+
+  it("title is action-oriented, not a bare place name", async () => {
+    const mockClient = makeMockClient(golden);
+    const { experience } = await structureExperience(INPUT, mockClient);
+    expect(experience).not.toBeNull();
+    if (!experience) return;
+
+    // Title should contain a verb (action word) — not just a noun phrase
+    // Simple heuristic: contains at least one space and isn't all title-case nouns
+    expect(experience.title).not.toMatch(/^[A-Z][a-z]+ [A-Z][a-z]+ [A-Z][a-z]+$/);
+    expect(experience.title.split(" ").length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("every source URL appears verbatim in the input text — no hallucination", async () => {
+    const mockClient = makeMockClient(golden);
+    const { experience } = await structureExperience(INPUT, mockClient);
+    expect(experience).not.toBeNull();
+    if (!experience) return;
+
+    const inputContent = `${rawText}\n${SOURCE_URL}`;
+    for (const source of experience.sources) {
+      if (source.url) {
+        expect(inputContent).toContain(source.url);
+      }
+    }
+  });
+
+  it("model confidence is between 0 and 1", async () => {
+    const mockClient = makeMockClient(golden);
+    const result = await structureExperience(INPUT, mockClient);
+    expect(result.modelConfidence).toBeGreaterThanOrEqual(0);
+    expect(result.modelConfidence).toBeLessThanOrEqual(1);
+  });
+
+  it("coordinates are in GeoJSON order [longitude, latitude]", async () => {
+    const mockClient = makeMockClient(golden);
+    const { experience } = await structureExperience(INPUT, mockClient);
+    expect(experience).not.toBeNull();
+    if (!experience) return;
+
+    const [lng, lat] = experience.location.coordinates;
+    // Chiang Mai is in Thailand: lat ~18-19°N, lng ~98-99°E
+    expect(lng).toBeGreaterThan(90);
+    expect(lng).toBeLessThan(110);
+    expect(lat).toBeGreaterThan(15);
+    expect(lat).toBeLessThan(25);
+  });
+});
+
+// ─── Fixture 2: Reddit — coffee micro-lot experience ─────────────────────────
+
+describe("structureExperience — Reddit coffee thread", () => {
+  const rawText = loadFixture("reddit-coffee-thread.md");
+  const golden = loadGolden("reddit-coffee-thread.json");
+  const SOURCE_URL = "https://www.reddit.com/r/chiangmai/comments/coffee_thread_2024";
+
+  const INPUT = {
+    rawText,
+    cityCode: "cmi",
+    cityName: "Chiang Mai",
+    sourceUrl: SOURCE_URL,
+    sourceType: "reddit" as const,
+  };
+
+  it("returns a non-null experience", async () => {
+    const mockClient = makeMockClient(golden);
+    const result = await structureExperience(INPUT, mockClient);
+    expect(result.experience).not.toBeNull();
+  });
+
+  it("category is 'coffee' for coffee-focused source", async () => {
+    const mockClient = makeMockClient(golden);
+    const { experience } = await structureExperience(INPUT, mockClient);
+    expect(experience).not.toBeNull();
+    expect(experience?.category).toBe("coffee");
+  });
+
+  it("every source URL appears verbatim in the input text — no hallucination", async () => {
+    const mockClient = makeMockClient(golden);
+    const { experience } = await structureExperience(INPUT, mockClient);
+    expect(experience).not.toBeNull();
+    if (!experience) return;
+
+    const inputContent = `${rawText}\n${SOURCE_URL}`;
+    for (const source of experience.sources) {
+      if (source.url) {
+        expect(inputContent).toContain(source.url);
+      }
+    }
+  });
+
+  it("realInconveniences includes at least one honest downside", async () => {
+    const mockClient = makeMockClient(golden);
+    const { experience } = await structureExperience(INPUT, mockClient);
+    expect(experience).not.toBeNull();
+    expect(experience?.realInconveniences.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("experience ID uses city code prefix", async () => {
+    const mockClient = makeMockClient(golden);
+    const { experience } = await structureExperience(INPUT, mockClient);
+    expect(experience?.id).toMatch(/^exp_cmi_/);
+  });
+
+  it("source type is set to 'reddit'", async () => {
+    const mockClient = makeMockClient(golden);
+    const { experience } = await structureExperience(INPUT, mockClient);
+    expect(experience).not.toBeNull();
+    if (!experience) return;
+    const hasRedditSource = experience.sources.some((s) => s.type === "reddit");
+    expect(hasRedditSource).toBe(true);
+  });
+});
+
+// ─── Fixture 3: Insufficient blurb — refusal behavior ────────────────────────
+
+describe("structureExperience — insufficient blurb (refusal)", () => {
+  const rawText = loadFixture("insufficient-blurb.txt");
+  const golden = loadGolden("insufficient-blurb.json");
+
+  const INPUT = {
+    rawText,
+    cityCode: "cmi",
+    cityName: "Chiang Mai",
+  };
+
+  it("returns null experience for thin source", async () => {
+    const mockClient = makeMockClient(golden);
+    const result = await structureExperience(INPUT, mockClient);
+    expect(result.experience).toBeNull();
+  });
+
+  it("provides a non-empty refusal reason", async () => {
+    const mockClient = makeMockClient(golden);
+    const result = await structureExperience(INPUT, mockClient);
+    expect(result.refusalReason).toBeDefined();
+    expect(typeof result.refusalReason).toBe("string");
+    expect(result.refusalReason!.length).toBeGreaterThan(10);
+  });
+
+  it("model confidence is 0 on refusal", async () => {
+    const mockClient = makeMockClient(golden);
+    const result = await structureExperience(INPUT, mockClient);
+    expect(result.modelConfidence).toBe(0);
+  });
+});
+
+// ─── Edge cases ───────────────────────────────────────────────────────────────
+
+describe("structureExperience — edge cases", () => {
+  it("handles model returning no tool call — returns null with reason", async () => {
+    const mockClient = {
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [{ type: "text", text: "I cannot help with that." }],
+          usage: { input_tokens: 50, output_tokens: 10 },
+          model: "claude-opus-4-7",
+        }),
+      },
+    } as unknown as Anthropic;
+
+    const result = await structureExperience(
+      { rawText: "some text", cityCode: "cmi", cityName: "Chiang Mai" },
+      mockClient,
+    );
+
+    expect(result.experience).toBeNull();
+    expect(result.refusalReason).toBeDefined();
+    expect(result.modelConfidence).toBe(0);
+  });
+
+  it("handles unknown tool name — returns null with reason", async () => {
+    const mockClient = {
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [
+            {
+              type: "tool_use",
+              name: "some_unknown_tool",
+              input: { data: "whatever" },
+            },
+          ],
+          usage: { input_tokens: 50, output_tokens: 20 },
+          model: "claude-opus-4-7",
+        }),
+      },
+    } as unknown as Anthropic;
+
+    const result = await structureExperience(
+      { rawText: "some text", cityCode: "cmi", cityName: "Chiang Mai" },
+      mockClient,
+    );
+
+    expect(result.experience).toBeNull();
+    expect(result.refusalReason).toContain("some_unknown_tool");
+    expect(result.modelConfidence).toBe(0);
+  });
+
+  it("handles API rejection (thrown error) — propagates exception", async () => {
+    const mockClient = {
+      messages: {
+        create: vi.fn().mockRejectedValue(new Error("Rate limit exceeded")),
+      },
+    } as unknown as Anthropic;
+
+    await expect(
+      structureExperience(
+        { rawText: "some text", cityCode: "cmi", cityName: "Chiang Mai" },
+        mockClient,
+      ),
+    ).rejects.toThrow("Rate limit exceeded");
+  });
+
+  it("ID slug is generated from title — no spaces or special chars", async () => {
+    const golden = loadGolden("wikivoyage-chiang-mai-suthep.json");
+    const mockClient = makeMockClient(golden);
+
+    const result = await structureExperience(
+      {
+        rawText: loadFixture("wikivoyage-chiang-mai-suthep.txt"),
+        cityCode: "cmi",
+        cityName: "Chiang Mai",
+        sourceUrl: "https://en.wikivoyage.org/wiki/Chiang_Mai/Doi_Suthep",
+        sourceType: "wikivoyage",
+      },
+      mockClient,
+    );
+
+    expect(result.experience).not.toBeNull();
+    if (!result.experience) return;
+
+    // ID must match pattern: exp_<cityCode>_<alphanumeric+underscores>
+    expect(result.experience.id).toMatch(/^exp_[a-z0-9]+_[a-z0-9_]+$/);
+  });
+
+  it("soloScore is initialized with zero values from AI pipeline", async () => {
+    const golden = loadGolden("reddit-coffee-thread.json");
+    const mockClient = makeMockClient(golden);
+
+    const result = await structureExperience(
+      {
+        rawText: loadFixture("reddit-coffee-thread.md"),
+        cityCode: "cmi",
+        cityName: "Chiang Mai",
+        sourceUrl: "https://www.reddit.com/r/chiangmai/comments/coffee_thread_2024",
+        sourceType: "reddit",
+      },
+      mockClient,
+    );
+
+    expect(result.experience).not.toBeNull();
+    if (!result.experience) return;
+
+    expect(result.experience.soloScore.basedOnCount).toBe(0);
+    expect(result.experience.soloScore.overall).toBe(0);
+  });
+
+  it("nearbyExperienceIds starts empty — populated by recommendation engine later", async () => {
+    const golden = loadGolden("wikivoyage-chiang-mai-suthep.json");
+    const mockClient = makeMockClient(golden);
+
+    const result = await structureExperience(
+      {
+        rawText: loadFixture("wikivoyage-chiang-mai-suthep.txt"),
+        cityCode: "cmi",
+        cityName: "Chiang Mai",
+        sourceUrl: "https://en.wikivoyage.org/wiki/Chiang_Mai/Doi_Suthep",
+        sourceType: "wikivoyage",
+      },
+      mockClient,
+    );
+
+    expect(result.experience?.nearbyExperienceIds).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #19

## Summary

- 3 fixture inputs: Wikivoyage (Doi Suthep cultural experience), Reddit (Ristr8to coffee lab), insufficient blurb (refusal case)
- Golden replay mocks — no `ANTHROPIC_API_KEY` needed in CI
- Full schema validation on every output field, URL grounding (asserts every `sources[].url` appears verbatim in input), refusal behavior
- Edge cases: no-tool-call response, unknown tool name, rate-limit error propagation, ID slug format, soloScore zero-init, empty nearbyExperienceIds

## Test plan

- [x] `pnpm --filter @solo-compass/ai test` — 27 tests pass (21 new + 6 existing)
- [x] `pnpm typecheck` — all 5 packages clean
- [x] No `ANTHROPIC_API_KEY` in environment during test run
- [ ] `pnpm --filter @solo-compass/ai test:live` — run manually with real API key to validate goldens match live model output

🤖 Generated with [Claude Code](https://claude.com/claude-code)