### PR TITLE
feat(ci): TS↔Swift schema parity guard (#18)

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -8,10 +8,35 @@ on:
   workflow_dispatch:
 
 jobs:
+  schema-parity:
+    name: TS↔Swift Schema Parity
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: '9'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check TS↔Swift schema parity
+        run: pnpm parity:check
+
   build-and-test:
     name: Build & Test
     runs-on: macos-latest
-    
+    needs: [schema-parity]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -22,11 +22,14 @@
     "clean": "turbo run clean && rm -rf node_modules",
     "format": "prettier --write \"**/*.{ts,tsx,md,json}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,md,json}\"",
-    "seed:chiang-mai": "tsx scripts/seed-load.ts"
+    "seed:chiang-mai": "tsx scripts/seed-load.ts",
+    "parity:check": "tsx scripts/check-swift-parity.ts"
   },
   "devDependencies": {
     "@types/node": "^22.7.0",
+    "glob": "^11.0.0",
     "prettier": "^3.3.3",
+    "ts-morph": "^24.0.0",
     "tsx": "^4.19.2",
     "turbo": "^2.1.3",
     "typescript": "^5.6.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,15 @@ importers:
       '@types/node':
         specifier: ^22.7.0
         version: 22.19.17
+      glob:
+        specifier: ^11.0.0
+        version: 11.1.0
       prettier:
         specifier: ^3.3.3
         version: 3.8.3
+      ts-morph:
+        specifier: ^24.0.0
+        version: 24.0.0
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -660,6 +666,10 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1555,6 +1565,9 @@ packages:
   '@telegraf/types@7.1.0':
     resolution: {integrity: sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==}
 
+  '@ts-morph/common@0.25.0':
+    resolution: {integrity: sha512-kMnZz+vGGHi4GoHnLmMhGNjm44kGtKUXGnOvrKmMwAuvNjM/PgKVGfUnL7IDvK7Jb2QQ82jq3Zmp04Gy+r3Dkg==}
+
   '@turbo/darwin-64@2.9.8':
     resolution: {integrity: sha512-zU1P95ygDpsQ+2QHh7CVTqvYwi9UBlhKWzoIyUnP3vUoge7H9SQEzrd8dj+XcTrslAp9Db3vIBcXtMVoTEYDnA==}
     cpu: [x64]
@@ -1813,6 +1826,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.10.27:
     resolution: {integrity: sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==}
     engines: {node: '>=6.0.0'}
@@ -1824,6 +1841,10 @@ packages:
 
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1890,6 +1911,9 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1916,6 +1940,10 @@ packages:
 
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   csscolorparser@1.0.3:
     resolution: {integrity: sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==}
@@ -2082,6 +2110,10 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
@@ -2145,6 +2177,12 @@ packages:
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
@@ -2220,6 +2258,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
+
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
@@ -2271,6 +2313,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2314,8 +2360,16 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@8.0.7:
     resolution: {integrity: sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minipass@4.2.8:
@@ -2424,8 +2478,18 @@ packages:
     resolution: {integrity: sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
   path-parse@1.0.7:
@@ -2434,6 +2498,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -2699,11 +2767,23 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   shimmer@1.2.1:
     resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2838,6 +2918,9 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  ts-morph@24.0.0:
+    resolution: {integrity: sha512-2OAOg/Ob5yx9Et7ZX4CvTCc0UFoZHwLEJ+dpDPSUi5TgwwlTlX47w+iFRrEwzUZwYACjq83cgjS/Da50Ga37uw==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3404,6 +3487,8 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@isaacs/cliui@9.0.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -4367,6 +4452,12 @@ snapshots:
 
   '@telegraf/types@7.1.0': {}
 
+  '@ts-morph/common@0.25.0':
+    dependencies:
+      minimatch: 9.0.9
+      path-browserify: 1.0.1
+      tinyglobby: 0.2.16
+
   '@turbo/darwin-64@2.9.8':
     optional: true
 
@@ -4659,6 +4750,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.10.27: {}
 
   binary-extensions@2.3.0: {}
@@ -4666,6 +4759,10 @@ snapshots:
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -4736,6 +4833,8 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  code-block-writer@13.0.3: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -4755,6 +4854,12 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   core-js@3.49.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   csscolorparser@1.0.3: {}
 
@@ -4932,6 +5037,11 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data-encoder@1.7.2: {}
 
   form-data@4.0.5:
@@ -4997,6 +5107,15 @@ snapshots:
       is-glob: 4.0.3
 
   glob-to-regexp@0.4.1: {}
+
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
 
   glob@9.3.5:
     dependencies:
@@ -5069,6 +5188,10 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
+
   jest-worker@27.5.1:
     dependencies:
       '@types/node': 22.19.17
@@ -5102,6 +5225,8 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.3.6: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -5166,7 +5291,15 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
   minimatch@8.0.7:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.0
 
@@ -5255,13 +5388,24 @@ snapshots:
 
   p-timeout@4.1.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
 
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.6
       minipass: 7.1.3
 
   pathe@1.1.2: {}
@@ -5564,9 +5708,17 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   shimmer@1.2.1: {}
 
   siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   source-map-js@1.2.1: {}
 
@@ -5709,6 +5861,11 @@ snapshots:
   tr46@0.0.3: {}
 
   ts-interface-checker@0.1.13: {}
+
+  ts-morph@24.0.0:
+    dependencies:
+      '@ts-morph/common': 0.25.0
+      code-block-writer: 13.0.3
 
   tslib@2.8.1: {}
 

--- a/scripts/check-swift-parity.ts
+++ b/scripts/check-swift-parity.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env tsx
+/**
+ * TS↔Swift schema parity guard.
+ *
+ * Usage:
+ *   pnpm parity:check
+ *   tsx scripts/check-swift-parity.ts [--verbose]
+ *
+ * Exits 0 when all watched interfaces match their Swift counterparts.
+ * Exits 1 and prints a diff report on any mismatch.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { extractTSStructs, SCHEMA_INTERFACES } from "./parity/ts-extractor.js";
+import { extractSwiftStructs } from "./parity/swift-extractor.js";
+import { compareStructs, formatReport } from "./parity/comparator.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const VERBOSE = process.argv.includes("--verbose");
+
+// ---------------------------------------------------------------------------
+// TS source globs (relative to ROOT)
+// ---------------------------------------------------------------------------
+const TS_GLOBS = [
+  "packages/core/src/experience.ts",
+  "packages/core/src/confidence.ts",
+  "packages/core/src/solo-score.ts",
+  "packages/core/src/geo.ts",
+];
+
+// ---------------------------------------------------------------------------
+// Swift source globs (relative to ROOT)
+// ---------------------------------------------------------------------------
+const SWIFT_GLOBS = ["apps/ios/SoloCompass/Models/*.swift"];
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  if (VERBOSE) {
+    console.log("🔍 Extracting TypeScript interfaces...");
+  }
+
+  let tsStructs;
+  try {
+    tsStructs = extractTSStructs(ROOT, TS_GLOBS);
+  } catch (err) {
+    console.error("❌ Failed to parse TypeScript sources:");
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  if (VERBOSE) {
+    console.log(`   Found ${tsStructs.length} TS struct(s): ${tsStructs.map((s) => s.name).join(", ")}`);
+    console.log("🔍 Extracting Swift structs...");
+  }
+
+  let swiftStructs;
+  try {
+    swiftStructs = extractSwiftStructs(ROOT, SWIFT_GLOBS);
+  } catch (err) {
+    console.error("❌ Failed to parse Swift sources:");
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  if (VERBOSE) {
+    console.log(`   Found ${swiftStructs.length} Swift struct(s): ${swiftStructs.map((s) => s.name).join(", ")}`);
+    for (const s of swiftStructs) {
+      console.log(`\n   ${s.name} (${s.file}):`);
+      for (const f of s.fields) {
+        console.log(`     ${f.name}: ${f.type}${f.optional ? "?" : ""}`);
+      }
+    }
+  }
+
+  const result = compareStructs(tsStructs, swiftStructs, SCHEMA_INTERFACES);
+  const report = formatReport(result);
+
+  process.stdout.write(report);
+
+  if (!result.ok) {
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/parity/README.md
+++ b/scripts/parity/README.md
@@ -1,0 +1,61 @@
+# TS ↔ Swift Schema Parity Guard
+
+Automated check that TypeScript interfaces in `packages/core/src/` are mirrored by matching Swift structs in `apps/ios/SoloCompass/Models/`.
+
+## How to run
+
+```bash
+pnpm parity:check          # exits 0 on match, 1 on mismatch
+```
+
+## Type mapping rules
+
+| TypeScript | Swift | Notes |
+|---|---|---|
+| `string` | `String` | |
+| `ExperienceId` (branded string) | `String` | Brand stripped at boundary |
+| `number` | `Double` or `Int` | Both accepted |
+| `boolean` | `Bool` | |
+| `readonly [number, number]` / `Coordinates` | `[Double]` | GeoJSON lon/lat tuple |
+| `T[]` / `readonly T[]` / `ReadonlyArray<T>` | `[T]` | Element type mapped recursively |
+| `field?: T` (optional) | `field: T?` | TS optional → Swift optional |
+| `string \| undefined` | `String?` | Same rule |
+| `Date` (string in TS, ISO 8601) | `Date` or `String` | Swift decodes from ISO string |
+| `ConfidenceLevel` (0\|1\|2\|3\|4\|5) | `Int` | Numeric union → Int |
+| Inline `{ ... }` shapes | Nested Swift struct | Checked by struct name match |
+
+## Optionality rules
+
+- TS `field?: T` must have Swift `field: T?` — a non-optional Swift field for an optional TS field is a **decoding crash risk**.
+- Swift `field: T?` for a required TS `field: T` is **allowed** (defensive decoding).
+
+## Ignored Swift-only fields
+
+Computed properties and UI helpers that exist only on the Swift side are skipped:
+
+- `id` (Identifiable conformance, derived from other fields)
+- `coordinate` / `clCoordinate` (computed from `location`)
+- `scoreColor`, `health` (computed from score/confidence)
+- `symbol`, `color`, `localizedTitle`, `localizedDescription` (UI layer)
+- `accessibilitySymbol`, `totalCount` (UI/derived)
+
+## Watched structs
+
+The following interfaces are checked for full parity:
+
+- `Experience`
+- `ExperienceLocation`
+- `TimeWindow`
+- `HowToStep`
+- `RealInconvenience`
+- `InformationSource`
+- `SoloScore`
+- `Confidence`
+
+## Adding a new field
+
+1. Add the field to the TS interface in `packages/core/src/experience.ts` (or relevant file).
+2. Add the corresponding Swift property to the matching struct in `apps/ios/SoloCompass/Models/Experience.swift`.
+3. Run `pnpm parity:check` locally — it must pass before merging.
+
+CI will block the PR if parity breaks.

--- a/scripts/parity/comparator.ts
+++ b/scripts/parity/comparator.ts
@@ -1,0 +1,306 @@
+/**
+ * Compares extracted TS and Swift struct fields for schema parity.
+ *
+ * Type compatibility rules (TS → Swift):
+ *   string / ExperienceId / branded string  →  String
+ *   number / ConfidenceLevel                →  Double | Int | Float
+ *   boolean                                 →  Bool
+ *   readonly [number, number] / Coordinates →  [Double] | [Double, Double]
+ *   readonly T[] / T[]                      →  [T]
+ *   T | undefined (optional)                →  T?
+ *   string literal union "a"|"b"            →  Swift enum (same name or known alias)
+ *   string (ISO 8601 date)                  →  Date (Swift decodes from string)
+ *   nested interface (same name)            →  Same struct name
+ *
+ * See scripts/parity/README.md for the full mapping table.
+ */
+
+import type { TSStruct, TSField } from "./ts-extractor.js";
+import type { SwiftStruct, SwiftField } from "./swift-extractor.js";
+
+export interface FieldMismatch {
+  structName: string;
+  fieldName: string;
+  tsType: string;
+  tsOptional: boolean;
+  swiftType?: string;
+  swiftOptional?: boolean;
+  issue: "missing_in_swift" | "missing_in_ts" | "type_mismatch" | "optionality_mismatch";
+}
+
+export interface ParityResult {
+  missingSwiftStructs: string[];
+  fieldMismatches: FieldMismatch[];
+  ok: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Type compatibility
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalise a raw TS type string.
+ * - Strips `readonly` modifier
+ * - Unwraps `ReadonlyArray<T>` → `T[]`
+ * - Resolves branded string types
+ */
+function normaliseTSType(raw: string): string {
+  let t = raw.trim();
+  // Branded type: `string & { readonly __brand: "..." }` → "string"
+  t = t.replace(/string\s*&\s*\{[^}]*\}/, "string");
+  // ReadonlyArray<T> → T[]
+  t = t.replace(/ReadonlyArray<(.+)>/, "$1[]");
+  // readonly T[] → T[]
+  t = t.replace(/^readonly\s+(.+\[\])$/, "$1");
+  // readonly [A, B] → [A, B]
+  t = t.replace(/^readonly\s+(\[.+\])$/, "$1");
+  // Collapse multi-line union formatting: leading `|` from ts-morph
+  t = t.replace(/^\|\s*/, "");
+  return t.trim().replace(/\s+/g, " ");
+}
+
+/** Strip Swift optionality marker. */
+function normaliseSwiftType(raw: string): string {
+  return raw.trim().replace(/\?$/, "");
+}
+
+/** True if the TS type is a string-literal union: `"a" | "b" | ...` */
+function isStringLiteralUnion(t: string): boolean {
+  return /^"[^"]+"(\s*\|\s*"[^"]+")+$/.test(t.trim());
+}
+
+/**
+ * True when a TS string-literal union is satisfied by a Swift enum or String.
+ * We accept any single-word Swift identifier (enum name) as compatible,
+ * because Swift enums have raw-value Codable that maps to the string literals.
+ */
+function stringUnionCompatible(swiftType: string): boolean {
+  // Swift enum: a single CamelCase identifier (not a primitive, not an array)
+  return /^[A-Z][A-Za-z0-9]*$/.test(swiftType) || swiftType === "String";
+}
+
+/**
+ * Known direct TS→Swift type aliases (ts normalised → swift normalised).
+ */
+const DIRECT: Record<string, string[]> = {
+  string: ["String", "URL", "Date"],  // Date: Swift decodes ISO 8601 strings
+  number: ["Double", "Int", "Float"],
+  boolean: ["Bool"],
+  "[number, number]": ["[Double]", "[Double, Double]"],
+  Date: ["Date", "String"],
+};
+
+/**
+ * Known named-type aliases from TS → Swift.
+ */
+const NAMED_ALIASES: Record<string, string> = {
+  ExperienceId: "String",
+  Coordinates: "[Double]",
+  ConfidenceLevel: "Int",
+  HealthStatus: "HealthStatus",
+  ExperienceCategory: "ExperienceCategory",
+  ExperienceLocation: "ExperienceLocation",
+  TimeWindow: "TimeWindow",
+  HowToStep: "HowToStep",
+  RealInconvenience: "RealInconvenience",
+  InformationSource: "InformationSource",
+  SoloScore: "SoloScore",
+  Confidence: "Confidence",
+};
+
+function typesCompatible(tsType: string, swiftType: string): boolean {
+  const normTS = normaliseTSType(tsType);
+  const normSW = normaliseSwiftType(swiftType);
+
+  // String literal union → Swift enum or String
+  if (isStringLiteralUnion(normTS)) {
+    return stringUnionCompatible(normSW);
+  }
+
+  // Direct primitive mappings
+  for (const [ts, swifts] of Object.entries(DIRECT)) {
+    if (normTS === ts && swifts.includes(normSW)) return true;
+  }
+
+  // Named aliases
+  if (NAMED_ALIASES[normTS] === normSW) return true;
+
+  // Same name (struct references another struct with same name)
+  if (normTS === normSW) return true;
+
+  // Arrays: T[] ↔ [T] — check element type compatibility
+  const tsArr = /^(.+)\[\]$/.exec(normTS);
+  const swArr = /^\[(.+)\]$/.exec(normSW);
+  if (tsArr && swArr) {
+    return typesCompatible(tsArr[1]!, swArr[1]!);
+  }
+
+  // Inline object shape `{ ... }` → accept if Swift has any struct name
+  // (we check these shapes via nested struct comparison, not field-by-field here)
+  if (normTS.startsWith("{")) return true;
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Fields to skip when checking Swift side
+// ---------------------------------------------------------------------------
+
+/**
+ * Swift-only computed/UI properties that have no TS counterpart.
+ * These are not schema fields — they're view helpers or Identifiable conformance.
+ */
+const IGNORED_SWIFT_FIELDS = new Set([
+  "id",
+  "coordinate",
+  "clCoordinate",
+  "scoreColor",
+  "health",
+  "symbol",
+  "color",
+  "localizedTitle",
+  "localizedDescription",
+  "accessibilitySymbol",
+  "totalCount",
+  // copy() method — not a stored property but just in case parser catches it
+  "copy",
+]);
+
+// ---------------------------------------------------------------------------
+// Main comparator
+// ---------------------------------------------------------------------------
+
+export function compareStructs(
+  tsStructs: TSStruct[],
+  swiftStructs: SwiftStruct[],
+  watchedNames: Set<string>,
+): ParityResult {
+  const swiftByName = new Map(swiftStructs.map((s) => [s.name, s]));
+  const tsByName = new Map(tsStructs.map((s) => [s.name, s]));
+
+  const missingSwiftStructs: string[] = [];
+  const fieldMismatches: FieldMismatch[] = [];
+
+  for (const structName of watchedNames) {
+    const ts = tsByName.get(structName);
+    const sw = swiftByName.get(structName);
+
+    if (!ts) continue;
+
+    if (!sw) {
+      missingSwiftStructs.push(structName);
+      continue;
+    }
+
+    const swiftFieldMap = new Map(sw.fields.map((f) => [f.name, f]));
+    const tsFieldMap = new Map(ts.fields.map((f) => [f.name, f]));
+
+    // TS → Swift: every TS field must be present and type-compatible
+    for (const tsField of ts.fields) {
+      const swField = swiftFieldMap.get(tsField.name);
+
+      if (!swField) {
+        fieldMismatches.push({
+          structName,
+          fieldName: tsField.name,
+          tsType: tsField.type,
+          tsOptional: tsField.optional,
+          issue: "missing_in_swift",
+        });
+        continue;
+      }
+
+      if (!typesCompatible(tsField.type, swField.type)) {
+        fieldMismatches.push({
+          structName,
+          fieldName: tsField.name,
+          tsType: tsField.type,
+          tsOptional: tsField.optional,
+          swiftType: swField.type,
+          swiftOptional: swField.optional,
+          issue: "type_mismatch",
+        });
+        continue;
+      }
+
+      // Optionality: TS required → Swift must not be MORE restrictive (non-optional is fine).
+      // TS optional → Swift must be optional too (non-optional = crash risk).
+      if (tsField.optional && !swField.optional) {
+        fieldMismatches.push({
+          structName,
+          fieldName: tsField.name,
+          tsType: tsField.type,
+          tsOptional: true,
+          swiftType: swField.type,
+          swiftOptional: false,
+          issue: "optionality_mismatch",
+        });
+      }
+    }
+
+    // Swift → TS: Swift stored fields not in TS are suspicious (unless ignored)
+    for (const swField of sw.fields) {
+      if (IGNORED_SWIFT_FIELDS.has(swField.name)) continue;
+      if (!tsFieldMap.has(swField.name)) {
+        fieldMismatches.push({
+          structName,
+          fieldName: swField.name,
+          tsType: "(absent)",
+          tsOptional: false,
+          swiftType: swField.type,
+          swiftOptional: swField.optional,
+          issue: "missing_in_ts",
+        });
+      }
+    }
+  }
+
+  return {
+    missingSwiftStructs,
+    fieldMismatches,
+    ok: missingSwiftStructs.length === 0 && fieldMismatches.length === 0,
+  };
+}
+
+export function formatReport(result: ParityResult): string {
+  if (result.ok) return "✅  TS↔Swift schema parity: all fields match.\n";
+
+  const lines: string[] = ["❌  TS↔Swift schema parity FAILED\n"];
+
+  if (result.missingSwiftStructs.length > 0) {
+    lines.push("Missing Swift structs:");
+    for (const name of result.missingSwiftStructs) {
+      lines.push(`  • ${name}`);
+    }
+    lines.push("");
+  }
+
+  if (result.fieldMismatches.length > 0) {
+    lines.push("Field mismatches:");
+    for (const m of result.fieldMismatches) {
+      const prefix = `  ${m.structName}.${m.fieldName}`;
+      switch (m.issue) {
+        case "missing_in_swift":
+          lines.push(`${prefix}  [missing in Swift]   TS: ${m.tsType}${m.tsOptional ? "?" : ""}`);
+          break;
+        case "missing_in_ts":
+          lines.push(`${prefix}  [missing in TS]      Swift: ${m.swiftType}${m.swiftOptional ? "?" : ""}`);
+          break;
+        case "type_mismatch":
+          lines.push(
+            `${prefix}  [type mismatch]      TS: ${m.tsType}  ↔  Swift: ${m.swiftType}${m.swiftOptional ? "?" : ""}`,
+          );
+          break;
+        case "optionality_mismatch":
+          lines.push(
+            `${prefix}  [optionality]        TS: ${m.tsType}?  but Swift: ${m.swiftType} (non-optional)`,
+          );
+          break;
+      }
+    }
+    lines.push("");
+  }
+
+  lines.push("Run `pnpm parity:check` locally to reproduce.");
+  return lines.join("\n");
+}

--- a/scripts/parity/swift-extractor.ts
+++ b/scripts/parity/swift-extractor.ts
@@ -1,0 +1,155 @@
+/**
+ * Extracts struct/class field definitions from Swift source files using regex.
+ * No Swift compiler required — parses `let`/`var` property declarations inside
+ * `struct` and `class` blocks, without descending into nested types.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { glob } from "glob";
+
+export interface SwiftField {
+  name: string;
+  type: string;
+  optional: boolean;
+}
+
+export interface SwiftStruct {
+  name: string;
+  fields: SwiftField[];
+  file: string;
+}
+
+// Matches a stored property (let/var) at the top level of a struct body.
+// Group 1: name, Group 2: type (may end with ?)
+const STORED_PROP_RE =
+  /^[ \t]+(?:(?:public|private|internal|fileprivate)\s+)?(?:let|var)\s+(\w+)\s*:\s*([^\n{/=]+?)(?:\s*=\s*[^\n]+)?[ \t]*(?:\/\/[^\n]*)?\n/gm;
+
+function parseSwiftType(raw: string): { type: string; optional: boolean } {
+  const trimmed = raw.trim();
+  if (trimmed.endsWith("?")) {
+    return { type: trimmed.slice(0, -1).trim(), optional: true };
+  }
+  const optMatch = /^Optional<(.+)>$/.exec(trimmed);
+  if (optMatch) {
+    return { type: optMatch[1]!.trim(), optional: true };
+  }
+  return { type: trimmed, optional: false };
+}
+
+/** Find the index of the matching closing brace. `openIdx` must point at `{`. */
+function findClosingBrace(src: string, openIdx: number): number {
+  let depth = 0;
+  for (let i = openIdx; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return src.length - 1;
+}
+
+interface StructRange {
+  name: string;
+  bodyStart: number; // index after the opening `{`
+  bodyEnd: number;   // index of the closing `}`
+}
+
+/**
+ * Scan `src` for all top-level struct/class declarations and return their
+ * body ranges.  Nested structs are NOT included (they are their own entries
+ * but we only add them once from the outer scan).
+ */
+function findAllStructRanges(src: string): StructRange[] {
+  const STRUCT_OPEN_RE =
+    /(?:^|\n)[ \t]*(?:(?:public|private|internal|fileprivate)\s+)?(?:struct|class)\s+(\w+)[^{]*\{/g;
+
+  const ranges: StructRange[] = [];
+  let m: RegExpExecArray | null;
+
+  while ((m = STRUCT_OPEN_RE.exec(src)) !== null) {
+    const name = m[1]!;
+    // The `{` is the last char of the match
+    const openBraceIdx = m.index + m[0].length - 1;
+    const closeBraceIdx = findClosingBrace(src, openBraceIdx);
+    ranges.push({ name, bodyStart: openBraceIdx + 1, bodyEnd: closeBraceIdx });
+  }
+
+  return ranges;
+}
+
+/**
+ * Given a struct body (between `{` and `}`), strip out any nested struct/class/
+ * enum/extension bodies so that STORED_PROP_RE only sees the direct members.
+ */
+function stripNestedBodies(body: string): string {
+  // Replace any nested `struct Foo { ... }` / `class Foo { ... }` / `enum Foo { ... }`
+  // with just the declaration line, removing the body.
+  // We iterate until no more replacements are needed (handles deeply nested).
+  const NESTED_RE =
+    /(?:(?:public|private|internal|fileprivate)\s+)?(?:struct|class|enum|extension)\s+\w+[^{]*\{/g;
+
+  let result = body;
+  let safety = 0;
+
+  while (safety++ < 20) {
+    NESTED_RE.lastIndex = 0;
+    const m = NESTED_RE.exec(result);
+    if (!m) break;
+
+    const openIdx = m.index + m[0].length - 1;
+    const closeIdx = findClosingBrace(result, openIdx);
+    // Replace the entire nested block (opening keyword → closing `}`) with a placeholder
+    result = result.slice(0, m.index) + "/* nested */" + result.slice(closeIdx + 1);
+  }
+
+  return result;
+}
+
+function parseDirectFields(body: string): SwiftField[] {
+  const clean = stripNestedBodies(body);
+  const fields: SwiftField[] = [];
+
+  STORED_PROP_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+
+  while ((m = STORED_PROP_RE.exec(clean)) !== null) {
+    const rawName = m[1]!;
+    const rawType = m[2]!.trim();
+
+    // Skip if the "type" looks like a block expression (computed var)
+    if (rawType.includes("{")) continue;
+
+    const { type, optional } = parseSwiftType(rawType);
+    fields.push({ name: rawName, type, optional });
+  }
+
+  return fields;
+}
+
+export function extractSwiftStructs(rootDir: string, swiftGlobs: string[]): SwiftStruct[] {
+  const structs: SwiftStruct[] = [];
+
+  for (const pattern of swiftGlobs) {
+    const files = glob.sync(pattern, { cwd: rootDir, absolute: true });
+
+    for (const filePath of files) {
+      const src = fs.readFileSync(filePath, "utf8");
+      const relFile = path.relative(rootDir, filePath);
+
+      const ranges = findAllStructRanges(src);
+
+      for (const range of ranges) {
+        const body = src.slice(range.bodyStart, range.bodyEnd);
+        const fields = parseDirectFields(body);
+
+        if (fields.length > 0) {
+          structs.push({ name: range.name, fields, file: relFile });
+        }
+      }
+    }
+  }
+
+  return structs;
+}

--- a/scripts/parity/ts-extractor.ts
+++ b/scripts/parity/ts-extractor.ts
@@ -1,0 +1,98 @@
+/**
+ * Extracts struct/interface field definitions from TypeScript source files.
+ * Uses ts-morph for AST-level accuracy — no regex hacks on TS syntax.
+ */
+
+import { Project, SyntaxKind, type InterfaceDeclaration, type TypeAliasDeclaration } from "ts-morph";
+import path from "node:path";
+
+export interface TSField {
+  name: string;
+  type: string;
+  optional: boolean;
+  readonly: boolean;
+}
+
+export interface TSStruct {
+  name: string;
+  fields: TSField[];
+  /** Which file it came from (relative path) */
+  file: string;
+}
+
+function resolveType(typeText: string): string {
+  // Normalize whitespace and strip readonly array wrappers
+  return typeText.replace(/\s+/g, " ").trim();
+}
+
+function extractFromInterface(decl: InterfaceDeclaration, file: string): TSStruct {
+  const fields: TSField[] = [];
+
+  for (const prop of decl.getProperties()) {
+    const name = prop.getName();
+    const optional = prop.hasQuestionToken();
+    const readonly = prop.isReadonly();
+    const type = resolveType(prop.getTypeNode()?.getText() ?? prop.getType().getText());
+    fields.push({ name, type, optional, readonly });
+  }
+
+  return { name: decl.getName(), fields, file };
+}
+
+export function extractTSStructs(rootDir: string, globs: string[]): TSStruct[] {
+  const project = new Project({
+    tsConfigFilePath: path.join(rootDir, "packages/core/tsconfig.json"),
+    skipAddingFilesFromTsConfig: true,
+    addFilesFromTsConfig: false,
+  });
+
+  for (const glob of globs) {
+    project.addSourceFilesAtPaths(path.join(rootDir, glob));
+  }
+
+  // Add referenced files so types resolve correctly
+  project.resolveSourceFileDependencies();
+
+  const structs: TSStruct[] = [];
+
+  for (const sourceFile of project.getSourceFiles()) {
+    const relFile = path.relative(rootDir, sourceFile.getFilePath());
+
+    // Interfaces
+    for (const decl of sourceFile.getInterfaces()) {
+      structs.push(extractFromInterface(decl, relFile));
+    }
+
+    // Type aliases that are object types (not unions/primitives)
+    for (const decl of sourceFile.getTypeAliases()) {
+      const typeNode = decl.getTypeNode();
+      if (!typeNode) continue;
+      if (typeNode.getKind() === SyntaxKind.TypeLiteral) {
+        // Inline object type — treat like an interface
+        const fields: TSField[] = [];
+        for (const member of typeNode.getChildrenOfKind(SyntaxKind.PropertySignature)) {
+          const name = member.getName();
+          const optional = member.hasQuestionToken();
+          const readonly = member.isReadonly();
+          const type = resolveType(member.getTypeNode()?.getText() ?? "unknown");
+          fields.push({ name, type, optional, readonly });
+        }
+        structs.push({ name: decl.getName(), fields, file: relFile });
+      }
+    }
+  }
+
+  return structs;
+}
+
+/** Return only the structs that are part of the Experience schema (not utility types). */
+export const SCHEMA_INTERFACES = new Set([
+  "Experience",
+  "ExperienceLocation",
+  "TimeWindow",
+  "HowToStep",
+  "RealInconvenience",
+  "InformationSource",
+  "SoloScore",
+  "Confidence",
+]);


### PR DESCRIPTION
Closes #18

## Summary

- **ts-morph AST extractor** parses `packages/core/src/*.ts` — pulls every interface/type field with name, type text, and optionality
- **Regex Swift parser** extracts stored `let`/`var` fields from `apps/ios/SoloCompass/Models/*.swift` — nested struct bodies are stripped so inner types don't bleed into parent fields
- **Comparator** maps TS→Swift types: primitives, branded strings, string-literal unions→Swift enums, ISO-string dates→`Date`, arrays, inline object shapes
- **CI gate** — new `schema-parity` job on `ubuntu-latest` runs before `build-and-test`; blocks iOS builds on mismatch
- **`pnpm parity:check`** — runnable locally, `--verbose` flag shows full parsed struct dump

## Type mapping highlights

| TS | Swift |
|---|---|
| `string` / `ExperienceId` | `String` |
| `number` | `Double` or `Int` |
| `"a" \| "b" \| "c"` (union) | Swift `enum` (any single identifier) |
| `string` (ISO 8601 date field) | `Date` |
| `boolean` | `Bool` |
| `T[]` / `readonly T[]` | `[T]` |
| `field?: T` | `field: T?` |

## Test plan

- [x] `pnpm parity:check` exits 0 on current codebase
- [x] `pnpm typecheck` passes across all packages
- [x] Verified mismatch detection: adding a fake field to a watched struct produces exit 1 with a clear diff report
- [x] Nested Swift structs (`DurationRange`, `Stats`, `Breakdown`, `Signals`) do not bleed fields into parent struct

🤖 Generated with [Claude Code](https://claude.com/claude-code)