### PR TITLE
feat: city switcher + empty-state fallback (closes #58, closes #59)

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		E7B5B022519434F7C07818CF /* ExperienceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F087E4FA7161529378098C /* ExperienceService.swift */; };
 		EBE1ACB7D574EE000B028B23 /* SoloCompassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3CB5045CE59A613B5CAAF5 /* SoloCompassTests.swift */; };
 		F5677DCF081E506C7E32243F /* VoiceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120FC7465285714C5FA8F96D /* VoiceService.swift */; };
+		3EC7A09FE9C1EC22473F46A6 /* CityPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F46276DB7A174176C81C63 /* CityPickerSheet.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +68,7 @@
 		F4814DBCEAB5975B6338558D /* AIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIService.swift; sourceTree = "<group>"; };
 		F63FDD874A8F533F0717132A /* UserPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPreferences.swift; sourceTree = "<group>"; };
 		FAFFA243BC698EF20C6BC1EF /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
+		03F46276DB7A174176C81C63 /* CityPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityPickerSheet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -95,6 +97,7 @@
 			children = (
 				BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */,
 				0E0157D30FF53B21FF31D519 /* MarkerIconView.swift */,
+				03F46276DB7A174176C81C63 /* CityPickerSheet.swift */,
 			);
 			path = Map;
 			sourceTree = "<group>";
@@ -331,6 +334,7 @@
 				31F9538643C362D7EEF64C6B /* LocationService.swift in Sources */,
 				CE1A6A1D5EB25B2BEA5B29DA /* MapViewModel.swift in Sources */,
 				28E3EB1BFFB0A73A1C56FD54 /* MarkerIconView.swift in Sources */,
+				3EC7A09FE9C1EC22473F46A6 /* CityPickerSheet.swift in Sources */,
 				E5F463CE3CE822F7F96CA82C /* SoloCompassApp.swift in Sources */,
 				86F4628473C2D520D4C2FFFB /* SoloScoreBadge.swift in Sources */,
 				C2C0AF72D709EDC17C6ED874 /* UserPreferences.swift in Sources */,

--- a/apps/ios/SoloCompass/Models/UserPreferences.swift
+++ b/apps/ios/SoloCompass/Models/UserPreferences.swift
@@ -24,6 +24,13 @@ public final class UserPreferences {
         var completedExperiences: Set<String> = []
         var favoritedExperiences: Set<String> = []
         var pendingCheckIns: [String: Date] = [:]
+        var lastSelectedCity: String? = nil
+
+        enum CodingKeys: String, CodingKey {
+            case preferredCategories, dislikedCategories, soloTravelStyle, maxDistanceKm
+            case visitHistory, completedExperiences, favoritedExperiences, pendingCheckIns
+            case lastSelectedCity
+        }
 
         init() {}
 
@@ -35,7 +42,8 @@ public final class UserPreferences {
             visitHistory: [String: Date],
             completedExperiences: Set<String>,
             favoritedExperiences: Set<String>,
-            pendingCheckIns: [String: Date]
+            pendingCheckIns: [String: Date],
+            lastSelectedCity: String?
         ) {
             self.preferredCategories = preferredCategories
             self.dislikedCategories = dislikedCategories
@@ -45,6 +53,7 @@ public final class UserPreferences {
             self.completedExperiences = completedExperiences
             self.favoritedExperiences = favoritedExperiences
             self.pendingCheckIns = pendingCheckIns
+            self.lastSelectedCity = lastSelectedCity
         }
 
         init(from decoder: Decoder) throws {
@@ -57,6 +66,7 @@ public final class UserPreferences {
             self.completedExperiences = try c.decodeIfPresent(Set<String>.self, forKey: .completedExperiences) ?? []
             self.favoritedExperiences = try c.decodeIfPresent(Set<String>.self, forKey: .favoritedExperiences) ?? []
             self.pendingCheckIns = try c.decodeIfPresent([String: Date].self, forKey: .pendingCheckIns) ?? [:]
+            self.lastSelectedCity = try c.decodeIfPresent(String.self, forKey: .lastSelectedCity)
         }
     }
 
@@ -68,6 +78,7 @@ public final class UserPreferences {
     public var completedExperiences: Set<String> { didSet { persist() } }
     public var favoritedExperiences: Set<String> { didSet { persist() } }
     public var pendingCheckIns: [String: Date] { didSet { persist() } }
+    public var lastSelectedCity: String? { didSet { persist() } }
 
     private static let storageKey = "com.solocompass.userPreferences.v1"
     private let defaults: UserDefaults
@@ -83,6 +94,7 @@ public final class UserPreferences {
         self.completedExperiences = snapshot.completedExperiences
         self.favoritedExperiences = snapshot.favoritedExperiences
         self.pendingCheckIns = snapshot.pendingCheckIns
+        self.lastSelectedCity = snapshot.lastSelectedCity
     }
 
     private static func load(from defaults: UserDefaults) -> Snapshot {
@@ -106,7 +118,8 @@ public final class UserPreferences {
             visitHistory: visitHistory,
             completedExperiences: completedExperiences,
             favoritedExperiences: favoritedExperiences,
-            pendingCheckIns: pendingCheckIns
+            pendingCheckIns: pendingCheckIns,
+            lastSelectedCity: lastSelectedCity
         )
         do {
             let data = try JSONEncoder.iso8601Encoder.encode(snapshot)

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -100,7 +100,16 @@
 /* Map empty / loading */
 "map.empty.title" = "No experiences nearby";
 "map.empty.hint" = "Try clearing filters or moving the map.";
+"map.empty.radius" = "No experiences within %.0fkm";
+"map.empty.expand" = "Expand to 25km";
+"map.empty.browse" = "Browse %@";
+"map.empty.clearFilters" = "Clear filters";
 "map.loading" = "Loading map";
+
+/* City picker */
+"city.all" = "All Cities";
+"city.picker.title" = "Choose a city";
+"city.experienceCount" = "%d experiences";
 
 /* Action bar */
 "action.favorite" = "Add to favorites";

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -40,6 +40,73 @@ public final class MapViewModel {
         recenter(on: coordinate)
     }
 
+    // MARK: - City selection
+
+    /// Currently selected city code (e.g. "cmi"), nil = all cities.
+    public var selectedCity: String?
+
+    /// All cities derived from seed data: unique cityCode + centroid of their experiences.
+    public var availableCities: [(code: String, name: String, center: CLLocationCoordinate2D)] {
+        var cityExperiences: [String: [CLLocationCoordinate2D]] = [:]
+        for exp in experienceService.allExperiences {
+            guard let coord = exp.coordinate else { continue }
+            let code = exp.location.cityCode
+            cityExperiences[code, default: []].append(coord)
+        }
+        let nameMap = cityNameMap
+        return cityExperiences.compactMap { code, coords -> (String, String, CLLocationCoordinate2D)? in
+            guard !coords.isEmpty else { return nil }
+            let avgLat = coords.map(\.latitude).reduce(0, +) / Double(coords.count)
+            let avgLon = coords.map(\.longitude).reduce(0, +) / Double(coords.count)
+            let name = nameMap[code] ?? code
+            return (code, name, CLLocationCoordinate2D(latitude: avgLat, longitude: avgLon))
+        }
+        .sorted { $0.1 < $1.1 }
+    }
+
+    /// Human-readable city names keyed by city code.
+    private let cityNameMap: [String: String] = [
+        "cmi": "Chiang Mai",
+    ]
+
+    /// Center coordinate for the selected city, or the default if none selected.
+    public var defaultCenterForSelectedCity: CLLocationCoordinate2D {
+        guard let code = selectedCity,
+              let city = availableCities.first(where: { $0.code == code }) else {
+            return Self.defaultCenter
+        }
+        return city.center
+    }
+
+    /// Selects a city, recenters the map, and reloads experiences.
+    public func selectCity(_ cityCode: String?) {
+        selectedCity = cityCode
+        preferences.lastSelectedCity = cityCode
+        let center = defaultCenterForSelectedCity
+        cameraPosition = .region(MKCoordinateRegion(
+            center: center,
+            span: MKCoordinateSpan(latitudeDelta: 0.06, longitudeDelta: 0.06)
+        ))
+        loadNearbyExperiences()
+        updateBottomInfo()
+    }
+
+    /// Returns the city code whose experiences are collectively closest to the given coordinate.
+    public func nearestSeededCity(to coordinate: CLLocationCoordinate2D) -> String? {
+        let location = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+        var bestCode: String?
+        var bestDistance = Double.infinity
+        for city in availableCities {
+            let cityLoc = CLLocation(latitude: city.center.latitude, longitude: city.center.longitude)
+            let d = location.distance(from: cityLoc)
+            if d < bestDistance {
+                bestDistance = d
+                bestCode = city.code
+            }
+        }
+        return bestCode
+    }
+
     // MARK: - Published state
     // @ObservationIgnored avoids @Observable macro expanding MapCameraPosition
     // into a synthetic file that lacks `import MapKit`, causing build errors.
@@ -87,8 +154,28 @@ public final class MapViewModel {
         self.experienceService = experienceService
         self.aiService = aiService
         self.preferences = preferences
+        self.selectedCity = preferences.lastSelectedCity
+        let initialCenter: CLLocationCoordinate2D
+        if let savedCity = preferences.lastSelectedCity {
+            // Resolve center lazily — availableCities depends on experienceService which is set above.
+            // We compute inline here since computed properties aren't accessible before init ends.
+            var cityExps: [String: [CLLocationCoordinate2D]] = [:]
+            for exp in experienceService.allExperiences {
+                guard let coord = exp.coordinate else { continue }
+                cityExps[exp.location.cityCode, default: []].append(coord)
+            }
+            if let coords = cityExps[savedCity], !coords.isEmpty {
+                let avgLat = coords.map(\.latitude).reduce(0, +) / Double(coords.count)
+                let avgLon = coords.map(\.longitude).reduce(0, +) / Double(coords.count)
+                initialCenter = CLLocationCoordinate2D(latitude: avgLat, longitude: avgLon)
+            } else {
+                initialCenter = Self.defaultCenter
+            }
+        } else {
+            initialCenter = Self.defaultCenter
+        }
         self._cameraPosition = .region(MKCoordinateRegion(
-            center: Self.defaultCenter,
+            center: initialCenter,
             span: MKCoordinateSpan(latitudeDelta: 0.06, longitudeDelta: 0.06)
         ))
         loadNearbyExperiences()
@@ -98,9 +185,13 @@ public final class MapViewModel {
     // MARK: - Loading
 
     public func loadNearbyExperiences() {
-        let center = locationService.currentLocation?.coordinate ?? Self.defaultCenter
+        let center = locationService.currentLocation?.coordinate ?? defaultCenterForSelectedCity
         let radiusKm = max(1.0, preferences.maxDistanceKm)
         var nearby = experienceService.getExperiences(near: center, radiusKm: radiusKm)
+
+        if let cityCode = selectedCity {
+            nearby = nearby.filter { $0.location.cityCode == cityCode }
+        }
 
         if let category = selectedCategory {
             nearby = nearby.filter { $0.category == category }
@@ -164,6 +255,10 @@ public final class MapViewModel {
     public func refreshForLocation(_ coordinate: CLLocationCoordinate2D) {
         let radiusKm = max(1.0, preferences.maxDistanceKm)
         var nearby = experienceService.getExperiences(near: coordinate, radiusKm: radiusKm)
+
+        if let cityCode = selectedCity {
+            nearby = nearby.filter { $0.location.cityCode == cityCode }
+        }
 
         if let category = selectedCategory {
             nearby = nearby.filter { $0.category == category }
@@ -353,6 +448,11 @@ public final class MapViewModel {
             // Keep current state on error; record for UI to optionally surface.
             lastAIError = error.localizedDescription
         }
+    }
+
+    /// Number of experiences in a given city (for the city picker row subtitle).
+    public func experienceCount(for cityCode: String) -> Int {
+        experienceService.allExperiences.filter { $0.location.cityCode == cityCode }.count
     }
 
     // MARK: - Helpers

--- a/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+/// Bottom sheet for selecting a city (or "All Cities").
+/// Displayed when the user taps the city pill in the top-left of the map.
+public struct CityPickerSheet: View {
+    @Bindable var viewModel: MapViewModel
+    let onDismiss: () -> Void
+
+    public var body: some View {
+        NavigationStack {
+            List {
+                // "All Cities" option
+                Button {
+                    viewModel.selectCity(nil)
+                    onDismiss()
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(NSLocalizedString("city.all", comment: "All cities option"))
+                                .font(.body)
+                                .foregroundStyle(.primary)
+                        }
+                        Spacer()
+                        if viewModel.selectedCity == nil {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(.accentColor)
+                                .font(.body.weight(.semibold))
+                        }
+                    }
+                }
+
+                ForEach(viewModel.availableCities, id: \.code) { city in
+                    Button {
+                        viewModel.selectCity(city.code)
+                        onDismiss()
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(city.name)
+                                    .font(.body)
+                                    .foregroundStyle(.primary)
+                                Text(String(
+                                    format: NSLocalizedString("city.experienceCount", comment: "Experience count in city"),
+                                    viewModel.experienceCount(for: city.code)
+                                ))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            if viewModel.selectedCity == city.code {
+                                Image(systemName: "checkmark")
+                                    .foregroundStyle(.accentColor)
+                                    .font(.body.weight(.semibold))
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle(NSLocalizedString("city.picker.title", comment: "City picker sheet title"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(NSLocalizedString("common.cancel", comment: "Cancel")) {
+                        onDismiss()
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+}
+
+#Preview {
+    CityPickerSheet(
+        viewModel: MapViewModel(
+            locationService: LocationService.shared,
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: UserPreferences()
+        ),
+        onDismiss: {}
+    )
+}

--- a/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
@@ -23,7 +23,7 @@ public struct CityPickerSheet: View {
                         Spacer()
                         if viewModel.selectedCity == nil {
                             Image(systemName: "checkmark")
-                                .foregroundStyle(.accentColor)
+                                .foregroundStyle(.tint)
                                 .font(.body.weight(.semibold))
                         }
                     }
@@ -49,7 +49,7 @@ public struct CityPickerSheet: View {
                             Spacer()
                             if viewModel.selectedCity == city.code {
                                 Image(systemName: "checkmark")
-                                    .foregroundStyle(.accentColor)
+                                    .foregroundStyle(.tint)
                                     .font(.body.weight(.semibold))
                             }
                         }

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -115,7 +115,11 @@ public struct CompassMapView: View {
                 }
 
                 if viewModel.visibleExperiences.isEmpty {
-                    emptyStateOverlay(viewModel: viewModel)
+                    EmptyStateOverlay(
+                        viewModel: viewModel,
+                        preferences: preferences,
+                        locationService: locationService
+                    )
                 }
             } else {
                 ProgressView()
@@ -233,71 +237,6 @@ public struct CompassMapView: View {
         .accessibilityHint(Text(NSLocalizedString("city.picker.title", comment: "City picker sheet title")))
     }
 
-    // MARK: - Empty state
-
-    @ViewBuilder
-    private func emptyStateOverlay(viewModel: MapViewModel) -> some View {
-        VStack(spacing: 10) {
-            Image(systemName: "mappin.slash")
-                .font(.title2)
-                .foregroundStyle(.secondary)
-            Text(NSLocalizedString("map.empty.title", comment: "No experiences nearby"))
-                .font(.subheadline.weight(.medium))
-            Text(String(
-                format: NSLocalizedString("map.empty.radius", comment: "No experiences within radius"),
-                preferences.maxDistanceKm
-            ))
-            .font(.caption)
-            .foregroundStyle(.secondary)
-
-            VStack(spacing: 8) {
-                Button {
-                    preferences.maxDistanceKm = 25
-                    viewModel.loadNearbyExperiences()
-                    viewModel.updateBottomInfo()
-                } label: {
-                    Text(NSLocalizedString("map.empty.expand", comment: "Expand search radius to 25km"))
-                        .font(.subheadline.weight(.medium))
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.regular)
-
-                if let nearestCode = viewModel.nearestSeededCity(
-                    to: locationService.currentLocation?.coordinate ?? viewModel.defaultCenterForSelectedCity
-                ),
-                   let nearestCity = viewModel.availableCities.first(where: { $0.code == nearestCode }) {
-                    Button {
-                        viewModel.selectCity(nearestCode)
-                    } label: {
-                        Text(String(
-                            format: NSLocalizedString("map.empty.browse", comment: "Browse nearest city"),
-                            nearestCity.name
-                        ))
-                        .font(.subheadline)
-                        .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.regular)
-                }
-
-                Button {
-                    viewModel.clearFilters()
-                } label: {
-                    Text(NSLocalizedString("map.empty.clearFilters", comment: "Clear all filters"))
-                        .font(.subheadline)
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.regular)
-            }
-        }
-        .padding(16)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
-        .padding(.horizontal, 32)
-        .accessibilityElement(children: .combine)
-    }
-
     @ViewBuilder
     private func mapLayer(viewModel: MapViewModel) -> some View {
         let bindingCamera = Binding<MapCameraPosition>(
@@ -381,4 +320,72 @@ public struct CompassMapView: View {
         .environment(ExperienceService())
         .environment(AIService())
         .environment(UserPreferences())
+}
+
+private struct EmptyStateOverlay: View {
+    var viewModel: MapViewModel
+    var preferences: UserPreferences
+    var locationService: LocationService
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "mappin.slash")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text(NSLocalizedString("map.empty.title", comment: "No experiences nearby"))
+                .font(.subheadline.weight(.medium))
+            Text(String(
+                format: NSLocalizedString("map.empty.radius", comment: "No experiences within radius"),
+                preferences.maxDistanceKm
+            ))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            VStack(spacing: 8) {
+                Button {
+                    preferences.maxDistanceKm = 25
+                    viewModel.loadNearbyExperiences()
+                    viewModel.updateBottomInfo()
+                } label: {
+                    Text(NSLocalizedString("map.empty.expand", comment: "Expand search radius to 25km"))
+                        .font(.subheadline.weight(.medium))
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+
+                if let nearestCode = viewModel.nearestSeededCity(
+                    to: locationService.currentLocation?.coordinate ?? viewModel.defaultCenterForSelectedCity
+                ),
+                   let nearestCity = viewModel.availableCities.first(where: { $0.code == nearestCode }) {
+                    Button {
+                        viewModel.selectCity(nearestCode)
+                    } label: {
+                        Text(String(
+                            format: NSLocalizedString("map.empty.browse", comment: "Browse nearest city"),
+                            nearestCity.name
+                        ))
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.regular)
+                }
+
+                Button {
+                    viewModel.clearFilters()
+                } label: {
+                    Text(NSLocalizedString("map.empty.clearFilters", comment: "Clear all filters"))
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.regular)
+            }
+        }
+        .padding(16)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
+        .padding(.horizontal, 32)
+        .accessibilityElement(children: .combine)
+    }
 }

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -13,6 +13,7 @@ public struct CompassMapView: View {
     @State private var viewModel: MapViewModel?
     @State private var voiceService = VoiceService()
     @State private var dismissedAIError: String? = nil
+    @State private var isShowingCityPicker: Bool = false
 
     public init() {}
 
@@ -23,6 +24,13 @@ public struct CompassMapView: View {
                     .ignoresSafeArea()
 
                 VStack {
+                    HStack {
+                        cityPill(viewModel: viewModel)
+                            .padding(.leading, 12)
+                            .padding(.top, 8)
+                        Spacer()
+                    }
+
                     FilterBarView(
                         selectedCategory: viewModel.selectedCategory,
                         isNowSelected: viewModel.isNowFilter,
@@ -107,20 +115,7 @@ public struct CompassMapView: View {
                 }
 
                 if viewModel.visibleExperiences.isEmpty {
-                    VStack(spacing: 6) {
-                        Image(systemName: "mappin.slash")
-                            .font(.title2)
-                            .foregroundStyle(.secondary)
-                        Text(NSLocalizedString("map.empty.title", comment: "No experiences nearby"))
-                            .font(.subheadline.weight(.medium))
-                        Text(NSLocalizedString("map.empty.hint", comment: "Try adjusting filters or zooming out"))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    .padding(16)
-                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
-                    .padding(.horizontal, 32)
-                    .accessibilityElement(children: .combine)
+                    emptyStateOverlay(viewModel: viewModel)
                 }
             } else {
                 ProgressView()
@@ -131,12 +126,17 @@ public struct CompassMapView: View {
         .onAppear {
             locationService.requestPermission()
             if viewModel == nil {
-                viewModel = MapViewModel(
+                let vm = MapViewModel(
                     locationService: locationService,
                     experienceService: experienceService,
                     aiService: aiService,
                     preferences: preferences
                 )
+                viewModel = vm
+                // On first launch with no saved city and no GPS, prompt city picker.
+                if preferences.lastSelectedCity == nil && locationService.currentLocation == nil {
+                    isShowingCityPicker = true
+                }
             }
         }
         .onChange(of: locationService.currentLocation) { _, _ in
@@ -194,6 +194,108 @@ public struct CompassMapView: View {
                 }
             }
         }
+        .sheet(isPresented: $isShowingCityPicker) {
+            if let vm = viewModel {
+                CityPickerSheet(viewModel: vm) {
+                    isShowingCityPicker = false
+                }
+            }
+        }
+    }
+
+    // MARK: - City pill
+
+    @ViewBuilder
+    private func cityPill(viewModel: MapViewModel) -> some View {
+        let cityName: String = {
+            if let code = viewModel.selectedCity,
+               let city = viewModel.availableCities.first(where: { $0.code == code }) {
+                return city.name
+            }
+            return NSLocalizedString("city.all", comment: "All cities option")
+        }()
+
+        Button {
+            isShowingCityPicker = true
+        } label: {
+            HStack(spacing: 4) {
+                Text(cityName)
+                    .font(.subheadline.weight(.medium))
+                Image(systemName: "chevron.down")
+                    .font(.caption.weight(.semibold))
+            }
+            .foregroundStyle(.primary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(.regularMaterial, in: Capsule())
+        }
+        .accessibilityLabel(Text(cityName))
+        .accessibilityHint(Text(NSLocalizedString("city.picker.title", comment: "City picker sheet title")))
+    }
+
+    // MARK: - Empty state
+
+    @ViewBuilder
+    private func emptyStateOverlay(viewModel: MapViewModel) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: "mappin.slash")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text(NSLocalizedString("map.empty.title", comment: "No experiences nearby"))
+                .font(.subheadline.weight(.medium))
+            Text(String(
+                format: NSLocalizedString("map.empty.radius", comment: "No experiences within radius"),
+                preferences.maxDistanceKm
+            ))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            VStack(spacing: 8) {
+                Button {
+                    preferences.maxDistanceKm = 25
+                    viewModel.loadNearbyExperiences()
+                    viewModel.updateBottomInfo()
+                } label: {
+                    Text(NSLocalizedString("map.empty.expand", comment: "Expand search radius to 25km"))
+                        .font(.subheadline.weight(.medium))
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+
+                if let nearestCode = viewModel.nearestSeededCity(
+                    to: locationService.currentLocation?.coordinate ?? viewModel.defaultCenterForSelectedCity
+                ),
+                   let nearestCity = viewModel.availableCities.first(where: { $0.code == nearestCode }) {
+                    Button {
+                        viewModel.selectCity(nearestCode)
+                    } label: {
+                        Text(String(
+                            format: NSLocalizedString("map.empty.browse", comment: "Browse nearest city"),
+                            nearestCity.name
+                        ))
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.regular)
+                }
+
+                Button {
+                    viewModel.clearFilters()
+                } label: {
+                    Text(NSLocalizedString("map.empty.clearFilters", comment: "Clear all filters"))
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.regular)
+            }
+        }
+        .padding(16)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
+        .padding(.horizontal, 32)
+        .accessibilityElement(children: .combine)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Changes

### City Switcher (#58)
- Added city pill in the top-left of the map showing the current city (or "All Cities")
- New `CityPickerSheet` with city list, experience counts, and checkmark for selected
- `UserPreferences` now persists `lastSelectedCity` across launches
- `MapViewModel` filters experiences by selected city code
- First-launch auto-shows city picker when no saved city + no GPS
- `nearestSeededCity()` finds the closest city to any coordinate

### Empty-state Fallback (#59)
- Replaced dead-end "No experiences nearby" with actionable overlay
- Shows current radius, offers 3 actions:
  1. **Expand to 25km** — expands search radius
  2. **Browse {city}** — recenters to nearest seeded city
  3. **Clear filters** — removes all active filters

### Files Changed
- `UserPreferences.swift` — added `lastSelectedCity` with backward-compatible decoding
- `MapViewModel.swift` — city selection, filtering, nearest city lookup
- `CityPickerSheet.swift` — new bottom sheet for city selection
- `CompassMapView.swift` — city pill, empty-state actions, first-launch picker
- `Localizable.strings` — 7 new localized strings

Closes #58, closes #59