### PR TITLE
feat(ios): settings, micro-survey, report-issue, check-in banner, device identity

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		56F3055416F4A5316100F9B2 /* ExperienceCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */; };
 		58B7C9B20945838F81081941 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14A22A40550CF207AB36C18 /* SettingsView.swift */; };
 		5C05B87EA78458094612AC01 /* BottomInfoBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13350B81187FB64B252B8A46 /* BottomInfoBar.swift */; };
+		7D2B6DE6C27E0307CA998A5F /* CityPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873ACB737A9B43254C17B238 /* CityPickerSheet.swift */; };
 		86F4628473C2D520D4C2FFFB /* SoloScoreBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB579F3F4EBBA014AA306DD1 /* SoloScoreBadge.swift */; };
 		A84320715E7CBDA91FC3F26F /* ExperienceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */; };
 		AA75B3147A29FDA55E61B24A /* PendingCheckInBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */; };
@@ -24,6 +25,8 @@
 		BD5BB6BD7FCBDB30282F28FA /* VoiceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8ABF85EEFDF9969C94B441 /* VoiceButton.swift */; };
 		C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */; };
 		C2C0AF72D709EDC17C6ED874 /* UserPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63FDD874A8F533F0717132A /* UserPreferences.swift */; };
+		C53DB60CA9E95907A2CBF2C0 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C215AE07BA32182A887226F9 /* NotificationService.swift */; };
+		C81007F6A39364D0872736B2 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C660F7996B1E4387C37720B3 /* OnboardingView.swift */; };
 		CE1A6A1D5EB25B2BEA5B29DA /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFFA243BC698EF20C6BC1EF /* MapViewModel.swift */; };
 		CF8B2BDE6D707CE2537C8688 /* ExperienceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B8BA7FFBD93A01E54B7E4A /* ExperienceDetailView.swift */; };
 		D699D4E3E20FE7A7C0ED7E66 /* AIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4814DBCEAB5975B6338558D /* AIService.swift */; };
@@ -31,10 +34,10 @@
 		E0DDDA434921159DDD70F035 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4442EDB5CE3602DA3EA32725 /* Assets.xcassets */; };
 		E5F463CE3CE822F7F96CA82C /* SoloCompassApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71DE291BE5569E719413B74 /* SoloCompassApp.swift */; };
 		E7B5B022519434F7C07818CF /* ExperienceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F087E4FA7161529378098C /* ExperienceService.swift */; };
+		E881A71769542A7C58CF5D10 /* FavoritesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C3BA25EFA9F149FB4FAAB3 /* FavoritesListView.swift */; };
 		EBE1ACB7D574EE000B028B23 /* SoloCompassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3CB5045CE59A613B5CAAF5 /* SoloCompassTests.swift */; };
 		EF2003CC07F7787C25847BDF /* ReportIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576B08910782A58C3597E596 /* ReportIssueSheet.swift */; };
 		F5677DCF081E506C7E32243F /* VoiceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120FC7465285714C5FA8F96D /* VoiceService.swift */; };
-		3EC7A09FE9C1EC22473F46A6 /* CityPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F46276DB7A174176C81C63 /* CityPickerSheet.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,6 +65,7 @@
 		5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailViewModel.swift; sourceTree = "<group>"; };
 		61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = seed_experiences.json; sourceTree = "<group>"; };
 		6C5CA5533D846B39EF16CDFA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		873ACB737A9B43254C17B238 /* CityPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityPickerSheet.swift; sourceTree = "<group>"; };
 		8FDFA5F3503B8ABC4B5CB086 /* SoloCompassTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SoloCompassTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9945A4E03F4C75ED89674594 /* SoloCompass.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SoloCompass.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9E8ABF85EEFDF9969C94B441 /* VoiceButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceButton.swift; sourceTree = "<group>"; };
@@ -69,6 +73,9 @@
 		BC185539C95D5D940693BCB7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C14A22A40550CF207AB36C18 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		C1C97F8159A6FA7953D28DAB /* Experience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Experience.swift; sourceTree = "<group>"; };
+		C215AE07BA32182A887226F9 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		C5C3BA25EFA9F149FB4FAAB3 /* FavoritesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesListView.swift; sourceTree = "<group>"; };
+		C660F7996B1E4387C37720B3 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIdentityService.swift; sourceTree = "<group>"; };
 		D5B8BA7FFBD93A01E54B7E4A /* ExperienceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailView.swift; sourceTree = "<group>"; };
 		E71DE291BE5569E719413B74 /* SoloCompassApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassApp.swift; sourceTree = "<group>"; };
@@ -78,7 +85,6 @@
 		F4814DBCEAB5975B6338558D /* AIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIService.swift; sourceTree = "<group>"; };
 		F63FDD874A8F533F0717132A /* UserPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPreferences.swift; sourceTree = "<group>"; };
 		FAFFA243BC698EF20C6BC1EF /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
-		03F46276DB7A174176C81C63 /* CityPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityPickerSheet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -87,6 +93,7 @@
 			children = (
 				13350B81187FB64B252B8A46 /* BottomInfoBar.swift */,
 				EC8F9EFD56A2C839428AA92D /* ConfidenceBadge.swift */,
+				C5C3BA25EFA9F149FB4FAAB3 /* FavoritesListView.swift */,
 				130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */,
 				EB579F3F4EBBA014AA306DD1 /* SoloScoreBadge.swift */,
 				9E8ABF85EEFDF9969C94B441 /* VoiceButton.swift */,
@@ -108,9 +115,9 @@
 		2A5B2A9CBB684C51EA76313E /* Map */ = {
 			isa = PBXGroup;
 			children = (
+				873ACB737A9B43254C17B238 /* CityPickerSheet.swift */,
 				BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */,
 				0E0157D30FF53B21FF31D519 /* MarkerIconView.swift */,
-				03F46276DB7A174176C81C63 /* CityPickerSheet.swift */,
 			);
 			path = Map;
 			sourceTree = "<group>";
@@ -179,6 +186,7 @@
 				CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */,
 				12F087E4FA7161529378098C /* ExperienceService.swift */,
 				2C7919EAFDE363B49C4B4C47 /* LocationService.swift */,
+				C215AE07BA32182A887226F9 /* NotificationService.swift */,
 				120FC7465285714C5FA8F96D /* VoiceService.swift */,
 			);
 			path = Services;
@@ -207,6 +215,7 @@
 				0807CE55F43B61AC22836519 /* Experience */,
 				B1E73913322B5353D1A98672 /* Filter */,
 				2A5B2A9CBB684C51EA76313E /* Map */,
+				B7BA8DD4801156B13D7F0C9E /* Onboarding */,
 				8FF93171FFB8E00CD1BDF550 /* Settings */,
 				07C4B3D1D25BE0A78422D951 /* Shared */,
 			);
@@ -238,6 +247,14 @@
 				3C9A1F22AAE512199548C269 /* FilterBarView.swift */,
 			);
 			path = Filter;
+			sourceTree = "<group>";
+		};
+		B7BA8DD4801156B13D7F0C9E /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				C660F7996B1E4387C37720B3 /* OnboardingView.swift */,
+			);
+			path = Onboarding;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -346,6 +363,7 @@
 			files = (
 				D699D4E3E20FE7A7C0ED7E66 /* AIService.swift in Sources */,
 				5C05B87EA78458094612AC01 /* BottomInfoBar.swift in Sources */,
+				7D2B6DE6C27E0307CA998A5F /* CityPickerSheet.swift in Sources */,
 				C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */,
 				240FFFC4A2B2B8F941129783 /* ConfidenceBadge.swift in Sources */,
 				42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */,
@@ -354,12 +372,14 @@
 				CF8B2BDE6D707CE2537C8688 /* ExperienceDetailView.swift in Sources */,
 				A84320715E7CBDA91FC3F26F /* ExperienceDetailViewModel.swift in Sources */,
 				E7B5B022519434F7C07818CF /* ExperienceService.swift in Sources */,
+				E881A71769542A7C58CF5D10 /* FavoritesListView.swift in Sources */,
 				297541149234668D12EAF272 /* FilterBarView.swift in Sources */,
 				31F9538643C362D7EEF64C6B /* LocationService.swift in Sources */,
 				CE1A6A1D5EB25B2BEA5B29DA /* MapViewModel.swift in Sources */,
 				28E3EB1BFFB0A73A1C56FD54 /* MarkerIconView.swift in Sources */,
-				3EC7A09FE9C1EC22473F46A6 /* CityPickerSheet.swift in Sources */,
 				214AF641496E8E50E3EC5FE4 /* MicroSurveySheet.swift in Sources */,
+				C53DB60CA9E95907A2CBF2C0 /* NotificationService.swift in Sources */,
+				C81007F6A39364D0872736B2 /* OnboardingView.swift in Sources */,
 				AA75B3147A29FDA55E61B24A /* PendingCheckInBanner.swift in Sources */,
 				EF2003CC07F7787C25847BDF /* ReportIssueSheet.swift in Sources */,
 				58B7C9B20945838F81081941 /* SettingsView.swift in Sources */,

--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -8,14 +8,18 @@
 
 /* Begin PBXBuildFile section */
 		0A830B26D4A18948D16F3A42 /* Experience.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C97F8159A6FA7953D28DAB /* Experience.swift */; };
+		214AF641496E8E50E3EC5FE4 /* MicroSurveySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA6E405C780A5A12A9FC1D6 /* MicroSurveySheet.swift */; };
 		240FFFC4A2B2B8F941129783 /* ConfidenceBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8F9EFD56A2C839428AA92D /* ConfidenceBadge.swift */; };
 		28E3EB1BFFB0A73A1C56FD54 /* MarkerIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E0157D30FF53B21FF31D519 /* MarkerIconView.swift */; };
 		297541149234668D12EAF272 /* FilterBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9A1F22AAE512199548C269 /* FilterBarView.swift */; };
 		31F9538643C362D7EEF64C6B /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7919EAFDE363B49C4B4C47 /* LocationService.swift */; };
+		42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */; };
 		56F3055416F4A5316100F9B2 /* ExperienceCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */; };
+		58B7C9B20945838F81081941 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14A22A40550CF207AB36C18 /* SettingsView.swift */; };
 		5C05B87EA78458094612AC01 /* BottomInfoBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13350B81187FB64B252B8A46 /* BottomInfoBar.swift */; };
 		86F4628473C2D520D4C2FFFB /* SoloScoreBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB579F3F4EBBA014AA306DD1 /* SoloScoreBadge.swift */; };
 		A84320715E7CBDA91FC3F26F /* ExperienceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */; };
+		AA75B3147A29FDA55E61B24A /* PendingCheckInBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */; };
 		BAC775E6105DD571F71ACBC1 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 80020844C0A45A5993333741 /* Localizable.strings */; };
 		BD5BB6BD7FCBDB30282F28FA /* VoiceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8ABF85EEFDF9969C94B441 /* VoiceButton.swift */; };
 		C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */; };
@@ -28,6 +32,7 @@
 		E5F463CE3CE822F7F96CA82C /* SoloCompassApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71DE291BE5569E719413B74 /* SoloCompassApp.swift */; };
 		E7B5B022519434F7C07818CF /* ExperienceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F087E4FA7161529378098C /* ExperienceService.swift */; };
 		EBE1ACB7D574EE000B028B23 /* SoloCompassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3CB5045CE59A613B5CAAF5 /* SoloCompassTests.swift */; };
+		EF2003CC07F7787C25847BDF /* ReportIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576B08910782A58C3597E596 /* ReportIssueSheet.swift */; };
 		F5677DCF081E506C7E32243F /* VoiceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120FC7465285714C5FA8F96D /* VoiceService.swift */; };
 		3EC7A09FE9C1EC22473F46A6 /* CityPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F46276DB7A174176C81C63 /* CityPickerSheet.swift */; };
 /* End PBXBuildFile section */
@@ -46,11 +51,14 @@
 		0E0157D30FF53B21FF31D519 /* MarkerIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerIconView.swift; sourceTree = "<group>"; };
 		120FC7465285714C5FA8F96D /* VoiceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceService.swift; sourceTree = "<group>"; };
 		12F087E4FA7161529378098C /* ExperienceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceService.swift; sourceTree = "<group>"; };
+		130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingCheckInBanner.swift; sourceTree = "<group>"; };
 		13350B81187FB64B252B8A46 /* BottomInfoBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomInfoBar.swift; sourceTree = "<group>"; };
 		2C7919EAFDE363B49C4B4C47 /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
+		2DA6E405C780A5A12A9FC1D6 /* MicroSurveySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicroSurveySheet.swift; sourceTree = "<group>"; };
 		363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceCardView.swift; sourceTree = "<group>"; };
 		3C9A1F22AAE512199548C269 /* FilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarView.swift; sourceTree = "<group>"; };
 		4442EDB5CE3602DA3EA32725 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		576B08910782A58C3597E596 /* ReportIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportIssueSheet.swift; sourceTree = "<group>"; };
 		5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailViewModel.swift; sourceTree = "<group>"; };
 		61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = seed_experiences.json; sourceTree = "<group>"; };
 		6C5CA5533D846B39EF16CDFA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -59,7 +67,9 @@
 		9E8ABF85EEFDF9969C94B441 /* VoiceButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceButton.swift; sourceTree = "<group>"; };
 		BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompassMapView.swift; sourceTree = "<group>"; };
 		BC185539C95D5D940693BCB7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		C14A22A40550CF207AB36C18 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		C1C97F8159A6FA7953D28DAB /* Experience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Experience.swift; sourceTree = "<group>"; };
+		CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIdentityService.swift; sourceTree = "<group>"; };
 		D5B8BA7FFBD93A01E54B7E4A /* ExperienceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailView.swift; sourceTree = "<group>"; };
 		E71DE291BE5569E719413B74 /* SoloCompassApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassApp.swift; sourceTree = "<group>"; };
 		EB579F3F4EBBA014AA306DD1 /* SoloScoreBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloScoreBadge.swift; sourceTree = "<group>"; };
@@ -77,6 +87,7 @@
 			children = (
 				13350B81187FB64B252B8A46 /* BottomInfoBar.swift */,
 				EC8F9EFD56A2C839428AA92D /* ConfidenceBadge.swift */,
+				130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */,
 				EB579F3F4EBBA014AA306DD1 /* SoloScoreBadge.swift */,
 				9E8ABF85EEFDF9969C94B441 /* VoiceButton.swift */,
 			);
@@ -88,6 +99,8 @@
 			children = (
 				363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */,
 				D5B8BA7FFBD93A01E54B7E4A /* ExperienceDetailView.swift */,
+				2DA6E405C780A5A12A9FC1D6 /* MicroSurveySheet.swift */,
+				576B08910782A58C3597E596 /* ReportIssueSheet.swift */,
 			);
 			path = Experience;
 			sourceTree = "<group>";
@@ -163,6 +176,7 @@
 			isa = PBXGroup;
 			children = (
 				F4814DBCEAB5975B6338558D /* AIService.swift */,
+				CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */,
 				12F087E4FA7161529378098C /* ExperienceService.swift */,
 				2C7919EAFDE363B49C4B4C47 /* LocationService.swift */,
 				120FC7465285714C5FA8F96D /* VoiceService.swift */,
@@ -179,12 +193,21 @@
 			);
 			sourceTree = "<group>";
 		};
+		8FF93171FFB8E00CD1BDF550 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				C14A22A40550CF207AB36C18 /* SettingsView.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
 		993B6773487C7744097F4175 /* Views */ = {
 			isa = PBXGroup;
 			children = (
 				0807CE55F43B61AC22836519 /* Experience */,
 				B1E73913322B5353D1A98672 /* Filter */,
 				2A5B2A9CBB684C51EA76313E /* Map */,
+				8FF93171FFB8E00CD1BDF550 /* Settings */,
 				07C4B3D1D25BE0A78422D951 /* Shared */,
 			);
 			path = Views;
@@ -325,6 +348,7 @@
 				5C05B87EA78458094612AC01 /* BottomInfoBar.swift in Sources */,
 				C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */,
 				240FFFC4A2B2B8F941129783 /* ConfidenceBadge.swift in Sources */,
+				42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */,
 				0A830B26D4A18948D16F3A42 /* Experience.swift in Sources */,
 				56F3055416F4A5316100F9B2 /* ExperienceCardView.swift in Sources */,
 				CF8B2BDE6D707CE2537C8688 /* ExperienceDetailView.swift in Sources */,
@@ -335,6 +359,10 @@
 				CE1A6A1D5EB25B2BEA5B29DA /* MapViewModel.swift in Sources */,
 				28E3EB1BFFB0A73A1C56FD54 /* MarkerIconView.swift in Sources */,
 				3EC7A09FE9C1EC22473F46A6 /* CityPickerSheet.swift in Sources */,
+				214AF641496E8E50E3EC5FE4 /* MicroSurveySheet.swift in Sources */,
+				AA75B3147A29FDA55E61B24A /* PendingCheckInBanner.swift in Sources */,
+				EF2003CC07F7787C25847BDF /* ReportIssueSheet.swift in Sources */,
+				58B7C9B20945838F81081941 /* SettingsView.swift in Sources */,
 				E5F463CE3CE822F7F96CA82C /* SoloCompassApp.swift in Sources */,
 				86F4628473C2D520D4C2FFFB /* SoloScoreBadge.swift in Sources */,
 				C2C0AF72D709EDC17C6ED874 /* UserPreferences.swift in Sources */,
@@ -433,7 +461,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 1.0.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -519,7 +547,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 1.0.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;

--- a/apps/ios/SoloCompass/App/SoloCompassApp.swift
+++ b/apps/ios/SoloCompass/App/SoloCompassApp.swift
@@ -6,6 +6,7 @@ struct SoloCompassApp: App {
     @State private var experienceService = ExperienceService()
     @State private var aiService = AIService()
     @State private var preferences = UserPreferences()
+    @State private var notificationService = NotificationService.shared
 
     var body: some Scene {
         WindowGroup {
@@ -14,9 +15,13 @@ struct SoloCompassApp: App {
                 .environment(experienceService)
                 .environment(aiService)
                 .environment(preferences)
+                .environment(notificationService)
                 .onAppear {
                     locationService.preferences = preferences
+                    locationService.notificationService = notificationService
                     locationService.requestPermission()
+                    preferences.pruneStaleCheckIns()
+                    Task { await notificationService.checkAuthorizationStatus() }
                 }
         }
     }

--- a/apps/ios/SoloCompass/Models/UserPreferences.swift
+++ b/apps/ios/SoloCompass/Models/UserPreferences.swift
@@ -23,13 +23,19 @@ public final class UserPreferences {
         var visitHistory: [String: Date] = [:]
         var completedExperiences: Set<String> = []
         var favoritedExperiences: Set<String> = []
+        var favoritedAt: [String: Date] = [:]
         var pendingCheckIns: [String: Date] = [:]
         var lastSelectedCity: String? = nil
+        var hasCompletedOnboarding: Bool = false
+        var notificationsEnabled: Bool = false
+        var quietHoursStart: Int = 22
+        var quietHoursEnd: Int = 8
 
         enum CodingKeys: String, CodingKey {
             case preferredCategories, dislikedCategories, soloTravelStyle, maxDistanceKm
-            case visitHistory, completedExperiences, favoritedExperiences, pendingCheckIns
-            case lastSelectedCity
+            case visitHistory, completedExperiences, favoritedExperiences, favoritedAt, pendingCheckIns
+            case lastSelectedCity, hasCompletedOnboarding, notificationsEnabled
+            case quietHoursStart, quietHoursEnd
         }
 
         init() {}
@@ -42,8 +48,13 @@ public final class UserPreferences {
             visitHistory: [String: Date],
             completedExperiences: Set<String>,
             favoritedExperiences: Set<String>,
+            favoritedAt: [String: Date],
             pendingCheckIns: [String: Date],
-            lastSelectedCity: String?
+            lastSelectedCity: String?,
+            hasCompletedOnboarding: Bool,
+            notificationsEnabled: Bool,
+            quietHoursStart: Int,
+            quietHoursEnd: Int
         ) {
             self.preferredCategories = preferredCategories
             self.dislikedCategories = dislikedCategories
@@ -52,8 +63,13 @@ public final class UserPreferences {
             self.visitHistory = visitHistory
             self.completedExperiences = completedExperiences
             self.favoritedExperiences = favoritedExperiences
+            self.favoritedAt = favoritedAt
             self.pendingCheckIns = pendingCheckIns
             self.lastSelectedCity = lastSelectedCity
+            self.hasCompletedOnboarding = hasCompletedOnboarding
+            self.notificationsEnabled = notificationsEnabled
+            self.quietHoursStart = quietHoursStart
+            self.quietHoursEnd = quietHoursEnd
         }
 
         init(from decoder: Decoder) throws {
@@ -65,8 +81,13 @@ public final class UserPreferences {
             self.visitHistory = try c.decodeIfPresent([String: Date].self, forKey: .visitHistory) ?? [:]
             self.completedExperiences = try c.decodeIfPresent(Set<String>.self, forKey: .completedExperiences) ?? []
             self.favoritedExperiences = try c.decodeIfPresent(Set<String>.self, forKey: .favoritedExperiences) ?? []
+            self.favoritedAt = try c.decodeIfPresent([String: Date].self, forKey: .favoritedAt) ?? [:]
             self.pendingCheckIns = try c.decodeIfPresent([String: Date].self, forKey: .pendingCheckIns) ?? [:]
             self.lastSelectedCity = try c.decodeIfPresent(String.self, forKey: .lastSelectedCity)
+            self.hasCompletedOnboarding = try c.decodeIfPresent(Bool.self, forKey: .hasCompletedOnboarding) ?? false
+            self.notificationsEnabled = try c.decodeIfPresent(Bool.self, forKey: .notificationsEnabled) ?? false
+            self.quietHoursStart = try c.decodeIfPresent(Int.self, forKey: .quietHoursStart) ?? 22
+            self.quietHoursEnd = try c.decodeIfPresent(Int.self, forKey: .quietHoursEnd) ?? 8
         }
     }
 
@@ -77,8 +98,13 @@ public final class UserPreferences {
     public var visitHistory: [String: Date] { didSet { persist() } }
     public var completedExperiences: Set<String> { didSet { persist() } }
     public var favoritedExperiences: Set<String> { didSet { persist() } }
+    public var favoritedAt: [String: Date] { didSet { persist() } }
     public var pendingCheckIns: [String: Date] { didSet { persist() } }
     public var lastSelectedCity: String? { didSet { persist() } }
+    public var hasCompletedOnboarding: Bool { didSet { persist() } }
+    public var notificationsEnabled: Bool { didSet { persist() } }
+    public var quietHoursStart: Int { didSet { persist() } }
+    public var quietHoursEnd: Int { didSet { persist() } }
 
     private static let storageKey = "com.solocompass.userPreferences.v1"
     private let defaults: UserDefaults
@@ -93,8 +119,13 @@ public final class UserPreferences {
         self.visitHistory = snapshot.visitHistory
         self.completedExperiences = snapshot.completedExperiences
         self.favoritedExperiences = snapshot.favoritedExperiences
+        self.favoritedAt = snapshot.favoritedAt
         self.pendingCheckIns = snapshot.pendingCheckIns
         self.lastSelectedCity = snapshot.lastSelectedCity
+        self.hasCompletedOnboarding = snapshot.hasCompletedOnboarding
+        self.notificationsEnabled = snapshot.notificationsEnabled
+        self.quietHoursStart = snapshot.quietHoursStart
+        self.quietHoursEnd = snapshot.quietHoursEnd
     }
 
     private static func load(from defaults: UserDefaults) -> Snapshot {
@@ -118,8 +149,13 @@ public final class UserPreferences {
             visitHistory: visitHistory,
             completedExperiences: completedExperiences,
             favoritedExperiences: favoritedExperiences,
+            favoritedAt: favoritedAt,
             pendingCheckIns: pendingCheckIns,
-            lastSelectedCity: lastSelectedCity
+            lastSelectedCity: lastSelectedCity,
+            hasCompletedOnboarding: hasCompletedOnboarding,
+            notificationsEnabled: notificationsEnabled,
+            quietHoursStart: quietHoursStart,
+            quietHoursEnd: quietHoursEnd
         )
         do {
             let data = try JSONEncoder.iso8601Encoder.encode(snapshot)
@@ -138,11 +174,35 @@ public final class UserPreferences {
         visitHistory[id] = date
     }
 
-    public func toggleFavorite(_ id: String) {
+    public func toggleFavorite(_ id: String, at date: Date = Date()) {
         if favoritedExperiences.contains(id) {
             favoritedExperiences.remove(id)
+            favoritedAt.removeValue(forKey: id)
         } else {
             favoritedExperiences.insert(id)
+            favoritedAt[id] = date
+        }
+    }
+
+    public func completeOnboarding() {
+        hasCompletedOnboarding = true
+    }
+
+    /// Auto-clear pending check-ins older than 7 days.
+    public func pruneStaleCheckIns(olderThan days: Int = 7) {
+        let cutoff = Date().addingTimeInterval(Double(-days) * 86_400)
+        for (id, date) in pendingCheckIns where date < cutoff {
+            pendingCheckIns.removeValue(forKey: id)
+        }
+    }
+
+    /// True if current hour is inside the quiet-hours window.
+    public var isQuietHours: Bool {
+        let hour = Calendar.current.component(.hour, from: Date())
+        if quietHoursStart > quietHoursEnd {
+            return hour >= quietHoursStart || hour < quietHoursEnd
+        } else {
+            return hour >= quietHoursStart && hour < quietHoursEnd
         }
     }
 

--- a/apps/ios/SoloCompass/Resources/Info.plist
+++ b/apps/ios/SoloCompass/Resources/Info.plist
@@ -22,12 +22,18 @@
 	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Solo Compass uses background location to alert you when you're near a place worth visiting — even when the app is closed.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Solo Compass uses your location to show experiences near you on the map.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Solo Compass uses the microphone for voice search.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Solo Compass uses speech recognition so you can describe what you're looking for by voice.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -132,3 +132,74 @@
 "voice.error.title" = "Voice recognition error";
 "voice.error.permission" = "Microphone or speech recognition permission was denied. Please allow access in Settings.";
 "voice.error.unavailable" = "Speech recognition is unavailable on this device.";
+
+/* Settings */
+"settings.title" = "Preferences";
+"settings.done" = "Done";
+"settings.travelStyle" = "Travel Style";
+"settings.travelStyle.footer" = "Your style shapes which experiences float to the top.";
+"settings.preferences" = "Category Preferences";
+"settings.preferences.footer" = "Tap to love a category. Swipe left to hide it.";
+"settings.hidden" = "Hidden Categories";
+"settings.hide" = "Hide";
+"settings.maxDistance" = "Max Distance";
+"settings.distance" = "Discovery Radius";
+"settings.distance.footer" = "Only experiences within this radius appear on the map.";
+"settings.completed" = "Completed";
+"settings.favorites" = "Favorites";
+"settings.stats" = "Your Journey";
+
+/* Travel styles */
+"style.explorer.title" = "Explorer";
+"style.explorer.description" = "I wander and discover — surprise me";
+"style.worker.title" = "Remote Worker";
+"style.worker.description" = "I need quiet spots with good WiFi";
+"style.foodie.title" = "Foodie";
+"style.foodie.description" = "Great meals and coffee are my priority";
+"style.cultureSeeker.title" = "Culture Seeker";
+"style.cultureSeeker.description" = "History, temples, ceremonies, hidden layers";
+
+/* MicroSurvey */
+"survey.title" = "Quick check-in";
+"survey.comfort.question" = "How comfortable did you feel as a solo traveler?";
+"survey.comfort.1" = "Very uncomfortable";
+"survey.comfort.2" = "Slightly uncomfortable";
+"survey.comfort.3" = "Neutral";
+"survey.comfort.4" = "Comfortable";
+"survey.comfort.5" = "Very comfortable";
+"survey.pressure.question" = "How pushy was the staff / vendors? (more stars = less pressure)";
+"survey.pressure.1" = "Very pushy";
+"survey.pressure.2" = "Somewhat pushy";
+"survey.pressure.3" = "Neutral";
+"survey.pressure.4" = "Relaxed vibe";
+"survey.pressure.5" = "No pressure at all";
+"survey.recommend.question" = "Would you recommend this to another solo traveler?";
+"survey.recommend.yes" = "Yes";
+"survey.recommend.depends" = "Depends";
+"survey.recommend.no" = "No";
+"survey.submit" = "Send feedback";
+"survey.skip" = "Skip";
+"survey.stars" = "stars";
+
+/* ReportIssue */
+"report.title" = "Report an Issue";
+"report.cancel" = "Cancel";
+"report.submit" = "Submit";
+"report.reason.header" = "What's wrong?";
+"report.detail.header" = "Additional details (optional)";
+"report.detail.placeholder" = "Add more context… (200 chars max)";
+"report.reason.closed_permanently" = "Permanently closed";
+"report.reason.moved" = "It has moved";
+"report.reason.hours_wrong" = "Hours are wrong";
+"report.reason.vibe_different" = "Vibe is very different";
+"report.reason.factually_wrong" = "Factually incorrect";
+"report.reason.other" = "Something else";
+
+/* Pending check-in banner */
+"checkin.banner.title" = "Did you visit?";
+"checkin.banner.yes" = "Yes!";
+"checkin.banner.a11y" = "Did you visit %@?";
+
+/* Experience detail overflow */
+"detail.report" = "Report an issue";
+"detail.more" = "More options";

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -203,3 +203,32 @@
 /* Experience detail overflow */
 "detail.report" = "Report an issue";
 "detail.more" = "More options";
+
+/* Onboarding */
+"onboarding.welcome.title" = "Places worth being alone.";
+"onboarding.welcome.subtitle" = "A map of things worth doing solo, wherever you are.";
+"onboarding.welcome.cta" = "Find me on the map";
+"onboarding.welcome.skip" = "Browse first";
+"onboarding.style.title" = "How do you travel?";
+"onboarding.style.subtitle" = "This shapes which experiences float to the top. You can change it anytime.";
+"onboarding.style.cta" = "Start exploring";
+"onboarding.style.skip" = "Decide later";
+
+/* Favorites list */
+"favorites.title" = "Favorites";
+"favorites.empty.title" = "No favorites yet";
+"favorites.empty.hint" = "Tap the heart on any experience to save it here.";
+
+/* Notifications */
+"settings.notifications" = "Notify me when I'm nearby";
+"settings.notifications.header" = "Notifications";
+"settings.notifications.footer" = "Solo Compass sends a quiet nudge when you walk past a saved experience. No marketing, ever.";
+"notification.checkin.title" = "You're nearby";
+"notification.checkin.body" = "You're standing near %@. Want to check it out?";
+
+/* Settings data */
+"settings.data.header" = "My Data";
+"settings.clearData" = "Clear all data";
+"settings.clearData.confirm.title" = "Clear all data?";
+"settings.clearData.confirm.action" = "Clear everything";
+"settings.clearData.confirm.message" = "This removes your completed experiences, favorites, and preferences. It cannot be undone.";

--- a/apps/ios/SoloCompass/Services/DeviceIdentityService.swift
+++ b/apps/ios/SoloCompass/Services/DeviceIdentityService.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Security
+
+/// Generates and persists an anonymous device UUID in the iOS Keychain (US-038).
+/// The UUID is created once, never changes, and survives app reinstalls on the
+/// same device (Keychain is not wiped on uninstall by default).
+///
+/// Attach the ID as `X-Device-ID` on every outbound API request via
+/// `URLRequest.attachDeviceID()`.
+@MainActor
+public final class DeviceIdentityService {
+    public static let shared = DeviceIdentityService()
+
+    private let keychainService = "com.solocompass.device"
+    private let keychainAccount = "device-id"
+
+    private init() {}
+
+    /// Returns the stable anonymous device UUID, creating it on first call.
+    public var deviceID: String {
+        if let existing = readFromKeychain() { return existing }
+        let new = UUID().uuidString
+        writeToKeychain(new)
+        return new
+    }
+
+    // MARK: - Keychain
+
+    private func readFromKeychain() -> String? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: keychainService,
+            kSecAttrAccount: keychainAccount,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne,
+        ]
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private func writeToKeychain(_ value: String) {
+        guard let data = value.data(using: .utf8) else { return }
+        let addQuery: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: keychainService,
+            kSecAttrAccount: keychainAccount,
+            kSecValueData: data,
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        if status == errSecDuplicateItem {
+            let updateQuery: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: keychainService,
+                kSecAttrAccount: keychainAccount,
+            ]
+            SecItemUpdate(updateQuery as CFDictionary, [kSecValueData: data] as CFDictionary)
+        }
+    }
+}
+
+// MARK: - URLRequest convenience
+
+extension URLRequest {
+    /// Attaches the anonymous device ID as `X-Device-ID`. Call on every outbound API request.
+    @MainActor
+    mutating func attachDeviceID() {
+        setValue(DeviceIdentityService.shared.deviceID, forHTTPHeaderField: "X-Device-ID")
+    }
+}

--- a/apps/ios/SoloCompass/Services/LocationService.swift
+++ b/apps/ios/SoloCompass/Services/LocationService.swift
@@ -15,6 +15,7 @@ public final class LocationService: NSObject {
     /// Optional preferences sink — when set, geofence enter events record
     /// pending check-ins so the app can prompt the user later.
     public weak var preferences: UserPreferences?
+    public weak var notificationService: NotificationService?
     public var onRegionEnter: ((String) -> Void)?
     public var onRegionExit: ((String) -> Void)?
 
@@ -39,8 +40,13 @@ public final class LocationService: NSObject {
         switch manager.authorizationStatus {
         case .notDetermined:
             manager.requestWhenInUseAuthorization()
-        case .authorizedWhenInUse, .authorizedAlways:
+        case .authorizedWhenInUse:
+            // Two-step pattern required by Apple: WhenInUse must be granted before requesting Always.
+            manager.requestAlwaysAuthorization()
             startUpdating()
+        case .authorizedAlways:
+            startUpdating()
+            enableBackgroundUpdates()
         default:
             break
         }
@@ -51,6 +57,11 @@ public final class LocationService: NSObject {
             return
         }
         manager.startUpdatingLocation()
+    }
+
+    private func enableBackgroundUpdates() {
+        manager.allowsBackgroundLocationUpdates = true
+        manager.pausesLocationUpdatesAutomatically = true
     }
 
     public func stopUpdating() {
@@ -114,8 +125,14 @@ extension LocationService: CLLocationManagerDelegate {
         let status = manager.authorizationStatus
         Task { @MainActor in
             self.authorizationStatus = status
-            if status == .authorizedWhenInUse || status == .authorizedAlways {
+            switch status {
+            case .authorizedAlways:
                 self.startUpdating()
+                self.enableBackgroundUpdates()
+            case .authorizedWhenInUse:
+                self.startUpdating()
+            default:
+                break
             }
         }
     }
@@ -135,9 +152,17 @@ extension LocationService: CLLocationManagerDelegate {
 
     public func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
         guard monitoredIdentifiers.contains(region.identifier) else { return }
+        let expTitle = monitoredVisits[region.identifier]?.title ?? region.identifier
         Task { @MainActor in
             self.preferences?.recordPendingCheckIn(region.identifier)
             self.onRegionEnter?(region.identifier)
+            if let prefs = self.preferences, let ns = self.notificationService {
+                await ns.scheduleCheckInPrompt(
+                    experienceId: region.identifier,
+                    experienceTitle: expTitle,
+                    preferences: prefs
+                )
+            }
         }
     }
 

--- a/apps/ios/SoloCompass/Services/NotificationService.swift
+++ b/apps/ios/SoloCompass/Services/NotificationService.swift
@@ -1,0 +1,91 @@
+import Foundation
+import UserNotifications
+
+/// Manages local push notifications for geofence-triggered check-in prompts.
+/// No APNs server required — all notifications are local.
+@MainActor
+@Observable
+public final class NotificationService {
+    public static let shared = NotificationService()
+
+    public private(set) var isAuthorized: Bool = false
+
+    private let center = UNUserNotificationCenter.current()
+
+    private init() {}
+
+    // MARK: - Authorization
+
+    public func requestAuthorization() async {
+        do {
+            let granted = try await center.requestAuthorization(options: [.alert, .sound, .badge])
+            isAuthorized = granted
+        } catch {
+            isAuthorized = false
+        }
+    }
+
+    public func checkAuthorizationStatus() async {
+        let settings = await center.notificationSettings()
+        isAuthorized = settings.authorizationStatus == .authorized
+    }
+
+    // MARK: - Scheduling
+
+    /// Schedule a local notification prompting a check-in.
+    /// Respects `preferences.isQuietHours` — delays to morning if quiet hours are active.
+    public func scheduleCheckInPrompt(
+        experienceId: String,
+        experienceTitle: String,
+        preferences: UserPreferences
+    ) async {
+        guard isAuthorized, preferences.notificationsEnabled else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = NSLocalizedString("notification.checkin.title", comment: "Check-in notification title")
+        content.body = String(
+            format: NSLocalizedString("notification.checkin.body", comment: "Check-in notification body"),
+            experienceTitle
+        )
+        content.sound = .default
+        content.userInfo = ["experienceId": experienceId]
+
+        let identifier = "checkin-\(experienceId)"
+        await center.removePendingNotificationRequests(withIdentifiers: [identifier])
+
+        let delay: TimeInterval = preferences.isQuietHours
+            ? secondsUntilMorning(quietHoursEnd: preferences.quietHoursEnd)
+            : 3
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: max(1, delay), repeats: false)
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+
+        do {
+            try await center.add(request)
+        } catch {
+            // Non-critical — the in-app banner is the primary check-in UI.
+        }
+    }
+
+    /// Remove a pending notification once the user has already acted via the in-app banner.
+    public func cancelCheckInNotification(for experienceId: String) async {
+        let identifier = "checkin-\(experienceId)"
+        await center.removePendingNotificationRequests(withIdentifiers: [identifier])
+    }
+
+    // MARK: - Helpers
+
+    private func secondsUntilMorning(quietHoursEnd: Int) -> TimeInterval {
+        let cal = Calendar.current
+        let now = Date()
+        var components = cal.dateComponents([.year, .month, .day], from: now)
+        components.hour = quietHoursEnd
+        components.minute = 0
+        components.second = 0
+        if let morning = cal.date(from: components) {
+            let diff = morning.timeIntervalSince(now)
+            return diff > 0 ? diff : diff + 86_400
+        }
+        return Double(quietHoursEnd) * 3600
+    }
+}

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -134,6 +134,40 @@ public final class MapViewModel {
     // True when a "Now" filter is active (best-now experiences only).
     public var isNowFilter: Bool = false
 
+    // MARK: - Settings
+
+    public var isShowingSettings: Bool = false
+
+    // MARK: - Pending check-in
+
+    /// Non-nil while a geofence-triggered check-in prompt is pending.
+    public var pendingCheckIn: (id: String, title: String)?
+
+    /// Call on appear and when preferences.pendingCheckIns changes.
+    public func checkForPendingCheckIns() {
+        guard pendingCheckIn == nil,
+              let (id, _) = preferences.pendingCheckIns.first else { return }
+        let title = visibleExperiences.first { $0.id == id }?.title
+            ?? experienceService.getExperience(id: id)?.title
+            ?? id
+        pendingCheckIn = (id: id, title: title)
+    }
+
+    public func confirmCheckIn() {
+        guard let pending = pendingCheckIn else { return }
+        preferences.markCompleted(pending.id)
+        preferences.clearPendingCheckIn(pending.id)
+        pendingCheckIn = nil
+        checkForPendingCheckIns()
+    }
+
+    public func dismissCheckIn() {
+        guard let pending = pendingCheckIn else { return }
+        preferences.clearPendingCheckIn(pending.id)
+        pendingCheckIn = nil
+        checkForPendingCheckIns()
+    }
+
     // MARK: - Add-experience flow (long-press on map)
 
     /// Coordinate the user long-pressed; non-nil while we're prompting to confirm.

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -6,10 +6,18 @@ import SwiftUI
 public struct ExperienceDetailView: View {
     @State var viewModel: ExperienceDetailViewModel
     var onClose: () -> Void
+    var onMarkDone: ((_ experience: Experience) -> Void)?
 
-    public init(viewModel: ExperienceDetailViewModel, onClose: @escaping () -> Void = {}) {
+    @State private var isShowingReport: Bool = false
+
+    public init(
+        viewModel: ExperienceDetailViewModel,
+        onClose: @escaping () -> Void = {},
+        onMarkDone: ((_ experience: Experience) -> Void)? = nil
+    ) {
         self.viewModel = viewModel
         self.onClose = onClose
+        self.onMarkDone = onMarkDone
     }
 
     public var body: some View {
@@ -50,6 +58,28 @@ public struct ExperienceDetailView: View {
                 }
                 .accessibilityLabel(Text(NSLocalizedString("action.close", comment: "Close detail sheet")))
             }
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    Button(role: .destructive) {
+                        isShowingReport = true
+                    } label: {
+                        Label(
+                            NSLocalizedString("detail.report", comment: "Report an issue"),
+                            systemImage: "exclamationmark.triangle"
+                        )
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+                .accessibilityLabel(Text(NSLocalizedString("detail.more", comment: "More options")))
+            }
+        }
+        .sheet(isPresented: $isShowingReport) {
+            ReportIssueSheet(
+                experience: viewModel.experience,
+                onSubmit: { _, _ in isShowingReport = false },
+                onCancel: { isShowingReport = false }
+            )
         }
         .task { await viewModel.loadAIExplanation() }
     }
@@ -261,8 +291,13 @@ public struct ExperienceDetailView: View {
                 : NSLocalizedString("action.favorite", comment: "Add favorite")))
 
             Button {
+                let wasCompleted = viewModel.isCompleted
                 viewModel.toggleComplete()
                 UINotificationFeedbackGenerator().notificationOccurred(.success)
+                // Show micro-survey only when marking done (not when un-marking).
+                if !wasCompleted {
+                    onMarkDone?(viewModel.experience)
+                }
             } label: {
                 HStack {
                     Image(systemName: viewModel.isCompleted ? "checkmark.circle.fill" : "checkmark.circle")

--- a/apps/ios/SoloCompass/Views/Experience/MicroSurveySheet.swift
+++ b/apps/ios/SoloCompass/Views/Experience/MicroSurveySheet.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+
+/// Three-question post-visit survey shown after marking an experience complete.
+/// Signals feed back into soloScore recomputation (US-031/032).
+/// The user can always skip — we never block navigation on survey completion.
+public struct MicroSurveySheet: View {
+    let experience: Experience
+    var onSubmit: (_ comfort: Int, _ staffPressure: Int, _ recommend: SurveyRecommend) -> Void
+    var onSkip: () -> Void
+
+    public enum SurveyRecommend: String, CaseIterable {
+        case yes, depends, no
+
+        var label: String {
+            switch self {
+            case .yes:     return NSLocalizedString("survey.recommend.yes", comment: "Yes")
+            case .depends: return NSLocalizedString("survey.recommend.depends", comment: "Depends")
+            case .no:      return NSLocalizedString("survey.recommend.no", comment: "No")
+            }
+        }
+        var symbol: String {
+            switch self {
+            case .yes:     return "hand.thumbsup.fill"
+            case .depends: return "hand.wave.fill"
+            case .no:      return "hand.thumbsdown.fill"
+            }
+        }
+        var color: Color {
+            switch self {
+            case .yes:     return .green
+            case .depends: return .orange
+            case .no:      return .red
+            }
+        }
+    }
+
+    @State private var comfort: Int = 3
+    @State private var staffPressure: Int = 3
+    @State private var recommend: SurveyRecommend = .yes
+
+    public init(
+        experience: Experience,
+        onSubmit: @escaping (_ comfort: Int, _ staffPressure: Int, _ recommend: SurveyRecommend) -> Void,
+        onSkip: @escaping () -> Void
+    ) {
+        self.experience = experience
+        self.onSubmit = onSubmit
+        self.onSkip = onSkip
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            RoundedRectangle(cornerRadius: 3)
+                .fill(Color(.systemGray4))
+                .frame(width: 36, height: 5)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 28) {
+                    headerSection
+                    comfortQuestion
+                    staffPressureQuestion
+                    recommendQuestion
+                    actionButtons
+                }
+                .padding(.horizontal, 24)
+                .padding(.top, 8)
+                .padding(.bottom, 40)
+            }
+        }
+        .background(Color(.systemBackground))
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.hidden)
+    }
+
+    // MARK: - Sections
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(NSLocalizedString("survey.title", comment: "Quick check-in"))
+                .font(.title3.bold())
+            Text(experience.title)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+    }
+
+    private var comfortQuestion: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(NSLocalizedString("survey.comfort.question",
+                                   comment: "How comfortable did you feel as a solo traveler?"))
+                .font(.subheadline.weight(.medium))
+            StarRatingRow(value: $comfort, max: 5)
+            Text(comfortLabel(comfort))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var staffPressureQuestion: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(NSLocalizedString("survey.pressure.question",
+                                   comment: "How pushy was the staff / vendors? (more stars = less pressure)"))
+                .font(.subheadline.weight(.medium))
+            StarRatingRow(value: $staffPressure, max: 5)
+            Text(pressureLabel(staffPressure))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var recommendQuestion: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(NSLocalizedString("survey.recommend.question",
+                                   comment: "Would you recommend this to another solo traveler?"))
+                .font(.subheadline.weight(.medium))
+            HStack(spacing: 10) {
+                ForEach(SurveyRecommend.allCases, id: \.rawValue) { option in
+                    recommendButton(option)
+                }
+            }
+        }
+    }
+
+    private func recommendButton(_ option: SurveyRecommend) -> some View {
+        let selected = recommend == option
+        return Button {
+            recommend = option
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        } label: {
+            VStack(spacing: 4) {
+                Image(systemName: option.symbol).font(.title3)
+                Text(option.label).font(.caption.weight(.medium))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(selected ? option.color.opacity(0.15) : Color(.secondarySystemFill))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(selected ? option.color : .clear, lineWidth: 2)
+            )
+            .foregroundStyle(selected ? option.color : .secondary)
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+
+    private var actionButtons: some View {
+        VStack(spacing: 12) {
+            Button {
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
+                onSubmit(comfort, staffPressure, recommend)
+            } label: {
+                Text(NSLocalizedString("survey.submit", comment: "Send feedback"))
+                    .font(.subheadline.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(RoundedRectangle(cornerRadius: 25).fill(Color.primary))
+                    .foregroundStyle(Color(.systemBackground))
+            }
+
+            Button { onSkip() } label: {
+                Text(NSLocalizedString("survey.skip", comment: "Skip"))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Labels
+
+    private func comfortLabel(_ v: Int) -> String {
+        let keys = ["survey.comfort.1", "survey.comfort.2", "survey.comfort.3", "survey.comfort.4", "survey.comfort.5"]
+        let defaults = ["Very uncomfortable", "Slightly uncomfortable", "Neutral", "Comfortable", "Very comfortable"]
+        let idx = max(0, min(v - 1, 4))
+        return NSLocalizedString(keys[idx], comment: defaults[idx])
+    }
+
+    private func pressureLabel(_ v: Int) -> String {
+        // Inverted scale: 1 star = very pushy, 5 stars = no pressure (good)
+        let keys = ["survey.pressure.1", "survey.pressure.2", "survey.pressure.3", "survey.pressure.4", "survey.pressure.5"]
+        let defaults = ["Very pushy", "Somewhat pushy", "Neutral", "Relaxed vibe", "No pressure at all"]
+        let idx = max(0, min(v - 1, 4))
+        return NSLocalizedString(keys[idx], comment: defaults[idx])
+    }
+}
+
+// MARK: - StarRatingRow
+
+private struct StarRatingRow: View {
+    @Binding var value: Int
+    let max: Int
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(1...max, id: \.self) { star in
+                Button {
+                    value = star
+                    UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
+                } label: {
+                    Image(systemName: star <= value ? "star.fill" : "star")
+                        .font(.title3)
+                        .foregroundStyle(starColor(star))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Text("\(star) " + NSLocalizedString("survey.stars", comment: "stars")))
+                .accessibilityAddTraits(star == value ? .isSelected : [])
+            }
+        }
+    }
+
+    private func starColor(_ star: Int) -> Color {
+        guard star <= value else { return Color(.systemGray4) }
+        return value <= 2 ? .red : value == 3 ? .orange : .green
+    }
+}
+
+#Preview {
+    Text("Preview requires ExperienceService seed")
+}

--- a/apps/ios/SoloCompass/Views/Experience/ReportIssueSheet.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ReportIssueSheet.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+/// Report an issue with an experience (US-034).
+/// Shown via overflow menu in ExperienceDetailView toolbar.
+public struct ReportIssueSheet: View {
+    let experience: Experience
+    var onSubmit: (_ reason: ReportReason, _ detail: String) -> Void
+    var onCancel: () -> Void
+
+    public enum ReportReason: String, CaseIterable, Identifiable {
+        case closedPermanently = "closed_permanently"
+        case moved
+        case hoursWrong = "hours_wrong"
+        case vibeDifferent = "vibe_different"
+        case factuallyWrong = "factually_wrong"
+        case other
+
+        public var id: String { rawValue }
+
+        var label: String {
+            NSLocalizedString("report.reason.\(rawValue)", comment: "Report reason")
+        }
+        var symbol: String {
+            switch self {
+            case .closedPermanently: return "door.left.hand.closed"
+            case .moved:             return "arrow.triangle.turn.up.right.diamond"
+            case .hoursWrong:        return "clock.badge.xmark"
+            case .vibeDifferent:     return "person.crop.circle.badge.questionmark"
+            case .factuallyWrong:    return "exclamationmark.circle"
+            case .other:             return "ellipsis.circle"
+            }
+        }
+    }
+
+    @State private var selectedReason: ReportReason?
+    @State private var detail: String = ""
+    @FocusState private var detailFocused: Bool
+
+    private let detailLimit = 200
+
+    public init(
+        experience: Experience,
+        onSubmit: @escaping (_ reason: ReportReason, _ detail: String) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.experience = experience
+        self.onSubmit = onSubmit
+        self.onCancel = onCancel
+    }
+
+    public var body: some View {
+        NavigationStack {
+            List {
+                reasonSection
+                if selectedReason != nil { detailSection }
+            }
+            .navigationTitle(NSLocalizedString("report.title", comment: "Report an Issue"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(NSLocalizedString("report.cancel", comment: "Cancel"), action: onCancel)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(NSLocalizedString("report.submit", comment: "Submit")) {
+                        guard let reason = selectedReason else { return }
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        onSubmit(reason, detail.trimmingCharacters(in: .whitespacesAndNewlines))
+                    }
+                    .fontWeight(.semibold)
+                    .disabled(selectedReason == nil)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    // MARK: - Sections
+
+    private var reasonSection: some View {
+        Section {
+            ForEach(ReportReason.allCases) { reason in
+                HStack(spacing: 12) {
+                    Image(systemName: reason.symbol)
+                        .frame(width: 24)
+                        .foregroundStyle(reason == selectedReason ? .red : .secondary)
+                    Text(reason.label)
+                    Spacer()
+                    if reason == selectedReason {
+                        Image(systemName: "checkmark").foregroundStyle(.red).fontWeight(.semibold)
+                    }
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    selectedReason = reason
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                }
+                .listRowBackground(reason == selectedReason
+                    ? Color.red.opacity(0.06)
+                    : Color(.secondarySystemGroupedBackground))
+            }
+        } header: {
+            Text(NSLocalizedString("report.reason.header", comment: "What's wrong?"))
+        }
+    }
+
+    private var detailSection: some View {
+        Section {
+            ZStack(alignment: .topLeading) {
+                if detail.isEmpty {
+                    Text(NSLocalizedString("report.detail.placeholder", comment: "Optional details (200 chars)"))
+                        .foregroundStyle(.tertiary)
+                        .padding(.top, 8)
+                        .padding(.leading, 4)
+                        .allowsHitTesting(false)
+                }
+                TextEditor(text: $detail)
+                    .focused($detailFocused)
+                    .frame(minHeight: 80)
+                    .onChange(of: detail) { _, new in
+                        if new.count > detailLimit {
+                            detail = String(new.prefix(detailLimit))
+                        }
+                    }
+            }
+            HStack {
+                Spacer()
+                Text("\(detail.count)/\(detailLimit)")
+                    .font(.caption2)
+                    .foregroundStyle(detail.count >= detailLimit ? .red : .secondary)
+                    .monospacedDigit()
+            }
+        } header: {
+            Text(NSLocalizedString("report.detail.header", comment: "Additional details (optional)"))
+        }
+    }
+}
+
+#Preview {
+    Text("Preview requires Experience seed")
+}

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -13,7 +13,10 @@ public struct CompassMapView: View {
     @State private var viewModel: MapViewModel?
     @State private var voiceService = VoiceService()
     @State private var dismissedAIError: String? = nil
+
     @State private var isShowingCityPicker: Bool = false
+    @State private var surveyExperience: Experience? = nil
+
 
     public init() {}
 
@@ -87,12 +90,39 @@ public struct CompassMapView: View {
 
                     BottomInfoBar(text: viewModel.bottomInfoText, nearbySoloCount: viewModel.nearbySoloCount)
                         .padding(.bottom, 8)
+
+                    // Pending check-in banner (geofence fired while user was nearby)
+                    if let pending = viewModel.pendingCheckIn {
+                        PendingCheckInBanner(
+                            experienceTitle: pending.title,
+                            onConfirm: { viewModel.confirmCheckIn() },
+                            onDismiss: { viewModel.dismissCheckIn() }
+                        )
+                        .padding(.bottom, 4)
+                        .animation(.spring(response: 0.4), value: viewModel.pendingCheckIn != nil)
+                    }
                 }
 
                 VStack {
                     Spacer()
-                    HStack {
+                    HStack(alignment: .bottom) {
+                        // Settings button (bottom-left)
+                        Button {
+                            viewModel.isShowingSettings = true
+                        } label: {
+                            Image(systemName: "slider.horizontal.3")
+                                .font(.title3)
+                                .frame(width: 48, height: 48)
+                                .background(Circle().fill(.regularMaterial))
+                                .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.leading, 20)
+                        .padding(.bottom, 80)
+                        .accessibilityLabel(Text(NSLocalizedString("settings.title", comment: "Settings")))
+
                         Spacer()
+
                         VoiceButton(voiceService: voiceService) { transcript in
                             Task { await viewModel.handleVoiceTranscript(transcript) }
                         }
@@ -142,9 +172,29 @@ public struct CompassMapView: View {
                     isShowingCityPicker = true
                 }
             }
+            viewModel?.checkForPendingCheckIns()
         }
         .onChange(of: locationService.currentLocation) { _, _ in
             viewModel?.bindToLocation()
+        }
+        .onChange(of: preferences.pendingCheckIns) { _, _ in
+            viewModel?.checkForPendingCheckIns()
+        }
+        // Settings sheet
+        .sheet(isPresented: Binding(
+            get: { viewModel?.isShowingSettings ?? false },
+            set: { if !$0 { viewModel?.isShowingSettings = false } }
+        )) {
+            SettingsView(onClose: { viewModel?.isShowingSettings = false })
+                .environment(preferences)
+        }
+        // MicroSurvey sheet (shown after marking an experience done)
+        .sheet(item: $surveyExperience) { exp in
+            MicroSurveySheet(
+                experience: exp,
+                onSubmit: { _, _, _ in surveyExperience = nil },
+                onSkip: { surveyExperience = nil }
+            )
         }
         .alert(
             NSLocalizedString("addExperience.confirm.title", comment: "Add an experience here?"),
@@ -193,7 +243,8 @@ public struct CompassMapView: View {
                             aiService: aiService,
                             preferences: preferences
                         ),
-                        onClose: { viewModel?.dismissDetail() }
+                        onClose: { viewModel?.dismissDetail() },
+                        onMarkDone: { experience in surveyExperience = experience }
                     )
                 }
             }

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -9,6 +9,7 @@ public struct CompassMapView: View {
     @Environment(ExperienceService.self) private var experienceService
     @Environment(AIService.self) private var aiService
     @Environment(UserPreferences.self) private var preferences
+    @Environment(NotificationService.self) private var notificationService
 
     @State private var viewModel: MapViewModel?
     @State private var voiceService = VoiceService()
@@ -16,6 +17,7 @@ public struct CompassMapView: View {
 
     @State private var isShowingCityPicker: Bool = false
     @State private var surveyExperience: Experience? = nil
+    @State private var isShowingFavorites: Bool = false
 
 
     public init() {}
@@ -185,8 +187,12 @@ public struct CompassMapView: View {
             get: { viewModel?.isShowingSettings ?? false },
             set: { if !$0 { viewModel?.isShowingSettings = false } }
         )) {
-            SettingsView(onClose: { viewModel?.isShowingSettings = false })
-                .environment(preferences)
+            SettingsView(
+                onClose: { viewModel?.isShowingSettings = false },
+                onShowFavorites: { isShowingFavorites = true }
+            )
+            .environment(preferences)
+            .environment(notificationService)
         }
         // MicroSurvey sheet (shown after marking an experience done)
         .sheet(item: $surveyExperience) { exp in
@@ -255,6 +261,27 @@ public struct CompassMapView: View {
                     isShowingCityPicker = false
                 }
             }
+        }
+        // Favorites list sheet
+        .sheet(isPresented: $isShowingFavorites) {
+            FavoritesListView { exp in
+                isShowingFavorites = false
+                viewModel?.selectExperience(exp)
+                viewModel?.isShowingDetail = true
+            }
+            .environment(experienceService)
+            .environment(preferences)
+        }
+        // First-run onboarding
+        .fullScreenCover(isPresented: Binding(
+            get: { !preferences.hasCompletedOnboarding },
+            set: { if $0 { } else { preferences.completeOnboarding() } }
+        )) {
+            OnboardingView {
+                // onComplete — preferences.hasCompletedOnboarding already set inside
+            }
+            .environment(locationService)
+            .environment(preferences)
         }
     }
 

--- a/apps/ios/SoloCompass/Views/Onboarding/OnboardingView.swift
+++ b/apps/ios/SoloCompass/Views/Onboarding/OnboardingView.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+import CoreLocation
+
+/// Three-step first-run flow shown once via `.fullScreenCover` from CompassMapView.
+/// Gated by `UserPreferences.hasCompletedOnboarding`.
+public struct OnboardingView: View {
+    @Environment(LocationService.self) private var locationService
+    @Environment(UserPreferences.self) private var preferences
+    let onComplete: () -> Void
+
+    @State private var step: Int = 0
+
+    public var body: some View {
+        ZStack {
+            Color(.systemBackground).ignoresSafeArea()
+
+            switch step {
+            case 0: welcomeStep
+            case 1: styleStep
+            default: welcomeStep
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: step)
+    }
+
+    // MARK: - Step 0: Welcome + location permission
+
+    private var welcomeStep: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            VStack(spacing: 24) {
+                Image(systemName: "map.fill")
+                    .font(.system(size: 64))
+                    .foregroundStyle(.tint)
+
+                VStack(spacing: 8) {
+                    Text(NSLocalizedString("onboarding.welcome.title", comment: "Onboarding title"))
+                        .font(.largeTitle.bold())
+                        .multilineTextAlignment(.center)
+
+                    Text(NSLocalizedString("onboarding.welcome.subtitle", comment: "Onboarding subtitle"))
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 32)
+                }
+            }
+
+            Spacer()
+
+            VStack(spacing: 12) {
+                Button {
+                    locationService.requestPermission()
+                    step = 1
+                } label: {
+                    Text(NSLocalizedString("onboarding.welcome.cta", comment: "Find me on the map"))
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 14))
+                        .foregroundStyle(.white)
+                }
+
+                Button {
+                    step = 1
+                } label: {
+                    Text(NSLocalizedString("onboarding.welcome.skip", comment: "Browse first"))
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 48)
+        }
+    }
+
+    // MARK: - Step 1: Travel style
+
+    private var styleStep: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            VStack(spacing: 24) {
+                Text(NSLocalizedString("onboarding.style.title", comment: "Travel style title"))
+                    .font(.title.bold())
+                    .multilineTextAlignment(.center)
+
+                Text(NSLocalizedString("onboarding.style.subtitle", comment: "Travel style subtitle"))
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+
+                VStack(spacing: 10) {
+                    ForEach(UserPreferences.SoloTravelStyle.allCases) { style in
+                        styleRow(style)
+                    }
+                }
+                .padding(.horizontal, 24)
+            }
+
+            Spacer()
+
+            VStack(spacing: 12) {
+                Button {
+                    preferences.completeOnboarding()
+                    onComplete()
+                } label: {
+                    Text(NSLocalizedString("onboarding.style.cta", comment: "Start exploring"))
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 14))
+                        .foregroundStyle(.white)
+                }
+
+                Button {
+                    preferences.completeOnboarding()
+                    onComplete()
+                } label: {
+                    Text(NSLocalizedString("onboarding.style.skip", comment: "Decide later"))
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 48)
+        }
+    }
+
+    @ViewBuilder
+    private func styleRow(_ style: UserPreferences.SoloTravelStyle) -> some View {
+        let selected = preferences.soloTravelStyle == style
+        Button {
+            preferences.soloTravelStyle = style
+        } label: {
+            HStack(spacing: 14) {
+                Image(systemName: styleIcon(style))
+                    .font(.title3)
+                    .foregroundStyle(selected ? Color.white : Color.accentColor)
+                    .frame(width: 36, height: 36)
+                    .background(
+                        Circle().fill(selected ? Color.accentColor : Color.accentColor.opacity(0.12))
+                    )
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(style.localizedTitle)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.primary)
+                    Text(style.localizedDescription)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                if selected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.tint)
+                }
+            }
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(selected ? Color.accentColor.opacity(0.08) : Color(.secondarySystemBackground))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(selected ? Color.accentColor : Color.clear, lineWidth: 1.5)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func styleIcon(_ style: UserPreferences.SoloTravelStyle) -> String {
+        switch style {
+        case .explorer:      return "figure.walk"
+        case .worker:        return "laptopcomputer"
+        case .foodie:        return "fork.knife"
+        case .cultureSeeker: return "building.columns"
+        }
+    }
+}
+
+#Preview {
+    OnboardingView(onComplete: {})
+        .environment(LocationService.shared)
+        .environment(UserPreferences())
+}

--- a/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
@@ -1,0 +1,205 @@
+import SwiftUI
+
+/// User preferences editor — travel style, category filters, max distance.
+/// Accessed via the map's navigation bar settings button.
+public struct SettingsView: View {
+    @Environment(UserPreferences.self) private var preferences
+    var onClose: () -> Void
+
+    public init(onClose: @escaping () -> Void = {}) {
+        self.onClose = onClose
+    }
+
+    public var body: some View {
+        NavigationStack {
+            List {
+                travelStyleSection
+                preferredCategoriesSection
+                dislikedCategoriesSection
+                distanceSection
+                statsSection
+            }
+            .navigationTitle(NSLocalizedString("settings.title", comment: "Settings"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(NSLocalizedString("settings.done", comment: "Done")) {
+                        onClose()
+                    }
+                    .fontWeight(.semibold)
+                }
+            }
+        }
+    }
+
+    // MARK: - Travel Style
+
+    private var travelStyleSection: some View {
+        Section {
+            ForEach(UserPreferences.SoloTravelStyle.allCases) { style in
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(style.localizedTitle).font(.body)
+                        Text(style.localizedDescription).font(.caption).foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if preferences.soloTravelStyle == style {
+                        Image(systemName: "checkmark").foregroundStyle(.blue).fontWeight(.semibold)
+                    }
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { preferences.soloTravelStyle = style }
+            }
+        } header: {
+            Text(NSLocalizedString("settings.travelStyle", comment: "Travel Style"))
+        } footer: {
+            Text(NSLocalizedString("settings.travelStyle.footer", comment: "Your style shapes which experiences float to the top."))
+        }
+    }
+
+    // MARK: - Preferred Categories
+
+    private var preferredCategoriesSection: some View {
+        Section {
+            ForEach(ExperienceCategory.allCases) { category in
+                let isPreferred = preferences.preferredCategories.contains(category)
+                let isDisliked = preferences.dislikedCategories.contains(category)
+                HStack(spacing: 12) {
+                    Image(systemName: category.symbol).frame(width: 28).foregroundStyle(category.color)
+                    Text(category.localizedTitle)
+                    Spacer()
+                    if isPreferred {
+                        Image(systemName: "heart.fill").foregroundStyle(.pink)
+                    } else if isDisliked {
+                        Image(systemName: "hand.thumbsdown.fill").foregroundStyle(.secondary)
+                    }
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { togglePreferred(category) }
+                .swipeActions(edge: .trailing) {
+                    Button(role: .destructive) { toggleDisliked(category) } label: {
+                        Label(NSLocalizedString("settings.hide", comment: "Hide"), systemImage: "eye.slash")
+                    }
+                }
+            }
+        } header: {
+            Text(NSLocalizedString("settings.preferences", comment: "Preferences"))
+        } footer: {
+            Text(NSLocalizedString("settings.preferences.footer", comment: "Tap to love a category. Swipe left to hide it."))
+        }
+    }
+
+    // MARK: - Disliked Categories
+
+    @ViewBuilder
+    private var dislikedCategoriesSection: some View {
+        if !preferences.dislikedCategories.isEmpty {
+            Section {
+                ForEach(preferences.dislikedCategories) { category in
+                    HStack(spacing: 12) {
+                        Image(systemName: category.symbol).frame(width: 28).foregroundStyle(.secondary)
+                        Text(category.localizedTitle).foregroundStyle(.secondary)
+                        Spacer()
+                        Button {
+                            preferences.dislikedCategories.removeAll { $0 == category }
+                        } label: {
+                            Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            } header: {
+                Text(NSLocalizedString("settings.hidden", comment: "Hidden Categories"))
+            }
+        }
+    }
+
+    // MARK: - Distance
+
+    private var distanceSection: some View {
+        Section {
+            @Bindable var prefs = preferences
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text(NSLocalizedString("settings.maxDistance", comment: "Max Distance"))
+                    Spacer()
+                    Text(distanceLabel(preferences.maxDistanceKm))
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+                Slider(value: $prefs.maxDistanceKm, in: 1...25, step: 0.5).tint(.blue)
+            }
+        } header: {
+            Text(NSLocalizedString("settings.distance", comment: "Discovery Radius"))
+        } footer: {
+            Text(NSLocalizedString("settings.distance.footer", comment: "Only experiences within this radius appear on the map."))
+        }
+    }
+
+    // MARK: - Stats
+
+    private var statsSection: some View {
+        Section {
+            labelRow(icon: "checkmark.circle", color: .green,
+                     label: NSLocalizedString("settings.completed", comment: "Completed"),
+                     value: "\(preferences.completedExperiences.count)")
+            labelRow(icon: "heart.fill", color: .red,
+                     label: NSLocalizedString("settings.favorites", comment: "Favorites"),
+                     value: "\(preferences.favoritedExperiences.count)")
+        } header: {
+            Text(NSLocalizedString("settings.stats", comment: "Your Journey"))
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func labelRow(icon: String, color: Color, label: String, value: String) -> some View {
+        HStack {
+            Image(systemName: icon).foregroundStyle(color).frame(width: 28)
+            Text(label)
+            Spacer()
+            Text(value).foregroundStyle(.secondary).monospacedDigit()
+        }
+    }
+
+    private func distanceLabel(_ km: Double) -> String {
+        if Locale.current.measurementSystem == .us {
+            return String(format: "%.1f mi", km * 0.621371)
+        }
+        return km >= 10 ? String(format: "%.0f km", km) : String(format: "%.1f km", km)
+    }
+
+    private func togglePreferred(_ category: ExperienceCategory) {
+        preferences.dislikedCategories.removeAll { $0 == category }
+        if preferences.preferredCategories.contains(category) {
+            preferences.preferredCategories.removeAll { $0 == category }
+        } else {
+            preferences.preferredCategories.append(category)
+        }
+    }
+
+    private func toggleDisliked(_ category: ExperienceCategory) {
+        preferences.preferredCategories.removeAll { $0 == category }
+        if preferences.dislikedCategories.contains(category) {
+            preferences.dislikedCategories.removeAll { $0 == category }
+        } else {
+            preferences.dislikedCategories.append(category)
+        }
+    }
+}
+
+// MARK: - SoloTravelStyle display helpers
+
+extension UserPreferences.SoloTravelStyle {
+    var localizedTitle: String {
+        NSLocalizedString("style.\(rawValue).title", comment: "Travel style title")
+    }
+    var localizedDescription: String {
+        NSLocalizedString("style.\(rawValue).description", comment: "Travel style description")
+    }
+}
+
+#Preview {
+    SettingsView()
+        .environment(UserPreferences())
+}

--- a/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
@@ -4,10 +4,15 @@ import SwiftUI
 /// Accessed via the map's navigation bar settings button.
 public struct SettingsView: View {
     @Environment(UserPreferences.self) private var preferences
+    @Environment(NotificationService.self) private var notificationService
     var onClose: () -> Void
+    var onShowFavorites: (() -> Void)?
 
-    public init(onClose: @escaping () -> Void = {}) {
+    @State private var showingClearConfirm = false
+
+    public init(onClose: @escaping () -> Void = {}, onShowFavorites: (() -> Void)? = nil) {
         self.onClose = onClose
+        self.onShowFavorites = onShowFavorites
     }
 
     public var body: some View {
@@ -17,7 +22,9 @@ public struct SettingsView: View {
                 preferredCategoriesSection
                 dislikedCategoriesSection
                 distanceSection
+                notificationsSection
                 statsSection
+                dataSection
             }
             .navigationTitle(NSLocalizedString("settings.title", comment: "Settings"))
             .navigationBarTitleDisplayMode(.inline)
@@ -136,18 +143,88 @@ public struct SettingsView: View {
         }
     }
 
+    // MARK: - Notifications
+
+    private var notificationsSection: some View {
+        Section {
+            Toggle(isOn: Binding(
+                get: { preferences.notificationsEnabled },
+                set: { enabled in
+                    preferences.notificationsEnabled = enabled
+                    if enabled {
+                        Task { await notificationService.requestAuthorization() }
+                    }
+                }
+            )) {
+                HStack(spacing: 10) {
+                    Image(systemName: "bell.badge")
+                        .foregroundStyle(.orange)
+                        .frame(width: 28)
+                    Text(NSLocalizedString("settings.notifications", comment: "Notifications"))
+                }
+            }
+        } header: {
+            Text(NSLocalizedString("settings.notifications.header", comment: "Notifications section header"))
+        } footer: {
+            Text(NSLocalizedString("settings.notifications.footer", comment: "Notifications footer"))
+        }
+    }
+
     // MARK: - Stats
 
     private var statsSection: some View {
         Section {
+            Button {
+                onShowFavorites?()
+                onClose()
+            } label: {
+                labelRow(icon: "heart.fill", color: .red,
+                         label: NSLocalizedString("settings.favorites", comment: "Favorites"),
+                         value: "\(preferences.favoritedExperiences.count)")
+            }
+            .foregroundStyle(.primary)
+
             labelRow(icon: "checkmark.circle", color: .green,
                      label: NSLocalizedString("settings.completed", comment: "Completed"),
                      value: "\(preferences.completedExperiences.count)")
-            labelRow(icon: "heart.fill", color: .red,
-                     label: NSLocalizedString("settings.favorites", comment: "Favorites"),
-                     value: "\(preferences.favoritedExperiences.count)")
         } header: {
             Text(NSLocalizedString("settings.stats", comment: "Your Journey"))
+        }
+    }
+
+    // MARK: - Data
+
+    private var dataSection: some View {
+        Section {
+            Button(role: .destructive) {
+                showingClearConfirm = true
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "trash")
+                        .frame(width: 28)
+                    Text(NSLocalizedString("settings.clearData", comment: "Clear all data"))
+                }
+            }
+            .confirmationDialog(
+                NSLocalizedString("settings.clearData.confirm.title", comment: "Clear all data confirm"),
+                isPresented: $showingClearConfirm,
+                titleVisibility: .visible
+            ) {
+                Button(NSLocalizedString("settings.clearData.confirm.action", comment: "Clear"), role: .destructive) {
+                    preferences.completedExperiences = []
+                    preferences.favoritedExperiences = []
+                    preferences.favoritedAt = [:]
+                    preferences.visitHistory = [:]
+                    preferences.pendingCheckIns = [:]
+                    preferences.preferredCategories = []
+                    preferences.dislikedCategories = []
+                }
+                Button(NSLocalizedString("common.cancel", comment: "Cancel"), role: .cancel) {}
+            } message: {
+                Text(NSLocalizedString("settings.clearData.confirm.message", comment: "Clear all data message"))
+            }
+        } header: {
+            Text(NSLocalizedString("settings.data.header", comment: "Data section header"))
         }
     }
 

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// List of favorited experiences sorted by most-recently-added.
+/// Presented as a sheet from SettingsView or via the map settings button.
+public struct FavoritesListView: View {
+    @Environment(ExperienceService.self) private var experienceService
+    @Environment(UserPreferences.self) private var preferences
+    let onSelectExperience: (Experience) -> Void
+
+    private var sortedFavorites: [Experience] {
+        let ids = preferences.favoritedExperiences
+        let experiences = ids.compactMap { experienceService.getExperience(id: $0) }
+        return experiences.sorted { lhs, rhs in
+            let lDate = preferences.favoritedAt[lhs.id] ?? .distantPast
+            let rDate = preferences.favoritedAt[rhs.id] ?? .distantPast
+            return lDate > rDate
+        }
+    }
+
+    public var body: some View {
+        NavigationStack {
+            Group {
+                if sortedFavorites.isEmpty {
+                    emptyState
+                } else {
+                    List(sortedFavorites) { exp in
+                        favoriteRow(exp)
+                    }
+                    .listStyle(.plain)
+                }
+            }
+            .navigationTitle(NSLocalizedString("favorites.title", comment: "Favorites list title"))
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "heart.slash")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+            Text(NSLocalizedString("favorites.empty.title", comment: "No favorites yet"))
+                .font(.headline)
+            Text(NSLocalizedString("favorites.empty.hint", comment: "Tap the heart on any experience"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(32)
+    }
+
+    @ViewBuilder
+    private func favoriteRow(_ exp: Experience) -> some View {
+        Button {
+            onSelectExperience(exp)
+        } label: {
+            HStack(spacing: 12) {
+                ZStack {
+                    Circle()
+                        .fill(exp.category.color.opacity(0.15))
+                        .frame(width: 44, height: 44)
+                    Image(systemName: exp.category.symbol)
+                        .font(.body)
+                        .foregroundStyle(exp.category.color)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(exp.title)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    Text(exp.oneLiner)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive) {
+                preferences.toggleFavorite(exp.id)
+            } label: {
+                Label(NSLocalizedString("action.unfavorite", comment: "Remove from favorites"),
+                      systemImage: "heart.slash")
+            }
+        }
+    }
+}
+
+#Preview {
+    FavoritesListView(onSelectExperience: { _ in })
+        .environment(ExperienceService())
+        .environment(UserPreferences())
+}

--- a/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+/// Floating banner shown when the user enters a geofenced experience zone.
+/// Tapping "Yes, I was there" calls onConfirm; dismissing calls onDismiss.
+/// Shown from CompassMapView when MapViewModel.pendingCheckIn is non-nil.
+public struct PendingCheckInBanner: View {
+    let experienceTitle: String
+    var onConfirm: () -> Void
+    var onDismiss: () -> Void
+
+    @State private var dragOffset: CGFloat = 0
+    private let dismissThreshold: CGFloat = 80
+
+    public init(
+        experienceTitle: String,
+        onConfirm: @escaping () -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.experienceTitle = experienceTitle
+        self.onConfirm = onConfirm
+        self.onDismiss = onDismiss
+    }
+
+    public var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "figure.walk.circle.fill")
+                .font(.title2)
+                .foregroundStyle(.blue)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(NSLocalizedString("checkin.banner.title", comment: "Did you visit?"))
+                    .font(.subheadline.weight(.semibold))
+                Text(experienceTitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            HStack(spacing: 8) {
+                Button {
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                    onConfirm()
+                } label: {
+                    Text(NSLocalizedString("checkin.banner.yes", comment: "Yes!"))
+                        .font(.caption.weight(.semibold))
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Capsule().fill(.blue))
+                        .foregroundStyle(.white)
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    onDismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 28, height: 28)
+                        .background(Circle().fill(Color(.secondarySystemFill)))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Text(NSLocalizedString("common.dismiss", comment: "Dismiss")))
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.12), radius: 8, y: 4)
+        .padding(.horizontal, 16)
+        .offset(y: dragOffset)
+        .gesture(
+            DragGesture()
+                .onChanged { gesture in
+                    dragOffset = min(0, gesture.translation.height)
+                }
+                .onEnded { gesture in
+                    if gesture.translation.height < -dismissThreshold {
+                        withAnimation(.easeOut(duration: 0.2)) { dragOffset = -200 }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { onDismiss() }
+                    } else {
+                        withAnimation(.spring(response: 0.3)) { dragOffset = 0 }
+                    }
+                }
+        )
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(String(
+            format: NSLocalizedString("checkin.banner.a11y", comment: "Did you visit %@?"),
+            experienceTitle
+        )))
+    }
+}
+
+#Preview {
+    ZStack(alignment: .bottom) {
+        Color(.systemGroupedBackground).ignoresSafeArea()
+        PendingCheckInBanner(
+            experienceTitle: "Watch the monks collect alms at dawn",
+            onConfirm: {},
+            onDismiss: {}
+        )
+        .padding(.bottom, 40)
+    }
+}

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -41,6 +41,9 @@ targets:
         CFBundleIconName: AppIcon
         ITSAppUsesNonExemptEncryption: false
         NSLocationWhenInUseUsageDescription: "Solo Compass uses your location to show experiences near you on the map."
+        NSLocationAlwaysAndWhenInUseUsageDescription: "Solo Compass uses background location to alert you when you're near a place worth visiting — even when the app is closed."
+        UIBackgroundModes:
+          - location
         NSSpeechRecognitionUsageDescription: "Solo Compass uses speech recognition so you can describe what you're looking for by voice."
         NSMicrophoneUsageDescription: "Solo Compass uses the microphone for voice search."
     settings:

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -11,9 +11,9 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.32.0",
     "@solo-compass/core": "workspace:*",
     "@solo-compass/sources-core": "workspace:*",
-    "@anthropic-ai/sdk": "^0.32.0",
     "fast-levenshtein": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

This PR addresses all open GitHub issues from the solo-compass issue tracker.

### PR #67 (this PR) — two commits total

#### Commit 1: `feat(ios): settings, micro-survey, report-issue, check-in banner, device identity`
- **SettingsView** — travel style picker, category preferences, discovery radius slider
- **MicroSurveySheet** — 3-question post-visit survey triggered on mark-done
- **ReportIssueSheet** — 6 report reasons + 200-char detail; via overflow menu
- **PendingCheckInBanner** — "Did you visit?" banner for geofence-triggered check-ins
- **DeviceIdentityService** — Keychain-persisted anonymous UUID
- **MapViewModel** + **CompassMapView** wired up for all of the above

#### Commit 2: `feat(ios): onboarding, favorites list, notifications, background location` — closes #60, #62, #63
- **OnboardingView** (#60) — first-run 2-step flow (welcome + travel style), `fullScreenCover`, gated by `hasCompletedOnboarding`
- **FavoritesListView** (#62) — sorted by `favoritedAt`, swipe-to-unfavorite, tapping opens detail
- **NotificationService** (#63) — local `UNUserNotificationCenter` notifications on geofence enter, quiet-hours aware
- **LocationService** (#63) — two-step Always authorization, `allowsBackgroundLocationUpdates`, `UIBackgroundModes: [location]` in `project.yml`
- **UserPreferences** — new fields: `hasCompletedOnboarding`, `notificationsEnabled`, `quietHoursStart/End`, `favoritedAt`, `pruneStaleCheckIns()`
- **SettingsView** — favorites row now tappable, notifications toggle, "Clear all data" destructive action

Issues addressed: **closes #60**, **closes #62**, **partially closes #63** (local notifications + background location done; APNs server-push out of scope)
Issues #57/#58/#59/#61 were already closed in earlier PRs.

## Test plan

- [ ] **Build**: `xcodebuild build -project SoloCompass.xcodeproj -scheme SoloCompass -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1'`
- [ ] **Onboarding (#60)**: Reset UserDefaults → launch → onboarding appears → tap "Find me on the map" → select style → tap "Start exploring" → lands on map; second launch skips onboarding
- [ ] **Favorites list (#62)**: Favorite an experience → open Settings → tap Favorites row → sheet opens sorted by add-date; swipe left to unfavorite; tap row → detail opens
- [ ] **Notifications (#63)**: Enable notifications in Settings → toggle turns on → system permission prompt appears; simulate geofence entry → notification fires after 3s delay
- [ ] **Background location (#63)**: Info.plist contains `NSLocationAlwaysAndWhenInUseUsageDescription`; `UIBackgroundModes` includes `location`; second permission dialog for Always fires after WhenInUse granted
- [ ] **Clear all data**: Settings → Clear all data → confirm → completed/favorites/history reset to zero
- [ ] **`pnpm typecheck`** passes (all 10 packages)