### PR TITLE
fix(ios): refresh bottom-info greeting when app returns to foreground

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -10,6 +10,7 @@ public struct CompassMapView: View {
     @Environment(AIService.self) private var aiService
     @Environment(UserPreferences.self) private var preferences
     @Environment(NotificationService.self) private var notificationService
+    @Environment(\.scenePhase) private var scenePhase
 
     @State private var viewModel: MapViewModel?
     @State private var voiceService = VoiceService()
@@ -181,6 +182,11 @@ public struct CompassMapView: View {
         }
         .onChange(of: preferences.pendingCheckIns) { _, _ in
             viewModel?.checkForPendingCheckIns()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                viewModel?.updateBottomInfo()
+            }
         }
         // Settings sheet
         .sheet(isPresented: Binding(


### PR DESCRIPTION
## Summary

The bottom-info greeting was going stale across the morning→afternoon boundary. In the reported case, the screenshot shows **12:03** but the bar still reads `"Good morning. 0 coffee spots nearby are at their best right now."` — the user had opened the app before noon, the system clock rolled past 12:00, but `updateBottomInfo()` is only called on user-initiated state changes (filter / category / city / location load), so the cached morning copy stuck around.

Fix: observe `scenePhase` on `CompassMapView` and re-run `viewModel.updateBottomInfo()` whenever the app becomes `.active`. This covers the dominant case (user backgrounds the app, comes back later, or simply re-opens it after the hour rolls over).

## Test plan

- [ ] Open the app at e.g. 11:55, confirm `"Good morning…"`.
- [ ] Background the app, advance the simulator clock past noon, foreground — bar should switch to the afternoon copy (`"The light shifts in the next hour…"`).
- [ ] Same check across 17:00 (afternoon→evening) and 22:00 (evening→night) boundaries.
- [ ] Existing `MapViewModel` tests around `bottomInfoText` still pass.

Note: this does **not** cover the rare case where the app stays in the foreground continuously across an hour boundary; if that becomes a real complaint we can add a one-shot `Timer` that fires at the next hour transition.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjgmma27mABGqikQ8yPdH4)_