### PR TITLE
fix(#56): auto-recenter on first GPS fix at view appear

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -175,6 +175,9 @@ public struct CompassMapView: View {
                     isShowingCityPicker = true
                 }
             }
+            // Auto-recenter on first GPS fix — handles the case where location
+            // was already authorized before the view appeared (GH #56/#57).
+            viewModel?.bindToLocation()
             viewModel?.checkForPendingCheckIns()
         }
         .onChange(of: locationService.currentLocation) { _, _ in


### PR DESCRIPTION
## Summary

Part of #56 umbrella. Fixes sub-issue #57 — camera follows user location on first GPS fix.

## Root Cause

`bindToLocation()` was only wired through `.onChange(of: locationService.currentLocation)`, which fires only when the location **changes**. When a returning user (who has already granted location permission) opens the app, `currentLocation` may already be non-nil before `CompassMapView` appears, so `onChange` never fires and the map stays at the default Chiang Mai center.

## Fix

Add `viewModel?.bindToLocation()` to the `onAppear` block, so the auto-recenter logic runs both on initial view entry (handling already-resolved location) AND on subsequent location updates (via the existing `onChange` observer).

`bindToLocation()` is guarded by `hasAutoCentered` so it only fires once — subsequent user pan/zoom gestures are preserved.

## Remaining work for #56 umbrella

- #58 + #59: City switcher + geo-aware seed data fallback (still needed for users far from seeded cities)
- #60: First-run onboarding flow
- Others per umbrella checklist