### PR TITLE
fix(ci): unblock CI on org-owned repo (gitleaks license + anti-pattern-lint base drift)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -17,6 +17,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Use the gitleaks binary directly. The official gitleaks-action requires
+      # a paid license for organisation-owned repos; the binary itself is free
+      # under the MIT license and reads the repo's `.gitleaks.toml` config.
+      - name: Install gitleaks
+        run: |
+          GITLEAKS_VERSION=8.30.1
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /tmp gitleaks
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Run gitleaks
+        run: gitleaks detect --source . --config .gitleaks.toml --no-banner --redact --verbose

--- a/scripts/anti-pattern-lint.ts
+++ b/scripts/anti-pattern-lint.ts
@@ -69,10 +69,12 @@ function scan(diff: string): Hit[] {
     if (raw.includes("anti-pattern-lint:allow")) continue;
 
     // Skip the lint script itself — it legitimately mentions every keyword.
+    // Skip archived Ralph runs — frozen historical artefacts, not shipped product.
     if (
       currentFile === "scripts/anti-pattern-lint.ts" ||
       currentFile === "docs/PRIVACY.md" ||
-      currentFile === "CLAUDE.md"
+      currentFile === "CLAUDE.md" ||
+      currentFile.startsWith("scripts/ralph/archive/")
     ) {
       continue;
     }


### PR DESCRIPTION
## Summary

PR #71 merged to main with both `CI / typecheck + lint + format` and `Secret Scanning / Scan for secrets` red. Both failures were CI-config bugs, not code issues — and they will keep firing on every PR until fixed. This PR fixes both, atomically.

## Root causes

**1. `Secret Scanning` failed with `🛑 missing gitleaks license`**

`gitleaks/gitleaks-action@v2` requires a paid license for GitHub Organisation-owned repos (`[getyak] is an organization. License key is required.`). The gitleaks binary itself is MIT-licensed and free — only the wrapping Action requires payment. Switch to downloading and running the binary directly.

**2. `typecheck + lint + format` failed at the `anti-pattern lint` step with `fatal: Not a valid object name origin/main`**

`actions/checkout@v4` defaults to `fetch-depth: 1` (shallow). `scripts/anti-pattern-lint.ts` calls `git merge-base HEAD origin/main` to compute the diff against the base branch — which throws on shallow checkouts because `origin/main` isn't fetched. All three fallbacks in `getDiff()` fail for the same reason and the step crashes (this is what caused PR #71's `node:internal/errors:984` traceback).

## Fixes

- **`.github/workflows/ci.yml`** → set `actions/checkout` `fetch-depth: 0` so the merge-base lookup resolves on PR runs.
- **`scripts/anti-pattern-lint.ts`** → also skip `scripts/ralph/archive/**` since archived Ralph runs are frozen historical artefacts that legitimately mention legacy keywords (e.g. `badge`).
- **`.github/workflows/secret-scan.yml`** → replace `gitleaks/gitleaks-action@v2` with a step that downloads gitleaks 8.30.1 and runs `gitleaks detect --config .gitleaks.toml`. Same scanner, no licensing.

## Test plan

- [x] Local: `pnpm typecheck` ✓
- [x] Local: `pnpm format:check` ✓
- [x] Local: `pnpm tsx scripts/anti-pattern-lint.ts` ✓
- [x] Local: `pnpm tsx scripts/schema-dryrun.ts` ✓
- [x] Local: `gitleaks detect --source . --config .gitleaks.toml` → `no leaks found`
- [ ] CI: typecheck + lint + format passes
- [ ] CI: Secret Scanning passes
- [ ] CI: iOS CI passes (unaffected)