### PR TITLE
feat(ios): Explore here — real OSM POIs + AI-enriched Experiences anywhere

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		86F4628473C2D520D4C2FFFB /* SoloScoreBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB579F3F4EBBA014AA306DD1 /* SoloScoreBadge.swift */; };
 		A84320715E7CBDA91FC3F26F /* ExperienceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */; };
 		AA75B3147A29FDA55E61B24A /* PendingCheckInBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */; };
+		B28F15C454376D86258FCD77 /* OverpassService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67173C74F1A76C3CE5C38C0A /* OverpassService.swift */; };
 		BAC775E6105DD571F71ACBC1 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 80020844C0A45A5993333741 /* Localizable.strings */; };
 		BD5BB6BD7FCBDB30282F28FA /* VoiceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8ABF85EEFDF9969C94B441 /* VoiceButton.swift */; };
 		C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */; };
@@ -64,6 +65,7 @@
 		576B08910782A58C3597E596 /* ReportIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportIssueSheet.swift; sourceTree = "<group>"; };
 		5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailViewModel.swift; sourceTree = "<group>"; };
 		61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = seed_experiences.json; sourceTree = "<group>"; };
+		67173C74F1A76C3CE5C38C0A /* OverpassService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverpassService.swift; sourceTree = "<group>"; };
 		6C5CA5533D846B39EF16CDFA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		873ACB737A9B43254C17B238 /* CityPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityPickerSheet.swift; sourceTree = "<group>"; };
 		8FDFA5F3503B8ABC4B5CB086 /* SoloCompassTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SoloCompassTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -187,6 +189,7 @@
 				12F087E4FA7161529378098C /* ExperienceService.swift */,
 				2C7919EAFDE363B49C4B4C47 /* LocationService.swift */,
 				C215AE07BA32182A887226F9 /* NotificationService.swift */,
+				67173C74F1A76C3CE5C38C0A /* OverpassService.swift */,
 				120FC7465285714C5FA8F96D /* VoiceService.swift */,
 			);
 			path = Services;
@@ -311,7 +314,7 @@
 					};
 					D49FFD818AF5AD3EDE92522D = {
 						DevelopmentTeam = 6RG2F8YY59;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -380,6 +383,7 @@
 				214AF641496E8E50E3EC5FE4 /* MicroSurveySheet.swift in Sources */,
 				C53DB60CA9E95907A2CBF2C0 /* NotificationService.swift in Sources */,
 				C81007F6A39364D0872736B2 /* OnboardingView.swift in Sources */,
+				B28F15C454376D86258FCD77 /* OverpassService.swift in Sources */,
 				AA75B3147A29FDA55E61B24A /* PendingCheckInBanner.swift in Sources */,
 				EF2003CC07F7787C25847BDF /* ReportIssueSheet.swift in Sources */,
 				58B7C9B20945838F81081941 /* SettingsView.swift in Sources */,
@@ -584,6 +588,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -601,6 +608,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -232,3 +232,14 @@
 "settings.clearData.confirm.title" = "Clear all data?";
 "settings.clearData.confirm.action" = "Clear everything";
 "settings.clearData.confirm.message" = "This removes your completed experiences, favorites, and preferences. It cannot be undone.";
+
+/* Explore here */
+"explore.button" = "Explore here";
+"explore.aiBadge" = "AI-generated · OpenStreetMap";
+"explore.error.nothingFound" = "No public places found nearby. Try moving the map.";
+"explore.skeleton.oneLiner" = "A real spot pulled from OpenStreetMap.";
+"explore.skeleton.why" = "We don't have a curated story for this place yet. Visit, then add what you found.";
+
+/* Overpass errors */
+"overpass.error.url" = "Overpass endpoint URL is invalid.";
+"overpass.error.request" = "Map data request failed (status %d).";

--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -247,4 +247,210 @@ public final class AIService {
         }
         return try JSONDecoder().decode(AIResponse.self, from: data)
     }
+
+    // MARK: - Synthesize from OSM POIs (Explore Here)
+
+    /// Maximum POIs sent to the model in one call. Keeps prompt size and cost
+    /// predictable, and matches the product cap of 15 generated experiences.
+    public static let synthesisLimit = 15
+
+    /// Convert a batch of OSM POIs into Experiences. Sends a single Claude
+    /// request that returns a JSON array of experiences. Falls back to a
+    /// skeleton derived from OSM tags when the API key is missing or the
+    /// request fails — so users without an API key still get pins on the map.
+    public func synthesizeExperiences(
+        from pois: [OverpassService.POI],
+        cityCode: String,
+        locale: Locale = .current
+    ) async throws -> [Experience] {
+        let capped = Array(pois.prefix(Self.synthesisLimit))
+        guard !capped.isEmpty else { return [] }
+
+        let prompt = Self.synthesisPrompt(pois: capped, cityCode: cityCode, locale: locale)
+        do {
+            let raw = try await sendMessage(prompt: prompt)
+            return try Self.parseSynthesizedExperiences(raw, pois: capped, cityCode: cityCode)
+        } catch {
+            return capped.map { Self.skeletonExperience(from: $0, cityCode: cityCode) }
+        }
+    }
+
+    // MARK: - Synthesize helpers
+
+    private static func synthesisPrompt(pois: [OverpassService.POI], cityCode: String, locale: Locale) -> String {
+        let langTag = locale.language.languageCode?.identifier ?? "en"
+        let lines = pois.map { poi -> String in
+            let displayName = poi.nameEn ?? poi.name
+            let tagSummary = poi.tags
+                .filter { ["amenity", "tourism", "leisure", "natural", "shop", "cuisine", "opening_hours"].contains($0.key) }
+                .map { "\($0.key)=\($0.value)" }
+                .sorted()
+                .joined(separator: ", ")
+            return "- osmId=\(poi.osmId) name=\"\(poi.name)\" nameEn=\"\(displayName)\" lat=\(poi.lat) lon=\(poi.lon) tags=[\(tagSummary)]"
+        }.joined(separator: "\n")
+
+        return """
+        You are writing solo-traveler-focused entries for real places sourced from OpenStreetMap.
+
+        For each POI below, return ONE JSON object with these fields and nothing else:
+        {
+          "osmId": <int>,
+          "title": "<action-oriented sensory line, less than 14 words>",
+          "oneLiner": "<one concrete detail, less than 25 words>",
+          "whyItMatters": "<2-3 sentences for someone alone>",
+          "category": "food|coffee|culture|nature|work|wellness|nightlife|hidden",
+          "bestStartHour": <0-23>,
+          "bestEndHour": <0-23>,
+          "durationMinMinutes": <int>,
+          "durationMaxMinutes": <int>,
+          "howTo": ["step 1", "step 2", "step 3"],
+          "soloHint": "<one short hint for solo visitors>",
+          "soloOverall": <number 6.0-9.5>
+        }
+
+        Output a JSON array containing one object per POI, in input order. No prose. No markdown fences.
+
+        Output language: \(langTag).
+        City code: \(cityCode).
+
+        POIs:
+        \(lines)
+        """
+    }
+
+    private static func parseSynthesizedExperiences(
+        _ raw: String,
+        pois: [OverpassService.POI],
+        cityCode: String
+    ) throws -> [Experience] {
+        guard
+            let start = raw.firstIndex(of: "["),
+            let end = raw.lastIndex(of: "]"),
+            start <= end,
+            let data = String(raw[start...end]).data(using: .utf8)
+        else {
+            throw AIError.decodingFailed("no JSON array in synthesis response")
+        }
+
+        struct Item: Decodable {
+            let osmId: Int64
+            let title: String
+            let oneLiner: String
+            let whyItMatters: String
+            let category: String
+            let bestStartHour: Int?
+            let bestEndHour: Int?
+            let durationMinMinutes: Int?
+            let durationMaxMinutes: Int?
+            let howTo: [String]?
+            let soloHint: String?
+            let soloOverall: Double?
+        }
+        let items = try JSONDecoder().decode([Item].self, from: data)
+        let poiById = Dictionary(uniqueKeysWithValues: pois.map { ($0.osmId, $0) })
+        let now = Date()
+
+        return items.compactMap { item in
+            guard let poi = poiById[item.osmId] else { return nil }
+            let category = ExperienceCategory(rawValue: item.category) ?? OverpassService.category(for: poi.tags)
+            let startHour = item.bestStartHour.map { max(0, min(23, $0)) } ?? 9
+            let endHour = item.bestEndHour.map { max(0, min(23, $0)) } ?? 21
+            let dMin = item.durationMinMinutes ?? 30
+            let dMax = max(dMin, item.durationMaxMinutes ?? 90)
+            let overall = max(6.0, min(9.5, item.soloOverall ?? 7.0))
+            let breakdown = SoloScore.Breakdown(
+                seatingFriendly: overall, soloPatronRatio: overall, staffPressure: overall,
+                soloPortioning: overall, ambianceFit: overall, safety: overall
+            )
+            let howTo = (item.howTo ?? []).enumerated().map { HowToStep(order: $0.offset + 1, text: $0.element) }
+            return Experience(
+                id: "exp_osm_\(poi.osmId)",
+                title: item.title,
+                oneLiner: item.oneLiner,
+                whyItMatters: item.whyItMatters,
+                category: category,
+                location: ExperienceLocation(
+                    coordinates: [poi.lon, poi.lat],
+                    cityCode: cityCode,
+                    addressHint: nil,
+                    placeNameLocal: poi.name,
+                    placeNameRomanized: poi.nameEn
+                ),
+                bestTimes: [TimeWindow(startHour: startHour, endHour: endHour)],
+                durationMinutes: .init(min: dMin, max: dMax),
+                howTo: howTo,
+                realInconveniences: [],
+                soloScore: SoloScore(overall: overall, breakdown: breakdown, hint: item.soloHint, basedOnCount: 0),
+                sources: [
+                    InformationSource(
+                        type: .user,
+                        url: URL(string: "https://www.openstreetmap.org/node/\(poi.osmId)"),
+                        attribution: "© OpenStreetMap contributors + AI",
+                        verifiedAt: now
+                    )
+                ],
+                confidence: Confidence(
+                    level: 1,
+                    lastVerifiedAt: now,
+                    reason: "AI-synthesized from OpenStreetMap, unverified",
+                    signals: .init(aiScrapeAgeDays: 0, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)
+                ),
+                nearbyExperienceIds: [],
+                stats: .init(completionCount: 0, averageRating: 0),
+                status: .candidate,
+                createdAt: now,
+                updatedAt: now
+            )
+        }
+    }
+
+    /// Build a minimal Experience from raw OSM data, used when AI is unavailable.
+    /// Preserves coordinate + name + category; everything else is conservative defaults.
+    static func skeletonExperience(from poi: OverpassService.POI, cityCode: String) -> Experience {
+        let now = Date()
+        let category = OverpassService.category(for: poi.tags)
+        let displayName = poi.nameEn ?? poi.name
+        let breakdown = SoloScore.Breakdown(
+            seatingFriendly: 7, soloPatronRatio: 7, staffPressure: 7,
+            soloPortioning: 7, ambianceFit: 7, safety: 7
+        )
+        return Experience(
+            id: "exp_osm_\(poi.osmId)",
+            title: displayName,
+            oneLiner: NSLocalizedString("explore.skeleton.oneLiner", comment: "Generic OSM POI tagline"),
+            whyItMatters: NSLocalizedString("explore.skeleton.why", comment: "Generic OSM POI rationale"),
+            category: category,
+            location: ExperienceLocation(
+                coordinates: [poi.lon, poi.lat],
+                cityCode: cityCode,
+                addressHint: nil,
+                placeNameLocal: poi.name,
+                placeNameRomanized: poi.nameEn
+            ),
+            bestTimes: [TimeWindow(startHour: 9, endHour: 21)],
+            durationMinutes: .init(min: 30, max: 90),
+            howTo: [],
+            realInconveniences: [],
+            soloScore: SoloScore(overall: 7.0, breakdown: breakdown, hint: nil, basedOnCount: 0),
+            sources: [
+                InformationSource(
+                    type: .user,
+                    url: URL(string: "https://www.openstreetmap.org/node/\(poi.osmId)"),
+                    attribution: "© OpenStreetMap contributors",
+                    verifiedAt: now
+                )
+            ],
+            confidence: Confidence(
+                level: 1,
+                lastVerifiedAt: now,
+                reason: "OpenStreetMap entry, no AI enrichment",
+                signals: .init(aiScrapeAgeDays: 0, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)
+            ),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .candidate,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
 }

--- a/apps/ios/SoloCompass/Services/ExperienceService.swift
+++ b/apps/ios/SoloCompass/Services/ExperienceService.swift
@@ -71,6 +71,20 @@ public final class ExperienceService {
         preferences.toggleFavorite(id)
     }
 
+    /// Merge a batch of newly generated experiences into the in-memory store.
+    /// De-duplicates by id (existing entries win — they may have user state
+    /// like completion stats we don't want to clobber). Returns the count of
+    /// newly inserted experiences so callers can show feedback.
+    @discardableResult
+    public func appendGenerated(_ generated: [Experience]) -> Int {
+        let existingIds = Set(allExperiences.map(\.id))
+        let fresh = generated.filter { !existingIds.contains($0.id) }
+        guard !fresh.isEmpty else { return 0 }
+        allExperiences.append(contentsOf: fresh)
+        filteredExperiences = allExperiences
+        return fresh.count
+    }
+
     // MARK: - Loading
 
     private static func loadFromBundle() -> [Experience]? {

--- a/apps/ios/SoloCompass/Services/OverpassService.swift
+++ b/apps/ios/SoloCompass/Services/OverpassService.swift
@@ -1,0 +1,211 @@
+import Foundation
+import CoreLocation
+import Observation
+
+/// Talks to the public Overpass API (OpenStreetMap) to fetch real-world POIs
+/// near a coordinate. Used by the "Explore here" feature so users in cities
+/// outside our seed data still get something on the map.
+///
+/// Overpass is free, key-less, and globally covered, but rate-limited
+/// (~10k queries/day per IP on the public instance). We cap query size and
+/// give the caller a single retry on transient failures.
+///
+/// Data attribution: © OpenStreetMap contributors (ODbL). Surfaces must show this.
+@Observable
+public final class OverpassService {
+    /// A single OSM POI we care about — name + coordinate + raw tags.
+    public struct POI: Codable, Hashable, Identifiable {
+        public let osmId: Int64
+        public let name: String
+        public let nameEn: String?
+        public let lat: Double
+        public let lon: Double
+        public let tags: [String: String]
+
+        public var id: Int64 { osmId }
+
+        public var coordinate: CLLocationCoordinate2D {
+            CLLocationCoordinate2D(latitude: lat, longitude: lon)
+        }
+
+        public init(osmId: Int64, name: String, nameEn: String?, lat: Double, lon: Double, tags: [String: String]) {
+            self.osmId = osmId
+            self.name = name
+            self.nameEn = nameEn
+            self.lat = lat
+            self.lon = lon
+            self.tags = tags
+        }
+    }
+
+    public enum OverpassError: Error, LocalizedError {
+        case invalidURL
+        case requestFailed(status: Int)
+        case decodingFailed(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidURL:
+                return NSLocalizedString("overpass.error.url", comment: "Invalid Overpass URL")
+            case .requestFailed(let status):
+                return String(format: NSLocalizedString("overpass.error.request", comment: "Overpass request failed status %d"), status)
+            case .decodingFailed(let msg):
+                return msg
+            }
+        }
+    }
+
+    public private(set) var isFetching: Bool = false
+
+    private let session: URLSession
+    private let endpoint = URL(string: "https://overpass-api.de/api/interpreter")
+    private let maxResults: Int
+
+    public init(session: URLSession = .shared, maxResults: Int = 30) {
+        self.session = session
+        self.maxResults = maxResults
+    }
+
+    // MARK: - Public
+
+    /// Fetch up to `maxResults` POIs within `radiusMeters` of the coordinate.
+    /// Retries once on network/5xx failure.
+    public func fetchPOIs(
+        near coordinate: CLLocationCoordinate2D,
+        radiusMeters: Int = 3000
+    ) async throws -> [POI] {
+        guard let endpoint else { throw OverpassError.invalidURL }
+        await MainActor.run { self.isFetching = true }
+        defer { Task { @MainActor [weak self] in self?.isFetching = false } }
+
+        let query = Self.buildQuery(lat: coordinate.latitude, lon: coordinate.longitude, radiusMeters: radiusMeters, limit: maxResults)
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue("SoloCompass-iOS/1.0", forHTTPHeaderField: "User-Agent")
+        request.timeoutInterval = 20
+        request.httpBody = "data=\(query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")".data(using: .utf8)
+
+        do {
+            return try await performAndDecode(request)
+        } catch {
+            try? await Task.sleep(nanoseconds: 800_000_000)
+            return try await performAndDecode(request)
+        }
+    }
+
+    // MARK: - HTTP
+
+    private func performAndDecode(_ request: URLRequest) async throws -> [POI] {
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw OverpassError.requestFailed(status: 0)
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw OverpassError.requestFailed(status: http.statusCode)
+        }
+        return try Self.decodePOIs(from: data)
+    }
+
+    // MARK: - Query
+
+    static func buildQuery(lat: Double, lon: Double, radiusMeters: Int, limit: Int) -> String {
+        let around = "around:\(radiusMeters),\(lat),\(lon)"
+        return """
+        [out:json][timeout:15];
+        (
+          node["amenity"~"^(restaurant|cafe|bar|pub|fast_food|ice_cream|food_court|library|coworking_space|spa)$"](\(around));
+          node["tourism"~"^(attraction|viewpoint|gallery|museum|artwork|zoo|aquarium)$"](\(around));
+          node["leisure"~"^(park|garden|nature_reserve|fitness_centre)$"](\(around));
+          node["natural"~"^(beach|peak|hot_spring)$"](\(around));
+          node["shop"~"^(books|coffee|tea)$"](\(around));
+        );
+        out body \(limit);
+        """
+    }
+
+    // MARK: - Decode
+
+    static func decodePOIs(from data: Data) throws -> [POI] {
+        struct Wrapper: Decodable {
+            let elements: [Element]
+        }
+        struct Element: Decodable {
+            let id: Int64
+            let lat: Double?
+            let lon: Double?
+            let tags: [String: String]?
+        }
+        do {
+            let wrapper = try JSONDecoder().decode(Wrapper.self, from: data)
+            return wrapper.elements.compactMap { el -> POI? in
+                guard let lat = el.lat, let lon = el.lon, let tags = el.tags else { return nil }
+                let nameEn = tags["name:en"]
+                let name = tags["name"] ?? nameEn ?? ""
+                guard !name.isEmpty else { return nil }
+                return POI(osmId: el.id, name: name, nameEn: nameEn, lat: lat, lon: lon, tags: tags)
+            }
+        } catch {
+            throw OverpassError.decodingFailed(String(describing: error))
+        }
+    }
+
+    // MARK: - Tag → category
+
+    /// Map raw OSM tags to a Solo Compass `ExperienceCategory`. Ordering matters:
+    /// more specific tags (e.g. coworking_space) win over generic ones.
+    public static func category(for tags: [String: String]) -> ExperienceCategory {
+        if let amenity = tags["amenity"] {
+            switch amenity {
+            case "cafe", "ice_cream":
+                return .coffee
+            case "restaurant", "fast_food", "food_court":
+                return .food
+            case "bar", "pub":
+                return .nightlife
+            case "library", "coworking_space":
+                return .work
+            case "spa":
+                return .wellness
+            default:
+                break
+            }
+        }
+        if let shop = tags["shop"] {
+            switch shop {
+            case "coffee", "tea":
+                return .coffee
+            case "books":
+                return .work
+            default:
+                break
+            }
+        }
+        if let tourism = tags["tourism"] {
+            switch tourism {
+            case "attraction", "viewpoint", "artwork":
+                return .culture
+            case "gallery", "museum":
+                return .culture
+            case "zoo", "aquarium":
+                return .nature
+            default:
+                break
+            }
+        }
+        if let leisure = tags["leisure"] {
+            switch leisure {
+            case "park", "garden", "nature_reserve":
+                return .nature
+            case "fitness_centre":
+                return .wellness
+            default:
+                break
+            }
+        }
+        if tags["natural"] != nil {
+            return .nature
+        }
+        return .hidden
+    }
+}

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -195,4 +195,134 @@ final class SoloCompassTests: XCTestCase {
         XCTAssertTrue(reloaded.isCompleted("exp_test_1"))
         XCTAssertTrue(reloaded.isFavorited("exp_test_2"))
     }
+
+    // MARK: - Overpass tag mapping
+
+    func testOverpassCategoryFromAmenity() {
+        XCTAssertEqual(OverpassService.category(for: ["amenity": "cafe"]), .coffee)
+        XCTAssertEqual(OverpassService.category(for: ["amenity": "restaurant"]), .food)
+        XCTAssertEqual(OverpassService.category(for: ["amenity": "bar"]), .nightlife)
+        XCTAssertEqual(OverpassService.category(for: ["amenity": "library"]), .work)
+        XCTAssertEqual(OverpassService.category(for: ["amenity": "spa"]), .wellness)
+    }
+
+    func testOverpassCategoryFromTourismAndLeisure() {
+        XCTAssertEqual(OverpassService.category(for: ["tourism": "museum"]), .culture)
+        XCTAssertEqual(OverpassService.category(for: ["tourism": "viewpoint"]), .culture)
+        XCTAssertEqual(OverpassService.category(for: ["leisure": "park"]), .nature)
+        XCTAssertEqual(OverpassService.category(for: ["natural": "beach"]), .nature)
+    }
+
+    func testOverpassCategoryFallsBackToHidden() {
+        XCTAssertEqual(OverpassService.category(for: [:]), .hidden)
+        XCTAssertEqual(OverpassService.category(for: ["highway": "primary"]), .hidden)
+    }
+
+    func testOverpassCategorySpecificOverridesGeneric() {
+        let mixed: [String: String] = ["amenity": "coworking_space", "shop": "coffee"]
+        XCTAssertEqual(OverpassService.category(for: mixed), .work)
+    }
+
+    // MARK: - Overpass query / decode
+
+    func testOverpassQueryIncludesRadiusAndCoordinate() {
+        let q = OverpassService.buildQuery(lat: 21.0285, lon: 105.8542, radiusMeters: 3000, limit: 30)
+        XCTAssertTrue(q.contains("around:3000,21.0285,105.8542"))
+        XCTAssertTrue(q.contains("out body 30"))
+        XCTAssertTrue(q.contains("amenity"))
+    }
+
+    func testOverpassDecodePOIsExtractsNamedNodes() throws {
+        let json = """
+        {"elements":[
+          {"type":"node","id":1,"lat":21.0,"lon":105.8,"tags":{"name":"Quán Cà Phê","name:en":"The Cafe","amenity":"cafe"}},
+          {"type":"node","id":2,"lat":21.0,"lon":105.8,"tags":{"amenity":"cafe"}},
+          {"type":"node","id":3,"lat":21.0,"lon":105.8,"tags":{"name":"Park","leisure":"park"}}
+        ]}
+        """.data(using: .utf8)!
+        let pois = try OverpassService.decodePOIs(from: json)
+        // Node 2 has no name and must be filtered out.
+        XCTAssertEqual(pois.count, 2)
+        XCTAssertEqual(pois[0].nameEn, "The Cafe")
+        XCTAssertEqual(pois[0].osmId, 1)
+        XCTAssertEqual(pois[1].name, "Park")
+    }
+
+    // MARK: - AI synthesis fallback
+
+    @MainActor
+    func testSynthesizeExperiencesFallsBackWhenNoAPIKey() async throws {
+        unsetenv("ANTHROPIC_API_KEY")
+        let ai = AIService()
+        let pois: [OverpassService.POI] = [
+            .init(osmId: 100, name: "Cà phê Giảng", nameEn: "Giang Cafe",
+                  lat: 21.034, lon: 105.852,
+                  tags: ["amenity": "cafe", "name": "Cà phê Giảng"]),
+            .init(osmId: 101, name: "Hoàn Kiếm Lake", nameEn: nil,
+                  lat: 21.029, lon: 105.853,
+                  tags: ["leisure": "park"])
+        ]
+        let result = try await ai.synthesizeExperiences(from: pois, cityCode: "osm_21.0_105.9")
+        XCTAssertEqual(result.count, 2)
+        XCTAssertTrue(result.allSatisfy { $0.id.hasPrefix("exp_osm_") })
+        XCTAssertTrue(result.allSatisfy { $0.confidence.level == 1 })
+        XCTAssertEqual(result.first?.category, .coffee)
+        XCTAssertEqual(result.last?.category, .nature)
+    }
+
+    @MainActor
+    func testSynthesisLimitCapsInputs() async throws {
+        unsetenv("ANTHROPIC_API_KEY")
+        let ai = AIService()
+        let many: [OverpassService.POI] = (0..<25).map {
+            .init(osmId: Int64(1000 + $0), name: "Spot \($0)", nameEn: nil,
+                  lat: 0, lon: 0, tags: ["amenity": "restaurant"])
+        }
+        let result = try await ai.synthesizeExperiences(from: many, cityCode: "osm_0.0_0.0")
+        XCTAssertEqual(result.count, AIService.synthesisLimit)
+    }
+
+    // MARK: - ExperienceService.appendGenerated
+
+    func testAppendGeneratedDeduplicatesById() {
+        let service = ExperienceService()
+        let originalCount = service.allExperiences.count
+
+        let poi = OverpassService.POI(
+            osmId: 999,
+            name: "Test Place",
+            nameEn: nil,
+            lat: 0,
+            lon: 0,
+            tags: ["amenity": "cafe"]
+        )
+        let generated = AIService.skeletonExperience(from: poi, cityCode: "osm_0.0_0.0")
+
+        let firstAdded = service.appendGenerated([generated])
+        XCTAssertEqual(firstAdded, 1)
+        XCTAssertEqual(service.allExperiences.count, originalCount + 1)
+
+        let secondAdded = service.appendGenerated([generated])
+        XCTAssertEqual(secondAdded, 0)
+        XCTAssertEqual(service.allExperiences.count, originalCount + 1)
+    }
+
+    // MARK: - MapViewModel exploration
+
+    @MainActor
+    func testExploreCityCodeIsStableForNearbyCoordinates() {
+        let hanoiA = CLLocationCoordinate2D(latitude: 21.04, longitude: 105.83)
+        let hanoiB = CLLocationCoordinate2D(latitude: 21.03, longitude: 105.84)
+        let codeA = MapViewModel.cityCode(for: hanoiA)
+        let codeB = MapViewModel.cityCode(for: hanoiB)
+        XCTAssertEqual(codeA, codeB, "Coordinates within ~11km should share a city code")
+        XCTAssertTrue(codeA.hasPrefix("osm_"))
+    }
+
+    @MainActor
+    func testExploreCityCodeDiffersForDistantCoordinates() {
+        let hanoi = CLLocationCoordinate2D(latitude: 21.0285, longitude: 105.8542)
+        let tokyo = CLLocationCoordinate2D(latitude: 35.6762, longitude: 139.6503)
+        XCTAssertNotEqual(MapViewModel.cityCode(for: hanoi), MapViewModel.cityCode(for: tokyo))
+    }
 }

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -22,7 +22,13 @@ public final class MapViewModel {
     private let locationService: LocationService
     private let experienceService: ExperienceService
     private let aiService: AIService
+    private let overpassService: OverpassService
     private let preferences: UserPreferences
+
+    // MARK: - Explore-here state
+    public var isExploring: Bool = false
+    public var lastExploreError: String?
+    public var lastExploreAddedCount: Int = 0
 
     // MARK: - Auto-recenter
 
@@ -182,11 +188,13 @@ public final class MapViewModel {
         locationService: LocationService,
         experienceService: ExperienceService,
         aiService: AIService,
-        preferences: UserPreferences
+        preferences: UserPreferences,
+        overpassService: OverpassService = OverpassService()
     ) {
         self.locationService = locationService
         self.experienceService = experienceService
         self.aiService = aiService
+        self.overpassService = overpassService
         self.preferences = preferences
         self.selectedCity = preferences.lastSelectedCity
         let initialCenter: CLLocationCoordinate2D
@@ -487,6 +495,59 @@ public final class MapViewModel {
     /// Number of experiences in a given city (for the city picker row subtitle).
     public func experienceCount(for cityCode: String) -> Int {
         experienceService.allExperiences.filter { $0.location.cityCode == cityCode }.count
+    }
+
+    // MARK: - Explore Here
+
+    /// Pull real OSM POIs near `coordinate`, hand them to AIService for
+    /// solo-traveler enrichment, append the generated Experiences to the
+    /// store, and refresh the visible set. No-op if already exploring.
+    /// `cityCode` defaults to a stable hash of the coordinate so generated
+    /// experiences group together in city pills.
+    public func exploreNearby(
+        at coordinate: CLLocationCoordinate2D,
+        radiusMeters: Int = 3000
+    ) async {
+        guard !isExploring else { return }
+        isExploring = true
+        lastExploreError = nil
+        lastExploreAddedCount = 0
+        defer { isExploring = false }
+
+        let cityCode = Self.cityCode(for: coordinate)
+        do {
+            let pois = try await overpassService.fetchPOIs(near: coordinate, radiusMeters: radiusMeters)
+            guard !pois.isEmpty else {
+                lastExploreError = NSLocalizedString("explore.error.nothingFound", comment: "No POIs found nearby")
+                return
+            }
+            let generated = try await aiService.synthesizeExperiences(
+                from: pois,
+                cityCode: cityCode,
+                locale: .current
+            )
+            let added = experienceService.appendGenerated(generated)
+            lastExploreAddedCount = added
+            recenter(on: coordinate)
+        } catch {
+            lastExploreError = error.localizedDescription
+        }
+    }
+
+    /// Stable, lat/lon-derived city code used for OSM-generated entries so
+    /// the existing city pill / filter logic still works. Format:
+    /// `osm_<latRounded>_<lonRounded>`. Rounded to 1 decimal degree (~11 km).
+    static func cityCode(for coordinate: CLLocationCoordinate2D) -> String {
+        let lat = (coordinate.latitude * 10).rounded() / 10
+        let lon = (coordinate.longitude * 10).rounded() / 10
+        return String(format: "osm_%.1f_%.1f", lat, lon)
+    }
+
+    /// Best coordinate to anchor "Explore here" on: live GPS if available,
+    /// otherwise the currently-selected city center. Used by the map view's
+    /// Explore button.
+    public var exploreAnchorCoordinate: CLLocationCoordinate2D {
+        locationService.currentLocation?.coordinate ?? defaultCenterForSelectedCity
     }
 
     // MARK: - Helpers

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -88,6 +88,19 @@ public struct ExperienceDetailView: View {
 
     private var heroSection: some View {
         VStack(alignment: .leading, spacing: 12) {
+            if viewModel.experience.id.hasPrefix("exp_osm_") {
+                HStack(spacing: 6) {
+                    Image(systemName: "sparkles")
+                        .font(.caption2)
+                    Text(NSLocalizedString("explore.aiBadge", comment: "AI-generated from OpenStreetMap"))
+                        .font(.caption.weight(.medium))
+                }
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Capsule().fill(Color(.tertiarySystemFill)))
+                .accessibilityLabel(Text(NSLocalizedString("explore.aiBadge", comment: "AI-generated from OpenStreetMap")))
+            }
             HStack(spacing: 8) {
                 Image(systemName: viewModel.experience.category.symbol)
                     .font(.subheadline)

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -108,7 +108,6 @@ public struct CompassMapView: View {
                 VStack {
                     Spacer()
                     HStack(alignment: .bottom) {
-                        // Settings button (bottom-left)
                         Button {
                             viewModel.isShowingSettings = true
                         } label: {
@@ -122,6 +121,31 @@ public struct CompassMapView: View {
                         .padding(.leading, 20)
                         .padding(.bottom, 80)
                         .accessibilityLabel(Text(NSLocalizedString("settings.title", comment: "Settings")))
+
+                        // Explore-here button — pulls real OSM POIs near the
+                        // current location and asks AIService to enrich them.
+                        Button {
+                            let anchor = viewModel.exploreAnchorCoordinate
+                            Task { await viewModel.exploreNearby(at: anchor) }
+                        } label: {
+                            Group {
+                                if viewModel.isExploring {
+                                    ProgressView()
+                                        .progressViewStyle(.circular)
+                                } else {
+                                    Image(systemName: "sparkle.magnifyingglass")
+                                        .font(.title3)
+                                }
+                            }
+                            .frame(width: 48, height: 48)
+                            .background(Circle().fill(.regularMaterial))
+                            .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.leading, 12)
+                        .padding(.bottom, 80)
+                        .disabled(viewModel.isExploring)
+                        .accessibilityLabel(Text(NSLocalizedString("explore.button", comment: "Explore here")))
 
                         Spacer()
 

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -65,6 +65,9 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.solocompass.tests
+        GENERATE_INFOPLIST_FILE: YES
+        CODE_SIGN_STYLE: Automatic
+        CODE_SIGNING_ALLOWED: NO
     dependencies:
       - target: SoloCompass
 


### PR DESCRIPTION
## Summary
- New **Explore here** button on the map: pulls up to 30 real POIs from the public Overpass API within 3 km, asks `AIService` to enrich up to 15 of them into solo-traveler-focused Experiences, drops them on the map.
- Works in any city worldwide (Hanoi, Tokyo, you name it) — the curated seed only covers Chiang Mai today, so the rest of the planet was a blank map.
- Graceful fallback: when no `ANTHROPIC_API_KEY` is configured, OSM POIs become skeleton Experiences (real coords + name + tag-mapped category, default Solo Score 7.0). The feature is usable for free users.
- Generated entries are clearly marked: `id = exp_osm_<osmId>`, `confidence.level = 1`, `status = .candidate`, "AI-generated · OpenStreetMap" badge in detail view, "© OpenStreetMap contributors" in sources (ODbL compliance).

## What's in the diff
| File | Change |
|---|---|
| `Services/OverpassService.swift` | **NEW** — Overpass POST query, JSON decode, OSM-tag → `ExperienceCategory` mapping |
| `Services/AIService.swift` | `synthesizeExperiences(from:cityCode:locale:)` (single Claude call for the batch) + `skeletonExperience(...)` fallback |
| `Services/ExperienceService.swift` | `appendGenerated(_:)` — dedupe-by-id merge |
| `ViewModels/MapViewModel.swift` | `exploreNearby(at:radiusMeters:)` orchestration, `isExploring` state, stable `cityCode(for:)` |
| `Views/Map/CompassMapView.swift` | "Explore here" circular button next to Settings, with spinner while running |
| `Views/Experience/ExperienceDetailView.swift` | AI-generated badge for `exp_osm_*` entries |
| `Resources/en.lproj/Localizable.strings` | 7 new keys (`explore.*`, `overpass.*`) |
| `Tests/SoloCompassTests.swift` | +11 tests |
| `project.yml` + `project.pbxproj` | Fix pre-existing test target Info.plist signing so `xcodebuild test` succeeds |

## Test plan
- [x] `xcodebuild build` succeeds (iPhone 17 / iOS 26.4 simulator)
- [x] `xcodebuild test` — **24/24 passing** (11 new tests covering tag mapping, query construction, JSON decode, AI fallback, append dedupe, cityCode stability)
- [ ] Manual: launch in simulator, tap "Explore here" with no API key → skeleton pins appear on map
- [ ] Manual: launch with `ANTHROPIC_API_KEY` set → enriched Experiences with full title/oneLiner/howTo
- [ ] Manual: long-press the new pin → detail sheet shows "AI-generated · OpenStreetMap" badge
- [ ] Manual: verify the OSM attribution is visible on the source row