### PR TITLE
Feat/explore nearby

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		86F4628473C2D520D4C2FFFB /* SoloScoreBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB579F3F4EBBA014AA306DD1 /* SoloScoreBadge.swift */; };
 		A84320715E7CBDA91FC3F26F /* ExperienceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */; };
 		AA75B3147A29FDA55E61B24A /* PendingCheckInBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */; };
+		B28F15C454376D86258FCD77 /* OverpassService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67173C74F1A76C3CE5C38C0A /* OverpassService.swift */; };
 		BAC775E6105DD571F71ACBC1 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 80020844C0A45A5993333741 /* Localizable.strings */; };
 		BD5BB6BD7FCBDB30282F28FA /* VoiceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8ABF85EEFDF9969C94B441 /* VoiceButton.swift */; };
 		C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */; };
@@ -64,6 +65,7 @@
 		576B08910782A58C3597E596 /* ReportIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportIssueSheet.swift; sourceTree = "<group>"; };
 		5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailViewModel.swift; sourceTree = "<group>"; };
 		61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = seed_experiences.json; sourceTree = "<group>"; };
+		67173C74F1A76C3CE5C38C0A /* OverpassService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverpassService.swift; sourceTree = "<group>"; };
 		6C5CA5533D846B39EF16CDFA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		873ACB737A9B43254C17B238 /* CityPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityPickerSheet.swift; sourceTree = "<group>"; };
 		8FDFA5F3503B8ABC4B5CB086 /* SoloCompassTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SoloCompassTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -187,6 +189,7 @@
 				12F087E4FA7161529378098C /* ExperienceService.swift */,
 				2C7919EAFDE363B49C4B4C47 /* LocationService.swift */,
 				C215AE07BA32182A887226F9 /* NotificationService.swift */,
+				67173C74F1A76C3CE5C38C0A /* OverpassService.swift */,
 				120FC7465285714C5FA8F96D /* VoiceService.swift */,
 			);
 			path = Services;
@@ -311,7 +314,7 @@
 					};
 					D49FFD818AF5AD3EDE92522D = {
 						DevelopmentTeam = 6RG2F8YY59;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -380,6 +383,7 @@
 				214AF641496E8E50E3EC5FE4 /* MicroSurveySheet.swift in Sources */,
 				C53DB60CA9E95907A2CBF2C0 /* NotificationService.swift in Sources */,
 				C81007F6A39364D0872736B2 /* OnboardingView.swift in Sources */,
+				B28F15C454376D86258FCD77 /* OverpassService.swift in Sources */,
 				AA75B3147A29FDA55E61B24A /* PendingCheckInBanner.swift in Sources */,
 				EF2003CC07F7787C25847BDF /* ReportIssueSheet.swift in Sources */,
 				58B7C9B20945838F81081941 /* SettingsView.swift in Sources */,
@@ -584,6 +588,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -601,6 +608,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -232,3 +232,14 @@
 "settings.clearData.confirm.title" = "Clear all data?";
 "settings.clearData.confirm.action" = "Clear everything";
 "settings.clearData.confirm.message" = "This removes your completed experiences, favorites, and preferences. It cannot be undone.";
+
+/* Explore here */
+"explore.button" = "Explore here";
+"explore.aiBadge" = "AI-generated · OpenStreetMap";
+"explore.error.nothingFound" = "No public places found nearby. Try moving the map.";
+"explore.skeleton.oneLiner" = "A real spot pulled from OpenStreetMap.";
+"explore.skeleton.why" = "We don't have a curated story for this place yet. Visit, then add what you found.";
+
+/* Overpass errors */
+"overpass.error.url" = "Overpass endpoint URL is invalid.";
+"overpass.error.request" = "Map data request failed (status %d).";

--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -247,4 +247,210 @@ public final class AIService {
         }
         return try JSONDecoder().decode(AIResponse.self, from: data)
     }
+
+    // MARK: - Synthesize from OSM POIs (Explore Here)
+
+    /// Maximum POIs sent to the model in one call. Keeps prompt size and cost
+    /// predictable, and matches the product cap of 15 generated experiences.
+    public static let synthesisLimit = 15
+
+    /// Convert a batch of OSM POIs into Experiences. Sends a single Claude
+    /// request that returns a JSON array of experiences. Falls back to a
+    /// skeleton derived from OSM tags when the API key is missing or the
+    /// request fails — so users without an API key still get pins on the map.
+    public func synthesizeExperiences(
+        from pois: [OverpassService.POI],
+        cityCode: String,
+        locale: Locale = .current
+    ) async throws -> [Experience] {
+        let capped = Array(pois.prefix(Self.synthesisLimit))
+        guard !capped.isEmpty else { return [] }
+
+        let prompt = Self.synthesisPrompt(pois: capped, cityCode: cityCode, locale: locale)
+        do {
+            let raw = try await sendMessage(prompt: prompt)
+            return try Self.parseSynthesizedExperiences(raw, pois: capped, cityCode: cityCode)
+        } catch {
+            return capped.map { Self.skeletonExperience(from: $0, cityCode: cityCode) }
+        }
+    }
+
+    // MARK: - Synthesize helpers
+
+    private static func synthesisPrompt(pois: [OverpassService.POI], cityCode: String, locale: Locale) -> String {
+        let langTag = locale.language.languageCode?.identifier ?? "en"
+        let lines = pois.map { poi -> String in
+            let displayName = poi.nameEn ?? poi.name
+            let tagSummary = poi.tags
+                .filter { ["amenity", "tourism", "leisure", "natural", "shop", "cuisine", "opening_hours"].contains($0.key) }
+                .map { "\($0.key)=\($0.value)" }
+                .sorted()
+                .joined(separator: ", ")
+            return "- osmId=\(poi.osmId) name=\"\(poi.name)\" nameEn=\"\(displayName)\" lat=\(poi.lat) lon=\(poi.lon) tags=[\(tagSummary)]"
+        }.joined(separator: "\n")
+
+        return """
+        You are writing solo-traveler-focused entries for real places sourced from OpenStreetMap.
+
+        For each POI below, return ONE JSON object with these fields and nothing else:
+        {
+          "osmId": <int>,
+          "title": "<action-oriented sensory line, less than 14 words>",
+          "oneLiner": "<one concrete detail, less than 25 words>",
+          "whyItMatters": "<2-3 sentences for someone alone>",
+          "category": "food|coffee|culture|nature|work|wellness|nightlife|hidden",
+          "bestStartHour": <0-23>,
+          "bestEndHour": <0-23>,
+          "durationMinMinutes": <int>,
+          "durationMaxMinutes": <int>,
+          "howTo": ["step 1", "step 2", "step 3"],
+          "soloHint": "<one short hint for solo visitors>",
+          "soloOverall": <number 6.0-9.5>
+        }
+
+        Output a JSON array containing one object per POI, in input order. No prose. No markdown fences.
+
+        Output language: \(langTag).
+        City code: \(cityCode).
+
+        POIs:
+        \(lines)
+        """
+    }
+
+    private static func parseSynthesizedExperiences(
+        _ raw: String,
+        pois: [OverpassService.POI],
+        cityCode: String
+    ) throws -> [Experience] {
+        guard
+            let start = raw.firstIndex(of: "["),
+            let end = raw.lastIndex(of: "]"),
+            start <= end,
+            let data = String(raw[start...end]).data(using: .utf8)
+        else {
+            throw AIError.decodingFailed("no JSON array in synthesis response")
+        }
+
+        struct Item: Decodable {
+            let osmId: Int64
+            let title: String
+            let oneLiner: String
+            let whyItMatters: String
+            let category: String
+            let bestStartHour: Int?
+            let bestEndHour: Int?
+            let durationMinMinutes: Int?
+            let durationMaxMinutes: Int?
+            let howTo: [String]?
+            let soloHint: String?
+            let soloOverall: Double?
+        }
+        let items = try JSONDecoder().decode([Item].self, from: data)
+        let poiById = Dictionary(uniqueKeysWithValues: pois.map { ($0.osmId, $0) })
+        let now = Date()
+
+        return items.compactMap { item in
+            guard let poi = poiById[item.osmId] else { return nil }
+            let category = ExperienceCategory(rawValue: item.category) ?? OverpassService.category(for: poi.tags)
+            let startHour = item.bestStartHour.map { max(0, min(23, $0)) } ?? 9
+            let endHour = item.bestEndHour.map { max(0, min(23, $0)) } ?? 21
+            let dMin = item.durationMinMinutes ?? 30
+            let dMax = max(dMin, item.durationMaxMinutes ?? 90)
+            let overall = max(6.0, min(9.5, item.soloOverall ?? 7.0))
+            let breakdown = SoloScore.Breakdown(
+                seatingFriendly: overall, soloPatronRatio: overall, staffPressure: overall,
+                soloPortioning: overall, ambianceFit: overall, safety: overall
+            )
+            let howTo = (item.howTo ?? []).enumerated().map { HowToStep(order: $0.offset + 1, text: $0.element) }
+            return Experience(
+                id: "exp_osm_\(poi.osmId)",
+                title: item.title,
+                oneLiner: item.oneLiner,
+                whyItMatters: item.whyItMatters,
+                category: category,
+                location: ExperienceLocation(
+                    coordinates: [poi.lon, poi.lat],
+                    cityCode: cityCode,
+                    addressHint: nil,
+                    placeNameLocal: poi.name,
+                    placeNameRomanized: poi.nameEn
+                ),
+                bestTimes: [TimeWindow(startHour: startHour, endHour: endHour)],
+                durationMinutes: .init(min: dMin, max: dMax),
+                howTo: howTo,
+                realInconveniences: [],
+                soloScore: SoloScore(overall: overall, breakdown: breakdown, hint: item.soloHint, basedOnCount: 0),
+                sources: [
+                    InformationSource(
+                        type: .user,
+                        url: URL(string: "https://www.openstreetmap.org/node/\(poi.osmId)"),
+                        attribution: "© OpenStreetMap contributors + AI",
+                        verifiedAt: now
+                    )
+                ],
+                confidence: Confidence(
+                    level: 1,
+                    lastVerifiedAt: now,
+                    reason: "AI-synthesized from OpenStreetMap, unverified",
+                    signals: .init(aiScrapeAgeDays: 0, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)
+                ),
+                nearbyExperienceIds: [],
+                stats: .init(completionCount: 0, averageRating: 0),
+                status: .candidate,
+                createdAt: now,
+                updatedAt: now
+            )
+        }
+    }
+
+    /// Build a minimal Experience from raw OSM data, used when AI is unavailable.
+    /// Preserves coordinate + name + category; everything else is conservative defaults.
+    static func skeletonExperience(from poi: OverpassService.POI, cityCode: String) -> Experience {
+        let now = Date()
+        let category = OverpassService.category(for: poi.tags)
+        let displayName = poi.nameEn ?? poi.name
+        let breakdown = SoloScore.Breakdown(
+            seatingFriendly: 7, soloPatronRatio: 7, staffPressure: 7,
+            soloPortioning: 7, ambianceFit: 7, safety: 7
+        )
+        return Experience(
+            id: "exp_osm_\(poi.osmId)",
+            title: displayName,
+            oneLiner: NSLocalizedString("explore.skeleton.oneLiner", comment: "Generic OSM POI tagline"),
+            whyItMatters: NSLocalizedString("explore.skeleton.why", comment: "Generic OSM POI rationale"),
+            category: category,
+            location: ExperienceLocation(
+                coordinates: [poi.lon, poi.lat],
+                cityCode: cityCode,
+                addressHint: nil,
+                placeNameLocal: poi.name,
+                placeNameRomanized: poi.nameEn
+            ),
+            bestTimes: [TimeWindow(startHour: 9, endHour: 21)],
+            durationMinutes: .init(min: 30, max: 90),
+            howTo: [],
+            realInconveniences: [],
+            soloScore: SoloScore(overall: 7.0, breakdown: breakdown, hint: nil, basedOnCount: 0),
+            sources: [
+                InformationSource(
+                    type: .user,
+                    url: URL(string: "https://www.openstreetmap.org/node/\(poi.osmId)"),
+                    attribution: "© OpenStreetMap contributors",
+                    verifiedAt: now
+                )
+            ],
+            confidence: Confidence(
+                level: 1,
+                lastVerifiedAt: now,
+                reason: "OpenStreetMap entry, no AI enrichment",
+                signals: .init(aiScrapeAgeDays: 0, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)
+            ),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .candidate,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
 }

--- a/apps/ios/SoloCompass/Services/ExperienceService.swift
+++ b/apps/ios/SoloCompass/Services/ExperienceService.swift
@@ -71,6 +71,20 @@ public final class ExperienceService {
         preferences.toggleFavorite(id)
     }
 
+    /// Merge a batch of newly generated experiences into the in-memory store.
+    /// De-duplicates by id (existing entries win — they may have user state
+    /// like completion stats we don't want to clobber). Returns the count of
+    /// newly inserted experiences so callers can show feedback.
+    @discardableResult
+    public func appendGenerated(_ generated: [Experience]) -> Int {
+        let existingIds = Set(allExperiences.map(\.id))
+        let fresh = generated.filter { !existingIds.contains($0.id) }
+        guard !fresh.isEmpty else { return 0 }
+        allExperiences.append(contentsOf: fresh)
+        filteredExperiences = allExperiences
+        return fresh.count
+    }
+
     // MARK: - Loading
 
     private static func loadFromBundle() -> [Experience]? {

--- a/apps/ios/SoloCompass/Services/OverpassService.swift
+++ b/apps/ios/SoloCompass/Services/OverpassService.swift
@@ -1,0 +1,211 @@
+import Foundation
+import CoreLocation
+import Observation
+
+/// Talks to the public Overpass API (OpenStreetMap) to fetch real-world POIs
+/// near a coordinate. Used by the "Explore here" feature so users in cities
+/// outside our seed data still get something on the map.
+///
+/// Overpass is free, key-less, and globally covered, but rate-limited
+/// (~10k queries/day per IP on the public instance). We cap query size and
+/// give the caller a single retry on transient failures.
+///
+/// Data attribution: © OpenStreetMap contributors (ODbL). Surfaces must show this.
+@Observable
+public final class OverpassService {
+    /// A single OSM POI we care about — name + coordinate + raw tags.
+    public struct POI: Codable, Hashable, Identifiable {
+        public let osmId: Int64
+        public let name: String
+        public let nameEn: String?
+        public let lat: Double
+        public let lon: Double
+        public let tags: [String: String]
+
+        public var id: Int64 { osmId }
+
+        public var coordinate: CLLocationCoordinate2D {
+            CLLocationCoordinate2D(latitude: lat, longitude: lon)
+        }
+
+        public init(osmId: Int64, name: String, nameEn: String?, lat: Double, lon: Double, tags: [String: String]) {
+            self.osmId = osmId
+            self.name = name
+            self.nameEn = nameEn
+            self.lat = lat
+            self.lon = lon
+            self.tags = tags
+        }
+    }
+
+    public enum OverpassError: Error, LocalizedError {
+        case invalidURL
+        case requestFailed(status: Int)
+        case decodingFailed(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidURL:
+                return NSLocalizedString("overpass.error.url", comment: "Invalid Overpass URL")
+            case .requestFailed(let status):
+                return String(format: NSLocalizedString("overpass.error.request", comment: "Overpass request failed status %d"), status)
+            case .decodingFailed(let msg):
+                return msg
+            }
+        }
+    }
+
+    public private(set) var isFetching: Bool = false
+
+    private let session: URLSession
+    private let endpoint = URL(string: "https://overpass-api.de/api/interpreter")
+    private let maxResults: Int
+
+    public init(session: URLSession = .shared, maxResults: Int = 30) {
+        self.session = session
+        self.maxResults = maxResults
+    }
+
+    // MARK: - Public
+
+    /// Fetch up to `maxResults` POIs within `radiusMeters` of the coordinate.
+    /// Retries once on network/5xx failure.
+    public func fetchPOIs(
+        near coordinate: CLLocationCoordinate2D,
+        radiusMeters: Int = 3000
+    ) async throws -> [POI] {
+        guard let endpoint else { throw OverpassError.invalidURL }
+        await MainActor.run { self.isFetching = true }
+        defer { Task { @MainActor [weak self] in self?.isFetching = false } }
+
+        let query = Self.buildQuery(lat: coordinate.latitude, lon: coordinate.longitude, radiusMeters: radiusMeters, limit: maxResults)
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue("SoloCompass-iOS/1.0", forHTTPHeaderField: "User-Agent")
+        request.timeoutInterval = 20
+        request.httpBody = "data=\(query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")".data(using: .utf8)
+
+        do {
+            return try await performAndDecode(request)
+        } catch {
+            try? await Task.sleep(nanoseconds: 800_000_000)
+            return try await performAndDecode(request)
+        }
+    }
+
+    // MARK: - HTTP
+
+    private func performAndDecode(_ request: URLRequest) async throws -> [POI] {
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw OverpassError.requestFailed(status: 0)
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw OverpassError.requestFailed(status: http.statusCode)
+        }
+        return try Self.decodePOIs(from: data)
+    }
+
+    // MARK: - Query
+
+    static func buildQuery(lat: Double, lon: Double, radiusMeters: Int, limit: Int) -> String {
+        let around = "around:\(radiusMeters),\(lat),\(lon)"
+        return """
+        [out:json][timeout:15];
+        (
+          node["amenity"~"^(restaurant|cafe|bar|pub|fast_food|ice_cream|food_court|library|coworking_space|spa)$"](\(around));
+          node["tourism"~"^(attraction|viewpoint|gallery|museum|artwork|zoo|aquarium)$"](\(around));
+          node["leisure"~"^(park|garden|nature_reserve|fitness_centre)$"](\(around));
+          node["natural"~"^(beach|peak|hot_spring)$"](\(around));
+          node["shop"~"^(books|coffee|tea)$"](\(around));
+        );
+        out body \(limit);
+        """
+    }
+
+    // MARK: - Decode
+
+    static func decodePOIs(from data: Data) throws -> [POI] {
+        struct Wrapper: Decodable {
+            let elements: [Element]
+        }
+        struct Element: Decodable {
+            let id: Int64
+            let lat: Double?
+            let lon: Double?
+            let tags: [String: String]?
+        }
+        do {
+            let wrapper = try JSONDecoder().decode(Wrapper.self, from: data)
+            return wrapper.elements.compactMap { el -> POI? in
+                guard let lat = el.lat, let lon = el.lon, let tags = el.tags else { return nil }
+                let nameEn = tags["name:en"]
+                let name = tags["name"] ?? nameEn ?? ""
+                guard !name.isEmpty else { return nil }
+                return POI(osmId: el.id, name: name, nameEn: nameEn, lat: lat, lon: lon, tags: tags)
+            }
+        } catch {
+            throw OverpassError.decodingFailed(String(describing: error))
+        }
+    }
+
+    // MARK: - Tag → category
+
+    /// Map raw OSM tags to a Solo Compass `ExperienceCategory`. Ordering matters:
+    /// more specific tags (e.g. coworking_space) win over generic ones.
+    public static func category(for tags: [String: String]) -> ExperienceCategory {
+        if let amenity = tags["amenity"] {
+            switch amenity {
+            case "cafe", "ice_cream":
+                return .coffee
+            case "restaurant", "fast_food", "food_court":
+                return .food
+            case "bar", "pub":
+                return .nightlife
+            case "library", "coworking_space":
+                return .work
+            case "spa":
+                return .wellness
+            default:
+                break
+            }
+        }
+        if let shop = tags["shop"] {
+            switch shop {
+            case "coffee", "tea":
+                return .coffee
+            case "books":
+                return .work
+            default:
+                break
+            }
+        }
+        if let tourism = tags["tourism"] {
+            switch tourism {
+            case "attraction", "viewpoint", "artwork":
+                return .culture
+            case "gallery", "museum":
+                return .culture
+            case "zoo", "aquarium":
+                return .nature
+            default:
+                break
+            }
+        }
+        if let leisure = tags["leisure"] {
+            switch leisure {
+            case "park", "garden", "nature_reserve":
+                return .nature
+            case "fitness_centre":
+                return .wellness
+            default:
+                break
+            }
+        }
+        if tags["natural"] != nil {
+            return .nature
+        }
+        return .hidden
+    }
+}

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -195,4 +195,134 @@ final class SoloCompassTests: XCTestCase {
         XCTAssertTrue(reloaded.isCompleted("exp_test_1"))
         XCTAssertTrue(reloaded.isFavorited("exp_test_2"))
     }
+
+    // MARK: - Overpass tag mapping
+
+    func testOverpassCategoryFromAmenity() {
+        XCTAssertEqual(OverpassService.category(for: ["amenity": "cafe"]), .coffee)
+        XCTAssertEqual(OverpassService.category(for: ["amenity": "restaurant"]), .food)
+        XCTAssertEqual(OverpassService.category(for: ["amenity": "bar"]), .nightlife)
+        XCTAssertEqual(OverpassService.category(for: ["amenity": "library"]), .work)
+        XCTAssertEqual(OverpassService.category(for: ["amenity": "spa"]), .wellness)
+    }
+
+    func testOverpassCategoryFromTourismAndLeisure() {
+        XCTAssertEqual(OverpassService.category(for: ["tourism": "museum"]), .culture)
+        XCTAssertEqual(OverpassService.category(for: ["tourism": "viewpoint"]), .culture)
+        XCTAssertEqual(OverpassService.category(for: ["leisure": "park"]), .nature)
+        XCTAssertEqual(OverpassService.category(for: ["natural": "beach"]), .nature)
+    }
+
+    func testOverpassCategoryFallsBackToHidden() {
+        XCTAssertEqual(OverpassService.category(for: [:]), .hidden)
+        XCTAssertEqual(OverpassService.category(for: ["highway": "primary"]), .hidden)
+    }
+
+    func testOverpassCategorySpecificOverridesGeneric() {
+        let mixed: [String: String] = ["amenity": "coworking_space", "shop": "coffee"]
+        XCTAssertEqual(OverpassService.category(for: mixed), .work)
+    }
+
+    // MARK: - Overpass query / decode
+
+    func testOverpassQueryIncludesRadiusAndCoordinate() {
+        let q = OverpassService.buildQuery(lat: 21.0285, lon: 105.8542, radiusMeters: 3000, limit: 30)
+        XCTAssertTrue(q.contains("around:3000,21.0285,105.8542"))
+        XCTAssertTrue(q.contains("out body 30"))
+        XCTAssertTrue(q.contains("amenity"))
+    }
+
+    func testOverpassDecodePOIsExtractsNamedNodes() throws {
+        let json = """
+        {"elements":[
+          {"type":"node","id":1,"lat":21.0,"lon":105.8,"tags":{"name":"Quán Cà Phê","name:en":"The Cafe","amenity":"cafe"}},
+          {"type":"node","id":2,"lat":21.0,"lon":105.8,"tags":{"amenity":"cafe"}},
+          {"type":"node","id":3,"lat":21.0,"lon":105.8,"tags":{"name":"Park","leisure":"park"}}
+        ]}
+        """.data(using: .utf8)!
+        let pois = try OverpassService.decodePOIs(from: json)
+        // Node 2 has no name and must be filtered out.
+        XCTAssertEqual(pois.count, 2)
+        XCTAssertEqual(pois[0].nameEn, "The Cafe")
+        XCTAssertEqual(pois[0].osmId, 1)
+        XCTAssertEqual(pois[1].name, "Park")
+    }
+
+    // MARK: - AI synthesis fallback
+
+    @MainActor
+    func testSynthesizeExperiencesFallsBackWhenNoAPIKey() async throws {
+        unsetenv("ANTHROPIC_API_KEY")
+        let ai = AIService()
+        let pois: [OverpassService.POI] = [
+            .init(osmId: 100, name: "Cà phê Giảng", nameEn: "Giang Cafe",
+                  lat: 21.034, lon: 105.852,
+                  tags: ["amenity": "cafe", "name": "Cà phê Giảng"]),
+            .init(osmId: 101, name: "Hoàn Kiếm Lake", nameEn: nil,
+                  lat: 21.029, lon: 105.853,
+                  tags: ["leisure": "park"])
+        ]
+        let result = try await ai.synthesizeExperiences(from: pois, cityCode: "osm_21.0_105.9")
+        XCTAssertEqual(result.count, 2)
+        XCTAssertTrue(result.allSatisfy { $0.id.hasPrefix("exp_osm_") })
+        XCTAssertTrue(result.allSatisfy { $0.confidence.level == 1 })
+        XCTAssertEqual(result.first?.category, .coffee)
+        XCTAssertEqual(result.last?.category, .nature)
+    }
+
+    @MainActor
+    func testSynthesisLimitCapsInputs() async throws {
+        unsetenv("ANTHROPIC_API_KEY")
+        let ai = AIService()
+        let many: [OverpassService.POI] = (0..<25).map {
+            .init(osmId: Int64(1000 + $0), name: "Spot \($0)", nameEn: nil,
+                  lat: 0, lon: 0, tags: ["amenity": "restaurant"])
+        }
+        let result = try await ai.synthesizeExperiences(from: many, cityCode: "osm_0.0_0.0")
+        XCTAssertEqual(result.count, AIService.synthesisLimit)
+    }
+
+    // MARK: - ExperienceService.appendGenerated
+
+    func testAppendGeneratedDeduplicatesById() {
+        let service = ExperienceService()
+        let originalCount = service.allExperiences.count
+
+        let poi = OverpassService.POI(
+            osmId: 999,
+            name: "Test Place",
+            nameEn: nil,
+            lat: 0,
+            lon: 0,
+            tags: ["amenity": "cafe"]
+        )
+        let generated = AIService.skeletonExperience(from: poi, cityCode: "osm_0.0_0.0")
+
+        let firstAdded = service.appendGenerated([generated])
+        XCTAssertEqual(firstAdded, 1)
+        XCTAssertEqual(service.allExperiences.count, originalCount + 1)
+
+        let secondAdded = service.appendGenerated([generated])
+        XCTAssertEqual(secondAdded, 0)
+        XCTAssertEqual(service.allExperiences.count, originalCount + 1)
+    }
+
+    // MARK: - MapViewModel exploration
+
+    @MainActor
+    func testExploreCityCodeIsStableForNearbyCoordinates() {
+        let hanoiA = CLLocationCoordinate2D(latitude: 21.04, longitude: 105.83)
+        let hanoiB = CLLocationCoordinate2D(latitude: 21.03, longitude: 105.84)
+        let codeA = MapViewModel.cityCode(for: hanoiA)
+        let codeB = MapViewModel.cityCode(for: hanoiB)
+        XCTAssertEqual(codeA, codeB, "Coordinates within ~11km should share a city code")
+        XCTAssertTrue(codeA.hasPrefix("osm_"))
+    }
+
+    @MainActor
+    func testExploreCityCodeDiffersForDistantCoordinates() {
+        let hanoi = CLLocationCoordinate2D(latitude: 21.0285, longitude: 105.8542)
+        let tokyo = CLLocationCoordinate2D(latitude: 35.6762, longitude: 139.6503)
+        XCTAssertNotEqual(MapViewModel.cityCode(for: hanoi), MapViewModel.cityCode(for: tokyo))
+    }
 }

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -22,7 +22,13 @@ public final class MapViewModel {
     private let locationService: LocationService
     private let experienceService: ExperienceService
     private let aiService: AIService
+    private let overpassService: OverpassService
     private let preferences: UserPreferences
+
+    // MARK: - Explore-here state
+    public var isExploring: Bool = false
+    public var lastExploreError: String?
+    public var lastExploreAddedCount: Int = 0
 
     // MARK: - Auto-recenter
 
@@ -182,11 +188,13 @@ public final class MapViewModel {
         locationService: LocationService,
         experienceService: ExperienceService,
         aiService: AIService,
-        preferences: UserPreferences
+        preferences: UserPreferences,
+        overpassService: OverpassService = OverpassService()
     ) {
         self.locationService = locationService
         self.experienceService = experienceService
         self.aiService = aiService
+        self.overpassService = overpassService
         self.preferences = preferences
         self.selectedCity = preferences.lastSelectedCity
         let initialCenter: CLLocationCoordinate2D
@@ -487,6 +495,59 @@ public final class MapViewModel {
     /// Number of experiences in a given city (for the city picker row subtitle).
     public func experienceCount(for cityCode: String) -> Int {
         experienceService.allExperiences.filter { $0.location.cityCode == cityCode }.count
+    }
+
+    // MARK: - Explore Here
+
+    /// Pull real OSM POIs near `coordinate`, hand them to AIService for
+    /// solo-traveler enrichment, append the generated Experiences to the
+    /// store, and refresh the visible set. No-op if already exploring.
+    /// `cityCode` defaults to a stable hash of the coordinate so generated
+    /// experiences group together in city pills.
+    public func exploreNearby(
+        at coordinate: CLLocationCoordinate2D,
+        radiusMeters: Int = 3000
+    ) async {
+        guard !isExploring else { return }
+        isExploring = true
+        lastExploreError = nil
+        lastExploreAddedCount = 0
+        defer { isExploring = false }
+
+        let cityCode = Self.cityCode(for: coordinate)
+        do {
+            let pois = try await overpassService.fetchPOIs(near: coordinate, radiusMeters: radiusMeters)
+            guard !pois.isEmpty else {
+                lastExploreError = NSLocalizedString("explore.error.nothingFound", comment: "No POIs found nearby")
+                return
+            }
+            let generated = try await aiService.synthesizeExperiences(
+                from: pois,
+                cityCode: cityCode,
+                locale: .current
+            )
+            let added = experienceService.appendGenerated(generated)
+            lastExploreAddedCount = added
+            recenter(on: coordinate)
+        } catch {
+            lastExploreError = error.localizedDescription
+        }
+    }
+
+    /// Stable, lat/lon-derived city code used for OSM-generated entries so
+    /// the existing city pill / filter logic still works. Format:
+    /// `osm_<latRounded>_<lonRounded>`. Rounded to 1 decimal degree (~11 km).
+    static func cityCode(for coordinate: CLLocationCoordinate2D) -> String {
+        let lat = (coordinate.latitude * 10).rounded() / 10
+        let lon = (coordinate.longitude * 10).rounded() / 10
+        return String(format: "osm_%.1f_%.1f", lat, lon)
+    }
+
+    /// Best coordinate to anchor "Explore here" on: live GPS if available,
+    /// otherwise the currently-selected city center. Used by the map view's
+    /// Explore button.
+    public var exploreAnchorCoordinate: CLLocationCoordinate2D {
+        locationService.currentLocation?.coordinate ?? defaultCenterForSelectedCity
     }
 
     // MARK: - Helpers

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -88,6 +88,19 @@ public struct ExperienceDetailView: View {
 
     private var heroSection: some View {
         VStack(alignment: .leading, spacing: 12) {
+            if viewModel.experience.id.hasPrefix("exp_osm_") {
+                HStack(spacing: 6) {
+                    Image(systemName: "sparkles")
+                        .font(.caption2)
+                    Text(NSLocalizedString("explore.aiBadge", comment: "AI-generated from OpenStreetMap"))
+                        .font(.caption.weight(.medium))
+                }
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Capsule().fill(Color(.tertiarySystemFill)))
+                .accessibilityLabel(Text(NSLocalizedString("explore.aiBadge", comment: "AI-generated from OpenStreetMap")))
+            }
             HStack(spacing: 8) {
                 Image(systemName: viewModel.experience.category.symbol)
                     .font(.subheadline)

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -108,7 +108,6 @@ public struct CompassMapView: View {
                 VStack {
                     Spacer()
                     HStack(alignment: .bottom) {
-                        // Settings button (bottom-left)
                         Button {
                             viewModel.isShowingSettings = true
                         } label: {
@@ -122,6 +121,31 @@ public struct CompassMapView: View {
                         .padding(.leading, 20)
                         .padding(.bottom, 80)
                         .accessibilityLabel(Text(NSLocalizedString("settings.title", comment: "Settings")))
+
+                        // Explore-here button — pulls real OSM POIs near the
+                        // current location and asks AIService to enrich them.
+                        Button {
+                            let anchor = viewModel.exploreAnchorCoordinate
+                            Task { await viewModel.exploreNearby(at: anchor) }
+                        } label: {
+                            Group {
+                                if viewModel.isExploring {
+                                    ProgressView()
+                                        .progressViewStyle(.circular)
+                                } else {
+                                    Image(systemName: "sparkle.magnifyingglass")
+                                        .font(.title3)
+                                }
+                            }
+                            .frame(width: 48, height: 48)
+                            .background(Circle().fill(.regularMaterial))
+                            .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.leading, 12)
+                        .padding(.bottom, 80)
+                        .disabled(viewModel.isExploring)
+                        .accessibilityLabel(Text(NSLocalizedString("explore.button", comment: "Explore here")))
 
                         Spacer()
 

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -65,6 +65,9 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.solocompass.tests
+        GENERATE_INFOPLIST_FILE: YES
+        CODE_SIGN_STYLE: Automatic
+        CODE_SIGNING_ALLOWED: NO
     dependencies:
       - target: SoloCompass
 

--- a/scripts/ralph/archive/2026-05-09-deepseek-migration/prd.json
+++ b/scripts/ralph/archive/2026-05-09-deepseek-migration/prd.json
@@ -1,0 +1,180 @@
+{
+  "project": "Solo Compass \u2014 DeepSeek Migration (TS-only stories)",
+  "branchName": "ralph/deepseek-migration",
+  "description": "Migrate the @solo-compass/ai package from Anthropic Claude (claude-opus-4-7) to DeepSeek (deepseek-v4-pro) using OpenAI-compatible JSON mode. Adds resilience (retry/backoff), observability (Sentry + PostHog), and supply-chain hygiene (gitleaks). iOS changes are excluded from this Ralph run \u2014 handled separately. Pre-flight scaffolding (.env.example, .gitignore, packages/ai/package.json, cost-tracker.ts, client.ts) was committed in 0ed511c before this run; these stories pick up from that state. Full design in tasks/prd-deepseek-migration.md.",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Rewrite rank-experiences.ts for DeepSeek JSON mode",
+      "description": "As a developer, I need rank-experiences.ts to call DeepSeek via the OpenAI SDK using JSON mode instead of Anthropic tool-use, so the package compiles after the dependency switch.",
+      "acceptanceCriteria": [
+        "Remove `import Anthropic from \"@anthropic-ai/sdk\"` and replace with `import type OpenAI from \"openai\"` plus `import { createDeepseekClient, deepseekModel } from \"../client\"`",
+        "Replace tool-use block with chat.completions.create using response_format: { type: 'json_object' }",
+        "System prompt instructs the model to output ONLY a JSON object {\"ranked\":[{experienceId,score,reason}]} with no markdown fences",
+        "Add defensive fence-stripping helper that handles ```json...``` wrappers before JSON.parse",
+        "Optional `client?` parameter changes type from `Anthropic` to `OpenAI`; default falls back to createDeepseekClient()",
+        "Score clamping (0-100) and id-validation logic preserved exactly",
+        "withCostTracking integration preserved using new OpenAI.CompletionUsage shape",
+        "File no longer references claude-opus-4-7 or any Anthropic types",
+        "Typecheck passes (run: pnpm --filter @solo-compass/ai typecheck)"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Rewrite structure-experience.ts for DeepSeek JSON mode",
+      "description": "As a developer, I need structure-experience.ts to use DeepSeek JSON mode for both extraction and refusal paths, so AI source-compilation works end-to-end on the new provider.",
+      "acceptanceCriteria": [
+        "Remove all `@anthropic-ai/sdk` imports and tool-use schemas (EMIT_EXPERIENCE_TOOL, REFUSE_TOOL)",
+        "System prompt requires the model to output JSON {\"action\":\"emit\"|\"refuse\", ...} with all schema fields described inline as JSON Schema-style guidance",
+        "On action='refuse', return { experience: null, refusalReason, modelConfidence: 0 }",
+        "On action='emit', map JSON fields to the Experience type identically to the previous implementation (id slug, GeoJSON coords, status='candidate', soloScore zeroed)",
+        "Defensive fence-stripping in shared parser",
+        "Optional `client?` parameter is `OpenAI` type",
+        "max_tokens: 2048 (unchanged from Anthropic version)",
+        "Typecheck passes (run: pnpm --filter @solo-compass/ai typecheck)"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Update packages/ai index.ts exports for DeepSeek",
+      "description": "As a consumer of @solo-compass/ai, I need access to the new DeepSeek client factory so I can override the default client in tests or in apps that prefer dependency injection.",
+      "acceptanceCriteria": [
+        "Re-export `createDeepseekClient`, `deepseekModel`, `deepseekBaseURL` from `./client`",
+        "Existing exports (rankExperiences, structureExperience, parseIntent, dedup, trackCost, withCostTracking, all *Input/*Result types) remain unchanged",
+        "No remaining `Anthropic` type re-exports",
+        "Typecheck passes (run: pnpm --filter @solo-compass/ai typecheck)"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-004",
+      "title": "Rewrite rank-experiences.test.ts to mock OpenAI shape",
+      "description": "As a maintainer, I need the unit tests to mock OpenAI's response shape so anti-hallucination guards continue to run without real API calls.",
+      "acceptanceCriteria": [
+        "Replace `import type Anthropic from \"@anthropic-ai/sdk\"` with `import type OpenAI from \"openai\"`",
+        "makeMockClient returns an object shaped like OpenAI client: `{ chat: { completions: { create: vi.fn().mockResolvedValue({ choices: [{ message: { content: <JSON-string> } }], usage: { prompt_tokens, completion_tokens, total_tokens }, model }) } } }`",
+        "Mock JSON content is `JSON.stringify({ ranked: rankedItems })`",
+        "All six existing test cases preserved (id-not-invented, score clamp 100, score clamp 0, max-3-items, empty-input, reason pass-through)",
+        "Test suite passes (run: pnpm --filter @solo-compass/ai test)",
+        "Typecheck passes"
+      ],
+      "priority": 4,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-005",
+      "title": "Rewrite structure-experience.test.ts to mock OpenAI shape and delete obsolete __golden__ files",
+      "description": "As a maintainer, I need golden-replay tests rewritten so they mock OpenAI's JSON response (or skipped pending live regeneration), and the now-obsolete Anthropic tool-use golden files removed.",
+      "acceptanceCriteria": [
+        "Delete `packages/ai/src/__golden__/wikivoyage-chiang-mai-suthep.json`",
+        "Delete `packages/ai/src/__golden__/reddit-coffee-thread.json`",
+        "Delete `packages/ai/src/__golden__/insufficient-blurb.json`",
+        "Add `packages/ai/src/__golden__/README.md` explaining how to regenerate via `LIVE_API=true pnpm --filter @solo-compass/ai test:live` once a real DEEPSEEK_API_KEY is available",
+        "Replace `structure-experience.test.ts` golden-replay tests with mock-based tests that hardcode small synthetic JSON responses inline (covers: emit-success path, refuse path, fence-wrapped response stripping, malformed JSON returns null with refusalReason)",
+        "All assertions remain meaningful (schema validity, GeoJSON order, source-url-not-fabricated, refusal reason non-empty)",
+        "Test suite passes (run: pnpm --filter @solo-compass/ai test)",
+        "Typecheck passes"
+      ],
+      "priority": 5,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-006",
+      "title": "Add retry-with-backoff helper for DeepSeek calls",
+      "description": "As a user with flaky network or hitting DeepSeek rate limits, I need transient errors to be retried automatically so a single 429 or network blip does not break my recommendation request.",
+      "acceptanceCriteria": [
+        "Create `packages/ai/src/retry.ts` exporting `withRetry<T>(fn: () => Promise<T>, opts?: { maxAttempts?: number; backoffSecs?: number[]; signal?: AbortSignal }): Promise<T>`",
+        "Defaults: maxAttempts=3, backoffSecs=[0, 2, 6]",
+        "Retries on: network errors (TypeError, fetch errors), 429, 502, 503, 504",
+        "Does NOT retry on: 400, 401, 403, 422 (auth/format errors)",
+        "Each retry waits backoffSecs[attempt-1] seconds; after final attempt, throws the last error",
+        "Wrap the openai.chat.completions.create call in rank-experiences.ts and structure-experience.ts with `withRetry(...)`",
+        "Add unit tests in `packages/ai/src/__tests__/retry.test.ts` covering: success on first try, retry-then-succeed, give-up-after-max, no-retry-on-401",
+        "Use vi.useFakeTimers() to keep tests fast",
+        "Typecheck passes",
+        "Test suite passes (run: pnpm --filter @solo-compass/ai test)"
+      ],
+      "priority": 6,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-007",
+      "title": "Initialize Sentry in apps/bot and apps/web entry points",
+      "description": "As a maintainer, I need crash and error reports to flow into Sentry so I can detect production issues without users having to file bugs.",
+      "acceptanceCriteria": [
+        "apps/bot: at the very top of `src/index.ts`, before any other import, call `Sentry.init({ dsn: process.env.SENTRY_DSN, tracesSampleRate: 0.1, environment: process.env.NODE_ENV ?? 'development' })`. If SENTRY_DSN is empty or missing, skip init silently (do not throw).",
+        "apps/bot: existing `captureException` calls continue to work (they already imported from @sentry/node)",
+        "apps/web: create three sibling files at the project root \u2014 `sentry.client.config.ts`, `sentry.server.config.ts`, `sentry.edge.config.ts` \u2014 each calling `Sentry.init` from `@sentry/nextjs` with appropriate settings. tracesSampleRate=0.1, dsn from env.",
+        "apps/web: update `next.config.ts` to wrap export with `withSentryConfig` from @sentry/nextjs (silent: true to keep build logs clean)",
+        "Add `SENTRY_DSN=` (empty) to `.env.example` under a `# \u2500\u2500\u2500 Sentry (error tracking) \u2500\u2500\u2500` block",
+        "Add `NEXT_PUBLIC_SENTRY_DSN=` to .env.example with note that it is the same value as SENTRY_DSN but exposed to browser bundles",
+        "Both apps build without error when SENTRY_DSN is empty",
+        "Typecheck passes for both apps (run: pnpm --filter @solo-compass/bot typecheck && pnpm --filter @solo-compass/web typecheck)"
+      ],
+      "priority": 7,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-008",
+      "title": "Forward AI cost events to PostHog from cost-tracker",
+      "description": "As a maintainer, I want every AI call's cost emitted to PostHog (in addition to stdout) so I can build cost dashboards and alerts without rolling my own log aggregation.",
+      "acceptanceCriteria": [
+        "Add `posthog-node` runtime dependency to packages/ai/package.json (^4.0.0)",
+        "In cost-tracker.ts, add a module-scoped lazy-initialized PostHog client that reads `process.env.POSTHOG_API_KEY` and `process.env.POSTHOG_HOST` (default https://app.posthog.com). If POSTHOG_API_KEY is empty, skip and only stdout-log.",
+        "trackCost() calls posthog.capture({ distinctId: 'system', event: 'ai_cost', properties: { route, usd_cents, model, input_tokens, output_tokens, duration_ms } }) \u2014 non-blocking, errors silently swallowed (with console.warn) so AI calls never fail because of PostHog",
+        "Add `POSTHOG_API_KEY=` and `POSTHOG_HOST=https://app.posthog.com` placeholders to .env.example under `# \u2500\u2500\u2500 PostHog (cost telemetry) \u2500\u2500\u2500`",
+        "Add a unit test in packages/ai/src/__tests__/cost-tracker.test.ts: when POSTHOG_API_KEY is unset, no posthog import side-effects occur; when set, capture is called with expected event shape (mock the PostHog class)",
+        "Existing stdout JSON log line continues to be emitted unchanged (other consumers may rely on it)",
+        "Typecheck passes",
+        "Test suite passes"
+      ],
+      "priority": 8,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-009",
+      "title": "Add gitleaks secret-scanning GitHub Action",
+      "description": "As a maintainer, I need every push and PR to be scanned for accidentally committed secrets so a key leak is caught before it merges.",
+      "acceptanceCriteria": [
+        "Create `.github/workflows/secret-scan.yml` running on push (all branches) and pull_request",
+        "Workflow uses `gitleaks/gitleaks-action@v2` with default config",
+        "Workflow has `permissions: contents: read` only (least privilege)",
+        "Workflow fails (non-zero exit) when leaks are detected",
+        "Add `.gitleaks.toml` at repo root with allowlist entries for: (a) the Mapbox public-token placeholder pattern `pk.eyJ` in .env.example; (b) the Supabase placeholder URL pattern in .env.example; (c) the literal string `sk-replace-me`. The .toml extends gitleaks' default ruleset.",
+        "Add a 'Secret scanning' section to the root README.md describing how to run gitleaks locally (`gitleaks detect --source . --no-git`) and what the .gitleaks.toml allowlist exempts and why",
+        "Workflow runs in under 30 seconds on a typical push"
+      ],
+      "priority": 9,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-010",
+      "title": "Inject placeholder .env in iOS CI workflows",
+      "description": "As CI, I need a placeholder .env so the iOS build's generate_secrets.sh step (added in a separate iOS commit) does not fail in environments where real secrets are not (and should not be) available.",
+      "acceptanceCriteria": [
+        "Edit `.github/workflows/ios-ci.yml`: add a `Create placeholder .env` step that runs BEFORE `xcodegen` and writes a heredoc-style file to repo root with empty DEEPSEEK_API_KEY, default DEEPSEEK_BASE_URL/MODEL, empty SENTRY_DSN, and DEVELOPMENT_TEAM=$DEVELOPMENT_TEAM env",
+        "Edit `.github/workflows/testflight.yml`: same step but populated from `${{ secrets.DEEPSEEK_API_KEY }}`, `${{ secrets.SENTRY_DSN }}`, etc. (these GitHub Secrets are configured manually outside this PR; their absence at run time produces empty values which is acceptable for placeholder behavior)",
+        "Both workflows continue to pass schema-parity \u2192 build \u2192 test pipeline",
+        "ios-ci.yml job named like 'Build iOS app (placeholder secrets)' so reviewers see this is intentional",
+        "No real secrets committed in either workflow file"
+      ],
+      "priority": 10,
+      "passes": true,
+      "notes": ""
+    }
+  ]
+}

--- a/scripts/ralph/archive/2026-05-09-deepseek-migration/progress.txt
+++ b/scripts/ralph/archive/2026-05-09-deepseek-migration/progress.txt
@@ -1,0 +1,19 @@
+# Solo Compass — Ralph Progress Log
+Started: 2026-05-08
+Tool: claude
+Branch: ralph/deepseek-migration
+PRD: tasks/prd-deepseek-migration.md
+Stories: 10
+---
+[2026-05-08T09:30:57Z] Story #US-001: Rewrite rank-experiences.ts for DeepSeek JSON mode — PASSED
+[2026-05-08T09:35:30Z] Story #US-002: Rewrite structure-experience.ts for DeepSeek JSON mode — PASSED
+[2026-05-08T09:35:17Z] Story #US-002: Rewrite structure-experience.ts for DeepSeek JSON mode — PASSED
+[2026-05-08T09:35:43Z] Story #US-003: Update packages/ai index.ts exports for DeepSeek — PASSED
+[2026-05-08T09:37:04Z] Story #US-004: Rewrite rank-experiences.test.ts to mock OpenAI shape — PASSED
+[2026-05-08T09:39:31Z] Story #US-005: Rewrite structure-experience.test.ts to mock OpenAI shape and delete obsolete __golden__ files — PASSED
+[2026-05-08T09:41:25Z] Story #US-006: Add retry-with-backoff helper for DeepSeek calls — PASSED
+[2026-05-08T09:43:29Z] Story #US-007: Initialize Sentry in apps/bot and apps/web entry points — PASSED
+[2026-05-08T09:45:34Z] Story #US-008: Forward AI cost events to PostHog from cost-tracker — PASSED
+[2026-05-08T09:46:24Z] Story #US-009: Add gitleaks secret-scanning GitHub Action — PASSED
+[2026-05-08T09:47:10Z] Story #US-010: Inject placeholder .env in iOS CI workflows — PASSED
+[2026-05-08T09:47:10Z] Ralph complete after 10 iterations

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -1,179 +1,726 @@
 {
-  "project": "Solo Compass \u2014 DeepSeek Migration (TS-only stories)",
-  "branchName": "ralph/deepseek-migration",
-  "description": "Migrate the @solo-compass/ai package from Anthropic Claude (claude-opus-4-7) to DeepSeek (deepseek-v4-pro) using OpenAI-compatible JSON mode. Adds resilience (retry/backoff), observability (Sentry + PostHog), and supply-chain hygiene (gitleaks). iOS changes are excluded from this Ralph run \u2014 handled separately. Pre-flight scaffolding (.env.example, .gitignore, packages/ai/package.json, cost-tracker.ts, client.ts) was committed in 0ed511c before this run; these stories pick up from that state. Full design in tasks/prd-deepseek-migration.md.",
+  "project": "Solo Compass — Paid-App Foundation (iOS v1.1)",
+  "branchName": "ralph/paid-app-foundation",
+  "description": "Turn the iOS app from a memory-only demo into a shippable paid product. Adds: SwiftData persistence (all Experiences + user state), region-keyed caches for Overpass and Claude synthesis, Sonnet 4.6 default model + Haiku for explanations, hallucination-resistant prompt, AI-confidence visual downgrade, reverse geocoding, MicroSurvey writeback, three-state Solo-Score cold-start UX, StoreKit 2 freemium with 7-day trial (Apple price tier 2 monthly / tier 11 yearly, globally uniform), paywall, Supabase anonymous auth + outbox sync + shared synthesis cache + Edge Function (removes Anthropic key from client), optional Sign-in-with-Apple linking, privacy manifest + consent sheet, zh-Hans localization, TestFlight prep. Local-first invariant: SwiftData is the source of truth for every UI read; backend is sync + cache only; app must stay fully usable offline. Full design in tasks/prd-paid-app-foundation.md.",
   "userStories": [
     {
       "id": "US-001",
-      "title": "Rewrite rank-experiences.ts for DeepSeek JSON mode",
-      "description": "As a developer, I need rank-experiences.ts to call DeepSeek via the OpenAI SDK using JSON mode instead of Anthropic tool-use, so the package compiles after the dependency switch.",
+      "title": "Add SwiftData ModelContainer with empty schema scaffold",
+      "description": "As a developer, I need a SoloCompassModelContainer.swift file that wires up an empty SwiftData ModelContainer wrapped in a VersionedSchema (SoloCompassSchemaV1), so subsequent stories can register @Model classes incrementally.",
       "acceptanceCriteria": [
-        "Remove `import Anthropic from \"@anthropic-ai/sdk\"` and replace with `import type OpenAI from \"openai\"` plus `import { createDeepseekClient, deepseekModel } from \"../client\"`",
-        "Replace tool-use block with chat.completions.create using response_format: { type: 'json_object' }",
-        "System prompt instructs the model to output ONLY a JSON object {\"ranked\":[{experienceId,score,reason}]} with no markdown fences",
-        "Add defensive fence-stripping helper that handles ```json...``` wrappers before JSON.parse",
-        "Optional `client?` parameter changes type from `Anthropic` to `OpenAI`; default falls back to createDeepseekClient()",
-        "Score clamping (0-100) and id-validation logic preserved exactly",
-        "withCostTracking integration preserved using new OpenAI.CompletionUsage shape",
-        "File no longer references claude-opus-4-7 or any Anthropic types",
-        "Typecheck passes (run: pnpm --filter @solo-compass/ai typecheck)"
+        "Create apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift",
+        "Define enum SoloCompassSchemaV1: VersionedSchema with versionIdentifier = Schema.Version(1, 0, 0) and empty models array initially",
+        "Expose a static .shared ModelContainer using SoloCompassSchemaV1 backed by an on-disk SQLite store",
+        "Inject ModelContainer into SoloCompassApp via .modelContainer(SoloCompassModelContainer.shared)",
+        "App still builds and launches with no behavior change",
+        "Typecheck passes (run: cd apps/ios && xcodebuild build -project SoloCompass.xcodeproj -scheme SoloCompass -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest')"
       ],
       "priority": 1,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-002",
-      "title": "Rewrite structure-experience.ts for DeepSeek JSON mode",
-      "description": "As a developer, I need structure-experience.ts to use DeepSeek JSON mode for both extraction and refusal paths, so AI source-compilation works end-to-end on the new provider.",
+      "title": "Define ExperienceRecord @Model with two-way Experience mapping",
+      "description": "As a developer, I need an ExperienceRecord SwiftData @Model that round-trips losslessly with the existing Experience value type, so the app can persist seed and generated Experiences.",
       "acceptanceCriteria": [
-        "Remove all `@anthropic-ai/sdk` imports and tool-use schemas (EMIT_EXPERIENCE_TOOL, REFUSE_TOOL)",
-        "System prompt requires the model to output JSON {\"action\":\"emit\"|\"refuse\", ...} with all schema fields described inline as JSON Schema-style guidance",
-        "On action='refuse', return { experience: null, refusalReason, modelConfidence: 0 }",
-        "On action='emit', map JSON fields to the Experience type identically to the previous implementation (id slug, GeoJSON coords, status='candidate', soloScore zeroed)",
-        "Defensive fence-stripping in shared parser",
-        "Optional `client?` parameter is `OpenAI` type",
-        "max_tokens: 2048 (unchanged from Anthropic version)",
-        "Typecheck passes (run: pnpm --filter @solo-compass/ai typecheck)"
+        "Create apps/ios/SoloCompass/Persistence/Models/ExperienceRecord.swift",
+        "@Model class ExperienceRecord stores all Experience fields: id (unique), title, oneLiner, whyItMatters, category (raw String), latitude, longitude, cityCode, addressHint, placeNameLocal, placeNameRomanized, durationMin, durationMax, status (raw String), createdAt, updatedAt, plus encoded JSON Data blobs for bestTimes, howTo, realInconveniences, sources, soloScore, confidence, stats, nearbyExperienceIds",
+        "Initializer ExperienceRecord(from: Experience) populates all fields using JSONEncoder.iso8601Encoder for blob fields",
+        "Computed property var asValue: Experience decodes blobs and returns a value-type Experience",
+        "Register ExperienceRecord.self in SoloCompassSchemaV1.models",
+        "Unit test: round-trip the first ExperienceService.hardcodedSeed entry through ExperienceRecord(from:).asValue and assert id, title, category, soloScore.overall match",
+        "Typecheck passes",
+        "Tests pass (run: xcodebuild test -project SoloCompass.xcodeproj -scheme SoloCompass -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest')"
       ],
       "priority": 2,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-003",
-      "title": "Update packages/ai index.ts exports for DeepSeek",
-      "description": "As a consumer of @solo-compass/ai, I need access to the new DeepSeek client factory so I can override the default client in tests or in apps that prefer dependency injection.",
+      "title": "Add UserCompletionRecord and UserFavoriteRecord @Models",
+      "description": "As a developer, I need separate SwiftData tables for user completions and favorites so they can be queried per experience without mutating the Experience itself.",
       "acceptanceCriteria": [
-        "Re-export `createDeepseekClient`, `deepseekModel`, `deepseekBaseURL` from `./client`",
-        "Existing exports (rankExperiences, structureExperience, parseIntent, dedup, trackCost, withCostTracking, all *Input/*Result types) remain unchanged",
-        "No remaining `Anthropic` type re-exports",
-        "Typecheck passes (run: pnpm --filter @solo-compass/ai typecheck)"
+        "Create apps/ios/SoloCompass/Persistence/Models/UserCompletionRecord.swift with fields: id (UUID), experienceId (String, indexed), completedAt (Date)",
+        "Create apps/ios/SoloCompass/Persistence/Models/UserFavoriteRecord.swift with fields: id (UUID), experienceId (String, unique), favoritedAt (Date)",
+        "Register both in SoloCompassSchemaV1.models",
+        "Unit test: insert two UserFavoriteRecords with same experienceId — assert second insert throws or upserts (document chosen behavior)",
+        "Typecheck passes",
+        "Tests pass"
       ],
       "priority": 3,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-004",
-      "title": "Rewrite rank-experiences.test.ts to mock OpenAI shape",
-      "description": "As a maintainer, I need the unit tests to mock OpenAI's response shape so anti-hallucination guards continue to run without real API calls.",
+      "title": "Add MicroSurveyRecord and PendingCheckInRecord @Models",
+      "description": "As a developer, I need persistent storage for micro-survey responses and pending check-ins so the existing UI flows can write through.",
       "acceptanceCriteria": [
-        "Replace `import type Anthropic from \"@anthropic-ai/sdk\"` with `import type OpenAI from \"openai\"`",
-        "makeMockClient returns an object shaped like OpenAI client: `{ chat: { completions: { create: vi.fn().mockResolvedValue({ choices: [{ message: { content: <JSON-string> } }], usage: { prompt_tokens, completion_tokens, total_tokens }, model }) } } }`",
-        "Mock JSON content is `JSON.stringify({ ranked: rankedItems })`",
-        "All six existing test cases preserved (id-not-invented, score clamp 100, score clamp 0, max-3-items, empty-input, reason pass-through)",
-        "Test suite passes (run: pnpm --filter @solo-compass/ai test)",
-        "Typecheck passes"
+        "Create apps/ios/SoloCompass/Persistence/Models/MicroSurveyRecord.swift with fields: id (UUID), experienceId (String, indexed), comfort (Int 1-5), pressure (Int 1-5), recommend (String 'yes'|'depends'|'no'), submittedAt (Date), anonDeviceId (String)",
+        "Create apps/ios/SoloCompass/Persistence/Models/PendingCheckInRecord.swift with fields: id (UUID), experienceId (String, unique), triggeredAt (Date)",
+        "Register both in SoloCompassSchemaV1.models",
+        "Unit test: insert one MicroSurveyRecord and fetch it back, assert all fields match",
+        "Typecheck passes",
+        "Tests pass"
       ],
       "priority": 4,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-005",
-      "title": "Rewrite structure-experience.test.ts to mock OpenAI shape and delete obsolete __golden__ files",
-      "description": "As a maintainer, I need golden-replay tests rewritten so they mock OpenAI's JSON response (or skipped pending live regeneration), and the now-obsolete Anthropic tool-use golden files removed.",
+      "title": "Add ExploreCacheRecord and AISynthesisCacheRecord @Models",
+      "description": "As a developer, I need cache tables for Overpass POI batches and AI synthesis results so subsequent stories can implement TTL-based cache hits.",
       "acceptanceCriteria": [
-        "Delete `packages/ai/src/__golden__/wikivoyage-chiang-mai-suthep.json`",
-        "Delete `packages/ai/src/__golden__/reddit-coffee-thread.json`",
-        "Delete `packages/ai/src/__golden__/insufficient-blurb.json`",
-        "Add `packages/ai/src/__golden__/README.md` explaining how to regenerate via `LIVE_API=true pnpm --filter @solo-compass/ai test:live` once a real DEEPSEEK_API_KEY is available",
-        "Replace `structure-experience.test.ts` golden-replay tests with mock-based tests that hardcode small synthetic JSON responses inline (covers: emit-success path, refuse path, fence-wrapped response stripping, malformed JSON returns null with refusalReason)",
-        "All assertions remain meaningful (schema validity, GeoJSON order, source-url-not-fabricated, refusal reason non-empty)",
-        "Test suite passes (run: pnpm --filter @solo-compass/ai test)",
-        "Typecheck passes"
+        "Create apps/ios/SoloCompass/Persistence/Models/ExploreCacheRecord.swift with fields: regionKey (String, unique e.g. '21.03_105.85_3000'), osmJSON (Data), fetchedAt (Date), poiCount (Int)",
+        "Create apps/ios/SoloCompass/Persistence/Models/AISynthesisCacheRecord.swift with fields: cacheKey (String, unique SHA256 hex), experiencesJSON (Data), synthesizedAt (Date), modelName (String)",
+        "Register both in SoloCompassSchemaV1.models",
+        "Unit test: insert and fetch one record from each table, assert fields match",
+        "Typecheck passes",
+        "Tests pass"
       ],
       "priority": 5,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-006",
-      "title": "Add retry-with-backoff helper for DeepSeek calls",
-      "description": "As a user with flaky network or hitting DeepSeek rate limits, I need transient errors to be retried automatically so a single 429 or network blip does not break my recommendation request.",
+      "title": "Add DiscoveredCityRecord, RecentExploreRegion, AIUsageRecord @Models",
+      "description": "As a developer, I need three small @Models to back reverse-geocoded city names, last-explored regions for offline mode, and per-day AI usage counts.",
       "acceptanceCriteria": [
-        "Create `packages/ai/src/retry.ts` exporting `withRetry<T>(fn: () => Promise<T>, opts?: { maxAttempts?: number; backoffSecs?: number[]; signal?: AbortSignal }): Promise<T>`",
-        "Defaults: maxAttempts=3, backoffSecs=[0, 2, 6]",
-        "Retries on: network errors (TypeError, fetch errors), 429, 502, 503, 504",
-        "Does NOT retry on: 400, 401, 403, 422 (auth/format errors)",
-        "Each retry waits backoffSecs[attempt-1] seconds; after final attempt, throws the last error",
-        "Wrap the openai.chat.completions.create call in rank-experiences.ts and structure-experience.ts with `withRetry(...)`",
-        "Add unit tests in `packages/ai/src/__tests__/retry.test.ts` covering: success on first try, retry-then-succeed, give-up-after-max, no-retry-on-401",
-        "Use vi.useFakeTimers() to keep tests fast",
+        "Create apps/ios/SoloCompass/Persistence/Models/DiscoveredCityRecord.swift with fields: cityCode (String, unique), name (String), countryCode (String), centerLat (Double), centerLon (Double), discoveredAt (Date)",
+        "Create apps/ios/SoloCompass/Persistence/Models/RecentExploreRegion.swift with fields: id (UUID), centerLat (Double), centerLon (Double), radiusMeters (Int), exploredAt (Date)",
+        "Create apps/ios/SoloCompass/Persistence/Models/AIUsageRecord.swift with fields: id (UUID), date (Date, indexed, day-truncated), synthesisCalls (Int), explanationCalls (Int)",
+        "Register all three in SoloCompassSchemaV1.models",
+        "Unit test: insert one of each and fetch back, assert fields match",
         "Typecheck passes",
-        "Test suite passes (run: pnpm --filter @solo-compass/ai test)"
+        "Tests pass"
       ],
       "priority": 6,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-007",
-      "title": "Initialize Sentry in apps/bot and apps/web entry points",
-      "description": "As a maintainer, I need crash and error reports to flow into Sentry so I can detect production issues without users having to file bugs.",
+      "title": "Implement ExperienceRepository with seed import",
+      "description": "As a developer, I need an ExperienceRepository that owns SwiftData CRUD for experiences and seeds the bundle JSON on first launch.",
       "acceptanceCriteria": [
-        "apps/bot: at the very top of `src/index.ts`, before any other import, call `Sentry.init({ dsn: process.env.SENTRY_DSN, tracesSampleRate: 0.1, environment: process.env.NODE_ENV ?? 'development' })`. If SENTRY_DSN is empty or missing, skip init silently (do not throw).",
-        "apps/bot: existing `captureException` calls continue to work (they already imported from @sentry/node)",
-        "apps/web: create three sibling files at the project root \u2014 `sentry.client.config.ts`, `sentry.server.config.ts`, `sentry.edge.config.ts` \u2014 each calling `Sentry.init` from `@sentry/nextjs` with appropriate settings. tracesSampleRate=0.1, dsn from env.",
-        "apps/web: update `next.config.ts` to wrap export with `withSentryConfig` from @sentry/nextjs (silent: true to keep build logs clean)",
-        "Add `SENTRY_DSN=` (empty) to `.env.example` under a `# \u2500\u2500\u2500 Sentry (error tracking) \u2500\u2500\u2500` block",
-        "Add `NEXT_PUBLIC_SENTRY_DSN=` to .env.example with note that it is the same value as SENTRY_DSN but exposed to browser bundles",
-        "Both apps build without error when SENTRY_DSN is empty",
-        "Typecheck passes for both apps (run: pnpm --filter @solo-compass/bot typecheck && pnpm --filter @solo-compass/web typecheck)"
+        "Create apps/ios/SoloCompass/Persistence/ExperienceRepository.swift as a @MainActor class taking ModelContext",
+        "Method importSeedIfNeeded() reads UserPreferences.seedImported flag; if false, decodes Resources/JSON/seed_experiences.json and inserts each as ExperienceRecord, then sets the flag",
+        "Add Bool seedImported (default false) to UserPreferences with UserDefaults backing",
+        "Method allExperiences() -> [Experience] fetches all rows and returns asValue",
+        "Method experience(id:) -> Experience? fetches by id",
+        "Method nearby(coordinate:radiusKm:) -> [Experience] fetches and filters by distance, sorted ascending",
+        "Method appendGenerated(_ experiences: [Experience]) inserts new ExperienceRecords; idempotent by id (skip duplicates)",
+        "Unit test: empty store -> importSeedIfNeeded() -> assert allExperiences().count == 5 and seedImported == true; second call is no-op",
+        "Typecheck passes",
+        "Tests pass"
       ],
       "priority": 7,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-008",
-      "title": "Forward AI cost events to PostHog from cost-tracker",
-      "description": "As a maintainer, I want every AI call's cost emitted to PostHog (in addition to stdout) so I can build cost dashboards and alerts without rolling my own log aggregation.",
+      "title": "Refactor ExperienceService to delegate to ExperienceRepository",
+      "description": "As a developer, I need ExperienceService to become a thin facade over ExperienceRepository while preserving its existing public @Observable API so views compile unchanged.",
       "acceptanceCriteria": [
-        "Add `posthog-node` runtime dependency to packages/ai/package.json (^4.0.0)",
-        "In cost-tracker.ts, add a module-scoped lazy-initialized PostHog client that reads `process.env.POSTHOG_API_KEY` and `process.env.POSTHOG_HOST` (default https://app.posthog.com). If POSTHOG_API_KEY is empty, skip and only stdout-log.",
-        "trackCost() calls posthog.capture({ distinctId: 'system', event: 'ai_cost', properties: { route, usd_cents, model, input_tokens, output_tokens, duration_ms } }) \u2014 non-blocking, errors silently swallowed (with console.warn) so AI calls never fail because of PostHog",
-        "Add `POSTHOG_API_KEY=` and `POSTHOG_HOST=https://app.posthog.com` placeholders to .env.example under `# \u2500\u2500\u2500 PostHog (cost telemetry) \u2500\u2500\u2500`",
-        "Add a unit test in packages/ai/src/__tests__/cost-tracker.test.ts: when POSTHOG_API_KEY is unset, no posthog import side-effects occur; when set, capture is called with expected event shape (mock the PostHog class)",
-        "Existing stdout JSON log line continues to be emitted unchanged (other consumers may rely on it)",
+        "Modify apps/ios/SoloCompass/Services/ExperienceService.swift to hold a private ExperienceRepository instead of in-memory arrays",
+        "Existing public methods (allExperiences, filteredExperiences, getExperiences, getExperience, getBestNowExperiences, filter, appendGenerated, markCompleted, toggleFavorite) delegate to the repo and read-back",
+        "On init, call repository.importSeedIfNeeded() so existing tests/previews keep working",
+        "MapViewModel and ExperienceDetailViewModel and CompassMapView require zero source changes",
+        "Update existing tests testFilteringByCategoryAndDistance and testGetExperiencesNearReturnsSortedByDistance to pass against the new backing store",
         "Typecheck passes",
-        "Test suite passes"
+        "Tests pass"
       ],
       "priority": 8,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-009",
-      "title": "Add gitleaks secret-scanning GitHub Action",
-      "description": "As a maintainer, I need every push and PR to be scanned for accidentally committed secrets so a key leak is caught before it merges.",
+      "title": "Move UserPreferences completed/favorites lists into SwiftData",
+      "description": "As a user, I want my favorites and completed experiences to persist via SwiftData (not UserDefaults arrays) and survive a clean reinstall once I'm signed in.",
       "acceptanceCriteria": [
-        "Create `.github/workflows/secret-scan.yml` running on push (all branches) and pull_request",
-        "Workflow uses `gitleaks/gitleaks-action@v2` with default config",
-        "Workflow has `permissions: contents: read` only (least privilege)",
-        "Workflow fails (non-zero exit) when leaks are detected",
-        "Add `.gitleaks.toml` at repo root with allowlist entries for: (a) the Mapbox public-token placeholder pattern `pk.eyJ` in .env.example; (b) the Supabase placeholder URL pattern in .env.example; (c) the literal string `sk-replace-me`. The .toml extends gitleaks' default ruleset.",
-        "Add a 'Secret scanning' section to the root README.md describing how to run gitleaks locally (`gitleaks detect --source . --no-git`) and what the .gitleaks.toml allowlist exempts and why",
-        "Workflow runs in under 30 seconds on a typical push"
+        "UserPreferences.isCompleted(id) and isFavorited(id) become read-through to ExperienceRepository (which queries UserCompletionRecord / UserFavoriteRecord)",
+        "UserPreferences.markCompleted(id) inserts UserCompletionRecord; toggleFavorite(id) inserts/deletes UserFavoriteRecord",
+        "Migration: on first launch of v1.1, read the old UserDefaults completedExperienceIds and favoriteExperienceIds arrays, insert corresponding rows into SwiftData, then delete the old keys",
+        "Style, maxDistanceKm, dislikedCategories, lastSelectedCity remain in UserDefaults",
+        "Unit test: pre-populate UserDefaults with two completed ids and one favorite id, instantiate UserPreferences -> assert SwiftData has matching rows and old UserDefaults keys are cleared",
+        "Typecheck passes",
+        "Tests pass"
       ],
       "priority": 9,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-010",
-      "title": "Inject placeholder .env in iOS CI workflows",
-      "description": "As CI, I need a placeholder .env so the iOS build's generate_secrets.sh step (added in a separate iOS commit) does not fail in environments where real secrets are not (and should not be) available.",
+      "title": "Persist generated Experiences from exploreNearby through SwiftData",
+      "description": "As a user, I want OSM-generated Experiences to survive force-quit so I don't lose what I just discovered.",
       "acceptanceCriteria": [
-        "Edit `.github/workflows/ios-ci.yml`: add a `Create placeholder .env` step that runs BEFORE `xcodegen` and writes a heredoc-style file to repo root with empty DEEPSEEK_API_KEY, default DEEPSEEK_BASE_URL/MODEL, empty SENTRY_DSN, and DEVELOPMENT_TEAM=$DEVELOPMENT_TEAM env",
-        "Edit `.github/workflows/testflight.yml`: same step but populated from `${{ secrets.DEEPSEEK_API_KEY }}`, `${{ secrets.SENTRY_DSN }}`, etc. (these GitHub Secrets are configured manually outside this PR; their absence at run time produces empty values which is acceptable for placeholder behavior)",
-        "Both workflows continue to pass schema-parity \u2192 build \u2192 test pipeline",
-        "ios-ci.yml job named like 'Build iOS app (placeholder secrets)' so reviewers see this is intentional",
-        "No real secrets committed in either workflow file"
+        "MapViewModel.exploreNearby calls experienceService.appendGenerated which now writes through to SwiftData via the repo",
+        "After force-quit and relaunch, generated pins are still loaded into visibleExperiences (verify by extending an existing test that simulates exploration with mocked services)",
+        "ExperienceService.allExperiences after relaunch returns seed + previously-generated entries with correct ids",
+        "Unit test: append two generated Experiences via service, recreate the service against the same store, assert allExperiences contains them",
+        "Typecheck passes",
+        "Tests pass"
       ],
       "priority": 10,
-      "passes": true,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-011",
+      "title": "Implement Overpass cache layer with 14-day TTL",
+      "description": "As a product owner, I need OverpassService to reuse cached POIs by region so repeated Explore taps don't burn quota.",
+      "acceptanceCriteria": [
+        "OverpassService takes an optional ExperienceRepository in init for cache access",
+        "fetchPOIs computes regionKey = String(format: '%.2f_%.2f_%d', lat.rounded, lon.rounded, radiusMeters)",
+        "On call: fetch ExploreCacheRecord by regionKey; if found and now - fetchedAt < 14 days, decode osmJSON and return without HTTP",
+        "On miss: real fetch -> on success, write ExploreCacheRecord with the raw JSON Data and current timestamp",
+        "Add public method clearExploreCache() that deletes all ExploreCacheRecord rows",
+        "Unit test (URLProtocol stub): two consecutive fetchPOIs at the same coordinate trigger only one HTTP request",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 11,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-012",
+      "title": "Implement AI synthesis cache layer with 30-day TTL",
+      "description": "As a product owner, I need AIService.synthesizeExperiences to dedupe by POI batch hash so the same input never re-runs through Claude.",
+      "acceptanceCriteria": [
+        "Add CryptoKit import; helper that computes SHA256 hex of the canonical input: sorted osmIds joined by '|' + cityCode + locale.identifier + modelName",
+        "AIService takes an optional ExperienceRepository in init",
+        "synthesizeExperiences checks AISynthesisCacheRecord by cacheKey; if found and now - synthesizedAt < 30 days, decode experiencesJSON and return without HTTP",
+        "On miss + successful synthesis: write AISynthesisCacheRecord with the encoded [Experience] JSON",
+        "Skeleton fallback path does NOT write to cache (only successful real-AI results do)",
+        "Add public method clearSynthesisCache()",
+        "Unit test: with a stubbed network returning a fixed response, two consecutive synthesizeExperiences with same POIs trigger only one HTTP call and return identical results",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 12,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-013",
+      "title": "Switch default synthesis model to claude-sonnet-4-6 with Haiku for explanations",
+      "description": "As a product owner, I want AI generation cost to drop ~80% by routing synthesis through Sonnet 4.6 and explanations through Haiku 4.5.",
+      "acceptanceCriteria": [
+        "AIService gains three private model names: synthesisModel = 'claude-sonnet-4-6', explanationModel = 'claude-haiku-4-5-20251001', voiceIntentModel = 'claude-sonnet-4-6'",
+        "Each per-method sendMessage call uses the appropriate model (synthesizeExperiences -> synthesisModel; explainRecommendation -> explanationModel; processVoiceIntent -> voiceIntentModel; recommendExperiences -> synthesisModel)",
+        "Models are read from Secrets.plist keys ANTHROPIC_MODEL_SYNTHESIS, ANTHROPIC_MODEL_EXPLANATION, ANTHROPIC_MODEL_VOICE if present, otherwise use the defaults above",
+        "Env var AI_FORCE_OPUS=1 routes everything to claude-opus-4-7 for golden-set runs",
+        "Unit test: with Secrets.plist absent and AI_FORCE_OPUS unset, the synthesis prompt request body contains 'claude-sonnet-4-6'; with AI_FORCE_OPUS set, it contains 'claude-opus-4-7'",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 13,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-014",
+      "title": "Harden synthesis prompt against hallucinated specifics",
+      "description": "As a user, I need generated Experiences to never invent menu items, hours, prices, or interior details the model couldn't actually know.",
+      "acceptanceCriteria": [
+        "Update AIService.synthesisPrompt to include an explicit constraints block: 'Use ONLY the provided OSM tags. Do NOT invent menu items, interior details, hours, prices, owner backstories, or specific seating positions. If a field is not derivable from tags, write a generic safe value.'",
+        "howTo guidance changed to navigation steps only (no 'order the X', no 'sit at the Y')",
+        "Add 2 few-shot examples in the prompt: one good (tag-derived, generic) and one bad (hallucinated specifics) showing the expected style",
+        "New regression test: feed a single POI with tags {amenity: cafe, name: 'Quan A'} through skeleton fallback (so no live model call needed) and assert NONE of these phrases appear in oneLiner/whyItMatters/howTo: 'order the', 'try the', 'sit at the', 'best seat', 'the owner', 'opens at', 'closes at', 'menu', 'price', 'specialty'",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 14,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-015",
+      "title": "Add per-user daily AI quota with skeleton-mode degradation",
+      "description": "As a product owner, I want a hard daily cap on Claude calls per user so a runaway loop never costs more than a dollar.",
+      "acceptanceCriteria": [
+        "AIService gains async helper checkAndIncrementQuota(kind: .synthesis | .explanation) that reads/writes today's AIUsageRecord row",
+        "Free tier limit: synthesis 0, explanation 0 (effectively gated by entitlement; quota is the second line of defense)",
+        "Pro tier limit: synthesis 30/day, explanation 60/day; cache hits do NOT increment the counter",
+        "When limit hit, synthesizeExperiences sets a public quotaExceededAt: Date? and falls back to skeleton mode for remaining POIs in this call",
+        "MapViewModel exposes lastQuotaInfo: String? for UI (rendered in Story US-021)",
+        "Unit test: simulate 30 successful synthesis calls in one day, assert call 31 returns skeleton results and quotaExceededAt is set; assert counter resets after AIUsageRecord.date moves to next UTC day",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 15,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-016",
+      "title": "Add ReverseGeocodeService and DiscoveredCityRecord write-through",
+      "description": "As a user, I want my city picker to show real city names like 'Hanoi' instead of 'osm_21.0_105.9'.",
+      "acceptanceCriteria": [
+        "Create apps/ios/SoloCompass/Services/ReverseGeocodeService.swift wrapping CLGeocoder.reverseGeocodeLocation",
+        "Method resolve(coordinate:) async returns (cityCode: String, name: String, countryCode: String) where cityCode is a slug like 'vn-hanoi' (lowercased ISO country + locality dash-slug)",
+        "MapViewModel.exploreNearby (after successful POI fetch) calls the service; on success, upserts DiscoveredCityRecord and uses the resolved cityCode for the generated Experiences (instead of the synthetic osm_<lat>_<lon>)",
+        "On geocoder failure or offline, fall back to current osm_<lat>_<lon> cityCode; Experiences are still generated",
+        "Unit test (mocked geocoder): explore at Hanoi coords -> assert generated Experiences have cityCode 'vn-hanoi' and DiscoveredCityRecord row exists with name 'Hanoi'",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 16,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-017",
+      "title": "Auto-switch selected city after successful Explore",
+      "description": "As a user landing in a new city, I want the city filter to update automatically so I see the new pins without manual action.",
+      "acceptanceCriteria": [
+        "After exploreNearby appends N > 0 Experiences and ReverseGeocodeService returned a real cityCode, MapViewModel calls selectCity(resolvedCityCode)",
+        "MapViewModel.lastExploreToast: String? is set to 'Now exploring Hanoi · 12 places added' (or 'N places added near you' if geocoding failed)",
+        "availableCities now includes DiscoveredCityRecord rows so the new city appears in the picker immediately",
+        "cityNameMap is augmented with the discovered city so the city pill shows 'Hanoi' not 'vn-hanoi'",
+        "Unit test: with selectedCity = 'cmi' and mocked geocoder returning 'vn-hanoi'/'Hanoi', run exploreNearby at Hanoi coords -> assert selectedCity becomes 'vn-hanoi' and lastExploreToast contains 'Hanoi'",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 17,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-018",
+      "title": "Visual downgrade for confidence-1 markers",
+      "description": "As a user, I should immediately tell which pins are AI-guessed vs curated based on visual treatment.",
+      "acceptanceCriteria": [
+        "MarkerIconView gains a confidenceLevel: Int parameter (default 5 for backward compat)",
+        "When confidenceLevel <= 1: render with a dashed stroke border (lineWidth 2, dash [4,3]), 70% fill opacity, no shadow/glow, smaller badge (28x28 vs default 36x36)",
+        "When confidenceLevel >= 2: current rendering unchanged",
+        "Pass exp.confidence.level into MarkerIconView from CompassMapView and from candidate-experience markers",
+        "Unit test: render MarkerIconView with confidenceLevel 1 and confidenceLevel 4, assert SwiftUI snapshot identifiers differ (use ViewInspector or a hashable accessibility identifier)",
+        "Typecheck passes",
+        "Verify in simulator: tap Explore in Hanoi, confirm new pins are visually weaker than seed pins"
+      ],
+      "priority": 18,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-019",
+      "title": "Three-state Solo-Score cold-start UX in detail view",
+      "description": "As a user, the Solo Score on a detail view should clearly mark whether it's an AI estimate, an early signal, or community-validated.",
+      "acceptanceCriteria": [
+        "ExperienceDetailView reads exp.soloScore.basedOnCount and renders one of three header states: 'Solo Score (AI estimate)' when basedOnCount == 0, 'Solo Score (early)' when 1...2, 'Solo Score' when >= 3",
+        "When basedOnCount == 0, score number is rendered with .opacity(0.6) and a small 'AI estimate' Capsule pill next to it",
+        "When basedOnCount in 1...2, subtitle reads 'Based on N early reports'",
+        "When basedOnCount >= 3, subtitle reads 'Based on N solo travelers' (current copy)",
+        "Add localized keys: solo.estimate.pill, solo.basedOn.early, solo.section.estimate, solo.section.early to en.lproj/Localizable.strings",
+        "Unit test: render the section with basedOnCount 0, 1, 3 — assert the three different header strings are present",
+        "Typecheck passes",
+        "Verify in simulator: open a generated Experience (basedOnCount 0) and a seed Experience (basedOnCount > 3), confirm headers and pills differ"
+      ],
+      "priority": 19,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-020",
+      "title": "MicroSurvey writeback to SoloScore via SwiftData aggregation",
+      "description": "As a user, my honest survey responses should improve the Solo Score that the next traveler sees.",
+      "acceptanceCriteria": [
+        "MicroSurveySheet onSubmit callback now writes a MicroSurveyRecord via ExperienceRepository (helper recordSurvey(experienceId:comfort:pressure:recommend:))",
+        "ExperienceRepository gains aggregatedSoloScore(experienceId:) -> (overall: Double, count: Int) computing: localSurveyMean = mean of (comfort+pressure)/2 across MicroSurveyRecords for that id; recommendBoost = +0.5 if >= 50% of recommendations are 'yes'; final = clamp(0...10, 0.5*originalOverall + 0.5*localSurveyMean + recommendBoost)",
+        "Experience.soloScore.overall and basedOnCount become derived: when SwiftData has surveys, return the aggregated value; otherwise return the seed/AI value",
+        "Cache aggregation result for 60s per experienceId to avoid recomputing on every render",
+        "Unit test: insert two MicroSurveyRecords for one experienceId (comfort=5/pressure=4/recommend=yes, comfort=4/pressure=5/recommend=yes) and assert aggregatedSoloScore.count == 2 and overall is within expected range",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 20,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-021",
+      "title": "Surface explore errors and quota banners on the map",
+      "description": "As a user, I should see why Explore failed or fell back to skeleton mode instead of staring at a silent map.",
+      "acceptanceCriteria": [
+        "CompassMapView observes viewModel.lastExploreError, viewModel.lastExploreToast, viewModel.lastQuotaInfo",
+        "lastExploreError: dismissible orange banner just below the filter bar with the error text",
+        "lastExploreToast: ephemeral 3-second Capsule above BottomInfoBar (e.g. 'Now exploring Hanoi · 12 places added')",
+        "lastQuotaInfo: persistent yellow banner showing 'Daily AI limit reached, resets in Xh' that auto-disappears when the date rolls over",
+        "Add localized keys: explore.toast.added, explore.toast.addedNamed, explore.quota.dailyLimit",
+        "Unit test: simulate exploreNearby success -> assert lastExploreToast set; simulate quota exceeded -> assert lastQuotaInfo set",
+        "Typecheck passes",
+        "Verify in simulator: trigger Explore offline, confirm banner appears with airplane icon"
+      ],
+      "priority": 21,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-022",
+      "title": "Offline-mode fallback from RecentExploreRegion",
+      "description": "As a traveler with no signal, I should still see pins for the last region I explored.",
+      "acceptanceCriteria": [
+        "After every successful exploreNearby, write a RecentExploreRegion row (keep last 3, evict oldest)",
+        "When exploreNearby fails with a network error, find the closest RecentExploreRegion within 10 km of the requested coordinate; if found, query SwiftData for ExperienceRecord rows in that region and surface them",
+        "Set viewModel.lastExploreToast = 'Showing offline data from <relative-date>' if the region is older than 7 days",
+        "Unit test: simulate URLSession failure with one RecentExploreRegion present at the requested coordinate, assert offline pins are returned and toast is set",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 22,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-023",
+      "title": "Add StoreKit Configuration.storekit and SubscriptionService scaffold",
+      "description": "As a developer, I need a local StoreKit testing configuration and a SubscriptionService that fetches products and reports an entitlement enum.",
+      "acceptanceCriteria": [
+        "Create apps/ios/SoloCompass/Resources/Configuration.storekit with two auto-renewable subscriptions: com.solocompass.pro.monthly (Apple price tier 2, P1M, 7-day intro free trial) and com.solocompass.pro.yearly (Apple price tier 11, P1Y, 7-day intro free trial)",
+        "Create apps/ios/SoloCompass/Services/SubscriptionService.swift as @MainActor @Observable",
+        "Properties: products: [Product], entitlement: Entitlement (.free | .proTrial | .pro | .proExpired), isLoading: Bool",
+        "Method refreshEntitlement() iterates Transaction.currentEntitlements and sets entitlement",
+        "Listener task in init observes Transaction.updates and refreshes entitlement",
+        "Inject SubscriptionService into SoloCompassApp via .environment",
+        "project.yml updated to add the .storekit file under Resources",
+        "Unit test using Transaction.testSession: simulate purchase -> entitlement becomes .pro; simulate expiration -> entitlement becomes .proExpired",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 23,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-024",
+      "title": "Cache entitlement in Keychain for offline boot",
+      "description": "As a user, I shouldn't lose Pro access on a brief offline launch while StoreKit catches up.",
+      "acceptanceCriteria": [
+        "Add a small KeychainStore helper (Security framework) for read/write of a single 'entitlement' string key",
+        "SubscriptionService writes entitlement.rawValue to Keychain on every successful refreshEntitlement()",
+        "On init (before StoreKit responds), seed entitlement from Keychain so the UI can render Pro state immediately",
+        "When StoreKit returns, real value overrides cached value",
+        "Unit test: write '.pro' to Keychain, instantiate SubscriptionService -> entitlement == .pro before any StoreKit call",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 24,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-025",
+      "title": "Build PaywallView with monthly/yearly cards and free-trial CTA",
+      "description": "As a free user, I need a clear paywall to start a 7-day free trial with one tap.",
+      "acceptanceCriteria": [
+        "Create apps/ios/SoloCompass/Views/Paywall/PaywallView.swift",
+        "Layout: hero copy ('Unlock Solo Compass Pro'), bullet list (Explore Here AI synthesis, voice intent, AI explanations, daily quota 30+60), two product Cards stacked (yearly card has 'Best value' Capsule + per-month equivalent), 'Start 7-day free trial' primary button, 'Restore purchases' link, fine-print legal copy, 'Manage subscription' link to App Store",
+        "Localize en + zh-Hans (create Resources/zh-Hans.lproj/Localizable.strings if missing)",
+        "On product tap, call subscriptionService.purchase(product) which awaits Product.purchase(); on success, dismiss paywall and resume the gated action via a closure",
+        "Show ProgressView while products load",
+        "Unit test: render PaywallView in a SwiftUI test host with a mocked SubscriptionService returning two products, assert both card titles are present",
+        "Typecheck passes",
+        "Verify in simulator with the .storekit configuration: tap 'Start free trial', confirm StoreKit test sheet appears"
+      ],
+      "priority": 25,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-026",
+      "title": "Gate exploreNearby and AI explanations behind entitlement",
+      "description": "As a product owner, AI features should require Pro; free users see the paywall.",
+      "acceptanceCriteria": [
+        "MapViewModel.exploreNearby checks subscriptionService.entitlement: if .free or .proExpired, set viewModel.isShowingPaywall = true and return without calling Overpass or AIService",
+        "Free users still get an OSM-only skeleton mode path: a new exploreNearbyFreeMode that calls Overpass + the existing AIService skeleton fallback (no Anthropic call). Wired to a separate UI state so the paywall is the upgrade hook",
+        "ExperienceDetailViewModel.requestAIExplanation gated similarly: free users see a 'Subscribe to unlock AI Insight' teaser instead of 'Loading...'",
+        "MapViewModel.handleVoiceTranscript gated similarly: free users see a paywall on first voice tap",
+        "Explore button label flips to 'Explore (Pro)' with a lock SF Symbol when entitlement is free",
+        "CompassMapView presents PaywallView in a sheet bound to viewModel.isShowingPaywall",
+        "Unit test: with mocked SubscriptionService entitlement = .free, call exploreNearby -> assert isShowingPaywall = true and OverpassService was NOT called",
+        "Typecheck passes",
+        "Verify in simulator: as free user, tap Explore -> paywall appears; complete trial purchase -> next Explore proceeds normally"
+      ],
+      "priority": 26,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-027",
+      "title": "Restore purchases UI in Settings",
+      "description": "As a user reinstalling on a new phone, I want a one-tap 'Restore purchases' that re-grants Pro.",
+      "acceptanceCriteria": [
+        "SettingsView gains a 'Restore purchases' row under a 'Subscription' section, plus a 'Manage subscription' row that opens the App Store subscription management URL",
+        "Restore button calls AppStore.sync() then subscriptionService.refreshEntitlement(); shows a transient success/failure toast",
+        "Add localized keys: settings.subscription, settings.restore, settings.manage, restore.success, restore.failure",
+        "Unit test: with Transaction.testSession in a 'previously purchased' state, tapping Restore eventually sets entitlement to .pro",
+        "Typecheck passes",
+        "Verify in simulator: with .storekit testing config, simulate a previous purchase, tap Restore, confirm Pro is granted"
+      ],
+      "priority": 27,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-028",
+      "title": "Bootstrap Supabase project schema + RLS migrations",
+      "description": "As a developer, I need a checked-in Supabase migration that creates all backend tables and per-user RLS policies.",
+      "acceptanceCriteria": [
+        "Create infra/supabase/migrations/0001_init.sql with tables: profiles, user_completions, user_favorites, micro_surveys, subscription_events, synthesized_experiences, osm_pois, solo_score_signals, recent_explore_regions",
+        "Each user-data table has user_id uuid not null, updated_at timestamptz default now(), and RLS policies 'select/insert/update/delete WHERE user_id = auth.uid()'",
+        "synthesized_experiences and osm_pois are read-public (RLS allows select to anon and authenticated), write only via service-role",
+        "Add infra/supabase/test_rls.ts that connects with anon and authenticated keys and asserts: anon cannot read another user's favorites; authenticated user cannot read another user's favorites",
+        "Document required env vars (SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY) in .env.example",
+        "Add infra/supabase/README.md with apply/test instructions",
+        "Typecheck passes (no Swift changes)"
+      ],
+      "priority": 28,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-029",
+      "title": "Add Supabase Swift SDK and SupabaseClient service",
+      "description": "As a developer, I need a single-instance SupabaseClient that holds the client SDK and exposes auth + database APIs.",
+      "acceptanceCriteria": [
+        "Add 'supabase-swift' as an SPM dependency in project.yml under SoloCompass target packages",
+        "Create apps/ios/SoloCompass/Services/SupabaseClient.swift exposing SupabaseClient.shared",
+        "Reads SUPABASE_URL and SUPABASE_ANON_KEY from Secrets.plist (or env vars) at init",
+        "Behind feature flag FF_BACKEND_SYNC = false by default in Resources/FeatureFlags.plist",
+        "Inject into SoloCompassApp environment",
+        "When FF_BACKEND_SYNC is false, all Supabase calls become no-ops returning .success or empty arrays so the app keeps working",
+        "Unit test: with FF_BACKEND_SYNC false, SupabaseClient.shared.signInAnonymously() returns immediately without throwing",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 29,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-030",
+      "title": "Anonymous sign-in on first launch and DeviceIdentityService integration",
+      "description": "As a user, I want my data synced without creating an account.",
+      "acceptanceCriteria": [
+        "DeviceIdentityService.bootstrap() (called from SoloCompassApp.onAppear) calls SupabaseClient.shared.signInAnonymously() if no session is in Keychain",
+        "Resulting userId stored in Keychain under key 'sc.anon.userId'",
+        "Subsequent launches refresh the session via the SDK's built-in refresh-token flow",
+        "When FF_BACKEND_SYNC is false, this is a no-op",
+        "Unit test (with mocked SupabaseClient): first launch -> signInAnonymously called once and userId persisted; second launch -> session restored, signInAnonymously NOT called",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 30,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-031",
+      "title": "Outbox sync for user_completions and user_favorites",
+      "description": "As a user toggling between phone and iPad, I want my favorites and completed list to converge within seconds.",
+      "acceptanceCriteria": [
+        "Create apps/ios/SoloCompass/Services/SyncService.swift as @MainActor @Observable",
+        "Add PendingSyncRecord @Model with fields: id, tableName (String), operation (String 'upsert'|'delete'), payloadJSON (Data), createdAt",
+        "Every UserCompletionRecord/UserFavoriteRecord write also enqueues a PendingSyncRecord",
+        "SyncService.flush() iterates pending records and POSTs to Supabase with upsert; on success deletes the record; on failure leaves it for next retry",
+        "Background flush every 30s when app is foreground (Timer); also call on UIApplication.willEnterForeground",
+        "Inbound: pull rows where updated_at > lastPulledAt (stored in UserDefaults); merge into SwiftData by id with LWW (compare updated_at, ties broken by lex device_id)",
+        "When FF_BACKEND_SYNC is false, all sync paths are no-ops",
+        "Unit test (mocked Supabase): toggle a favorite -> assert PendingSyncRecord created; flush() -> assert record deleted and Supabase upsert called",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 31,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-032",
+      "title": "Subscription event telemetry to Supabase",
+      "description": "As a founder, I need every Transaction lifecycle event written to Supabase subscription_events for funnel analytics.",
+      "acceptanceCriteria": [
+        "SubscriptionService.refreshEntitlement also extracts the latest Transaction and emits a subscription_events row with: event_type ('subscribed'|'expired'|'in_grace_period'|'revoked'|'upgraded'), product_id, original_purchase_date, expires_date, is_in_trial_period, device_id (anon)",
+        "Writes are routed through SyncService outbox so they survive offline boots",
+        "No PII (no email, no Apple ID)",
+        "Console.log of the emitted row in DEBUG builds",
+        "When FF_BACKEND_SYNC is false, drop the event silently",
+        "Unit test: simulate a trial-start Transaction -> assert one PendingSyncRecord queued for subscription_events with event_type 'subscribed' and is_in_trial_period true",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 32,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-033",
+      "title": "Supabase Edge Function synthesize-experiences (Deno/TS)",
+      "description": "As a security-conscious developer, I need an Edge Function that holds the Anthropic key server-side so the iOS app no longer ships it.",
+      "acceptanceCriteria": [
+        "Create infra/supabase/functions/synthesize-experiences/index.ts (Deno runtime)",
+        "Function authenticates the caller via the Authorization header (Supabase user JWT)",
+        "Reads ANTHROPIC_API_KEY from Deno.env.get; calls Anthropic Messages API with claude-sonnet-4-6",
+        "Validates response shape (parses JSON array, asserts each item has osmId/title/oneLiner/whyItMatters/category)",
+        "Inserts the validated batch into synthesized_experiences (using service-role key) keyed by SHA256 of input POI batch + cityCode + locale",
+        "Rate-limits per auth.uid: 30 calls/day for Pro (look up profiles.entitlement_tier); 0 calls/day for free-tier users",
+        "Returns { experiences: Experience[] } in the same shape the iOS client expects",
+        "Add infra/supabase/functions/synthesize-experiences/README.md with deploy and test instructions",
+        "Add a curl-based integration test in infra/supabase/functions/synthesize-experiences/test.sh that authenticates with a test JWT and asserts a valid response",
+        "Typecheck passes (Deno: deno check index.ts)"
+      ],
+      "priority": 33,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-034",
+      "title": "Route iOS AIService through Edge Function and remove Anthropic key from client",
+      "description": "As a security-conscious developer, after this story the iOS bundle no longer contains an Anthropic API key.",
+      "acceptanceCriteria": [
+        "AIService.synthesizeExperiences (when FF_BACKEND_SYNC is true) calls SupabaseClient.shared.functions.invoke('synthesize-experiences', body: pois+cityCode+locale) instead of Anthropic directly",
+        "Response decoded into [Experience] using the same shape as before",
+        "Delete the ANTHROPIC_API_KEY field from Secrets.plist template and remove the resolveAPIKey() method's Secrets.plist read path; explanation/voice paths still use the SDK locally for now (gated by separate FF_LOCAL_AI_FALLBACK flag for staged rollout)",
+        "Skeleton fallback path unchanged: if Edge Function call fails or returns 5xx, fall back to skeleton",
+        "When FF_BACKEND_SYNC is false (beta.1 default), AIService keeps using the existing direct Anthropic path so testing can continue",
+        "Unit test (with mocked SupabaseClient.functions.invoke): assert synthesizeExperiences calls invoke with the right body and returns the decoded result",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 34,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-035",
+      "title": "Solo-Score signal aggregation via Supabase nightly function",
+      "description": "As a user, the Solo Scores I see should reflect actual community use, not just AI guesses.",
+      "acceptanceCriteria": [
+        "MicroSurvey submission also enqueues a solo_score_signals upsert via SyncService outbox (anon user_id, experience_id, comfort, pressure, recommend, submitted_at)",
+        "Add infra/supabase/functions/aggregate-solo-scores/index.ts (Deno) scheduled nightly via pg_cron: recomputes synthesized_experiences.aggregated_solo_score (mean+count) per experience_id from solo_score_signals over the last 90 days",
+        "iOS: on app foreground (FF_BACKEND_SYNC true), pull aggregated_solo_score for visible experiences and merge into ExperienceRecord.soloScore where signal_count >= 3",
+        "ExperienceRepository.aggregatedSoloScore(experienceId:) prefers the server aggregate when available, falls back to local survey aggregation",
+        "Unit test: set ExperienceRecord with server aggregate (signal_count 12, overall 8.4) and three local surveys, assert aggregatedSoloScore returns the server value",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 35,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-036",
+      "title": "Optional Sign-in-with-Apple to upgrade anonymous account",
+      "description": "As a user, I want to optionally link my anonymous Solo Compass account to my Apple ID for Family Sharing eligibility and account safety.",
+      "acceptanceCriteria": [
+        "SettingsView gains a row under 'My Data': 'Save with Apple' (when anonymous) / 'Linked to Apple ID' (when linked)",
+        "Tap presents AuthorizationAppleIDButton via ASAuthorizationController; on success, calls SupabaseClient.shared.auth.linkIdentity(provider: .apple) using the obtained credential",
+        "On link success: profiles.is_anonymous becomes false; all PendingSyncRecord entries are re-stamped with the new permanent userId; show success toast 'Linked to Apple ID'",
+        "On failure (user cancels, network error, etc): show toast 'Couldnt link account. Your data is still saved on this device.'",
+        "No real Apple email leaves the device (use private email relay)",
+        "Add capability 'Sign in with Apple' to project.yml entitlements",
+        "Document the flow in docs/PRIVACY.md",
+        "Unit test (mocked Supabase + ASAuthorization stub): start as anonymous with 3 favorites and 1 micro-survey, link to Apple, assert is_anonymous=false and all rows now belong to permanent userId",
+        "Typecheck passes",
+        "Verify in simulator: tap 'Save with Apple', confirm Apple sign-in sheet appears"
+      ],
+      "priority": 36,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-037",
+      "title": "First-run Explore-Here consent sheet",
+      "description": "As a privacy-conscious user, I want a clear opt-in moment before my coordinates leave the device.",
+      "acceptanceCriteria": [
+        "Create apps/ios/SoloCompass/Views/Onboarding/ExploreConsentSheet.swift",
+        "Shown via .sheet the first time the user taps Explore Here (gated by UserPreferences.exploreConsentGivenAt being nil)",
+        "Body explains: tapping Explore here sends your map center coordinate to OpenStreetMap (free, anonymous) and to our AI server; we never store who asked, only what was asked, for 30 days",
+        "Two buttons: 'Continue' (sets exploreConsentGivenAt = Date() and proceeds with the original explore action) and 'Not now' (dismisses, no explore)",
+        "Settings 'Privacy' section gains a 'Revoke explore consent' row that clears the flag",
+        "Add localized keys: explore.consent.title, explore.consent.body, explore.consent.continue, explore.consent.notNow, settings.privacy, settings.privacy.revokeConsent",
+        "Unit test: with consent unset, tap Explore -> sheet shown and OverpassService NOT called; tap Continue -> explore proceeds, consent flag set",
+        "Typecheck passes",
+        "Verify in simulator on a fresh install: tap Explore, confirm sheet appears once, tap Continue, confirm explore proceeds"
+      ],
+      "priority": 37,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-038",
+      "title": "Privacy manifest (PrivacyInfo.xcprivacy)",
+      "description": "As an App Store applicant, I need a Privacy Manifest declaring all collected data types accurately.",
+      "acceptanceCriteria": [
+        "Create apps/ios/SoloCompass/Resources/PrivacyInfo.xcprivacy",
+        "Declared data types with purpose 'AppFunctionality' and not used for tracking: NSPrivacyCollectedDataTypePreciseLocation, NSPrivacyCollectedDataTypeCoarseLocation, NSPrivacyCollectedDataTypeDeviceID (for sync), NSPrivacyCollectedDataTypePurchaseHistory (StoreKit), NSPrivacyCollectedDataTypeOtherDiagnosticData (sync events)",
+        "Declared API reasons (ReasonAPIs): UserDefaults (CA92.1), FileTimestamp (C617.1) — only those actually used",
+        "Add the file path to project.yml SoloCompass target sources",
+        "Verify by manual file inspection vs Apple's spec",
+        "Update docs/PRIVACY.md with the same declarations in human-readable form",
+        "Privacy policy URL (https://solocompass.app/privacy) added to Info.plist key NSPrivacyPolicyURL",
+        "Typecheck passes"
+      ],
+      "priority": 38,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-039",
+      "title": "zh-Hans localization for paywall, onboarding, and Explore strings",
+      "description": "As a Chinese-language user, I want the App Store-visible strings (paywall, onboarding, Explore button, errors) in Simplified Chinese.",
+      "acceptanceCriteria": [
+        "Create apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings",
+        "Translate every key currently used by paywall, onboarding sheets, Explore button/banners, error messages, AI-badge copy (a focused subset; deep app strings can fallback to English)",
+        "Translations done by hand (or with translator review notes); literal Apple-style tone",
+        "Add zh-Hans to CFBundleLocalizations in Info.plist (via project.yml info.properties)",
+        "Verify by running the app in Simulator with the device language set to Simplified Chinese",
+        "Typecheck passes",
+        "Verify in simulator: switch language to Simplified Chinese, open paywall, confirm strings render correctly"
+      ],
+      "priority": 39,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-040",
+      "title": "Schema parity check across iOS and TypeScript",
+      "description": "As a developer, pnpm parity:check should cover the new fields so future iOS-side schema changes don't drift from the TS schema.",
+      "acceptanceCriteria": [
+        "packages/core/src/experience.ts gets matching additions: id-prefix constant 'exp_osm_', confidenceLevel === 1 semantics for AI-generated entries, DiscoveredCity type matching DiscoveredCityRecord fields",
+        "scripts/check-swift-parity.ts extended: walk the new SwiftData @Model files, extract field names+types, compare against TS interfaces, fail the script on drift",
+        "Run pnpm parity:check locally and confirm it passes",
+        "CI: .github/workflows/ci.yml already runs parity:check; verify it still passes",
+        "Update PR template (if exists) to add 'Updated TS schema if Swift schema changed' checkbox",
+        "Typecheck passes (run: pnpm typecheck)"
+      ],
+      "priority": 40,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-041",
+      "title": "TestFlight prep: review prompt, App Store metadata stubs, BETA docs",
+      "description": "As a founder, I need TestFlight to upload cleanly and metadata stubs ready for App Store submission.",
+      "acceptanceCriteria": [
+        "Add SKStoreReviewController.requestReview() trigger after the user marks their 3rd Experience as completed (UserPreferences gains reviewPromptShown bool)",
+        "Create docs/APP_STORE.md with sections: SKU IDs, price tiers (2 monthly / 11 yearly), keywords (en + zh), category Travel, age 4+, screenshots checklist, ASO description draft (en + zh)",
+        "Create docs/BETA.md with beta tester invite list placeholder and feedback collection process (a Supabase form, link TBD)",
+        "Verify .github/workflows/testflight.yml works on this branch by committing a test tag (or document manual TestFlight upload steps)",
+        "Add a 'What's new in this version' template to docs/CHANGELOG.md for v1.1.0",
+        "Typecheck passes",
+        "Verify in simulator: complete 3 experiences in a row, confirm review prompt appears (in DEBUG build with a flag override)"
+      ],
+      "priority": 41,
+      "passes": false,
       "notes": ""
     }
   ]

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -1,19 +1,7 @@
 # Solo Compass — Ralph Progress Log
-Started: 2026-05-08
+Started: 2026-05-09
 Tool: claude
-Branch: ralph/deepseek-migration
-PRD: tasks/prd-deepseek-migration.md
-Stories: 10
+Branch: ralph/paid-app-foundation
+PRD: tasks/prd-paid-app-foundation.md
+Stories: 41
 ---
-[2026-05-08T09:30:57Z] Story #US-001: Rewrite rank-experiences.ts for DeepSeek JSON mode — PASSED
-[2026-05-08T09:35:30Z] Story #US-002: Rewrite structure-experience.ts for DeepSeek JSON mode — PASSED
-[2026-05-08T09:35:17Z] Story #US-002: Rewrite structure-experience.ts for DeepSeek JSON mode — PASSED
-[2026-05-08T09:35:43Z] Story #US-003: Update packages/ai index.ts exports for DeepSeek — PASSED
-[2026-05-08T09:37:04Z] Story #US-004: Rewrite rank-experiences.test.ts to mock OpenAI shape — PASSED
-[2026-05-08T09:39:31Z] Story #US-005: Rewrite structure-experience.test.ts to mock OpenAI shape and delete obsolete __golden__ files — PASSED
-[2026-05-08T09:41:25Z] Story #US-006: Add retry-with-backoff helper for DeepSeek calls — PASSED
-[2026-05-08T09:43:29Z] Story #US-007: Initialize Sentry in apps/bot and apps/web entry points — PASSED
-[2026-05-08T09:45:34Z] Story #US-008: Forward AI cost events to PostHog from cost-tracker — PASSED
-[2026-05-08T09:46:24Z] Story #US-009: Add gitleaks secret-scanning GitHub Action — PASSED
-[2026-05-08T09:47:10Z] Story #US-010: Inject placeholder .env in iOS CI workflows — PASSED
-[2026-05-08T09:47:10Z] Ralph complete after 10 iterations

--- a/tasks/prd-paid-app-foundation.md
+++ b/tasks/prd-paid-app-foundation.md
@@ -1,0 +1,598 @@
+# PRD: Paid-App Foundation — Persistence, Caching, Freemium & Cross-Device Sync
+
+> **Status:** Draft
+> **Owner:** @cubxxw
+> **Target release:** v1.1.0 (iOS), feeds eventual web/bot parity
+> **Branch convention:** `feat/<short-slug>` per user-story batch
+> **Related:** `tasks/prd-data-engine-v2.md`, `tasks/prd-deepseek-migration.md`
+
+---
+
+## 1. Introduction / Overview
+
+Solo Compass today is a SwiftUI map app with five Chiang Mai seed Experiences and a working "Explore here" flow that pulls real OpenStreetMap POIs and asks Claude to enrich them into solo-traveler entries. Everything beyond `UserPreferences` lives in memory — close the app and all generated content is gone. There is no caching layer, no cost control on AI calls, no monetization, and no way for the app to get smarter over time.
+
+This PRD turns the current technical demo into a **shippable, paid iOS app** by adding four foundations:
+
+1. **Local persistence** — every Experience (seed, OSM-generated, user-added) survives app restarts via SwiftData.
+2. **Smart caching & cost control** — Explore-here results cached by region for 14 days; Claude calls deduplicated; cheaper model by default.
+3. **Freemium monetization** — base map + filter + completed/favorites are free; AI-powered Explore Here, voice intent, and AI explanations require an active subscription via StoreKit 2.
+4. **Supabase backend** — anonymous device identity, cross-device sync of user data and generated Experiences, telemetry on Solo-Score signals to power the "data flywheel."
+
+The ultimate target: a v1.1 iOS build that can stand on its own in the App Store, generate revenue, and feed real usage data back into Experience quality.
+
+---
+
+## 2. Goals
+
+- **G1 — No more data loss.** Generated Experiences and user state persist across app launches and device restarts (target: 100% retention of synthesized content for 90 days).
+- **G2 — Cost-controlled AI.** Average cost per active user per day ≤ **$0.02** for free tier (zero AI calls) and ≤ **$0.30** for paid tier (cached, deduped, Sonnet-based).
+- **G3 — Working free → paid funnel.** Subscribe screen reachable in ≤ 2 taps from any AI-gated action; 7-day free trial; restore-purchase flow works on fresh install.
+- **G4 — Cross-device continuity.** A signed-in user opening the app on a second device sees the same favorites, completed list, generated Experiences, and Solo-Score history within 5 seconds.
+- **G5 — Trust-preserving AI.** Generated Experiences visually distinguish themselves from curated content and never invent specific facts the model could not verify (no fake menu items, hours, or interior details).
+- **G6 — App Store ready.** Privacy manifest, ATT prompt, refund-of-trial flow, IAP receipts, ITP/Family Sharing all configured. Pass App Store review on first submission.
+- **G7 — Local-first.** Every UI read comes from SwiftData; Supabase is sync + shared cache only. App stays fully usable when offline or when the backend is down.
+
+---
+
+## 3. User Stories
+
+> Stories are grouped into 6 epics totaling 31 user stories. Each story is sized to ~1–2 focused implementation sessions and references existing files where possible. Order follows recommended build sequence.
+
+### Epic A: Local Persistence (SwiftData)
+
+#### US-A1: Define SwiftData schema mirroring current Codable models
+**Description:** As a developer, I want a SwiftData store that mirrors `Experience`, `Confidence`, `SoloScore`, `ExperienceLocation`, `TimeWindow`, `HowToStep`, `RealInconvenience`, `InformationSource`, and `Stats` so the app has a single source of truth on disk.
+
+**Acceptance Criteria:**
+- [ ] New file `apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift` exposes a `ModelContainer` configured with all `@Model` types.
+- [ ] New `@Model` classes in `apps/ios/SoloCompass/Persistence/Models/`: `ExperienceRecord`, `ConfidenceRecord`, `SoloScoreRecord`, `LocationRecord`, `TimeWindowRecord`, `HowToStepRecord`, `RealInconvenienceRecord`, `SourceRecord`, `StatsRecord`, `UserCompletionRecord`, `UserFavoriteRecord`, `MicroSurveyRecord`, `ExploreCacheRecord`.
+- [ ] Two-way mapping: `ExperienceRecord(from: Experience)` initializer + `var asValue: Experience` computed property. Round-trip is lossless.
+- [ ] Model versioning: schema is wrapped in a `VersionedSchema` named `SoloCompassSchemaV1` for future migration.
+- [ ] Unit test: round-trip a hardcoded `Experience` through `ExperienceRecord` → fetch → `asValue` and assert equality.
+- [ ] `xcodebuild test` passes.
+
+#### US-A2: Replace ExperienceService in-memory store with SwiftData-backed repository
+**Description:** As a user, I want every Experience I see on the map to come from local storage, so closing and reopening the app does not lose any of my discovered places.
+
+**Acceptance Criteria:**
+- [ ] New `ExperienceRepository` (in `Persistence/`) owns CRUD against the `ModelContainer`. `ExperienceService` becomes a thin facade that delegates to the repo and exposes the existing `@Observable` API for views.
+- [ ] On first launch with empty store: bundle seed (`Resources/JSON/seed_experiences.json`) is imported once. A boolean flag `seedImported` is stored in `UserPreferences` so re-imports skip.
+- [ ] `appendGenerated([Experience])` writes through to SwiftData and is **idempotent by id**.
+- [ ] `markCompleted(id)` writes a `UserCompletionRecord` (separate table; never mutates the Experience) and the existing `Stats.completionCount` derives from a query.
+- [ ] Acceptance test: launch app, run "Explore here" in Hanoi, force-quit, relaunch — all generated pins are still on the map.
+- [ ] Unit test: write 30 generated Experiences, query nearby with radius 5 km, assert correct subset returned in correct order.
+- [ ] `xcodebuild test` passes.
+
+#### US-A3: Migrate UserPreferences mutable state into SwiftData
+**Description:** As a user, I want my favorites, completed list, micro-survey responses, and pending check-ins to persist reliably across app reinstalls when I'm signed in.
+
+**Acceptance Criteria:**
+- [ ] `UserPreferences` retains `UserDefaults` for **scalar settings only** (style, max distance, disliked categories, last selected city).
+- [ ] Lists move to SwiftData: `UserCompletionRecord`, `UserFavoriteRecord`, `MicroSurveyRecord`, `PendingCheckInRecord`.
+- [ ] `isCompleted(id)` / `isFavorited(id)` become repository queries; existing call sites in `MapViewModel`, `ExperienceDetailViewModel`, settings/favorites views unchanged.
+- [ ] Migration: on first launch of v1.1, read existing `UserDefaults` arrays for completed/favorites and seed the SwiftData tables, then clear the old keys.
+- [ ] Unit test: pre-populate `UserDefaults` with legacy completed array → boot the app → assert SwiftData has matching `UserCompletionRecord` rows and old keys are gone.
+
+#### US-A4: Persist offline map regions for last-explored area
+**Description:** As a traveler with flaky data, I want the last region I explored to be browsable offline (markers + detail data, not basemap tiles).
+
+**Acceptance Criteria:**
+- [ ] Last 3 explored regions (lat/lon center + radius) recorded in a `RecentExploreRegion` SwiftData table.
+- [ ] When `Explore here` is offline, the app still shows pins from the last region matching the current map center within 10 km — using only SwiftData reads.
+- [ ] A small banner ("Showing offline data from <date>") appears when the data is older than 7 days.
+- [ ] Unit test: simulate `URLSession` failure → `exploreNearby` returns cached region's pins, sets banner state.
+
+---
+
+### Epic B: Smart Caching & Cost Control
+
+#### US-B1: Region-keyed cache for Overpass queries
+**Description:** As a product owner, I don't want users repeatedly burning Overpass quota by tapping "Explore here" in the same area.
+
+**Acceptance Criteria:**
+- [ ] New `ExploreCacheRecord` in SwiftData: `regionKey: String` (e.g. `"21.03_105.85_3000"`), `osmJSON: Data`, `fetchedAt: Date`, `poiCount: Int`.
+- [ ] `OverpassService.fetchPOIs` consults cache first; cache hit if `now - fetchedAt < 14 days` and `regionKey` matches at 0.01° rounding (~1.1 km grid).
+- [ ] Cache miss → real fetch → write through.
+- [ ] Cache hit count surfaced in settings → "Storage" row ("Cached 12 regions, 248 POIs"). User-visible **Clear cache** button purges `ExploreCacheRecord` and `ExperienceRecord` rows where `id LIKE 'exp_osm_%'`.
+- [ ] Unit test (`URLProtocol` stub): two consecutive `fetchPOIs` calls in same region trigger only one HTTP request.
+
+#### US-B2: Region-keyed cache for AI synthesis results
+**Description:** As a product owner, I want Claude calls deduplicated so the same OSM batch never gets re-synthesized.
+
+**Acceptance Criteria:**
+- [ ] Cache key = SHA256 of sorted `osmId` list + cityCode + locale + model name. Stored in `AISynthesisCacheRecord`.
+- [ ] `AIService.synthesizeExperiences` checks the cache before calling the network. Hit → decode persisted `[Experience]` JSON. Miss → call → write through.
+- [ ] TTL **30 days**.
+- [ ] Cache stats exposed alongside Overpass cache in settings.
+- [ ] Unit test: same input batch hits the network once, returns identical Experiences twice.
+
+#### US-B3: Switch default synthesis model to Sonnet 4.6 with Haiku fallback
+**Description:** As a product owner, I want AI generation cost to drop ~80% without a noticeable quality regression.
+
+**Acceptance Criteria:**
+- [ ] `AIService` gains `model` config: `synthesisModel = "claude-sonnet-4-6"`, `explanationModel = "claude-haiku-4-5-20251001"`, `voiceIntentModel = "claude-sonnet-4-6"`.
+- [ ] `recommendExperiences` and `synthesizeExperiences` use synthesis model; `explainRecommendation` uses Haiku.
+- [ ] All three are read from `Secrets.plist` keys with defaults so QA can override per-build.
+- [ ] A debug flag `AI_FORCE_OPUS=1` env var still routes everything to Opus for golden-set comparison.
+- [ ] Snapshot test: synthesizing 5 fixed POIs with each model produces parseable JSON of the expected shape.
+
+#### US-B4: Hallucination-resistant synthesis prompt
+**Description:** As a user, I need to trust generated content not to invent facts the model can't actually know.
+
+**Acceptance Criteria:**
+- [ ] Updated prompt explicitly instructs: "Use ONLY the provided OSM tags. Do NOT invent menu items, interior details, hours, prices, owner backstories, or specific seating positions. If a field is not derivable from tags, write a generic safe value."
+- [ ] `howTo` is constrained to navigation steps only (no "order the X").
+- [ ] Prompt includes 2 few-shot examples showing **good** (tag-derived, generic) vs **bad** (hallucinated specifics) outputs.
+- [ ] New regression test: feed a POI with only `{amenity: cafe, name: "Quán A"}` and assert the model output's `whyItMatters` and `howTo` do **not** contain any of the banned phrase patterns (regex list of 20+ red flags).
+
+#### US-B5: Per-user daily AI quota with graceful degradation
+**Description:** As a product owner, I want a hard cap on Claude spend per user per day so a runaway loop never costs more than $1.
+
+**Acceptance Criteria:**
+- [ ] `UserPreferences` adds `aiCallsToday: Int` and `aiCallsResetDate: Date` (rolling UTC day).
+- [ ] Free tier limit: 0 paid AI calls (Explore-Here disabled, see Epic D).
+- [ ] Paid tier: 30 synthesis calls/day, 60 explanation calls/day. Counter increments on every Anthropic POST regardless of cache hits (cache hits don't count).
+- [ ] When limit hit: feature falls back to skeleton mode + visible banner "Daily AI limit reached, resets in Xh".
+- [ ] Counter persists in SwiftData (`AIUsageRecord`) — survives kills.
+
+---
+
+### Epic C: Trust & UX Polish for Generated Content
+
+#### US-C1: Visual downgrade for `confidence.level == 1` Experiences
+**Description:** As a user, I want to immediately tell which pins are AI-guessed vs curated.
+
+**Acceptance Criteria:**
+- [ ] `MarkerIconView` renders confidence-1 pins with: dashed stroke border, 70% opacity, no glow, smaller badge.
+- [ ] Detail view: existing "AI-generated · OpenStreetMap" badge is upgraded with a tappable info icon that opens an info sheet explaining the source and recommending the user verify on-site.
+- [ ] Sources section explicitly shows "© OpenStreetMap contributors" with a link to the OSM node URL.
+- [ ] Verify in simulator using `xcrun simctl` and a manual screenshot review.
+
+#### US-C2: Surface explore errors and skeleton-mode state to the user
+**Description:** As a user, when AI synthesis silently fails I should know that what I'm looking at is OSM-only, and when Explore fails completely I should see why.
+
+**Acceptance Criteria:**
+- [ ] `MapViewModel.lastExploreError` is rendered as a dismissible banner (reuse existing `lastAIError` style in `CompassMapView`).
+- [ ] When `synthesizeExperiences` falls back to skeleton mode, set `lastExploreInfo = "Showing real places without AI enrichment — subscribe for richer descriptions."` (free tier) or `"AI is offline."` (paid tier with API failure).
+- [ ] Banner has a "Subscribe" CTA in free-tier copy linking to the paywall (Epic D).
+- [ ] Unit test: force `synthesizeExperiences` to throw → assert info banner state set correctly per subscription tier.
+
+#### US-C3: Reverse-geocode discovered regions into real city names
+**Description:** As a user, I shouldn't see "osm_21.0_105.9" in my city picker — I should see "Hanoi".
+
+**Acceptance Criteria:**
+- [ ] New `ReverseGeocodeService` wraps `CLGeocoder.reverseGeocodeLocation`.
+- [ ] On successful Explore: resolve coordinate → `city, countryCode`. Persist to `DiscoveredCityRecord` (cityCode = ISO-3166-2-region-or-locality-slug, name = localized).
+- [ ] `MapViewModel.cityCode(for:)` consults `DiscoveredCityRecord` first; falls back to current `osm_<lat>_<lon>` only when geocoder fails or offline.
+- [ ] Generated Experiences in that region get the resolved cityCode written into `ExperienceRecord.location.cityCode`.
+- [ ] City picker shows real names; tapping a discovered city centers the map and loads cached pins.
+
+#### US-C4: Auto-switch selected city after successful Explore
+**Description:** As a user who lands in a new city and taps Explore, I should immediately see the new pins without manually changing the city filter.
+
+**Acceptance Criteria:**
+- [ ] After `exploreNearby` adds N > 0 generated Experiences, `MapViewModel` calls `selectCity(resolvedCityCode)` so the visible-experiences filter no longer hides them.
+- [ ] If reverse-geocoding succeeded, the city name briefly toasts: "Now exploring Hanoi · 12 places added".
+- [ ] If geocoding failed, fallback toast: "12 places added near you".
+- [ ] Unit test: with `selectedCity = "cmi"`, run `exploreNearby` at Hanoi coords with mocked geocoder → assert `selectedCity` becomes the Hanoi cityCode.
+
+#### US-C5b: Cold-start UX for Solo-Score (zero-signal regions)
+**Description:** As a user discovering a new region, I should see a useful Solo Score on every pin — clearly marked as an AI estimate when no community data exists yet, transitioning naturally to community-backed numbers as signals arrive.
+
+**Acceptance Criteria:**
+- [ ] `SoloScore` view component takes a new `signalCount: Int` parameter and renders three visual states:
+  - `signalCount == 0`: dimmed score color + "AI estimate" pill + tap-to-explain tooltip
+  - `signalCount` in `1...2`: normal score + "Based on N early reports" subtext
+  - `signalCount >= 3`: normal score + "Based on N solo travelers" subtext (current behavior)
+- [ ] Pin marker color saturation scales with `signalCount` (dimmed when 0, full when >=3) so the map at a glance shows community-validated places more prominently than AI estimates.
+- [ ] Detail view's solo-score section header reads "Solo Score (AI estimate)" / "Solo Score (early)" / "Solo Score" matching the three states.
+- [ ] Unit test: render `SoloScoreView` with each of `0, 1, 2, 3, 12` signals — assert the right state markers appear.
+- [ ] Snapshot test for each state in light + dark mode.
+
+#### US-C5: MicroSurvey responses feed back into SoloScore
+**Description:** As a user, my honest feedback on a place should improve its Solo Score for the next traveler — making the app smarter every week.
+
+**Acceptance Criteria:**
+- [ ] `MicroSurveySheet` writes a `MicroSurveyRecord` (rating fields + experienceId + timestamp + anonymizedDeviceId).
+- [ ] `SoloScore.overall` becomes a derived computed property: `0.5 * seedOrAI + 0.5 * meanOfLocalSurveys` (weighted by `basedOnCount`). Cached on read for 60s to avoid recomputing on every render.
+- [ ] `basedOnCount` reflects local survey count (cross-device count comes in Epic E).
+- [ ] When a user submits a survey their immediate next view of the Experience shows the updated score.
+- [ ] Unit test: submit two surveys with comfort=5, pressure=4, recommend=yes → assert resulting `overall` matches the formula.
+
+---
+
+### Epic D: Freemium & StoreKit 2
+
+#### US-D1: Subscription product setup & local entitlement check
+**Description:** As a developer, I need StoreKit 2 wired up with two subscription SKUs and an offline-tolerant entitlement source of truth.
+
+**Acceptance Criteria:**
+- [ ] New file `apps/ios/SoloCompass/Services/SubscriptionService.swift` (`@MainActor @Observable`). Manages `StoreKit.Product` fetch, purchase, restore, transaction listener.
+- [ ] App Store Connect SKUs (created out-of-band, documented in `docs/APP_STORE.md`):
+  - `com.solocompass.pro.monthly` — monthly subscription, 7-day free trial, intro offer once per Apple ID
+  - `com.solocompass.pro.yearly` — yearly subscription, 7-day free trial, ~55% savings vs monthly
+- [ ] `SubscriptionService.entitlement: Entitlement` is one of `.free | .proTrial | .pro | .proExpired`. Computed from `Transaction.currentEntitlements`.
+- [ ] Entitlement is **cached in Keychain** so a brief offline launch still respects it.
+- [ ] Listener auto-updates entitlement on renewal/cancellation.
+- [ ] Unit test with `Testing` framework + `Transaction.testSession` covers: free → trial → paid → expired transitions.
+
+#### US-D2: Paywall view
+**Description:** As a free user tapping an AI-gated action, I land on a clear paywall where I can start a free trial.
+
+**Acceptance Criteria:**
+- [ ] New `apps/ios/SoloCompass/Views/Paywall/PaywallView.swift`. Shows: hero copy, two product cards (monthly / yearly with "Best value" badge), "Start 7-day free trial" CTA, fine-print, "Restore purchases" link, "Manage subscription" deep link to App Store Settings.
+- [ ] Localized en + zh-Hans (`Resources/zh-Hans.lproj/Localizable.strings` created).
+- [ ] Paywall reachable via `viewModel.isShowingPaywall = true` from any AI-gated CTA.
+- [ ] On successful purchase: dismiss paywall, retry the original action automatically (e.g. resume `exploreNearby`).
+- [ ] Verify in simulator using StoreKit testing config (`Configuration.storekit` file in `apps/ios/`).
+
+#### US-D3: Gate AI features behind entitlement
+**Description:** As the product owner, I want AI features (Explore Here synthesis, voice intent, AI explanations) to require a Pro subscription.
+
+**Acceptance Criteria:**
+- [ ] `MapViewModel.exploreNearby` and `handleVoiceTranscript` and `ExperienceDetailViewModel.requestAIExplanation` consult `SubscriptionService.entitlement`. If `.free` or `.proExpired`: route to paywall instead of network call.
+- [ ] Free users still get: full map, filters, seed Experiences, completed/favorites, micro-survey, settings, **OSM-only Explore Here in skeleton mode** (no Claude call) — this is the "show, don't tell" funnel.
+- [ ] The Explore button label changes to "Explore (Pro)" with a small lock icon when free.
+- [ ] Detail view's "AI insight" section shows a paywall teaser instead of "Loading…" for free users.
+- [ ] Unit test: as `.free`, calling `exploreNearby` sets `isShowingPaywall = true` and does not invoke `OverpassService` or `AIService`.
+
+#### US-D4: Trial-to-paid conversion analytics
+**Description:** As a founder, I need to know how many trials convert and where users drop off.
+
+**Acceptance Criteria:**
+- [ ] On every `Transaction` lifecycle event (`subscribed`, `expired`, `inGracePeriod`, `revoked`, `upgraded`), emit a Supabase `subscription_events` row (Epic E).
+- [ ] Column: `device_id`, `event_type`, `product_id`, `original_purchase_date`, `expires_date`, `is_in_trial_period`.
+- [ ] No PII (no email, no Apple ID).
+- [ ] Local sanity log in Console for debug builds.
+
+#### US-D5: Refund-of-trial & restore-on-fresh-install flow
+**Description:** As a user reinstalling on a new phone, I shouldn't have to pay again.
+
+**Acceptance Criteria:**
+- [ ] App boot on new device with same Apple ID -> `Transaction.currentEntitlements` populates -> entitlement set to `.pro` automatically without user action.
+- [ ] Settings -> "Restore purchases" button explicitly calls `AppStore.sync()` and surfaces success/failure as a toast.
+- [ ] If a user cancels mid-trial inside Settings.app, app reflects `.free` within 1 minute via the transaction listener.
+
+---
+
+### Epic E: Supabase Backend & Cross-Device Sync
+
+#### US-E1: Anonymous device identity via Supabase Auth
+**Description:** As a user, I want my data synced without creating an account or giving an email.
+
+**Acceptance Criteria:**
+- [ ] Existing `DeviceIdentityService` extended to call `supabase.auth.signInAnonymously()` on first launch and store the resulting `userId` in Keychain.
+- [ ] On subsequent launches, refresh-token flow keeps the session alive.
+- [ ] On entitlement change (`.proTrial` -> `.pro`), update a `profiles` row with `entitlement_tier`.
+- [ ] If the user later wants account portability, they can link Apple ID via "Sign in with Apple" — this upgrades the anonymous user to a permanent one (this US covers anon-only; Apple-link is a follow-up).
+- [ ] Supabase project bootstrap script in `infra/supabase/` (SQL + RLS policies) checked in.
+
+#### US-E2: Schema and RLS policies on Supabase
+**Description:** As a developer, I need a backend schema that mirrors local SwiftData tables and enforces per-user data isolation.
+
+**Acceptance Criteria:**
+- [ ] Tables: `profiles`, `user_completions`, `user_favorites`, `micro_surveys`, `subscription_events`, `synthesized_experiences` (canonical AI output, dedupable across users), `osm_pois` (canonical OSM cache), `solo_score_signals`.
+- [ ] Row-Level Security: every user-data table allows `select/insert/update/delete WHERE user_id = auth.uid()`. `synthesized_experiences` and `osm_pois` are **read-public, write-server-role**.
+- [ ] Migration files in `infra/supabase/migrations/0001_*.sql`.
+- [ ] Smoke test script: `infra/supabase/test_rls.ts` runs anon vs user role queries and asserts isolation.
+
+#### US-E3: Outbox sync for user data
+**Description:** As a user toggling between phone and iPad, I want my favorites and completed list to converge within seconds.
+
+**Acceptance Criteria:**
+- [ ] New `SyncService` (in `Services/`) implements outbox pattern: any local mutation to user-data tables also writes to a `PendingSyncRecord` queue.
+- [ ] Background flush every 30s and on app foreground; uses Supabase's REST upsert with `If-Match` on `updated_at` for last-write-wins.
+- [ ] Inbound: pull diff (`updated_at > lastPulledAt`) for each user-data table on foreground; merge into SwiftData by id.
+- [ ] Conflicts resolved by `updated_at` desc (LWW); ties broken by `device_id` lex order.
+- [ ] Unit test: simulate two devices mutating the same favorite — assert eventual consistency after one round-trip each.
+
+#### US-E4: Server-side AI synthesis cache (sharing across users)
+**Description:** As a product owner, when User A in Hanoi has paid for AI synthesis of a region, User B's nearby request should reuse it for free.
+
+**Acceptance Criteria:**
+- [ ] `AIService.synthesizeExperiences` consults Supabase `synthesized_experiences` table by region+POI hash before calling Claude.
+- [ ] On cache miss + paid call: write the result back to `synthesized_experiences` (server-role via a Supabase Edge Function with service-role key — client never has it).
+- [ ] Free users **read** the shared cache (so a paid user's exploration "lights up" the area for everyone) — this is the core flywheel and a marketing hook.
+- [ ] Edge Function `synthesize-experiences` (Deno/TS) does the Anthropic call server-side, validates the response, dedup-writes to `synthesized_experiences`. Client just calls the function.
+- [ ] **API key never ships in the iOS app after this milestone.** `Secrets.plist` `ANTHROPIC_API_KEY` is removed.
+- [ ] Edge Function rate-limits per `auth.uid()`: 30 calls/day for Pro, 0 for free.
+
+#### US-E6: Optional Sign-in-with-Apple to upgrade anonymous account
+**Description:** As a user who wants Family Sharing eligibility or extra account-recovery safety, I want to link my anonymous Solo Compass account to my Apple ID without losing my data.
+
+**Acceptance Criteria:**
+- [ ] Settings has a new row under "My Data": **"Save with Apple"** (when anonymous) / **"Linked to Apple ID"** (when linked).
+- [ ] Tapping "Save with Apple" presents the system Sign-in-with-Apple sheet. On success, calls `supabase.auth.linkIdentity(provider: .apple)` to merge the anonymous user into a permanent one.
+- [ ] All existing local SwiftData rows keep their `anonUserId` linkage; the Supabase `profiles` table updates `is_anonymous = false` and stores the Apple email relay (private relay, not real email).
+- [ ] No Apple ID data leaves the device beyond what Supabase Auth needs (sub claim + email relay). Documented in `docs/PRIVACY.md`.
+- [ ] If link fails (network, user cancels): toast "Couldn't link account. Your data is still saved on this device." No data is lost or corrupted.
+- [ ] Family Sharing: linked accounts that share a Family receive Pro entitlement automatically via StoreKit Family Sharing (already supported by `Transaction.currentEntitlements`); document the limit (one paying organizer + 5 family members).
+- [ ] Unit test (`Transaction.testSession` + Supabase mocked): anonymous user with 3 favorites and 1 micro-survey links to Apple → assert all rows now belong to permanent userId, anon session is deleted server-side.
+
+#### US-E5: Solo-Score signal aggregation
+**Description:** As a user, I should see Solo Scores that reflect actual community use, not just AI guesses.
+
+**Acceptance Criteria:**
+- [ ] On every micro-survey submit, `SyncService` writes a `solo_score_signals` row (anon user_id, experienceId, comfort, pressure, recommend, timestamp).
+- [ ] Nightly Supabase scheduled function recomputes `synthesized_experiences.aggregated_solo_score` (mean/median + sample size) for each experienceId.
+- [ ] Client pulls the aggregate on app foreground and merges into `ExperienceRecord.soloScore` if `signal_count >= 3`.
+- [ ] Detail view displays "Based on N solo travelers" using the real count.
+
+---
+
+### Epic F: App Store Readiness & Privacy
+
+#### US-F1: Privacy manifest and ATT prompt
+**Description:** As an App Store applicant, I need a privacy manifest declaring data use and ATT prompts where appropriate.
+
+**Acceptance Criteria:**
+- [ ] `apps/ios/SoloCompass/Resources/PrivacyInfo.xcprivacy` lists: precise location, coarse location, device ID (Supabase anon), purchases (StoreKit), diagnostics (Supabase events).
+- [ ] No data is marked as used for tracking. ATT prompt skipped (not needed without tracking).
+- [ ] Privacy policy at `https://solocompass.app/privacy` (placeholder OK; URL configured in `Info.plist`).
+- [ ] First-run onboarding screen explains: location stays on device + sent to OSM/Anthropic during Explore Here; entitlement events sent to Supabase for sync; nothing else.
+
+#### US-F2: First-run Explore-Here consent screen
+**Description:** As a privacy-conscious user, I want a clear opt-in moment before my coordinates leave the device.
+
+**Acceptance Criteria:**
+- [ ] New view `Onboarding/ExploreConsentSheet.swift` shown the first time the user taps Explore Here.
+- [ ] Explains: "Tapping Explore here sends your map center coordinate to OpenStreetMap (free, anonymous) and to our AI server. We never store who asked, only what was asked, for 30 days."
+- [ ] Two buttons: "Continue" (proceeds + sets `userPreferences.exploreConsentGivenAt`) and "Not now".
+- [ ] Subsequent taps skip the sheet.
+- [ ] Settings has a "Revoke consent" row that clears the flag and disables Explore Here.
+
+#### US-F3: Schema parity check across iOS and TypeScript
+**Description:** As a developer, I need `pnpm parity:check` to cover the new fields so future changes don't drift.
+
+**Acceptance Criteria:**
+- [ ] `packages/core/src/experience.ts` adds the same prefixes (`exp_osm_`), confidence-level-1 semantics, and `discoveredCity` types as iOS.
+- [ ] `scripts/check-swift-parity.ts` extended to check the new model classes vs TS types.
+- [ ] CI job `.github/workflows/ci.yml` runs `pnpm parity:check` and fails on drift.
+- [ ] PR template adds checkbox: "Updated TS schema if Swift schema changed."
+
+#### US-F4: Localization for zh-Hans
+**Description:** As a Chinese-language user, I want the app and paywall in Simplified Chinese.
+
+**Acceptance Criteria:**
+- [ ] `Resources/zh-Hans.lproj/Localizable.strings` covers every key in `en.lproj`. Translations done by hand for app-store-visible strings (paywall, onboarding, Explore button, errors).
+- [ ] App Store description, keywords, screenshots have zh-Hans variants.
+- [ ] Default fallback to English remains for missing keys.
+
+#### US-F5: TestFlight beta and App Store metadata
+**Description:** As a founder, I want a TestFlight build with 20 beta testers feeding usage data before public launch.
+
+**Acceptance Criteria:**
+- [ ] `.github/workflows/testflight.yml` already exists; verify it works on this branch and uploads on tag `v1.1.0-beta.N`.
+- [ ] App Store Connect entry filled: name, subtitle, keywords (en + zh), 6 screenshots per locale (iPhone 17 Pro), category Travel, age 4+.
+- [ ] In-app review prompt (`SKStoreReviewController.requestReview()`) triggered after the user marks 3rd Experience completed (not before).
+- [ ] Beta tester invite list documented in `docs/BETA.md`.
+
+---
+
+## 4. Functional Requirements
+
+### Persistence
+- **FR-1:** All Experiences (seed, OSM-generated, user-added) stored in SwiftData; bundle seed imported once on first launch.
+- **FR-2:** User completion, favorites, and micro-surveys stored in SwiftData; legacy `UserDefaults` arrays migrated automatically.
+- **FR-3:** SwiftData schema is versioned; v1 schema declared explicitly to allow future migrations.
+
+### Caching & Cost
+- **FR-4:** Overpass results cached for 14 days, keyed by 0.01 degree rounded coordinate + radius.
+- **FR-5:** Claude synthesis results cached for 30 days locally and indefinitely server-side via Supabase.
+- **FR-6:** Default synthesis model is Sonnet 4.6; explanation model is Haiku 4.5; Opus is gated behind a debug flag only.
+- **FR-7:** Per-user daily AI quota: free=0, Pro=30 syntheses + 60 explanations.
+
+### Trust & UX
+- **FR-8:** Pins with `confidence.level == 1` render with dashed border, 70% opacity, and an info disclosure in detail view.
+- **FR-9:** OSM-derived Experiences must include `(c) OpenStreetMap contributors` in `sources` and link to the node URL.
+- **FR-10:** Synthesis prompt forbids invented specifics (menu items, hours, prices, interior details, owner backstories).
+- **FR-11:** Reverse geocoding resolves city names; falls back to `osm_<lat>_<lon>` only when geocoder fails.
+
+### Freemium & Monetization
+- **FR-12:** Two subscription products with **globally uniform Apple price tiers** (auto-converted per region by App Store):
+  - Monthly: Apple price tier 2 (~$1.99 USD; ¥12 CNY; €1.99; ¥300 JPY).
+  - Yearly: Apple price tier 11 (~$14.99 USD; ¥98 CNY; €14.99; ¥2200 JPY).
+  - Both with 7-day intro free trial.
+- **FR-13:** AI features (Explore Here synthesis, voice intent, AI explanations) require `entitlement` in `{.proTrial, .pro}`. Free users see paywall instead.
+- **FR-14:** Free users still receive OSM skeleton mode for Explore Here so they see value before subscribing.
+- **FR-15:** Restore purchases works without sign-in via Apple ID.
+- **FR-16:** Entitlement cached in Keychain for offline boot.
+- **FR-16b:** Sign-in-with-Apple linking is supported in v1.1 (US-E6) and unlocks Family Sharing eligibility; remains optional.
+
+### Backend & Sync
+- **FR-17:** Supabase anonymous auth on first launch; `userId` persisted in Keychain.
+- **FR-18:** Outbox sync flushes every 30 s and on foreground; LWW conflict resolution.
+- **FR-19:** All Anthropic calls go through a Supabase Edge Function after Epic E ships; the iOS app no longer holds the API key.
+- **FR-20:** Solo-Score aggregates recomputed nightly server-side; clients pull on foreground.
+- **FR-24 (Local-first invariant):** SwiftData is the source of truth for every UI read. The app must be fully usable with Supabase unreachable: full map, all generated Experiences, completed/favorites, micro-survey submission (queued for later), entitlement check (Keychain cache). Backend writes are best-effort; failure must never block a UI action or surface a blocking error.
+- **FR-25:** Supabase region: Singapore (`ap-southeast-1`) for v1.1; Tokyo failover documented but not provisioned.
+
+### Privacy & Compliance
+- **FR-21:** `PrivacyInfo.xcprivacy` declares all collected data types accurately; nothing is used for tracking.
+- **FR-22:** First-run consent sheet required before Explore Here ever sends coordinates off-device; revocable in Settings.
+- **FR-23:** Privacy policy URL configured in `Info.plist` and reachable.
+
+---
+
+## 5. Non-Goals (Out of Scope)
+
+- **No social graph.** No friends, no public profiles, no following, no likes from other users.
+- **No web app or bot in this PRD.** Supabase schema is shared so they can land later, but `apps/web` and `apps/bot` are not built in v1.1.
+- **No mandatory sign-in.** Sign-in-with-Apple is optional (US-E6) and only used to upgrade an anonymous account. The default flow stays anonymous.
+- **No offline basemap tiles.** Offline mode shows pins and detail data on Apple's blank basemap; downloading MapKit tiles is post-v1.1.
+- **No third-party POI sources** beyond OpenStreetMap (no Foursquare, Google Places, Yelp, TripAdvisor).
+- **No human moderation queue** for AI content in v1.1; rely on prompt constraints + visual downgrade. Moderation is v1.2.
+- **No analytics SDKs** (no Mixpanel/Amplitude/Sentry). All events go to our own Supabase tables.
+- **No push notifications beyond the existing geofence check-in nudge.**
+- **No iPad-optimized layout.** App runs on iPad but UI is the iPhone layout scaled.
+- **No referral / promo-code system in v1.1.** Standard Apple promo codes via App Store Connect only.
+
+---
+
+## 6. Design Considerations
+
+- **Reuse existing components:** `MarkerIconView`, `ConfidenceBadge`, `ExperienceCardView`, `BottomInfoBar`, `FilterBarView`. No design system overhaul.
+- **Paywall visual style:** Match existing `.regularMaterial` / SF Symbols aesthetic; no animated gradients or stock illustration. One product hero + two cards.
+- **Skeleton-mode pin:** dashed stroke outline + 70% opacity (already prototyped for the long-press candidate marker — reuse that path).
+- **City picker:** discovered cities show a small sparkle icon next to the name to indicate AI-explored; curated cities (Chiang Mai today) show a star icon.
+- **Toasts:** lightweight `Capsule()` over `BottomInfoBar`, auto-dismiss in 3 s. Reuse the AI-error banner pattern.
+- **Free vs Pro affordance:** Lock icon on the Explore button when free; subscribe CTA in info banners. No nag screens or interstitials.
+
+---
+
+## 7. Technical Considerations
+
+### Stack additions
+- **SwiftData** — iOS 17+ (already deployment target).
+- **StoreKit 2** — new dependency, no third-party.
+- **Supabase Swift SDK** — `supabase-swift` via SPM (one of the few cases the project breaks its "zero deps" rule; documented in `CLAUDE.md`).
+- **Supabase project** — single project, two schemas (`public`, `private`). Hosted on Supabase Cloud (free tier covers the first 50k MAU; budget upgrade documented).
+- **Supabase Edge Functions** — Deno runtime; one function (`synthesize-experiences`) holds the Anthropic key.
+
+### Migration path
+1. Land Epic A (persistence) on `feat/persistence-swiftdata` — no behavior change for users.
+2. Land Epic B (caching + Sonnet) on `feat/ai-cost-control`.
+3. Land Epic C (UX polish) on `feat/explore-trust`.
+4. Land Epic D (StoreKit) on `feat/freemium-paywall` — first user-visible paid moment.
+5. Land Epic E (Supabase) on `feat/backend-sync` — removes API key from client; this is the highest-risk merge and gets staged behind a feature flag.
+6. Land Epic F (privacy/store) on `feat/app-store-prep` — final polish.
+7. Tag `v1.1.0-beta.1`, push to TestFlight, gather 2 weeks of feedback, then `v1.1.0`.
+
+### Feature flags
+- `FF_BACKEND_SYNC` — gates Supabase calls; off by default in beta.1, on by beta.3.
+- `FF_PAYWALL_ENABLED` — lets us TestFlight without showing the paywall to early testers.
+- Stored in `Resources/FeatureFlags.plist` and overridable via launch args.
+
+### Performance budgets
+- App cold-start time: <= 1.0 s on iPhone 14 (currently ~0.7 s; SwiftData container init must not regress).
+- Map first-pin-render: <= 300 ms after location lock.
+- Explore Here end-to-end (cache miss): <= 6 s on a good network; (cache hit): <= 200 ms.
+- Sync round-trip: <= 1 s on 4G.
+- SwiftData query for "experiences within 5 km, filtered by category": <= 50 ms with 1000 records.
+
+### Risks
+- **R1 — SwiftData migrations are fragile.** Mitigate by versioning the schema from day 1 and never modifying v1 in place.
+- **R2 — Apple may reject "anonymous account auto-creation".** Mitigate by making the anonymous account explicit in onboarding ("Solo Compass uses an anonymous device ID to sync across your devices. No email needed.").
+- **R3 — Supabase Edge Function cold start.** First call may take 2–3 s; warm pings every 5 min via cron. Document fallback (skeleton mode if Edge Function times out).
+- **R4 — Sonnet output quality regression vs Opus.** Mitigate via golden-set snapshot tests in US-B3 and ability to toggle back.
+- **R5 — Server-side cache "lights up regions for free users" creates a vector for Pro users to feel cheated.** Counter by making the value of Pro about *speed of fresh exploration* + *daily quota* + *future AI features*, not exclusivity of past cache hits. Document this in the paywall copy.
+
+---
+
+## 8. Success Metrics
+
+### North-Star
+- **Daily Active Paid Users (DAPU)** — target 200 by week 4 post-launch.
+
+### Activation
+- >= 60% of users who tap "Explore Here" on free tier reach the paywall.
+- >= 15% of paywall views start the free trial.
+- >= 40% of trials convert to paid (industry benchmark: 30-50% for utility apps).
+
+### Retention
+- Day-7 retention free: >= 25%.
+- Day-7 retention paid: >= 60%.
+- Day-30 retention paid: >= 40%.
+
+### Cost
+- Average AI cost per paid user per day <= $0.30.
+- >= 50% of synthesis requests served from cache after week 4 (the flywheel).
+
+### Trust / Quality
+- < 5% of generated Experiences flagged via Report Issue ("factually incorrect").
+- >= 60% of generated Experiences in a region get at least 1 micro-survey within 60 days.
+
+### Engineering
+- All 6 epics ship within a 6-week calendar window.
+- `xcodebuild test` passes on every PR; coverage on new code >= 75%.
+- Zero P0 crashes in production for 14 days post-launch (measured via Apple's Crashes & Energy logs).
+
+---
+
+## 9. Resolved Decisions & Remaining Open Questions
+
+### Resolved (decided 2026-05-09 with @cubxxw)
+
+1. **Pricing — globally uniform USD-anchored tiers (Apple auto-converts).**
+   - Monthly: **Apple price tier 2** (~$1.99 USD; ¥12 CNY; ¥300 JPY; €1.99 EUR). Anchor product, lowers friction.
+   - Yearly: **Apple price tier 11** (~$14.99 USD; ¥98 CNY; ¥2200 JPY; €14.99 EUR). ~37% savings, nudges to annual.
+   - Both with **7-day free trial**. No per-region discounts; same Apple tier ID applied everywhere — App Store auto-converts to local currency at Apple's official tiers, removing the need to maintain a price matrix.
+   - Documented in `docs/APP_STORE.md` for ASO localization.
+
+2. **Sign-in-with-Apple linking — included in v1.1.**
+   - Promoted from Epic E follow-up to **US-E6** (new). Anonymous users can optionally tap "Save my data with Apple" in Settings to link their session, enabling Family Sharing eligibility from day 1 and protecting against accidental anon-token loss.
+   - Still optional — anonymous-only flow remains the default.
+
+3. **Backend posture — local-first, cloud as cache & sync only.**
+   - SwiftData remains the **source of truth** for every read in the UI. Supabase serves three purposes: (a) outbox sync target; (b) shared AI synthesis cache; (c) Edge Function host for the Anthropic key.
+   - The app must be **fully usable with Supabase unreachable**. All sync writes are best-effort; all reads can be served entirely from local SwiftData.
+   - Supabase region: **Singapore** (`ap-southeast-1`) — closest to expected APAC user base; Tokyo as failover region documented but not provisioned in v1.1.
+   - This is a stronger constraint than the original draft; it adds explicit **FR-24** below and is reflected in updated US-E3 acceptance criteria.
+
+4. **Solo-Score cold-start — show a clearly-marked AI estimate, not a hidden field.**
+   - When `signal_count == 0`: render the score with a small "AI estimate" pill and dimmed color; tooltip on the score reads "Estimated by AI from venue tags. Solo travelers haven't reported in yet."
+   - When `signal_count` between 1–2: render normally but show "Based on N early reports" instead of the usual basedOn copy.
+   - When `signal_count >= 3`: full-strength score, "Based on N solo travelers".
+   - This is the best UX trade-off — hiding the score makes the map feel empty for new regions, but unmarked AI estimates would erode trust over time. Documented as **US-C5b** below.
+
+### Remaining open (defer)
+
+- **OSM attribution placement.** Sources section is fine for ODbL legal minimum; consider a one-line credit at the bottom of the detail view in v1.2 if any contributor flags it. *Owner: @cubxxw, beta-stage decision.*
+- **Skeleton-mode richness.** OSM name + tag-derived category is the v1.1 minimum. If beta users say "this looks empty," add one heuristic-driven sentence (template per category) in a hot-fix. *Owner: product, validate in beta.*
+- **Refund policy for hitting daily AI quota.** Standard Apple refund process applies; we'll publish a one-line "no manual refunds for quota usage" policy in the paywall fine print. *Owner: @cubxxw, before App Store submission.*
+- **Edge Function language.** Deno/TS confirmed by default to keep the team in one language. *Owner: @cubxxw.*
+
+---
+
+## 10. Sequencing Summary
+
+| Week | Focus | Branches | Deliverable |
+|---|---|---|---|
+| 1 | Epic A: Persistence | `feat/persistence-swiftdata` | All data on disk; no UX change |
+| 2 | Epic B: Cost control | `feat/ai-cost-control` | Sonnet default + caching live |
+| 3 | Epic C: Trust UX | `feat/explore-trust` | Visual downgrade + reverse geocode + survey feedback |
+| 4 | Epic D: StoreKit | `feat/freemium-paywall` | Paywall live behind FF |
+| 5 | Epic E: Supabase | `feat/backend-sync` | Server cache + sync + key removed from client + optional Apple ID link (US-E6) |
+| 6 | Epic F: Store prep | `feat/app-store-prep` | TestFlight beta.1 |
+| 7-8 | Beta feedback | hot-fix branches | `v1.1.0` GA |
+
+---
+
+## 11. Appendix — Files Touched (estimated)
+
+**New files (~25):**
+- `Persistence/SoloCompassModelContainer.swift`
+- `Persistence/Models/*.swift` (~13 `@Model` classes)
+- `Persistence/ExperienceRepository.swift`
+- `Persistence/SyncService.swift`
+- `Services/SubscriptionService.swift`
+- `Services/ReverseGeocodeService.swift`
+- `Services/SupabaseClient.swift`
+- `Views/Paywall/PaywallView.swift`
+- `Views/Onboarding/ExploreConsentSheet.swift`
+- `Resources/zh-Hans.lproj/Localizable.strings`
+- `Resources/Configuration.storekit`
+- `Resources/PrivacyInfo.xcprivacy`
+- `infra/supabase/migrations/0001_init.sql`
+- `infra/supabase/functions/synthesize-experiences/index.ts`
+- `docs/APP_STORE.md`, `docs/BETA.md`, `docs/PRIVACY.md`
+- `tests/persistence/`, `tests/subscription/`, `tests/sync/`
+
+**Modified (~12):**
+- `Services/AIService.swift` — model config + cache + Edge Function call
+- `Services/OverpassService.swift` — cache integration
+- `Services/ExperienceService.swift` — repo facade
+- `ViewModels/MapViewModel.swift` — entitlement gates + auto city switch
+- `ViewModels/ExperienceDetailViewModel.swift` — survey writeback
+- `Views/Map/CompassMapView.swift` — paywall sheet, banner upgrades
+- `Views/Map/MarkerIconView.swift` — confidence-1 visual downgrade
+- `Views/Experience/ExperienceDetailView.swift` — paywall teaser, source link
+- `Models/UserPreferences.swift` — quota fields, consent flags
+- `App/SoloCompassApp.swift` — ModelContainer, SubscriptionService injection
+- `project.yml` — capabilities (in-app purchase, Supabase URL config)
+- `packages/core/src/experience.ts` — schema parity
+
+---
+
+*End of PRD. Implementation starts on `feat/persistence-swiftdata` after PRD approval.*


### PR DESCRIPTION
…where in the world

Adds a one-tap "Explore here" button on the map that pulls real POIs from
the public Overpass API (OpenStreetMap) within a 3 km radius and asks
AIService to enrich up to 15 of them into solo-traveler-focused
Experiences. Generated entries get a stable `exp_osm_<id>` and
`confidence.level = 1`, surface an "AI-generated · OpenStreetMap" badge,
and attribute "© OpenStreetMap contributors" in sources.

Why: outside Chiang Mai the seed library is empty, so users in any other
city saw a blank map. This makes the app useful in Hanoi, Tokyo, etc.
without paying the cost of growing the curated seed.

- OverpassService: fetch + decode + tag→category mapping
- AIService.synthesizeExperiences: single Claude call for the batch,
  with a tag-derived skeleton fallback when no API key (so the feature
  still works for free users)
- ExperienceService.appendGenerated: dedupe-by-id merge into the store
- MapViewModel.exploreNearby: orchestrates fetch → synth → append, with
  isExploring state for the button spinner
- Detail view: AI badge for `exp_osm_*` entries
- project.yml: fix pre-existing test target Info.plist signing config so
  `xcodebuild test` works locally and on CI

24/24 tests passing.<!--
Thanks for the PR. Read CONTRIBUTING.md and CLAUDE.md if you haven't.
Skip sections that don't apply.
-->

## What

<!-- One sentence: what does this PR change? -->

## Why

<!-- One paragraph: what problem does this solve? Link the issue. -->

Closes #

## Three-pillar check

Before merging, confirm this change respects:

- [ ] **Map-First** — does not move users away from the map without strong reason
- [ ] **Experience-as-Unit** — does not introduce "place" / "POI" concepts at the domain level
- [ ] **AI doesn't decide** — recommendations remain options + reasons, not single answers

If any is violated, explain in **Why** above why an exception is justified.

## Schema impact

<!-- Did you add/remove/rename a field in packages/core? If yes, the iOS app must mirror. -->

- [ ] No schema change
- [ ] Schema changed; iOS parity tracking issue: #

## Testing

<!-- How did you verify? -->

## Screenshots / video

<!-- If UI change. -->
