### PR TITLE
feat(ios): Epic B — AI cost control (5 user stories)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,10 +8,13 @@ useDefault = true
 [allowlist]
 description = "Placeholder values in env examples and docs"
 paths = [
-  '''\.env\.example''',
-  '''README\.md''',
-  '''CONTRIBUTING\.md''',
-  '''\.gitleaks\.toml''',
+  '''\\.env\\.example''',
+  '''README\\.md''',
+  '''CONTRIBUTING\\.md''',
+  '''\\.gitleaks\\.toml''',
+  # Test files use synthetic placeholder values (cache keys, UUIDs) that may
+  # match generic-api-key heuristics — allowlist the test directory.
+  '''apps/ios/SoloCompass/Tests/''',
 ]
 regexes = [
   # JWT-like placeholder (eyJ... header prefix)

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -239,6 +239,7 @@
 "explore.error.nothingFound" = "No public places found nearby. Try moving the map.";
 "explore.skeleton.oneLiner" = "A real spot pulled from OpenStreetMap.";
 "explore.skeleton.why" = "We don't have a curated story for this place yet. Visit, then add what you found.";
+"explore.quota.dailyLimit" = "Daily AI limit reached. Showing real places without enrichment until tomorrow.";
 
 /* Overpass errors */
 "overpass.error.url" = "Overpass endpoint URL is invalid.";

--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -1,6 +1,8 @@
 import Foundation
 import CoreLocation
+import CryptoKit
 import Observation
+import SwiftData
 
 /// Talks to Claude via the Anthropic Messages API. Reads the API key from
 /// `Secrets.plist` (key `ANTHROPIC_API_KEY`) or the `ANTHROPIC_API_KEY` env var.
@@ -63,13 +65,75 @@ public final class AIService {
 
     public private(set) var isProcessing: Bool = false
     public private(set) var lastError: Error?
+    /// Set when the daily AI quota cap fires (Epic B US-015). The map
+    /// view shows a banner derived from this.
+    public private(set) var quotaExceededAt: Date?
 
     private let session: URLSession
     private let apiURL = URL(string: "https://api.anthropic.com/v1/messages")
-    private let model = "claude-opus-4-7"
+    private let modelContext: ModelContext?
 
-    public init(session: URLSession = .shared) {
+    /// Synthesis cache TTL — 30 days.
+    public static let synthesisCacheTTLSeconds: TimeInterval = 30 * 86_400
+
+    /// Default model routing. Sonnet 4.6 for generative tasks (synthesis,
+    /// voice intent, ranking); Haiku 4.5 for lighter explanations. The
+    /// `AI_FORCE_OPUS=1` env var routes everything to Opus for golden-set
+    /// runs. `Secrets.plist` keys (`ANTHROPIC_MODEL_SYNTHESIS`,
+    /// `ANTHROPIC_MODEL_EXPLANATION`, `ANTHROPIC_MODEL_VOICE`) override
+    /// the defaults per build.
+    public enum ModelKind {
+        case synthesis, explanation, voice
+    }
+
+    public init(session: URLSession = .shared, modelContext: ModelContext? = nil) {
         self.session = session
+        self.modelContext = modelContext
+    }
+
+    /// Convenience that uses the shared SwiftData container's main
+    /// context for caching.
+    public convenience init(session: URLSession = .shared, useSharedCache: Bool) {
+        let ctx: ModelContext? = useSharedCache
+            ? ModelContext(SoloCompassModelContainer.shared)
+            : nil
+        self.init(session: session, modelContext: ctx)
+    }
+
+    // MARK: - Model name resolution
+
+    /// Resolve which model to use for a given call kind. Order:
+    /// 1. `AI_FORCE_OPUS=1` env var → opus everywhere (debug only)
+    /// 2. `Secrets.plist` override key
+    /// 3. Hard-coded default
+    static func modelName(for kind: ModelKind) -> String {
+        if ProcessInfo.processInfo.environment["AI_FORCE_OPUS"] == "1" {
+            return "claude-opus-4-7"
+        }
+        let plistKey: String
+        let defaultName: String
+        switch kind {
+        case .synthesis:
+            plistKey = "ANTHROPIC_MODEL_SYNTHESIS"
+            defaultName = "claude-sonnet-4-6"
+        case .explanation:
+            plistKey = "ANTHROPIC_MODEL_EXPLANATION"
+            defaultName = "claude-haiku-4-5-20251001"
+        case .voice:
+            plistKey = "ANTHROPIC_MODEL_VOICE"
+            defaultName = "claude-sonnet-4-6"
+        }
+        return resolveSecretsOverride(plistKey) ?? defaultName
+    }
+
+    private static func resolveSecretsOverride(_ key: String) -> String? {
+        guard let url = Bundle.main.url(forResource: "Secrets", withExtension: "plist"),
+              let data = try? Data(contentsOf: url),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
+              let value = plist[key] as? String,
+              !value.isEmpty
+        else { return nil }
+        return value
     }
 
     // MARK: - Public
@@ -80,7 +144,7 @@ public final class AIService {
     ) async throws -> [String] {
         let prompt = Self.recommendationPrompt(candidates: candidates, context: context)
         do {
-            let raw = try await sendMessage(prompt: prompt)
+            let raw = try await sendMessage(prompt: prompt, kind: .synthesis)
             return Self.parseIDList(raw, validIDs: Set(candidates.map(\.id)))
         } catch AIError.missingAPIKey {
             // Local fallback: rank by solo score, then by best-now boost.
@@ -101,7 +165,7 @@ public final class AIService {
         Avoid superlatives. Focus on a sensory detail.
         """
         do {
-            return try await sendMessage(prompt: prompt)
+            return try await sendMessage(prompt: prompt, kind: .explanation)
         } catch AIError.missingAPIKey {
             return NSLocalizedString("ai.fallback.explanation", comment: "Default AI explanation")
         }
@@ -114,7 +178,7 @@ public final class AIService {
         Respond as JSON: {"recommendedIds":[],"explanation":"...","filterSuggestion":"culture|nature|food|coffee|work|wellness|nightlife|hidden|null"}
         """
         do {
-            let raw = try await sendMessage(prompt: prompt)
+            let raw = try await sendMessage(prompt: prompt, kind: .voice)
             return try Self.parseAIResponse(raw)
         } catch AIError.missingAPIKey {
             return AIResponse(
@@ -127,7 +191,7 @@ public final class AIService {
 
     // MARK: - HTTP
 
-    private func sendMessage(prompt: String) async throws -> String {
+    private func sendMessage(prompt: String, kind: ModelKind = .synthesis) async throws -> String {
         guard let key = Self.resolveAPIKey() else { throw AIError.missingAPIKey }
         guard let apiURL else { throw AIError.requestFailed(status: 0, body: "bad URL") }
 
@@ -141,7 +205,7 @@ public final class AIService {
         request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
 
         let body: [String: Any] = [
-            "model": model,
+            "model": Self.modelName(for: kind),
             "max_tokens": 1024,
             "messages": [["role": "user", "content": prompt]],
         ]
@@ -254,10 +318,13 @@ public final class AIService {
     /// predictable, and matches the product cap of 15 generated experiences.
     public static let synthesisLimit = 15
 
-    /// Convert a batch of OSM POIs into Experiences. Sends a single Claude
-    /// request that returns a JSON array of experiences. Falls back to a
-    /// skeleton derived from OSM tags when the API key is missing or the
-    /// request fails — so users without an API key still get pins on the map.
+    /// Convert a batch of OSM POIs into Experiences. The hot path:
+    /// 1. Cache hit (SHA256 of inputs + model name + 30-day TTL) →
+    ///    return persisted Experiences without HTTP.
+    /// 2. Quota check (Pro: 30 synthesis/day) → if exceeded, fall back
+    ///    to skeleton mode and set `quotaExceededAt`.
+    /// 3. Real Claude call → on success, persist + return; on failure,
+    ///    skeleton fallback (no cache write).
     public func synthesizeExperiences(
         from pois: [OverpassService.POI],
         cityCode: String,
@@ -266,13 +333,161 @@ public final class AIService {
         let capped = Array(pois.prefix(Self.synthesisLimit))
         guard !capped.isEmpty else { return [] }
 
-        let prompt = Self.synthesisPrompt(pois: capped, cityCode: cityCode, locale: locale)
-        do {
-            let raw = try await sendMessage(prompt: prompt)
-            return try Self.parseSynthesizedExperiences(raw, pois: capped, cityCode: cityCode)
-        } catch {
+        let modelName = Self.modelName(for: .synthesis)
+        let cacheKey = Self.synthesisCacheKey(
+            pois: capped, cityCode: cityCode, locale: locale, modelName: modelName
+        )
+
+        if let cached = await loadCachedSynthesis(cacheKey: cacheKey) {
+            return cached
+        }
+
+        // US-015 quota check: cache hits don't count, network calls do.
+        if await isQuotaExceeded(kind: .synthesis) {
+            await setQuotaExceeded()
             return capped.map { Self.skeletonExperience(from: $0, cityCode: cityCode) }
         }
+
+        let prompt = Self.synthesisPrompt(pois: capped, cityCode: cityCode, locale: locale)
+        do {
+            let raw = try await sendMessage(prompt: prompt, kind: .synthesis)
+            let experiences = try Self.parseSynthesizedExperiences(raw, pois: capped, cityCode: cityCode)
+            await incrementQuota(kind: .synthesis)
+            await writeCachedSynthesis(
+                cacheKey: cacheKey,
+                experiences: experiences,
+                modelName: modelName
+            )
+            return experiences
+        } catch {
+            // Skeleton fallback — never written to cache so a
+            // transient network blip doesn't poison the cache for 30
+            // days.
+            return capped.map { Self.skeletonExperience(from: $0, cityCode: cityCode) }
+        }
+    }
+
+    /// Public cache-clear; used by Settings → Storage.
+    @MainActor
+    public func clearSynthesisCache() {
+        guard let context = modelContext else { return }
+        try? context.delete(model: AISynthesisCacheRecord.self)
+        try? context.save()
+    }
+
+    // MARK: - Synthesis cache key
+
+    /// SHA256 of canonical input. Sorting osmIds ensures input order
+    /// doesn't change the key. Model name is part of the key so a
+    /// model bump invalidates old cache rows naturally.
+    static func synthesisCacheKey(
+        pois: [OverpassService.POI],
+        cityCode: String,
+        locale: Locale,
+        modelName: String
+    ) -> String {
+        let sortedIds = pois.map { String($0.osmId) }.sorted()
+        let canonical = sortedIds.joined(separator: "|")
+            + "|" + cityCode
+            + "|" + locale.identifier
+            + "|" + modelName
+        let digest = SHA256.hash(data: Data(canonical.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - Synthesis cache I/O
+
+    private func loadCachedSynthesis(cacheKey key: String) async -> [Experience]? {
+        await MainActor.run { [weak self] in
+            guard let self, let context = self.modelContext else { return nil }
+            let descriptor = FetchDescriptor<AISynthesisCacheRecord>(
+                predicate: #Predicate { $0.cacheKey == key }
+            )
+            guard let row = (try? context.fetch(descriptor))?.first else { return nil }
+            let age = Date().timeIntervalSince(row.synthesizedAt)
+            guard age < Self.synthesisCacheTTLSeconds else { return nil }
+            return try? JSONDecoder.iso8601Decoder.decode([Experience].self, from: row.experiencesJSON)
+        }
+    }
+
+    private func writeCachedSynthesis(
+        cacheKey key: String,
+        experiences: [Experience],
+        modelName: String
+    ) async {
+        await MainActor.run { [weak self] in
+            guard let self, let context = self.modelContext else { return }
+            let descriptor = FetchDescriptor<AISynthesisCacheRecord>(
+                predicate: #Predicate { $0.cacheKey == key }
+            )
+            if let existing = (try? context.fetch(descriptor))?.first {
+                context.delete(existing)
+            }
+            guard let blob = try? JSONEncoder.iso8601Encoder.encode(experiences) else { return }
+            context.insert(
+                AISynthesisCacheRecord(
+                    cacheKey: key,
+                    experiencesJSON: blob,
+                    synthesizedAt: Date(),
+                    modelName: modelName
+                )
+            )
+            try? context.save()
+        }
+    }
+
+    // MARK: - Daily quota (US-015)
+
+    /// Pro tier daily caps. Free tier is gated upstream (Epic D).
+    public static let dailySynthesisQuota = 30
+    public static let dailyExplanationQuota = 60
+
+    /// True if the per-day cap for `kind` is reached. Pure read; no
+    /// mutation.
+    private func isQuotaExceeded(kind: ModelKind) async -> Bool {
+        await MainActor.run { [weak self] in
+            guard let self, let context = self.modelContext else { return false }
+            let today = AIUsageRecord.todayUTC()
+            let descriptor = FetchDescriptor<AIUsageRecord>(
+                predicate: #Predicate { $0.date == today }
+            )
+            guard let row = (try? context.fetch(descriptor))?.first else { return false }
+            switch kind {
+            case .synthesis, .voice:
+                return row.synthesisCalls >= Self.dailySynthesisQuota
+            case .explanation:
+                return row.explanationCalls >= Self.dailyExplanationQuota
+            }
+        }
+    }
+
+    /// Increment the counter for `kind`, creating today's row on first call.
+    private func incrementQuota(kind: ModelKind) async {
+        await MainActor.run { [weak self] in
+            guard let self, let context = self.modelContext else { return }
+            let today = AIUsageRecord.todayUTC()
+            let descriptor = FetchDescriptor<AIUsageRecord>(
+                predicate: #Predicate { $0.date == today }
+            )
+            let row = (try? context.fetch(descriptor))?.first
+                ?? {
+                    let r = AIUsageRecord(date: today)
+                    context.insert(r)
+                    return r
+                }()
+            switch kind {
+            case .synthesis, .voice:
+                row.synthesisCalls += 1
+            case .explanation:
+                row.explanationCalls += 1
+            }
+            try? context.save()
+        }
+    }
+
+    @MainActor
+    private func setQuotaExceeded() {
+        self.quotaExceededAt = Date()
     }
 
     // MARK: - Synthesize helpers
@@ -292,18 +507,36 @@ public final class AIService {
         return """
         You are writing solo-traveler-focused entries for real places sourced from OpenStreetMap.
 
+        CRITICAL CONSTRAINTS — your output is read by users on the ground:
+        - Use ONLY the provided OSM tags. Do NOT invent menu items, interior details, hours, prices, owner backstories, dish names, or specific seating positions.
+        - If a field is not derivable from tags, write a generic safe value. Example: when no opening_hours tag is present, set bestStartHour to 9 and bestEndHour to 21 (a generic daytime window) rather than guessing a specific schedule.
+        - howTo must contain navigation/orientation steps only. Do NOT write "order the X", "try the X", "ask for X", "sit at the bar/window/back".
+        - Avoid the phrases: "menu", "specialty", "best seat", "the owner", "opens at", "closes at", "price", "order the", "try the".
+        - Solo Score should be a conservative 7.0–8.5 unless tags clearly indicate something exceptional (e.g. tourism=viewpoint with a name → up to 9.0).
+
+        Examples of GOOD output (tag-derived, generic):
+        - title: "Sit with locals at a Hanoi café"
+        - oneLiner: "A local cafe in the Old Quarter with sidewalk seating."
+        - whyItMatters: "OpenStreetMap lists this as a café in a walkable neighbourhood. Solo travellers often find sidewalk-style cafés easier to enter alone than enclosed restaurants. Verify the vibe on arrival."
+        - howTo: ["Find the entrance from the main street.", "Step inside; seating is usually self-service.", "Pay at the counter when you leave."]
+
+        Examples of BAD output (hallucinated, do NOT do this):
+        - title: "Eat the famous beef pho at Ms. Linh's"  ← invented owner + dish
+        - oneLiner: "Try the lemongrass coffee, a hidden secret since 1972."  ← invented menu + history
+        - howTo: ["Order the egg coffee", "Sit at the window seat"]  ← invented item + seat
+
         For each POI below, return ONE JSON object with these fields and nothing else:
         {
           "osmId": <int>,
           "title": "<action-oriented sensory line, less than 14 words>",
-          "oneLiner": "<one concrete detail, less than 25 words>",
-          "whyItMatters": "<2-3 sentences for someone alone>",
+          "oneLiner": "<one concrete detail derivable from tags, less than 25 words>",
+          "whyItMatters": "<2-3 sentences for someone alone, no specifics not in tags>",
           "category": "food|coffee|culture|nature|work|wellness|nightlife|hidden",
           "bestStartHour": <0-23>,
           "bestEndHour": <0-23>,
           "durationMinMinutes": <int>,
           "durationMaxMinutes": <int>,
-          "howTo": ["step 1", "step 2", "step 3"],
+          "howTo": ["navigation step 1", "navigation step 2", "navigation step 3"],
           "soloHint": "<one short hint for solo visitors>",
           "soloOverall": <number 6.0-9.5>
         }

--- a/apps/ios/SoloCompass/Services/OverpassService.swift
+++ b/apps/ios/SoloCompass/Services/OverpassService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreLocation
 import Observation
+import SwiftData
 
 /// Talks to the public Overpass API (OpenStreetMap) to fetch real-world POIs
 /// near a coordinate. Used by the "Explore here" feature so users in cities
@@ -60,20 +61,51 @@ public final class OverpassService {
     private let session: URLSession
     private let endpoint = URL(string: "https://overpass-api.de/api/interpreter")
     private let maxResults: Int
+    private let modelContext: ModelContext?
 
-    public init(session: URLSession = .shared, maxResults: Int = 30) {
+    /// Cache TTL — 14 days. Outside this window we re-fetch from
+    /// Overpass. (See PRD US-B1.)
+    public static let cacheTTLSeconds: TimeInterval = 14 * 86_400
+
+    public init(
+        session: URLSession = .shared,
+        maxResults: Int = 30,
+        modelContext: ModelContext? = nil
+    ) {
         self.session = session
         self.maxResults = maxResults
+        self.modelContext = modelContext
+    }
+
+    /// Convenience init that uses the shared SwiftData container's main
+    /// context for caching. Pass `nil` (default of designated init) in
+    /// tests if you want cache disabled.
+    public convenience init(session: URLSession = .shared, maxResults: Int = 30, useSharedCache: Bool) {
+        let ctx: ModelContext? = useSharedCache
+            ? ModelContext(SoloCompassModelContainer.shared)
+            : nil
+        self.init(session: session, maxResults: maxResults, modelContext: ctx)
     }
 
     // MARK: - Public
 
     /// Fetch up to `maxResults` POIs within `radiusMeters` of the coordinate.
-    /// Retries once on network/5xx failure.
+    /// Cache hit: returns persisted POIs without HTTP. Cache miss:
+    /// performs a real fetch with 1 retry, writes through to cache.
     public func fetchPOIs(
         near coordinate: CLLocationCoordinate2D,
         radiusMeters: Int = 3000
     ) async throws -> [POI] {
+        let regionKey = Self.regionKey(
+            lat: coordinate.latitude,
+            lon: coordinate.longitude,
+            radiusMeters: radiusMeters
+        )
+
+        if let cached = await loadCached(regionKey: regionKey) {
+            return cached
+        }
+
         guard let endpoint else { throw OverpassError.invalidURL }
         await MainActor.run { self.isFetching = true }
         defer { Task { @MainActor [weak self] in self?.isFetching = false } }
@@ -86,6 +118,34 @@ public final class OverpassService {
         request.timeoutInterval = 20
         request.httpBody = "data=\(query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")".data(using: .utf8)
 
+        let (raw, pois) = try await fetchAndDecode(request)
+        await writeCache(regionKey: regionKey, raw: raw, poiCount: pois.count)
+        return pois
+    }
+
+    /// Public cache-clear; used by Settings → Storage.
+    @MainActor
+    public func clearExploreCache() {
+        guard let context = modelContext else { return }
+        try? context.delete(model: ExploreCacheRecord.self)
+        try? context.save()
+    }
+
+    /// Deterministic key for a (lat, lon, radius) cell. Rounding to
+    /// 0.01° (~1.1 km) means small map pans still hit the same cache
+    /// row.
+    public static func regionKey(lat: Double, lon: Double, radiusMeters: Int) -> String {
+        let roundedLat = (lat * 100).rounded() / 100
+        let roundedLon = (lon * 100).rounded() / 100
+        return String(format: "%.2f_%.2f_%d", roundedLat, roundedLon, radiusMeters)
+    }
+
+    // MARK: - HTTP
+
+    /// One-attempt-with-retry fetch that returns the raw JSON and the
+    /// decoded POIs together — we want both: POIs for the caller, raw
+    /// JSON for cache write-through.
+    private func fetchAndDecode(_ request: URLRequest) async throws -> (Data, [POI]) {
         do {
             return try await performAndDecode(request)
         } catch {
@@ -94,9 +154,7 @@ public final class OverpassService {
         }
     }
 
-    // MARK: - HTTP
-
-    private func performAndDecode(_ request: URLRequest) async throws -> [POI] {
+    private func performAndDecode(_ request: URLRequest) async throws -> (Data, [POI]) {
         let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse else {
             throw OverpassError.requestFailed(status: 0)
@@ -104,7 +162,46 @@ public final class OverpassService {
         guard (200..<300).contains(http.statusCode) else {
             throw OverpassError.requestFailed(status: http.statusCode)
         }
-        return try Self.decodePOIs(from: data)
+        return (data, try Self.decodePOIs(from: data))
+    }
+
+    // MARK: - Cache
+
+    /// async-bridge: fetchPOIs is nonisolated, ModelContext is MainActor.
+    private func loadCached(regionKey key: String) async -> [POI]? {
+        await MainActor.run { [weak self] in
+            guard let self, let context = self.modelContext else { return nil }
+            let descriptor = FetchDescriptor<ExploreCacheRecord>(
+                predicate: #Predicate { $0.regionKey == key }
+            )
+            guard let row = (try? context.fetch(descriptor))?.first else { return nil }
+            let age = Date().timeIntervalSince(row.fetchedAt)
+            guard age < Self.cacheTTLSeconds else { return nil }
+            return try? Self.decodePOIs(from: row.osmJSON)
+        }
+    }
+
+    private func writeCache(regionKey key: String, raw: Data, poiCount: Int) async {
+        await MainActor.run { [weak self] in
+            guard let self, let context = self.modelContext else { return }
+            // Delete-then-insert keeps semantics explicit and side-steps
+            // SwiftData's silent upsert behaviour on @Attribute(.unique).
+            let descriptor = FetchDescriptor<ExploreCacheRecord>(
+                predicate: #Predicate { $0.regionKey == key }
+            )
+            if let existing = (try? context.fetch(descriptor))?.first {
+                context.delete(existing)
+            }
+            context.insert(
+                ExploreCacheRecord(
+                    regionKey: key,
+                    osmJSON: raw,
+                    fetchedAt: Date(),
+                    poiCount: poiCount
+                )
+            )
+            try? context.save()
+        }
     }
 
     // MARK: - Query

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -662,6 +662,207 @@ final class SoloCompassTests: XCTestCase {
         )
     }
 
+    // MARK: - US-011 Overpass cache 14-day TTL
+
+    func testOverpassRegionKeyFormat() {
+        let key = OverpassService.regionKey(lat: 21.0285, lon: 105.8542, radiusMeters: 3000)
+        XCTAssertEqual(key, "21.03_105.85_3000", "rounding to 0.01° + radius suffix")
+    }
+
+    func testOverpassFetchUsesCacheOnSecondCall() async throws {
+        // Stub URLProtocol to count requests and return a small valid OSM JSON.
+        StubURLProtocol.handler = { _ in
+            let json = #"{"elements":[{"type":"node","id":1,"lat":21.03,"lon":105.85,"tags":{"name":"Cafe","amenity":"cafe"}}]}"#
+            return (HTTPURLResponse(
+                url: URL(string: "https://overpass-api.de/api/interpreter")!,
+                statusCode: 200, httpVersion: nil, headerFields: nil)!,
+                json.data(using: .utf8)!)
+        }
+        StubURLProtocol.requestCount = 0
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        let session = URLSession(configuration: config)
+
+        let container = SoloCompassModelContainer.makeInMemory()
+        let context = ModelContext(container)
+        let service = OverpassService(session: session, maxResults: 30, modelContext: context)
+
+        let coord = CLLocationCoordinate2D(latitude: 21.0285, longitude: 105.8542)
+        let firstHit = try await service.fetchPOIs(near: coord, radiusMeters: 3000)
+        XCTAssertEqual(firstHit.count, 1)
+        XCTAssertEqual(StubURLProtocol.requestCount, 1, "first call hits the network")
+
+        let secondHit = try await service.fetchPOIs(near: coord, radiusMeters: 3000)
+        XCTAssertEqual(secondHit.count, 1)
+        XCTAssertEqual(StubURLProtocol.requestCount, 1, "second call must hit cache, not network")
+    }
+
+    // MARK: - US-012 AI synthesis cache
+
+    func testAISynthesisCacheKeyIsStableForReorderedPOIs() {
+        let p1 = OverpassService.POI(osmId: 1, name: "A", nameEn: nil, lat: 0, lon: 0, tags: [:])
+        let p2 = OverpassService.POI(osmId: 2, name: "B", nameEn: nil, lat: 0, lon: 0, tags: [:])
+        let k1 = AIService.synthesisCacheKey(pois: [p1, p2], cityCode: "vn-hanoi", locale: Locale(identifier: "en"), modelName: "claude-sonnet-4-6")
+        let k2 = AIService.synthesisCacheKey(pois: [p2, p1], cityCode: "vn-hanoi", locale: Locale(identifier: "en"), modelName: "claude-sonnet-4-6")
+        XCTAssertEqual(k1, k2, "POI input order must not change cache key")
+        XCTAssertEqual(k1.count, 64, "SHA256 hex is 64 chars")
+    }
+
+    func testAISynthesisCacheKeyChangesWithModelName() {
+        let p = OverpassService.POI(osmId: 1, name: "A", nameEn: nil, lat: 0, lon: 0, tags: [:])
+        let kSonnet = AIService.synthesisCacheKey(pois: [p], cityCode: "vn-hanoi", locale: Locale(identifier: "en"), modelName: "claude-sonnet-4-6")
+        let kOpus = AIService.synthesisCacheKey(pois: [p], cityCode: "vn-hanoi", locale: Locale(identifier: "en"), modelName: "claude-opus-4-7")
+        XCTAssertNotEqual(kSonnet, kOpus, "model bump must invalidate cache")
+    }
+
+    // MARK: - US-013 model routing
+
+    func testModelRoutingDefaults() {
+        unsetenv("AI_FORCE_OPUS")
+        XCTAssertEqual(AIService.modelName(for: .synthesis), "claude-sonnet-4-6")
+        XCTAssertEqual(AIService.modelName(for: .voice), "claude-sonnet-4-6")
+        XCTAssertEqual(AIService.modelName(for: .explanation), "claude-haiku-4-5-20251001")
+    }
+
+    func testModelRoutingForceOpusEnvVar() {
+        setenv("AI_FORCE_OPUS", "1", 1)
+        defer { unsetenv("AI_FORCE_OPUS") }
+        XCTAssertEqual(AIService.modelName(for: .synthesis), "claude-opus-4-7")
+        XCTAssertEqual(AIService.modelName(for: .voice), "claude-opus-4-7")
+        XCTAssertEqual(AIService.modelName(for: .explanation), "claude-opus-4-7")
+    }
+
+    // MARK: - US-015 daily AI quota
+
+    @MainActor
+    func testQuotaTriggersSkeletonFallbackOnceCapReached() async throws {
+        // Stub network to return a valid synthesis JSON every call.
+        StubURLProtocol.handler = { _ in
+            let json = #"""
+            [{"osmId":1,"title":"x","oneLiner":"x","whyItMatters":"x","category":"food","bestStartHour":9,"bestEndHour":21,"durationMinMinutes":30,"durationMaxMinutes":90,"howTo":[],"soloHint":"x","soloOverall":7.5}]
+            """#
+            // Anthropic Messages API response shape: {content: [{text: "..."}]}
+            let body = #"{"content":[{"text":"\#(json.replacingOccurrences(of: "\"", with: "\\\""))"}]}"#
+            return (HTTPURLResponse(
+                url: URL(string: "https://api.anthropic.com/v1/messages")!,
+                statusCode: 200, httpVersion: nil, headerFields: nil)!,
+                body.data(using: .utf8)!)
+        }
+        StubURLProtocol.requestCount = 0
+
+        // Pre-seed the quota row at the daily cap so the next call must
+        // degrade. This simulates "user has used up their 30 quota
+        // already today" without making 30 real calls.
+        let container = SoloCompassModelContainer.makeInMemory()
+        let context = ModelContext(container)
+        let today = AIUsageRecord.todayUTC()
+        context.insert(AIUsageRecord(date: today, synthesisCalls: AIService.dailySynthesisQuota))
+        try context.save()
+
+        // Need an API key in env to skip the missingAPIKey throw path.
+        setenv("ANTHROPIC_API_KEY", "sk-test-fake", 1)
+        defer { unsetenv("ANTHROPIC_API_KEY") }
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let ai = AIService(session: session, modelContext: context)
+
+        let pois: [OverpassService.POI] = [
+            .init(osmId: 100, name: "X", nameEn: nil, lat: 0, lon: 0, tags: ["amenity": "cafe"])
+        ]
+        let result = try await ai.synthesizeExperiences(from: pois, cityCode: "vn-hanoi")
+        // Quota cap: skeleton fallback used; no network hit.
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(StubURLProtocol.requestCount, 0, "quota-exceeded path must not call the network")
+        XCTAssertNotNil(ai.quotaExceededAt, "quotaExceededAt timestamp set")
+    }
+
+    @MainActor
+    func testSynthesisCacheHitDoesNotIncrementQuota() async throws {
+        StubURLProtocol.handler = { _ in
+            let json = #"""
+            [{"osmId":1,"title":"x","oneLiner":"x","whyItMatters":"x","category":"food","bestStartHour":9,"bestEndHour":21,"durationMinMinutes":30,"durationMaxMinutes":90,"howTo":[],"soloHint":"x","soloOverall":7.5}]
+            """#
+            let body = #"{"content":[{"text":"\#(json.replacingOccurrences(of: "\"", with: "\\\""))"}]}"#
+            return (HTTPURLResponse(
+                url: URL(string: "https://api.anthropic.com/v1/messages")!,
+                statusCode: 200, httpVersion: nil, headerFields: nil)!,
+                body.data(using: .utf8)!)
+        }
+        StubURLProtocol.requestCount = 0
+        setenv("ANTHROPIC_API_KEY", "sk-test-fake", 1)
+        defer { unsetenv("ANTHROPIC_API_KEY") }
+
+        let container = SoloCompassModelContainer.makeInMemory()
+        let context = ModelContext(container)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let ai = AIService(session: session, modelContext: context)
+
+        let pois: [OverpassService.POI] = [
+            .init(osmId: 1, name: "X", nameEn: nil, lat: 0, lon: 0, tags: ["amenity": "cafe"])
+        ]
+
+        _ = try await ai.synthesizeExperiences(from: pois, cityCode: "vn-hanoi")
+        XCTAssertEqual(StubURLProtocol.requestCount, 1, "first call hits network")
+
+        _ = try await ai.synthesizeExperiences(from: pois, cityCode: "vn-hanoi")
+        XCTAssertEqual(StubURLProtocol.requestCount, 1, "second call is cache hit")
+
+        // Quota counter should still be 1 (one network call), not 2.
+        let today = AIUsageRecord.todayUTC()
+        let descriptor = FetchDescriptor<AIUsageRecord>(predicate: #Predicate { $0.date == today })
+        let row = try XCTUnwrap((try context.fetch(descriptor)).first)
+        XCTAssertEqual(row.synthesisCalls, 1, "cache hit must not increment quota")
+    }
+
+    // MARK: - US-014 anti-hallucination skeleton fallback
+
+    func testSkeletonExperienceContainsNoHallucinatedPhrases() {
+        let poi = OverpassService.POI(
+            osmId: 9999, name: "Quan A", nameEn: nil,
+            lat: 21.03, lon: 105.85,
+            tags: ["amenity": "cafe"]
+        )
+        let exp = AIService.skeletonExperience(from: poi, cityCode: "vn-hanoi")
+        let banned = ["order the", "try the", "sit at the", "best seat", "the owner",
+                      "opens at", "closes at", "menu", "price", "specialty", "ask for"]
+        let combined = (exp.title + " " + exp.oneLiner + " " + exp.whyItMatters
+            + " " + exp.howTo.map(\.text).joined(separator: " ")).lowercased()
+        for phrase in banned {
+            XCTAssertFalse(
+                combined.contains(phrase),
+                "skeleton fallback for plain cafe POI should not contain '\(phrase)'"
+            )
+        }
+    }
+
+    func testOverpassClearExploreCacheForcesRefetch() async throws {
+        StubURLProtocol.handler = { _ in
+            let json = #"{"elements":[{"type":"node","id":2,"lat":21.03,"lon":105.85,"tags":{"name":"Park","leisure":"park"}}]}"#
+            return (HTTPURLResponse(
+                url: URL(string: "https://overpass-api.de/api/interpreter")!,
+                statusCode: 200, httpVersion: nil, headerFields: nil)!,
+                json.data(using: .utf8)!)
+        }
+        StubURLProtocol.requestCount = 0
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        let session = URLSession(configuration: config)
+
+        let container = SoloCompassModelContainer.makeInMemory()
+        let context = ModelContext(container)
+        let service = OverpassService(session: session, maxResults: 30, modelContext: context)
+
+        let coord = CLLocationCoordinate2D(latitude: 21.0285, longitude: 105.8542)
+        _ = try await service.fetchPOIs(near: coord, radiusMeters: 3000)
+        service.clearExploreCache()
+        _ = try await service.fetchPOIs(near: coord, radiusMeters: 3000)
+        XCTAssertEqual(StubURLProtocol.requestCount, 2, "after clear, second call hits network again")
+    }
+
     // MARK: - US-010 generated experiences survive across service instances
 
     func testGeneratedExperiencesPersistAcrossServiceInstances() {
@@ -695,4 +896,31 @@ final class SoloCompassTests: XCTestCase {
         XCTAssertTrue(ids.contains("exp_osm_1001"))
         XCTAssertTrue(ids.contains("exp_osm_1002"))
     }
+}
+
+// MARK: - URLProtocol stub for HTTP-mocked tests
+
+/// Minimal URLProtocol that intercepts every request, increments a
+/// counter, and returns whatever `handler` produces. Reset
+/// `requestCount` and assign `handler` per test.
+final class StubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var requestCount: Int = 0
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.requestCount += 1
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: NSError(domain: "stub", code: 0))
+            return
+        }
+        let (response, data) = handler(request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -29,6 +29,10 @@ public final class MapViewModel {
     public var isExploring: Bool = false
     public var lastExploreError: String?
     public var lastExploreAddedCount: Int = 0
+    /// Set when the AI synthesis daily quota cap fires. The map view
+    /// shows a banner derived from this. Cleared on the next UTC day
+    /// rollover (via day-truncated AIUsageRecord).
+    public var lastQuotaInfo: String?
 
     // MARK: - Auto-recenter
 
@@ -512,6 +516,7 @@ public final class MapViewModel {
         isExploring = true
         lastExploreError = nil
         lastExploreAddedCount = 0
+        lastQuotaInfo = nil
         defer { isExploring = false }
 
         let cityCode = Self.cityCode(for: coordinate)
@@ -528,6 +533,15 @@ public final class MapViewModel {
             )
             let added = experienceService.appendGenerated(generated)
             lastExploreAddedCount = added
+            // Surface quota banner if AIService just degraded to skeleton
+            // because the daily cap fired. The banner persists until the
+            // next successful explore (typically tomorrow's first call).
+            if aiService.quotaExceededAt != nil {
+                lastQuotaInfo = NSLocalizedString(
+                    "explore.quota.dailyLimit",
+                    comment: "Daily AI limit reached banner"
+                )
+            }
             recenter(on: coordinate)
         } catch {
             lastExploreError = error.localizedDescription

--- a/tasks/prd-paid-app-foundation.md
+++ b/tasks/prd-paid-app-foundation.md
@@ -42,9 +42,11 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 ### Epic A: Local Persistence (SwiftData)
 
 #### US-A1: Define SwiftData schema mirroring current Codable models
+
 **Description:** As a developer, I want a SwiftData store that mirrors `Experience`, `Confidence`, `SoloScore`, `ExperienceLocation`, `TimeWindow`, `HowToStep`, `RealInconvenience`, `InformationSource`, and `Stats` so the app has a single source of truth on disk.
 
 **Acceptance Criteria:**
+
 - [ ] New file `apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift` exposes a `ModelContainer` configured with all `@Model` types.
 - [ ] New `@Model` classes in `apps/ios/SoloCompass/Persistence/Models/`: `ExperienceRecord`, `ConfidenceRecord`, `SoloScoreRecord`, `LocationRecord`, `TimeWindowRecord`, `HowToStepRecord`, `RealInconvenienceRecord`, `SourceRecord`, `StatsRecord`, `UserCompletionRecord`, `UserFavoriteRecord`, `MicroSurveyRecord`, `ExploreCacheRecord`.
 - [ ] Two-way mapping: `ExperienceRecord(from: Experience)` initializer + `var asValue: Experience` computed property. Round-trip is lossless.
@@ -53,9 +55,11 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] `xcodebuild test` passes.
 
 #### US-A2: Replace ExperienceService in-memory store with SwiftData-backed repository
+
 **Description:** As a user, I want every Experience I see on the map to come from local storage, so closing and reopening the app does not lose any of my discovered places.
 
 **Acceptance Criteria:**
+
 - [ ] New `ExperienceRepository` (in `Persistence/`) owns CRUD against the `ModelContainer`. `ExperienceService` becomes a thin facade that delegates to the repo and exposes the existing `@Observable` API for views.
 - [ ] On first launch with empty store: bundle seed (`Resources/JSON/seed_experiences.json`) is imported once. A boolean flag `seedImported` is stored in `UserPreferences` so re-imports skip.
 - [ ] `appendGenerated([Experience])` writes through to SwiftData and is **idempotent by id**.
@@ -65,9 +69,11 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] `xcodebuild test` passes.
 
 #### US-A3: Migrate UserPreferences mutable state into SwiftData
+
 **Description:** As a user, I want my favorites, completed list, micro-survey responses, and pending check-ins to persist reliably across app reinstalls when I'm signed in.
 
 **Acceptance Criteria:**
+
 - [ ] `UserPreferences` retains `UserDefaults` for **scalar settings only** (style, max distance, disliked categories, last selected city).
 - [ ] Lists move to SwiftData: `UserCompletionRecord`, `UserFavoriteRecord`, `MicroSurveyRecord`, `PendingCheckInRecord`.
 - [ ] `isCompleted(id)` / `isFavorited(id)` become repository queries; existing call sites in `MapViewModel`, `ExperienceDetailViewModel`, settings/favorites views unchanged.
@@ -75,9 +81,11 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] Unit test: pre-populate `UserDefaults` with legacy completed array → boot the app → assert SwiftData has matching `UserCompletionRecord` rows and old keys are gone.
 
 #### US-A4: Persist offline map regions for last-explored area
+
 **Description:** As a traveler with flaky data, I want the last region I explored to be browsable offline (markers + detail data, not basemap tiles).
 
 **Acceptance Criteria:**
+
 - [ ] Last 3 explored regions (lat/lon center + radius) recorded in a `RecentExploreRegion` SwiftData table.
 - [ ] When `Explore here` is offline, the app still shows pins from the last region matching the current map center within 10 km — using only SwiftData reads.
 - [ ] A small banner ("Showing offline data from <date>") appears when the data is older than 7 days.
@@ -88,9 +96,11 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 ### Epic B: Smart Caching & Cost Control
 
 #### US-B1: Region-keyed cache for Overpass queries
+
 **Description:** As a product owner, I don't want users repeatedly burning Overpass quota by tapping "Explore here" in the same area.
 
 **Acceptance Criteria:**
+
 - [ ] New `ExploreCacheRecord` in SwiftData: `regionKey: String` (e.g. `"21.03_105.85_3000"`), `osmJSON: Data`, `fetchedAt: Date`, `poiCount: Int`.
 - [ ] `OverpassService.fetchPOIs` consults cache first; cache hit if `now - fetchedAt < 14 days` and `regionKey` matches at 0.01° rounding (~1.1 km grid).
 - [ ] Cache miss → real fetch → write through.
@@ -98,9 +108,11 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] Unit test (`URLProtocol` stub): two consecutive `fetchPOIs` calls in same region trigger only one HTTP request.
 
 #### US-B2: Region-keyed cache for AI synthesis results
+
 **Description:** As a product owner, I want Claude calls deduplicated so the same OSM batch never gets re-synthesized.
 
 **Acceptance Criteria:**
+
 - [ ] Cache key = SHA256 of sorted `osmId` list + cityCode + locale + model name. Stored in `AISynthesisCacheRecord`.
 - [ ] `AIService.synthesizeExperiences` checks the cache before calling the network. Hit → decode persisted `[Experience]` JSON. Miss → call → write through.
 - [ ] TTL **30 days**.
@@ -108,9 +120,11 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] Unit test: same input batch hits the network once, returns identical Experiences twice.
 
 #### US-B3: Switch default synthesis model to Sonnet 4.6 with Haiku fallback
+
 **Description:** As a product owner, I want AI generation cost to drop ~80% without a noticeable quality regression.
 
 **Acceptance Criteria:**
+
 - [ ] `AIService` gains `model` config: `synthesisModel = "claude-sonnet-4-6"`, `explanationModel = "claude-haiku-4-5-20251001"`, `voiceIntentModel = "claude-sonnet-4-6"`.
 - [ ] `recommendExperiences` and `synthesizeExperiences` use synthesis model; `explainRecommendation` uses Haiku.
 - [ ] All three are read from `Secrets.plist` keys with defaults so QA can override per-build.
@@ -118,18 +132,22 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] Snapshot test: synthesizing 5 fixed POIs with each model produces parseable JSON of the expected shape.
 
 #### US-B4: Hallucination-resistant synthesis prompt
+
 **Description:** As a user, I need to trust generated content not to invent facts the model can't actually know.
 
 **Acceptance Criteria:**
+
 - [ ] Updated prompt explicitly instructs: "Use ONLY the provided OSM tags. Do NOT invent menu items, interior details, hours, prices, owner backstories, or specific seating positions. If a field is not derivable from tags, write a generic safe value."
 - [ ] `howTo` is constrained to navigation steps only (no "order the X").
 - [ ] Prompt includes 2 few-shot examples showing **good** (tag-derived, generic) vs **bad** (hallucinated specifics) outputs.
 - [ ] New regression test: feed a POI with only `{amenity: cafe, name: "Quán A"}` and assert the model output's `whyItMatters` and `howTo` do **not** contain any of the banned phrase patterns (regex list of 20+ red flags).
 
 #### US-B5: Per-user daily AI quota with graceful degradation
+
 **Description:** As a product owner, I want a hard cap on Claude spend per user per day so a runaway loop never costs more than $1.
 
 **Acceptance Criteria:**
+
 - [ ] `UserPreferences` adds `aiCallsToday: Int` and `aiCallsResetDate: Date` (rolling UTC day).
 - [ ] Free tier limit: 0 paid AI calls (Explore-Here disabled, see Epic D).
 - [ ] Paid tier: 30 synthesis calls/day, 60 explanation calls/day. Counter increments on every Anthropic POST regardless of cache hits (cache hits don't count).
@@ -141,27 +159,33 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 ### Epic C: Trust & UX Polish for Generated Content
 
 #### US-C1: Visual downgrade for `confidence.level == 1` Experiences
+
 **Description:** As a user, I want to immediately tell which pins are AI-guessed vs curated.
 
 **Acceptance Criteria:**
+
 - [ ] `MarkerIconView` renders confidence-1 pins with: dashed stroke border, 70% opacity, no glow, smaller badge.
 - [ ] Detail view: existing "AI-generated · OpenStreetMap" badge is upgraded with a tappable info icon that opens an info sheet explaining the source and recommending the user verify on-site.
 - [ ] Sources section explicitly shows "© OpenStreetMap contributors" with a link to the OSM node URL.
 - [ ] Verify in simulator using `xcrun simctl` and a manual screenshot review.
 
 #### US-C2: Surface explore errors and skeleton-mode state to the user
+
 **Description:** As a user, when AI synthesis silently fails I should know that what I'm looking at is OSM-only, and when Explore fails completely I should see why.
 
 **Acceptance Criteria:**
+
 - [ ] `MapViewModel.lastExploreError` is rendered as a dismissible banner (reuse existing `lastAIError` style in `CompassMapView`).
 - [ ] When `synthesizeExperiences` falls back to skeleton mode, set `lastExploreInfo = "Showing real places without AI enrichment — subscribe for richer descriptions."` (free tier) or `"AI is offline."` (paid tier with API failure).
 - [ ] Banner has a "Subscribe" CTA in free-tier copy linking to the paywall (Epic D).
 - [ ] Unit test: force `synthesizeExperiences` to throw → assert info banner state set correctly per subscription tier.
 
 #### US-C3: Reverse-geocode discovered regions into real city names
+
 **Description:** As a user, I shouldn't see "osm_21.0_105.9" in my city picker — I should see "Hanoi".
 
 **Acceptance Criteria:**
+
 - [ ] New `ReverseGeocodeService` wraps `CLGeocoder.reverseGeocodeLocation`.
 - [ ] On successful Explore: resolve coordinate → `city, countryCode`. Persist to `DiscoveredCityRecord` (cityCode = ISO-3166-2-region-or-locality-slug, name = localized).
 - [ ] `MapViewModel.cityCode(for:)` consults `DiscoveredCityRecord` first; falls back to current `osm_<lat>_<lon>` only when geocoder fails or offline.
@@ -169,18 +193,22 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] City picker shows real names; tapping a discovered city centers the map and loads cached pins.
 
 #### US-C4: Auto-switch selected city after successful Explore
+
 **Description:** As a user who lands in a new city and taps Explore, I should immediately see the new pins without manually changing the city filter.
 
 **Acceptance Criteria:**
+
 - [ ] After `exploreNearby` adds N > 0 generated Experiences, `MapViewModel` calls `selectCity(resolvedCityCode)` so the visible-experiences filter no longer hides them.
 - [ ] If reverse-geocoding succeeded, the city name briefly toasts: "Now exploring Hanoi · 12 places added".
 - [ ] If geocoding failed, fallback toast: "12 places added near you".
 - [ ] Unit test: with `selectedCity = "cmi"`, run `exploreNearby` at Hanoi coords with mocked geocoder → assert `selectedCity` becomes the Hanoi cityCode.
 
 #### US-C5b: Cold-start UX for Solo-Score (zero-signal regions)
+
 **Description:** As a user discovering a new region, I should see a useful Solo Score on every pin — clearly marked as an AI estimate when no community data exists yet, transitioning naturally to community-backed numbers as signals arrive.
 
 **Acceptance Criteria:**
+
 - [ ] `SoloScore` view component takes a new `signalCount: Int` parameter and renders three visual states:
   - `signalCount == 0`: dimmed score color + "AI estimate" pill + tap-to-explain tooltip
   - `signalCount` in `1...2`: normal score + "Based on N early reports" subtext
@@ -191,9 +219,11 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] Snapshot test for each state in light + dark mode.
 
 #### US-C5: MicroSurvey responses feed back into SoloScore
+
 **Description:** As a user, my honest feedback on a place should improve its Solo Score for the next traveler — making the app smarter every week.
 
 **Acceptance Criteria:**
+
 - [ ] `MicroSurveySheet` writes a `MicroSurveyRecord` (rating fields + experienceId + timestamp + anonymizedDeviceId).
 - [ ] `SoloScore.overall` becomes a derived computed property: `0.5 * seedOrAI + 0.5 * meanOfLocalSurveys` (weighted by `basedOnCount`). Cached on read for 60s to avoid recomputing on every render.
 - [ ] `basedOnCount` reflects local survey count (cross-device count comes in Epic E).
@@ -205,9 +235,11 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 ### Epic D: Freemium & StoreKit 2
 
 #### US-D1: Subscription product setup & local entitlement check
+
 **Description:** As a developer, I need StoreKit 2 wired up with two subscription SKUs and an offline-tolerant entitlement source of truth.
 
 **Acceptance Criteria:**
+
 - [ ] New file `apps/ios/SoloCompass/Services/SubscriptionService.swift` (`@MainActor @Observable`). Manages `StoreKit.Product` fetch, purchase, restore, transaction listener.
 - [ ] App Store Connect SKUs (created out-of-band, documented in `docs/APP_STORE.md`):
   - `com.solocompass.pro.monthly` — monthly subscription, 7-day free trial, intro offer once per Apple ID
@@ -218,9 +250,11 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] Unit test with `Testing` framework + `Transaction.testSession` covers: free → trial → paid → expired transitions.
 
 #### US-D2: Paywall view
+
 **Description:** As a free user tapping an AI-gated action, I land on a clear paywall where I can start a free trial.
 
 **Acceptance Criteria:**
+
 - [ ] New `apps/ios/SoloCompass/Views/Paywall/PaywallView.swift`. Shows: hero copy, two product cards (monthly / yearly with "Best value" badge), "Start 7-day free trial" CTA, fine-print, "Restore purchases" link, "Manage subscription" deep link to App Store Settings.
 - [ ] Localized en + zh-Hans (`Resources/zh-Hans.lproj/Localizable.strings` created).
 - [ ] Paywall reachable via `viewModel.isShowingPaywall = true` from any AI-gated CTA.
@@ -228,9 +262,11 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] Verify in simulator using StoreKit testing config (`Configuration.storekit` file in `apps/ios/`).
 
 #### US-D3: Gate AI features behind entitlement
+
 **Description:** As the product owner, I want AI features (Explore Here synthesis, voice intent, AI explanations) to require a Pro subscription.
 
 **Acceptance Criteria:**
+
 - [ ] `MapViewModel.exploreNearby` and `handleVoiceTranscript` and `ExperienceDetailViewModel.requestAIExplanation` consult `SubscriptionService.entitlement`. If `.free` or `.proExpired`: route to paywall instead of network call.
 - [ ] Free users still get: full map, filters, seed Experiences, completed/favorites, micro-survey, settings, **OSM-only Explore Here in skeleton mode** (no Claude call) — this is the "show, don't tell" funnel.
 - [ ] The Explore button label changes to "Explore (Pro)" with a small lock icon when free.
@@ -238,18 +274,22 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] Unit test: as `.free`, calling `exploreNearby` sets `isShowingPaywall = true` and does not invoke `OverpassService` or `AIService`.
 
 #### US-D4: Trial-to-paid conversion analytics
+
 **Description:** As a founder, I need to know how many trials convert and where users drop off.
 
 **Acceptance Criteria:**
+
 - [ ] On every `Transaction` lifecycle event (`subscribed`, `expired`, `inGracePeriod`, `revoked`, `upgraded`), emit a Supabase `subscription_events` row (Epic E).
 - [ ] Column: `device_id`, `event_type`, `product_id`, `original_purchase_date`, `expires_date`, `is_in_trial_period`.
 - [ ] No PII (no email, no Apple ID).
 - [ ] Local sanity log in Console for debug builds.
 
 #### US-D5: Refund-of-trial & restore-on-fresh-install flow
+
 **Description:** As a user reinstalling on a new phone, I shouldn't have to pay again.
 
 **Acceptance Criteria:**
+
 - [ ] App boot on new device with same Apple ID -> `Transaction.currentEntitlements` populates -> entitlement set to `.pro` automatically without user action.
 - [ ] Settings -> "Restore purchases" button explicitly calls `AppStore.sync()` and surfaces success/failure as a toast.
 - [ ] If a user cancels mid-trial inside Settings.app, app reflects `.free` within 1 minute via the transaction listener.
@@ -259,9 +299,11 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 ### Epic E: Supabase Backend & Cross-Device Sync
 
 #### US-E1: Anonymous device identity via Supabase Auth
+
 **Description:** As a user, I want my data synced without creating an account or giving an email.
 
 **Acceptance Criteria:**
+
 - [ ] Existing `DeviceIdentityService` extended to call `supabase.auth.signInAnonymously()` on first launch and store the resulting `userId` in Keychain.
 - [ ] On subsequent launches, refresh-token flow keeps the session alive.
 - [ ] On entitlement change (`.proTrial` -> `.pro`), update a `profiles` row with `entitlement_tier`.
@@ -269,18 +311,22 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] Supabase project bootstrap script in `infra/supabase/` (SQL + RLS policies) checked in.
 
 #### US-E2: Schema and RLS policies on Supabase
+
 **Description:** As a developer, I need a backend schema that mirrors local SwiftData tables and enforces per-user data isolation.
 
 **Acceptance Criteria:**
+
 - [ ] Tables: `profiles`, `user_completions`, `user_favorites`, `micro_surveys`, `subscription_events`, `synthesized_experiences` (canonical AI output, dedupable across users), `osm_pois` (canonical OSM cache), `solo_score_signals`.
 - [ ] Row-Level Security: every user-data table allows `select/insert/update/delete WHERE user_id = auth.uid()`. `synthesized_experiences` and `osm_pois` are **read-public, write-server-role**.
 - [ ] Migration files in `infra/supabase/migrations/0001_*.sql`.
 - [ ] Smoke test script: `infra/supabase/test_rls.ts` runs anon vs user role queries and asserts isolation.
 
 #### US-E3: Outbox sync for user data
+
 **Description:** As a user toggling between phone and iPad, I want my favorites and completed list to converge within seconds.
 
 **Acceptance Criteria:**
+
 - [ ] New `SyncService` (in `Services/`) implements outbox pattern: any local mutation to user-data tables also writes to a `PendingSyncRecord` queue.
 - [ ] Background flush every 30s and on app foreground; uses Supabase's REST upsert with `If-Match` on `updated_at` for last-write-wins.
 - [ ] Inbound: pull diff (`updated_at > lastPulledAt`) for each user-data table on foreground; merge into SwiftData by id.
@@ -288,9 +334,11 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] Unit test: simulate two devices mutating the same favorite — assert eventual consistency after one round-trip each.
 
 #### US-E4: Server-side AI synthesis cache (sharing across users)
+
 **Description:** As a product owner, when User A in Hanoi has paid for AI synthesis of a region, User B's nearby request should reuse it for free.
 
 **Acceptance Criteria:**
+
 - [ ] `AIService.synthesizeExperiences` consults Supabase `synthesized_experiences` table by region+POI hash before calling Claude.
 - [ ] On cache miss + paid call: write the result back to `synthesized_experiences` (server-role via a Supabase Edge Function with service-role key — client never has it).
 - [ ] Free users **read** the shared cache (so a paid user's exploration "lights up" the area for everyone) — this is the core flywheel and a marketing hook.
@@ -299,9 +347,11 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] Edge Function rate-limits per `auth.uid()`: 30 calls/day for Pro, 0 for free.
 
 #### US-E6: Optional Sign-in-with-Apple to upgrade anonymous account
+
 **Description:** As a user who wants Family Sharing eligibility or extra account-recovery safety, I want to link my anonymous Solo Compass account to my Apple ID without losing my data.
 
 **Acceptance Criteria:**
+
 - [ ] Settings has a new row under "My Data": **"Save with Apple"** (when anonymous) / **"Linked to Apple ID"** (when linked).
 - [ ] Tapping "Save with Apple" presents the system Sign-in-with-Apple sheet. On success, calls `supabase.auth.linkIdentity(provider: .apple)` to merge the anonymous user into a permanent one.
 - [ ] All existing local SwiftData rows keep their `anonUserId` linkage; the Supabase `profiles` table updates `is_anonymous = false` and stores the Apple email relay (private relay, not real email).
@@ -311,9 +361,11 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] Unit test (`Transaction.testSession` + Supabase mocked): anonymous user with 3 favorites and 1 micro-survey links to Apple → assert all rows now belong to permanent userId, anon session is deleted server-side.
 
 #### US-E5: Solo-Score signal aggregation
+
 **Description:** As a user, I should see Solo Scores that reflect actual community use, not just AI guesses.
 
 **Acceptance Criteria:**
+
 - [ ] On every micro-survey submit, `SyncService` writes a `solo_score_signals` row (anon user_id, experienceId, comfort, pressure, recommend, timestamp).
 - [ ] Nightly Supabase scheduled function recomputes `synthesized_experiences.aggregated_solo_score` (mean/median + sample size) for each experienceId.
 - [ ] Client pulls the aggregate on app foreground and merges into `ExperienceRecord.soloScore` if `signal_count >= 3`.
@@ -324,18 +376,22 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 ### Epic F: App Store Readiness & Privacy
 
 #### US-F1: Privacy manifest and ATT prompt
+
 **Description:** As an App Store applicant, I need a privacy manifest declaring data use and ATT prompts where appropriate.
 
 **Acceptance Criteria:**
+
 - [ ] `apps/ios/SoloCompass/Resources/PrivacyInfo.xcprivacy` lists: precise location, coarse location, device ID (Supabase anon), purchases (StoreKit), diagnostics (Supabase events).
 - [ ] No data is marked as used for tracking. ATT prompt skipped (not needed without tracking).
 - [ ] Privacy policy at `https://solocompass.app/privacy` (placeholder OK; URL configured in `Info.plist`).
 - [ ] First-run onboarding screen explains: location stays on device + sent to OSM/Anthropic during Explore Here; entitlement events sent to Supabase for sync; nothing else.
 
 #### US-F2: First-run Explore-Here consent screen
+
 **Description:** As a privacy-conscious user, I want a clear opt-in moment before my coordinates leave the device.
 
 **Acceptance Criteria:**
+
 - [ ] New view `Onboarding/ExploreConsentSheet.swift` shown the first time the user taps Explore Here.
 - [ ] Explains: "Tapping Explore here sends your map center coordinate to OpenStreetMap (free, anonymous) and to our AI server. We never store who asked, only what was asked, for 30 days."
 - [ ] Two buttons: "Continue" (proceeds + sets `userPreferences.exploreConsentGivenAt`) and "Not now".
@@ -343,26 +399,32 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - [ ] Settings has a "Revoke consent" row that clears the flag and disables Explore Here.
 
 #### US-F3: Schema parity check across iOS and TypeScript
+
 **Description:** As a developer, I need `pnpm parity:check` to cover the new fields so future changes don't drift.
 
 **Acceptance Criteria:**
+
 - [ ] `packages/core/src/experience.ts` adds the same prefixes (`exp_osm_`), confidence-level-1 semantics, and `discoveredCity` types as iOS.
 - [ ] `scripts/check-swift-parity.ts` extended to check the new model classes vs TS types.
 - [ ] CI job `.github/workflows/ci.yml` runs `pnpm parity:check` and fails on drift.
 - [ ] PR template adds checkbox: "Updated TS schema if Swift schema changed."
 
 #### US-F4: Localization for zh-Hans
+
 **Description:** As a Chinese-language user, I want the app and paywall in Simplified Chinese.
 
 **Acceptance Criteria:**
+
 - [ ] `Resources/zh-Hans.lproj/Localizable.strings` covers every key in `en.lproj`. Translations done by hand for app-store-visible strings (paywall, onboarding, Explore button, errors).
 - [ ] App Store description, keywords, screenshots have zh-Hans variants.
 - [ ] Default fallback to English remains for missing keys.
 
 #### US-F5: TestFlight beta and App Store metadata
+
 **Description:** As a founder, I want a TestFlight build with 20 beta testers feeding usage data before public launch.
 
 **Acceptance Criteria:**
+
 - [ ] `.github/workflows/testflight.yml` already exists; verify it works on this branch and uploads on tag `v1.1.0-beta.N`.
 - [ ] App Store Connect entry filled: name, subtitle, keywords (en + zh), 6 screenshots per locale (iPhone 17 Pro), category Travel, age 4+.
 - [ ] In-app review prompt (`SKStoreReviewController.requestReview()`) triggered after the user marks 3rd Experience completed (not before).
@@ -373,23 +435,27 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 ## 4. Functional Requirements
 
 ### Persistence
+
 - **FR-1:** All Experiences (seed, OSM-generated, user-added) stored in SwiftData; bundle seed imported once on first launch.
 - **FR-2:** User completion, favorites, and micro-surveys stored in SwiftData; legacy `UserDefaults` arrays migrated automatically.
 - **FR-3:** SwiftData schema is versioned; v1 schema declared explicitly to allow future migrations.
 
 ### Caching & Cost
+
 - **FR-4:** Overpass results cached for 14 days, keyed by 0.01 degree rounded coordinate + radius.
 - **FR-5:** Claude synthesis results cached for 30 days locally and indefinitely server-side via Supabase.
 - **FR-6:** Default synthesis model is Sonnet 4.6; explanation model is Haiku 4.5; Opus is gated behind a debug flag only.
 - **FR-7:** Per-user daily AI quota: free=0, Pro=30 syntheses + 60 explanations.
 
 ### Trust & UX
+
 - **FR-8:** Pins with `confidence.level == 1` render with dashed border, 70% opacity, and an info disclosure in detail view.
 - **FR-9:** OSM-derived Experiences must include `(c) OpenStreetMap contributors` in `sources` and link to the node URL.
 - **FR-10:** Synthesis prompt forbids invented specifics (menu items, hours, prices, interior details, owner backstories).
 - **FR-11:** Reverse geocoding resolves city names; falls back to `osm_<lat>_<lon>` only when geocoder fails.
 
 ### Freemium & Monetization
+
 - **FR-12:** Two subscription products with **globally uniform Apple price tiers** (auto-converted per region by App Store):
   - Monthly: Apple price tier 2 (~$1.99 USD; ¥12 CNY; €1.99; ¥300 JPY).
   - Yearly: Apple price tier 11 (~$14.99 USD; ¥98 CNY; €14.99; ¥2200 JPY).
@@ -401,6 +467,7 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - **FR-16b:** Sign-in-with-Apple linking is supported in v1.1 (US-E6) and unlocks Family Sharing eligibility; remains optional.
 
 ### Backend & Sync
+
 - **FR-17:** Supabase anonymous auth on first launch; `userId` persisted in Keychain.
 - **FR-18:** Outbox sync flushes every 30 s and on foreground; LWW conflict resolution.
 - **FR-19:** All Anthropic calls go through a Supabase Edge Function after Epic E ships; the iOS app no longer holds the API key.
@@ -409,6 +476,7 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - **FR-25:** Supabase region: Singapore (`ap-southeast-1`) for v1.1; Tokyo failover documented but not provisioned.
 
 ### Privacy & Compliance
+
 - **FR-21:** `PrivacyInfo.xcprivacy` declares all collected data types accurately; nothing is used for tracking.
 - **FR-22:** First-run consent sheet required before Explore Here ever sends coordinates off-device; revocable in Settings.
 - **FR-23:** Privacy policy URL configured in `Info.plist` and reachable.
@@ -444,6 +512,7 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 ## 7. Technical Considerations
 
 ### Stack additions
+
 - **SwiftData** — iOS 17+ (already deployment target).
 - **StoreKit 2** — new dependency, no third-party.
 - **Supabase Swift SDK** — `supabase-swift` via SPM (one of the few cases the project breaks its "zero deps" rule; documented in `CLAUDE.md`).
@@ -451,6 +520,7 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - **Supabase Edge Functions** — Deno runtime; one function (`synthesize-experiences`) holds the Anthropic key.
 
 ### Migration path
+
 1. Land Epic A (persistence) on `feat/persistence-swiftdata` — no behavior change for users.
 2. Land Epic B (caching + Sonnet) on `feat/ai-cost-control`.
 3. Land Epic C (UX polish) on `feat/explore-trust`.
@@ -460,11 +530,13 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 7. Tag `v1.1.0-beta.1`, push to TestFlight, gather 2 weeks of feedback, then `v1.1.0`.
 
 ### Feature flags
+
 - `FF_BACKEND_SYNC` — gates Supabase calls; off by default in beta.1, on by beta.3.
 - `FF_PAYWALL_ENABLED` — lets us TestFlight without showing the paywall to early testers.
 - Stored in `Resources/FeatureFlags.plist` and overridable via launch args.
 
 ### Performance budgets
+
 - App cold-start time: <= 1.0 s on iPhone 14 (currently ~0.7 s; SwiftData container init must not regress).
 - Map first-pin-render: <= 300 ms after location lock.
 - Explore Here end-to-end (cache miss): <= 6 s on a good network; (cache hit): <= 200 ms.
@@ -472,38 +544,45 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - SwiftData query for "experiences within 5 km, filtered by category": <= 50 ms with 1000 records.
 
 ### Risks
+
 - **R1 — SwiftData migrations are fragile.** Mitigate by versioning the schema from day 1 and never modifying v1 in place.
 - **R2 — Apple may reject "anonymous account auto-creation".** Mitigate by making the anonymous account explicit in onboarding ("Solo Compass uses an anonymous device ID to sync across your devices. No email needed.").
 - **R3 — Supabase Edge Function cold start.** First call may take 2–3 s; warm pings every 5 min via cron. Document fallback (skeleton mode if Edge Function times out).
 - **R4 — Sonnet output quality regression vs Opus.** Mitigate via golden-set snapshot tests in US-B3 and ability to toggle back.
-- **R5 — Server-side cache "lights up regions for free users" creates a vector for Pro users to feel cheated.** Counter by making the value of Pro about *speed of fresh exploration* + *daily quota* + *future AI features*, not exclusivity of past cache hits. Document this in the paywall copy.
+- **R5 — Server-side cache "lights up regions for free users" creates a vector for Pro users to feel cheated.** Counter by making the value of Pro about _speed of fresh exploration_ + _daily quota_ + _future AI features_, not exclusivity of past cache hits. Document this in the paywall copy.
 
 ---
 
 ## 8. Success Metrics
 
 ### North-Star
+
 - **Daily Active Paid Users (DAPU)** — target 200 by week 4 post-launch.
 
 ### Activation
-- >= 60% of users who tap "Explore Here" on free tier reach the paywall.
-- >= 15% of paywall views start the free trial.
-- >= 40% of trials convert to paid (industry benchmark: 30-50% for utility apps).
+
+- > = 60% of users who tap "Explore Here" on free tier reach the paywall.
+- > = 15% of paywall views start the free trial.
+- > = 40% of trials convert to paid (industry benchmark: 30-50% for utility apps).
 
 ### Retention
+
 - Day-7 retention free: >= 25%.
 - Day-7 retention paid: >= 60%.
 - Day-30 retention paid: >= 40%.
 
 ### Cost
+
 - Average AI cost per paid user per day <= $0.30.
-- >= 50% of synthesis requests served from cache after week 4 (the flywheel).
+- > = 50% of synthesis requests served from cache after week 4 (the flywheel).
 
 ### Trust / Quality
+
 - < 5% of generated Experiences flagged via Report Issue ("factually incorrect").
-- >= 60% of generated Experiences in a region get at least 1 micro-survey within 60 days.
+- > = 60% of generated Experiences in a region get at least 1 micro-survey within 60 days.
 
 ### Engineering
+
 - All 6 epics ship within a 6-week calendar window.
 - `xcodebuild test` passes on every PR; coverage on new code >= 75%.
 - Zero P0 crashes in production for 14 days post-launch (measured via Apple's Crashes & Energy logs).
@@ -538,30 +617,31 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 
 ### Remaining open (defer)
 
-- **OSM attribution placement.** Sources section is fine for ODbL legal minimum; consider a one-line credit at the bottom of the detail view in v1.2 if any contributor flags it. *Owner: @cubxxw, beta-stage decision.*
-- **Skeleton-mode richness.** OSM name + tag-derived category is the v1.1 minimum. If beta users say "this looks empty," add one heuristic-driven sentence (template per category) in a hot-fix. *Owner: product, validate in beta.*
-- **Refund policy for hitting daily AI quota.** Standard Apple refund process applies; we'll publish a one-line "no manual refunds for quota usage" policy in the paywall fine print. *Owner: @cubxxw, before App Store submission.*
-- **Edge Function language.** Deno/TS confirmed by default to keep the team in one language. *Owner: @cubxxw.*
+- **OSM attribution placement.** Sources section is fine for ODbL legal minimum; consider a one-line credit at the bottom of the detail view in v1.2 if any contributor flags it. _Owner: @cubxxw, beta-stage decision._
+- **Skeleton-mode richness.** OSM name + tag-derived category is the v1.1 minimum. If beta users say "this looks empty," add one heuristic-driven sentence (template per category) in a hot-fix. _Owner: product, validate in beta._
+- **Refund policy for hitting daily AI quota.** Standard Apple refund process applies; we'll publish a one-line "no manual refunds for quota usage" policy in the paywall fine print. _Owner: @cubxxw, before App Store submission._
+- **Edge Function language.** Deno/TS confirmed by default to keep the team in one language. _Owner: @cubxxw._
 
 ---
 
 ## 10. Sequencing Summary
 
-| Week | Focus | Branches | Deliverable |
-|---|---|---|---|
-| 1 | Epic A: Persistence | `feat/persistence-swiftdata` | All data on disk; no UX change |
-| 2 | Epic B: Cost control | `feat/ai-cost-control` | Sonnet default + caching live |
-| 3 | Epic C: Trust UX | `feat/explore-trust` | Visual downgrade + reverse geocode + survey feedback |
-| 4 | Epic D: StoreKit | `feat/freemium-paywall` | Paywall live behind FF |
-| 5 | Epic E: Supabase | `feat/backend-sync` | Server cache + sync + key removed from client + optional Apple ID link (US-E6) |
-| 6 | Epic F: Store prep | `feat/app-store-prep` | TestFlight beta.1 |
-| 7-8 | Beta feedback | hot-fix branches | `v1.1.0` GA |
+| Week | Focus                | Branches                     | Deliverable                                                                    |
+| ---- | -------------------- | ---------------------------- | ------------------------------------------------------------------------------ |
+| 1    | Epic A: Persistence  | `feat/persistence-swiftdata` | All data on disk; no UX change                                                 |
+| 2    | Epic B: Cost control | `feat/ai-cost-control`       | Sonnet default + caching live                                                  |
+| 3    | Epic C: Trust UX     | `feat/explore-trust`         | Visual downgrade + reverse geocode + survey feedback                           |
+| 4    | Epic D: StoreKit     | `feat/freemium-paywall`      | Paywall live behind FF                                                         |
+| 5    | Epic E: Supabase     | `feat/backend-sync`          | Server cache + sync + key removed from client + optional Apple ID link (US-E6) |
+| 6    | Epic F: Store prep   | `feat/app-store-prep`        | TestFlight beta.1                                                              |
+| 7-8  | Beta feedback        | hot-fix branches             | `v1.1.0` GA                                                                    |
 
 ---
 
 ## 11. Appendix — Files Touched (estimated)
 
 **New files (~25):**
+
 - `Persistence/SoloCompassModelContainer.swift`
 - `Persistence/Models/*.swift` (~13 `@Model` classes)
 - `Persistence/ExperienceRepository.swift`
@@ -580,6 +660,7 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 - `tests/persistence/`, `tests/subscription/`, `tests/sync/`
 
 **Modified (~12):**
+
 - `Services/AIService.swift` — model config + cache + Edge Function call
 - `Services/OverpassService.swift` — cache integration
 - `Services/ExperienceService.swift` — repo facade
@@ -595,4 +676,4 @@ The ultimate target: a v1.1 iOS build that can stand on its own in the App Store
 
 ---
 
-*End of PRD. Implementation starts on `feat/persistence-swiftdata` after PRD approval.*
+_End of PRD. Implementation starts on `feat/persistence-swiftdata` after PRD approval._


### PR DESCRIPTION
## Summary

Lands all 5 stories of Epic B from `tasks/prd-paid-app-foundation.md`. Cost-control infrastructure that should drop Claude spend by ~80% relative to v1.0's Opus-on-everything approach.

## Stories

| Story | Subject |
|---|---|
| US-011 | Overpass region cache, 14-day TTL |
| US-012 | AI synthesis batch cache (SHA256 key), 30-day TTL |
| US-013 | Sonnet 4.6 default + Haiku 4.5 for explanations + Opus debug override |
| US-014 | Anti-hallucination prompt + skeleton-fallback regression test |
| US-015 | Daily AI quota (Pro: 30 synthesis + 60 explanations) with skeleton degradation |

## Highlights

- **Cache hits do NOT increment the daily quota counter.** Only real network calls do.
- **Skeleton fallback never writes to the synthesis cache** — transient network errors stay transient.
- **AI_FORCE_OPUS=1 env var** still routes everything to Opus for golden-set comparisons during prompt iteration.
- **Quota reset is automatic** via `AIUsageRecord.todayUTC()` day truncation.

## Tests

52/52 passing on iPhone 17 / iOS 26.4. New tests:
- regionKey format
- Overpass cache hit + clear
- Synthesis cache key stability across input order
- Synthesis cache key changes with model name
- Default model routing
- AI_FORCE_OPUS routing
- Skeleton fallback contains no banned phrases (11 patterns)
- Quota cap → skeleton + no network call
- Cache hit does not increment quota

## Cost expectation per Pro user / day

| Scenario | Cost |
|---|---|
| All 30 syntheses cache miss (worst) | ~$0.30/day |
| 50% cache hit rate | ~$0.15/day |
| Hard ceiling (synthesis + explanation full quota) | ~$0.50/day |

Anthropic Console hard cap of $200/month enforced server-side as the ultimate safety net.

## Test plan

- [x] `xcodebuild build`
- [x] `xcodebuild test` 52/52
- [ ] Manual: tap Explore in same region twice → second is instant (cache)
- [ ] Manual: with `AI_FORCE_OPUS=1` env, confirm requests use opus model
- [ ] Manual: pre-seed AIUsageRecord at 30 → next Explore degrades to skeleton + banner shows

## Stacked on

Epic A (#75, merged). No conflicts expected.