### PR TITLE
feat(ios): Epic C — trust + UX polish (5 user stories)

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		56F3055416F4A5316100F9B2 /* ExperienceCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */; };
 		58B7C9B20945838F81081941 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14A22A40550CF207AB36C18 /* SettingsView.swift */; };
 		5C05B87EA78458094612AC01 /* BottomInfoBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13350B81187FB64B252B8A46 /* BottomInfoBar.swift */; };
+		62BB74EC16B92899A9A6A44C /* ReverseGeocodeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BDF8B4B7CC82F3845C5068 /* ReverseGeocodeService.swift */; };
 		7C14629A3FAB31975BFBB0A6 /* ExperienceRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A250916F91C8EF0BE90DF763 /* ExperienceRepository.swift */; };
 		7D2B6DE6C27E0307CA998A5F /* CityPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873ACB737A9B43254C17B238 /* CityPickerSheet.swift */; };
 		86F4628473C2D520D4C2FFFB /* SoloScoreBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB579F3F4EBBA014AA306DD1 /* SoloScoreBadge.swift */; };
@@ -80,6 +81,7 @@
 		5CA0BAEC05B72704552C0906 /* PendingCheckInRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingCheckInRecord.swift; sourceTree = "<group>"; };
 		5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailViewModel.swift; sourceTree = "<group>"; };
 		61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = seed_experiences.json; sourceTree = "<group>"; };
+		64BDF8B4B7CC82F3845C5068 /* ReverseGeocodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseGeocodeService.swift; sourceTree = "<group>"; };
 		67173C74F1A76C3CE5C38C0A /* OverpassService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverpassService.swift; sourceTree = "<group>"; };
 		6C5CA5533D846B39EF16CDFA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		791CBEDE09220728AD52AAAD /* UserFavoriteRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFavoriteRecord.swift; sourceTree = "<group>"; };
@@ -232,6 +234,7 @@
 				2C7919EAFDE363B49C4B4C47 /* LocationService.swift */,
 				C215AE07BA32182A887226F9 /* NotificationService.swift */,
 				67173C74F1A76C3CE5C38C0A /* OverpassService.swift */,
+				64BDF8B4B7CC82F3845C5068 /* ReverseGeocodeService.swift */,
 				120FC7465285714C5FA8F96D /* VoiceService.swift */,
 			);
 			path = Services;
@@ -447,6 +450,7 @@
 				ACBA4CEE6B78AA04DBD26709 /* PendingCheckInRecord.swift in Sources */,
 				9C8CC563D33FDBB3DF57A841 /* RecentExploreRegion.swift in Sources */,
 				EF2003CC07F7787C25847BDF /* ReportIssueSheet.swift in Sources */,
+				62BB74EC16B92899A9A6A44C /* ReverseGeocodeService.swift in Sources */,
 				58B7C9B20945838F81081941 /* SettingsView.swift in Sources */,
 				E5F463CE3CE822F7F96CA82C /* SoloCompassApp.swift in Sources */,
 				13E5AEAEE5194DDB79AE92AC /* SoloCompassModelContainer.swift in Sources */,

--- a/apps/ios/SoloCompass/Persistence/ExperienceRepository.swift
+++ b/apps/ios/SoloCompass/Persistence/ExperienceRepository.swift
@@ -208,6 +208,120 @@ public final class ExperienceRepository {
         return ((try? context.fetch(descriptor)) ?? []).map(\.experienceId)
     }
 
+    // MARK: - Micro-survey writeback (Epic C US-020)
+
+    /// Record one micro-survey row. Comfort/pressure/recommend are all
+    /// independent dimensions; we don't pre-aggregate at write time so
+    /// later changes to the formula don't require migrating rows.
+    public func recordSurvey(
+        experienceId: String,
+        comfort: Int,
+        pressure: Int,
+        recommend: String,
+        anonDeviceId: String,
+        at date: Date = Date()
+    ) {
+        context.insert(
+            MicroSurveyRecord(
+                experienceId: experienceId,
+                comfort: comfort,
+                pressure: pressure,
+                recommend: recommend,
+                submittedAt: date,
+                anonDeviceId: anonDeviceId
+            )
+        )
+        try? context.save()
+    }
+
+    public func surveyCount(experienceId: String) -> Int {
+        let id = experienceId
+        let descriptor = FetchDescriptor<MicroSurveyRecord>(
+            predicate: #Predicate { $0.experienceId == id }
+        )
+        return (try? context.fetchCount(descriptor)) ?? 0
+    }
+
+    /// Aggregate the local survey signals into a Solo-Score-like value.
+    /// Formula: localSurveyMean = mean of (comfort + pressure) / 2, on a
+    /// 0–10 scale (raw 1–5 doubled). recommendBoost = +0.5 when ≥ 50 %
+    /// of recommendations are "yes". Final = clamp(0...10, original/2 +
+    /// localSurveyMean/2 + recommendBoost). Returns `nil` if no surveys
+    /// exist (caller falls back to the seed/AI score). Cached for 60 s
+    /// per experience id to avoid recomputing on every render.
+    public func aggregatedSoloScore(
+        experienceId: String,
+        seedOverall: Double
+    ) -> (overall: Double, count: Int)? {
+        if let cached = aggregatedScoreCache[experienceId],
+           Date().timeIntervalSince(cached.cachedAt) < 60 {
+            return (cached.overall, cached.count)
+        }
+        let id = experienceId
+        let descriptor = FetchDescriptor<MicroSurveyRecord>(
+            predicate: #Predicate { $0.experienceId == id }
+        )
+        guard let surveys = try? context.fetch(descriptor), !surveys.isEmpty else {
+            return nil
+        }
+        let comfortAvg = Double(surveys.map(\.comfort).reduce(0, +)) / Double(surveys.count)
+        let pressureAvg = Double(surveys.map(\.pressure).reduce(0, +)) / Double(surveys.count)
+        // 1–5 → 0–10 scale: ((comfort + pressure) / 2) * 2
+        let localOnTen = ((comfortAvg + pressureAvg) / 2.0) * 2.0
+        let yesCount = surveys.filter { $0.recommend == "yes" }.count
+        let recommendBoost = (Double(yesCount) / Double(surveys.count)) >= 0.5 ? 0.5 : 0.0
+        let blended = (seedOverall * 0.5 + localOnTen * 0.5) + recommendBoost
+        let clamped = max(0.0, min(10.0, blended))
+        aggregatedScoreCache[experienceId] = (clamped, surveys.count, Date())
+        return (clamped, surveys.count)
+    }
+
+    /// 60-second per-experience cache for aggregatedSoloScore. Cleared
+    /// on app foreground (caller responsibility) so a freshly synced
+    /// signal lights up.
+    private var aggregatedScoreCache: [String: (overall: Double, count: Int, cachedAt: Date)] = [:]
+
+    // MARK: - Discovered cities (Epic C US-016/017)
+
+    /// Upsert a discovered city. Idempotent by `cityCode`.
+    public func recordDiscoveredCity(
+        cityCode: String,
+        name: String,
+        countryCode: String,
+        center: (lat: Double, lon: Double)
+    ) {
+        let descriptor = FetchDescriptor<DiscoveredCityRecord>(
+            predicate: #Predicate { $0.cityCode == cityCode }
+        )
+        if let existing = (try? context.fetch(descriptor))?.first {
+            // Refresh fields if metadata changed (e.g. localized name in
+            // a new locale).
+            existing.name = name
+            existing.countryCode = countryCode
+            existing.centerLat = center.lat
+            existing.centerLon = center.lon
+            try? context.save()
+            return
+        }
+        context.insert(
+            DiscoveredCityRecord(
+                cityCode: cityCode,
+                name: name,
+                countryCode: countryCode,
+                centerLat: center.lat,
+                centerLon: center.lon
+            )
+        )
+        try? context.save()
+    }
+
+    public func allDiscoveredCities() -> [DiscoveredCityRecord] {
+        let descriptor = FetchDescriptor<DiscoveredCityRecord>(
+            sortBy: [SortDescriptor(\.discoveredAt, order: .reverse)]
+        )
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
     // MARK: - Bulk operations
 
     /// Wipe every user-data row. Does NOT delete experiences (they reseed

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -35,6 +35,10 @@
 "solo.ambiance" = "Ambiance fits solo";
 "solo.safety" = "Safety alone";
 "solo.basedOn" = "Based on %d solo travelers";
+"solo.basedOn.early" = "Based on %d early reports";
+"solo.estimate.pill" = "AI estimate";
+"solo.section.estimate" = "Solo Score (AI estimate)";
+"solo.section.early" = "Solo Score (early)";
 
 /* Sections */
 "section.whyItMatters" = "Why it matters";
@@ -240,6 +244,8 @@
 "explore.skeleton.oneLiner" = "A real spot pulled from OpenStreetMap.";
 "explore.skeleton.why" = "We don't have a curated story for this place yet. Visit, then add what you found.";
 "explore.quota.dailyLimit" = "Daily AI limit reached. Showing real places without enrichment until tomorrow.";
+"explore.toast.addedNamed" = "Now exploring %1$@ · %2$d places added";
+"explore.toast.added" = "%d places added near you";
 
 /* Overpass errors */
 "overpass.error.url" = "Overpass endpoint URL is invalid.";

--- a/apps/ios/SoloCompass/Services/ReverseGeocodeService.swift
+++ b/apps/ios/SoloCompass/Services/ReverseGeocodeService.swift
@@ -1,0 +1,92 @@
+import Foundation
+import CoreLocation
+import Contacts
+
+/// Wraps `CLGeocoder.reverseGeocodeLocation` and produces a slug-style
+/// city code that's stable across runs. Used by Epic C US-C3 so the
+/// city picker shows real names like "Hanoi" instead of synthetic
+/// `osm_21.0_105.9`.
+///
+/// `@MainActor` because `CLGeocoder` is not Sendable in a thread-safe
+/// way and we want the call site predictable. Apple rate-limits
+/// reverse geocoding (50/min/app) — we let the OS handle that and just
+/// surface failures as `nil`.
+@MainActor
+public final class ReverseGeocodeService {
+    public struct Resolved: Equatable, Sendable {
+        public let cityCode: String       // slug like "vn-hanoi"
+        public let name: String           // localized "Hanoi"
+        public let countryCode: String    // ISO 3166-1 alpha-2 lowercase
+
+        public init(cityCode: String, name: String, countryCode: String) {
+            self.cityCode = cityCode
+            self.name = name
+            self.countryCode = countryCode
+        }
+    }
+
+    private let geocoder: CLGeocoder
+
+    public init(geocoder: CLGeocoder = CLGeocoder()) {
+        self.geocoder = geocoder
+    }
+
+    /// Resolve a coordinate into a (cityCode, name, countryCode) tuple.
+    /// Returns nil on geocoder failure / offline / rate-limit — callers
+    /// must fall back to the synthetic `osm_<lat>_<lon>` cityCode.
+    public func resolve(coordinate: CLLocationCoordinate2D) async -> Resolved? {
+        let location = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+        do {
+            let placemarks = try await geocoder.reverseGeocodeLocation(location)
+            guard let placemark = placemarks.first else { return nil }
+            return Self.makeResolved(from: placemark)
+        } catch {
+            #if DEBUG
+            print("[ReverseGeocodeService] reverse geocode failed: \(error)")
+            #endif
+            return nil
+        }
+    }
+
+    /// Static so the slug logic is unit-testable without a real geocoder.
+    static func makeResolved(from placemark: CLPlacemark) -> Resolved? {
+        // Locality (city) is the granularity we want; if missing fall
+        // back to subAdministrativeArea (county) then administrativeArea
+        // (state/province). We use whichever the country provides.
+        let rawCity = placemark.locality
+            ?? placemark.subAdministrativeArea
+            ?? placemark.administrativeArea
+        let rawCountry = placemark.isoCountryCode
+        guard let cityName = rawCity, let country = rawCountry, !cityName.isEmpty, !country.isEmpty else {
+            return nil
+        }
+        let countryCode = country.lowercased()
+        let citySlug = slugify(cityName)
+        guard !citySlug.isEmpty else { return nil }
+        return Resolved(
+            cityCode: "\(countryCode)-\(citySlug)",
+            name: cityName,
+            countryCode: countryCode
+        )
+    }
+
+    /// Lowercase ASCII slug. Spaces → "-"; non-alphanumeric stripped.
+    /// Diacritics folded so "México" becomes "mexico".
+    static func slugify(_ raw: String) -> String {
+        let folded = raw.folding(options: .diacriticInsensitive, locale: .init(identifier: "en"))
+        var slug = ""
+        var lastWasDash = false
+        for scalar in folded.lowercased().unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) {
+                slug.append(Character(scalar))
+                lastWasDash = false
+            } else if !lastWasDash && !slug.isEmpty {
+                slug.append("-")
+                lastWasDash = true
+            }
+        }
+        // Trim trailing dash.
+        while slug.hasSuffix("-") { slug.removeLast() }
+        return slug
+    }
+}

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -863,6 +863,73 @@ final class SoloCompassTests: XCTestCase {
         XCTAssertEqual(StubURLProtocol.requestCount, 2, "after clear, second call hits network again")
     }
 
+    // MARK: - US-016 ReverseGeocodeService slug
+
+    func testReverseGeocodeSlugifyHandlesDiacriticsAndSpaces() {
+        XCTAssertEqual(ReverseGeocodeService.slugify("Hà Nội"), "ha-noi")
+        XCTAssertEqual(ReverseGeocodeService.slugify("New York"), "new-york")
+        XCTAssertEqual(ReverseGeocodeService.slugify("São Paulo"), "sao-paulo")
+        XCTAssertEqual(ReverseGeocodeService.slugify("  Trim  Me  "), "trim-me")
+        XCTAssertEqual(ReverseGeocodeService.slugify("123-Main"), "123-main")
+        XCTAssertEqual(ReverseGeocodeService.slugify(""), "")
+    }
+
+    // MARK: - US-018 marker low-confidence visual
+
+    func testMarkerIconViewLowConfidenceFlag() {
+        let normal = MarkerIconView(category: .food, state: .default, confidenceLevel: 4)
+        let low = MarkerIconView(category: .food, state: .default, confidenceLevel: 1)
+        XCTAssertFalse(normal.isLowConfidence)
+        XCTAssertTrue(low.isLowConfidence)
+    }
+
+    // MARK: - US-020 aggregated solo score
+
+    func testAggregatedSoloScoreReturnsNilWhenNoSurveys() {
+        let container = SoloCompassModelContainer.makeInMemory()
+        let context = ModelContext(container)
+        let repo = ExperienceRepository(context: context, preferences: nil)
+        XCTAssertNil(repo.aggregatedSoloScore(experienceId: "exp_unsurveyed", seedOverall: 8.0))
+    }
+
+    func testAggregatedSoloScoreBlendsLocalSurveysWithSeed() throws {
+        let container = SoloCompassModelContainer.makeInMemory()
+        let context = ModelContext(container)
+        let repo = ExperienceRepository(context: context, preferences: nil)
+        let id = "exp_surveyed"
+
+        repo.recordSurvey(
+            experienceId: id, comfort: 5, pressure: 4, recommend: "yes", anonDeviceId: "d1"
+        )
+        repo.recordSurvey(
+            experienceId: id, comfort: 4, pressure: 5, recommend: "yes", anonDeviceId: "d2"
+        )
+
+        let agg = try XCTUnwrap(repo.aggregatedSoloScore(experienceId: id, seedOverall: 8.0))
+        // (4.5 + 4.5) / 2 = 4.5 raw → *2 = 9.0 local-on-ten
+        // 8.0 * 0.5 + 9.0 * 0.5 + 0.5 (recommend boost) = 9.0
+        XCTAssertEqual(agg.overall, 9.0, accuracy: 0.01)
+        XCTAssertEqual(agg.count, 2)
+    }
+
+    func testRecordDiscoveredCityIsIdempotent() {
+        let container = SoloCompassModelContainer.makeInMemory()
+        let context = ModelContext(container)
+        let repo = ExperienceRepository(context: context, preferences: nil)
+
+        repo.recordDiscoveredCity(
+            cityCode: "vn-hanoi", name: "Hanoi", countryCode: "vn",
+            center: (lat: 21.0285, lon: 105.8542)
+        )
+        repo.recordDiscoveredCity(
+            cityCode: "vn-hanoi", name: "Hanoi", countryCode: "vn",
+            center: (lat: 21.03, lon: 105.85)
+        )
+        let cities = repo.allDiscoveredCities()
+        XCTAssertEqual(cities.count, 1, "second insert with same cityCode should upsert, not duplicate")
+        XCTAssertEqual(cities[0].centerLat, 21.03, accuracy: 0.001)
+    }
+
     // MARK: - US-010 generated experiences survive across service instances
 
     func testGeneratedExperiencesPersistAcrossServiceInstances() {

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -23,6 +23,7 @@ public final class MapViewModel {
     private let experienceService: ExperienceService
     private let aiService: AIService
     private let overpassService: OverpassService
+    private let geocodeService: ReverseGeocodeService
     private let preferences: UserPreferences
 
     // MARK: - Explore-here state
@@ -33,6 +34,12 @@ public final class MapViewModel {
     /// shows a banner derived from this. Cleared on the next UTC day
     /// rollover (via day-truncated AIUsageRecord).
     public var lastQuotaInfo: String?
+    /// Ephemeral 3-second toast above BottomInfoBar. Set after a
+    /// successful Explore; cleared by the view after the timer fires.
+    /// Format examples:
+    /// - "Now exploring Hanoi · 12 places added" (geocode succeeded)
+    /// - "12 places added near you" (geocode failed / offline)
+    public var lastExploreToast: String?
 
     // MARK: - Auto-recenter
 
@@ -55,7 +62,10 @@ public final class MapViewModel {
     /// Currently selected city code (e.g. "cmi"), nil = all cities.
     public var selectedCity: String?
 
-    /// All cities derived from seed data: unique cityCode + centroid of their experiences.
+    /// All cities the user can pick from: seed-derived ones (centroid of
+    /// matching experiences) plus reverse-geocoded discoveries from
+    /// previous Explore sessions (Epic C US-016/017). Discovered cities
+    /// override seed-derived names when the codes match.
     public var availableCities: [(code: String, name: String, center: CLLocationCoordinate2D)] {
         var cityExperiences: [String: [CLLocationCoordinate2D]] = [:]
         for exp in experienceService.allExperiences {
@@ -64,17 +74,31 @@ public final class MapViewModel {
             cityExperiences[code, default: []].append(coord)
         }
         let nameMap = cityNameMap
-        return cityExperiences.compactMap { code, coords -> (String, String, CLLocationCoordinate2D)? in
-            guard !coords.isEmpty else { return nil }
+        var byCode: [String: (code: String, name: String, center: CLLocationCoordinate2D)] = [:]
+
+        // Seed-derived rows first.
+        for (code, coords) in cityExperiences where !coords.isEmpty {
             let avgLat = coords.map(\.latitude).reduce(0, +) / Double(coords.count)
             let avgLon = coords.map(\.longitude).reduce(0, +) / Double(coords.count)
             let name = nameMap[code] ?? code
-            return (code, name, CLLocationCoordinate2D(latitude: avgLat, longitude: avgLon))
+            byCode[code] = (code, name, CLLocationCoordinate2D(latitude: avgLat, longitude: avgLon))
         }
-        .sorted { $0.1 < $1.1 }
+
+        // Discovered city rows take precedence on name (real city name
+        // is better than slug fallback).
+        for row in experienceService.repo.allDiscoveredCities() {
+            byCode[row.cityCode] = (
+                row.cityCode,
+                row.name,
+                CLLocationCoordinate2D(latitude: row.centerLat, longitude: row.centerLon)
+            )
+        }
+
+        return Array(byCode.values).sorted { $0.name < $1.name }
     }
 
-    /// Human-readable city names keyed by city code.
+    /// Static seed-city names. Discovered-city names come from
+    /// `DiscoveredCityRecord` via `availableCities`.
     private let cityNameMap: [String: String] = [
         "cmi": "Chiang Mai",
     ]
@@ -193,12 +217,14 @@ public final class MapViewModel {
         experienceService: ExperienceService,
         aiService: AIService,
         preferences: UserPreferences,
-        overpassService: OverpassService = OverpassService()
+        overpassService: OverpassService = OverpassService(),
+        geocodeService: ReverseGeocodeService = ReverseGeocodeService()
     ) {
         self.locationService = locationService
         self.experienceService = experienceService
         self.aiService = aiService
         self.overpassService = overpassService
+        self.geocodeService = geocodeService
         self.preferences = preferences
         self.selectedCity = preferences.lastSelectedCity
         let initialCenter: CLLocationCoordinate2D
@@ -517,15 +543,32 @@ public final class MapViewModel {
         lastExploreError = nil
         lastExploreAddedCount = 0
         lastQuotaInfo = nil
+        lastExploreToast = nil
         defer { isExploring = false }
 
-        let cityCode = Self.cityCode(for: coordinate)
         do {
             let pois = try await overpassService.fetchPOIs(near: coordinate, radiusMeters: radiusMeters)
             guard !pois.isEmpty else {
                 lastExploreError = NSLocalizedString("explore.error.nothingFound", comment: "No POIs found nearby")
                 return
             }
+
+            // US-016: try a real city name first; fall back to the
+            // synthetic osm_<lat>_<lon> only when the geocoder fails.
+            let resolved = await geocodeService.resolve(coordinate: coordinate)
+            let cityCode = resolved?.cityCode ?? Self.cityCode(for: coordinate)
+
+            // Persist the discovered city so the picker shows real names
+            // on subsequent launches.
+            if let resolved {
+                experienceService.repo.recordDiscoveredCity(
+                    cityCode: resolved.cityCode,
+                    name: resolved.name,
+                    countryCode: resolved.countryCode,
+                    center: (lat: coordinate.latitude, lon: coordinate.longitude)
+                )
+            }
+
             let generated = try await aiService.synthesizeExperiences(
                 from: pois,
                 cityCode: cityCode,
@@ -533,15 +576,32 @@ public final class MapViewModel {
             )
             let added = experienceService.appendGenerated(generated)
             lastExploreAddedCount = added
-            // Surface quota banner if AIService just degraded to skeleton
-            // because the daily cap fired. The banner persists until the
-            // next successful explore (typically tomorrow's first call).
+
+            // US-015: surface quota banner if AIService just degraded.
             if aiService.quotaExceededAt != nil {
                 lastQuotaInfo = NSLocalizedString(
                     "explore.quota.dailyLimit",
                     comment: "Daily AI limit reached banner"
                 )
             }
+
+            // US-017: auto-switch to the city we just discovered so the
+            // city filter doesn't hide the new pins. Then build a toast.
+            if added > 0 {
+                selectCity(cityCode)
+                if let resolved {
+                    lastExploreToast = String(
+                        format: NSLocalizedString("explore.toast.addedNamed", comment: "Now exploring %@ · %d places added"),
+                        resolved.name, added
+                    )
+                } else {
+                    lastExploreToast = String(
+                        format: NSLocalizedString("explore.toast.added", comment: "%d places added near you"),
+                        added
+                    )
+                }
+            }
+
             recenter(on: coordinate)
         } catch {
             lastExploreError = error.localizedDescription

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -228,8 +228,56 @@ public struct ExperienceDetailView: View {
     }
 
     private var soloScoreSection: some View {
-        sectionContainer(title: NSLocalizedString("section.soloScore", comment: "")) {
-            SoloScoreBadge(score: viewModel.experience.soloScore, style: .full)
+        // US-019 three-state cold-start UX: header copy + opacity +
+        // optional pill change with `basedOnCount`. Hiding the score
+        // would make the map feel empty for new regions, and showing
+        // an unmarked AI estimate would erode trust — so we mark it.
+        let count = viewModel.experience.soloScore.basedOnCount
+        let titleKey: String
+        let subtitle: String?
+        let isEstimate: Bool
+
+        switch count {
+        case 0:
+            titleKey = "solo.section.estimate"
+            subtitle = nil
+            isEstimate = true
+        case 1...2:
+            titleKey = "solo.section.early"
+            subtitle = String(
+                format: NSLocalizedString("solo.basedOn.early", comment: "Based on N early reports"),
+                count
+            )
+            isEstimate = false
+        default:
+            titleKey = "section.soloScore"
+            subtitle = String(
+                format: NSLocalizedString("solo.basedOn", comment: "Based on N solo travelers"),
+                count
+            )
+            isEstimate = false
+        }
+
+        return sectionContainer(title: NSLocalizedString(titleKey, comment: "")) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    SoloScoreBadge(score: viewModel.experience.soloScore, style: .full)
+                        .opacity(isEstimate ? 0.6 : 1.0)
+                    if isEstimate {
+                        Text(NSLocalizedString("solo.estimate.pill", comment: "AI estimate pill"))
+                            .font(.caption.weight(.medium))
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 3)
+                            .background(Capsule().fill(Color(.tertiarySystemFill)))
+                            .accessibilityLabel(Text(NSLocalizedString("solo.estimate.pill", comment: "")))
+                    }
+                }
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
         }
     }
 

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -222,7 +222,18 @@ public struct CompassMapView: View {
         .sheet(item: $surveyExperience) { exp in
             MicroSurveySheet(
                 experience: exp,
-                onSubmit: { _, _, _ in surveyExperience = nil },
+                onSubmit: { comfort, pressure, recommend in
+                    // US-020: persist via the repo so the aggregated
+                    // SoloScore reflects this immediately.
+                    experienceService.repo.recordSurvey(
+                        experienceId: exp.id,
+                        comfort: comfort,
+                        pressure: pressure,
+                        recommend: recommend.rawValue,
+                        anonDeviceId: DeviceIdentityService.shared.deviceID
+                    )
+                    surveyExperience = nil
+                },
                 onSkip: { surveyExperience = nil }
             )
         }
@@ -357,7 +368,11 @@ public struct CompassMapView: View {
                                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
                             } label: {
                                 VStack(spacing: 2) {
-                                    MarkerIconView(category: exp.category, state: viewModel.markerState(for: exp))
+                                    MarkerIconView(
+                                        category: exp.category,
+                                        state: viewModel.markerState(for: exp),
+                                        confidenceLevel: exp.confidence.level
+                                    )
                                     if case .footprinted = viewModel.markerState(for: exp) {
                                         Text("\(viewModel.footprintCount(for: exp))")
                                             .font(.caption2.weight(.semibold))

--- a/apps/ios/SoloCompass/Views/Map/MarkerIconView.swift
+++ b/apps/ios/SoloCompass/Views/Map/MarkerIconView.swift
@@ -3,21 +3,38 @@ import SwiftUI
 /// Custom marker icon, 44x44 tap target. The visual changes with marker state;
 /// the surrounding circle is always the category color, plus state-specific
 /// adornments (gold glow, checkmark, heart, countdown, footprint).
+///
+/// `confidenceLevel` (0–5) drives a visual downgrade: level <= 1 uses a
+/// dashed border, 70% fill opacity, no shadow, and a smaller 28×28 dot,
+/// so AI-generated entries (Epic C US-018) are clearly distinguishable
+/// from curated content at a glance.
 public struct MarkerIconView: View {
     let category: ExperienceCategory
     let state: ExperienceMarkerState
+    let confidenceLevel: Int
 
     @State private var pulse = false
 
-    public init(category: ExperienceCategory, state: ExperienceMarkerState) {
+    public init(
+        category: ExperienceCategory,
+        state: ExperienceMarkerState,
+        confidenceLevel: Int = 5
+    ) {
         self.category = category
         self.state = state
+        self.confidenceLevel = confidenceLevel
     }
+
+    /// True when this marker should render in "AI-generated, low
+    /// confidence" mode. Currently fires only at level 0–1 (Epic A US-A1
+    /// reserves level 1 for AI-synthesized OSM entries).
+    var isLowConfidence: Bool { confidenceLevel <= 1 }
 
     public var body: some View {
         ZStack {
-            // Pulse ring for "best now"
-            if case .bestNow = state {
+            // Pulse ring for "best now" (suppress on low-confidence — we
+            // don't want AI-guessed entries imitating verified excitement)
+            if case .bestNow = state, !isLowConfidence {
                 Circle()
                     .fill(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255).opacity(0.4))
                     .frame(width: 56, height: 56)
@@ -29,15 +46,13 @@ public struct MarkerIconView: View {
 
             Circle()
                 .fill(fillColor)
-                .frame(width: 36, height: 36)
-                .overlay(
-                    Circle().stroke(.white, lineWidth: 2)
-                )
+                .frame(width: dotSize, height: dotSize)
+                .overlay(borderOverlay)
                 .shadow(color: shadowColor, radius: shadowRadius)
                 .opacity(opacity)
 
             Image(systemName: category.symbol)
-                .font(.subheadline.weight(.semibold))
+                .font(iconFont)
                 .foregroundStyle(.white)
                 .opacity(opacity)
 
@@ -45,6 +60,26 @@ public struct MarkerIconView: View {
         }
         .frame(width: 44, height: 44)
         .accessibilityLabel(Text(accessibilityLabel))
+    }
+
+    private var dotSize: CGFloat { isLowConfidence ? 28 : 36 }
+    private var iconFont: Font {
+        isLowConfidence ? .caption.weight(.semibold) : .subheadline.weight(.semibold)
+    }
+
+    @ViewBuilder
+    private var borderOverlay: some View {
+        if isLowConfidence {
+            // Dashed white border so AI-generated pins read as
+            // "tentative" before the user even taps.
+            Circle()
+                .strokeBorder(
+                    Color.white,
+                    style: StrokeStyle(lineWidth: 2, dash: [4, 3])
+                )
+        } else {
+            Circle().stroke(.white, lineWidth: 2)
+        }
     }
 
     private var fillColor: Color {
@@ -63,6 +98,7 @@ public struct MarkerIconView: View {
     }
 
     private var shadowRadius: CGFloat {
+        if isLowConfidence { return 0 }
         switch state {
         case .bestNow: return 8
         default: return 3
@@ -70,10 +106,9 @@ public struct MarkerIconView: View {
     }
 
     private var opacity: Double {
-        switch state {
-        case .completed: return 0.45
-        default: return 1.0
-        }
+        if case .completed = state { return 0.45 }
+        if isLowConfidence { return 0.7 }
+        return 1.0
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

All 5 stories of Epic C from \`tasks/prd-paid-app-foundation.md\`. UX-layer polish: real city names instead of \`osm_21.0_105.9\` slugs, AI pins look visually weaker, cold-start Solo Score is honest about AI estimation, micro-surveys make the score smarter over time.

## Stories

| Story | Subject |
|---|---|
| US-016 | ReverseGeocodeService + DiscoveredCityRecord write-through |
| US-017 | Auto-switch selected city after Explore + ephemeral toast |
| US-018 | Visual downgrade for confidence-1 markers (dashed, smaller, dimmer) |
| US-019 | Three-state Solo Score cold-start UX (AI estimate / early / verified) |
| US-020 | MicroSurvey writeback + aggregated SoloScore (blends seed + local) |

## Highlights

- **No silent AI estimates.** Cold-start scores show a "AI estimate" pill at 60% opacity. After 1-2 surveys → "early reports". After 3+ → normal.
- **Discovered cities outrank slug fallbacks.** \`availableCities\` merges seed + \`DiscoveredCityRecord\`; discovered names always win on display.
- **Geocoder failure is handled.** Rate-limit / offline / no-locality → fall back to synthetic \`osm_<lat>_<lon>\` cityCode. Pins still appear.
- **Aggregate formula is documented.** \`(seed × 0.5) + (localOnTen × 0.5) + recommendBoost\`. 60-second cache.

## Tests

57/57 passing on iPhone 17 / iOS 26.4. New tests:
- Slugify (diacritics + spaces + edge cases)
- Marker isLowConfidence boundary
- aggregatedSoloScore: nil with no surveys; matches formula with 2 surveys
- recordDiscoveredCity idempotent

## Test plan

- [x] \`xcodebuild build\`
- [x] \`xcodebuild test\` 57/57
- [ ] Manual: tap Explore in Hanoi, confirm city pill shows \"Hanoi\" not \`vn-hanoi\`
- [ ] Manual: confirm AI pins have dashed border + smaller dot vs seed pins
- [ ] Manual: open generated experience, confirm \"Solo Score (AI estimate)\" header
- [ ] Manual: complete 3 surveys, confirm score moves toward survey average

## Stacked on

Epic A (#75) and Epic B (#76), both merged.