### PR TITLE
feat: Epic E — Supabase backend + cross-device sync (7 user stories)

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		116FF0278F882D45402B0E78 /* ExperienceRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03076AD221F78BBDE981C3A /* ExperienceRecord.swift */; };
 		13E5AEAEE5194DDB79AE92AC /* SoloCompassModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5435FBA9527C07A9FB07D46 /* SoloCompassModelContainer.swift */; };
 		15A48470CBEBB6D31C2201D9 /* Configuration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = D4C10384834D53FE83113D51 /* Configuration.storekit */; };
+		18D372538603D7A46EE6C86F /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B73212B8F704EABD27EF5B /* FeatureFlags.swift */; };
 		193FE8EBE03520DF740EE78D /* PaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92F9A65ACFD3B9518A364B0 /* PaywallView.swift */; };
 		1BF34EAE036021423C1ACE2D /* ExploreCacheRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F76E8EBB87A2F70FEA1BB0 /* ExploreCacheRecord.swift */; };
 		214AF641496E8E50E3EC5FE4 /* MicroSurveySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA6E405C780A5A12A9FC1D6 /* MicroSurveySheet.swift */; };
@@ -26,6 +27,7 @@
 		58B7C9B20945838F81081941 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14A22A40550CF207AB36C18 /* SettingsView.swift */; };
 		5C05B87EA78458094612AC01 /* BottomInfoBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13350B81187FB64B252B8A46 /* BottomInfoBar.swift */; };
 		62BB74EC16B92899A9A6A44C /* ReverseGeocodeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BDF8B4B7CC82F3845C5068 /* ReverseGeocodeService.swift */; };
+		641D80BD116D6F255A9ED26A /* PendingSyncRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A92E0AE1868C3A165F3E95 /* PendingSyncRecord.swift */; };
 		7C14629A3FAB31975BFBB0A6 /* ExperienceRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A250916F91C8EF0BE90DF763 /* ExperienceRepository.swift */; };
 		7D2B6DE6C27E0307CA998A5F /* CityPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873ACB737A9B43254C17B238 /* CityPickerSheet.swift */; };
 		86F4628473C2D520D4C2FFFB /* SoloScoreBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB579F3F4EBBA014AA306DD1 /* SoloScoreBadge.swift */; };
@@ -34,12 +36,14 @@
 		AA75B3147A29FDA55E61B24A /* PendingCheckInBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */; };
 		ACBA4CEE6B78AA04DBD26709 /* PendingCheckInRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA0BAEC05B72704552C0906 /* PendingCheckInRecord.swift */; };
 		B28F15C454376D86258FCD77 /* OverpassService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67173C74F1A76C3CE5C38C0A /* OverpassService.swift */; };
+		B478C92BB2249C0D5009AABD /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6163572F4644BF852B35FDA4 /* SyncService.swift */; };
 		BAC775E6105DD571F71ACBC1 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 80020844C0A45A5993333741 /* Localizable.strings */; };
 		BCD734EA6E4D5CE922D0621D /* SubscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B8A80F048D74BEDB8C1132 /* SubscriptionService.swift */; };
 		BD5BB6BD7FCBDB30282F28FA /* VoiceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8ABF85EEFDF9969C94B441 /* VoiceButton.swift */; };
 		C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */; };
 		C2C0AF72D709EDC17C6ED874 /* UserPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63FDD874A8F533F0717132A /* UserPreferences.swift */; };
 		C53DB60CA9E95907A2CBF2C0 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C215AE07BA32182A887226F9 /* NotificationService.swift */; };
+		C735986DAC69807F27CC0E39 /* FeatureFlags.plist in Resources */ = {isa = PBXBuildFile; fileRef = 409FB4B0922C4A1D8AAEB1D1 /* FeatureFlags.plist */; };
 		C7F4A9BD252AC60BDBD74585 /* MicroSurveyRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23043E51C493093CF7244629 /* MicroSurveyRecord.swift */; };
 		C81007F6A39364D0872736B2 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C660F7996B1E4387C37720B3 /* OnboardingView.swift */; };
 		CE1A6A1D5EB25B2BEA5B29DA /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFFA243BC698EF20C6BC1EF /* MapViewModel.swift */; };
@@ -52,6 +56,7 @@
 		E7B5B022519434F7C07818CF /* ExperienceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F087E4FA7161529378098C /* ExperienceService.swift */; };
 		E881A71769542A7C58CF5D10 /* FavoritesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C3BA25EFA9F149FB4FAAB3 /* FavoritesListView.swift */; };
 		EBE1ACB7D574EE000B028B23 /* SoloCompassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3CB5045CE59A613B5CAAF5 /* SoloCompassTests.swift */; };
+		EC5A75D4BC8E0C767D06C424 /* SupabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E406C379247653B4AA5A3E0E /* SupabaseClient.swift */; };
 		EDBD7B0E715165E71BC0C17D /* DiscoveredCityRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE05EF69960CBB73431A6F2F /* DiscoveredCityRecord.swift */; };
 		EF2003CC07F7787C25847BDF /* ReportIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576B08910782A58C3597E596 /* ReportIssueSheet.swift */; };
 		F34C1A42668EF5151AFEE3C3 /* AISynthesisCacheRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E69F3EF6F0100CFA47DAFE /* AISynthesisCacheRecord.swift */; };
@@ -81,16 +86,20 @@
 		33B8A80F048D74BEDB8C1132 /* SubscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionService.swift; sourceTree = "<group>"; };
 		363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceCardView.swift; sourceTree = "<group>"; };
 		3C9A1F22AAE512199548C269 /* FilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarView.swift; sourceTree = "<group>"; };
+		409FB4B0922C4A1D8AAEB1D1 /* FeatureFlags.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = FeatureFlags.plist; sourceTree = "<group>"; };
 		4442EDB5CE3602DA3EA32725 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		576B08910782A58C3597E596 /* ReportIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportIssueSheet.swift; sourceTree = "<group>"; };
 		5CA0BAEC05B72704552C0906 /* PendingCheckInRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingCheckInRecord.swift; sourceTree = "<group>"; };
 		5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailViewModel.swift; sourceTree = "<group>"; };
+		6163572F4644BF852B35FDA4 /* SyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncService.swift; sourceTree = "<group>"; };
 		61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = seed_experiences.json; sourceTree = "<group>"; };
 		64BDF8B4B7CC82F3845C5068 /* ReverseGeocodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseGeocodeService.swift; sourceTree = "<group>"; };
 		6556C23BF1B228BF686C5500 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
 		67173C74F1A76C3CE5C38C0A /* OverpassService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverpassService.swift; sourceTree = "<group>"; };
 		6C5CA5533D846B39EF16CDFA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		791CBEDE09220728AD52AAAD /* UserFavoriteRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFavoriteRecord.swift; sourceTree = "<group>"; };
+		79B73212B8F704EABD27EF5B /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
+		81A92E0AE1868C3A165F3E95 /* PendingSyncRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingSyncRecord.swift; sourceTree = "<group>"; };
 		873ACB737A9B43254C17B238 /* CityPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityPickerSheet.swift; sourceTree = "<group>"; };
 		8FDFA5F3503B8ABC4B5CB086 /* SoloCompassTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SoloCompassTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9748B0A808BC06F6EDED3C3B /* RecentExploreRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentExploreRegion.swift; sourceTree = "<group>"; };
@@ -113,6 +122,7 @@
 		D4C10384834D53FE83113D51 /* Configuration.storekit */ = {isa = PBXFileReference; path = Configuration.storekit; sourceTree = "<group>"; };
 		D5B8BA7FFBD93A01E54B7E4A /* ExperienceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailView.swift; sourceTree = "<group>"; };
 		E03076AD221F78BBDE981C3A /* ExperienceRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceRecord.swift; sourceTree = "<group>"; };
+		E406C379247653B4AA5A3E0E /* SupabaseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseClient.swift; sourceTree = "<group>"; };
 		E71DE291BE5569E719413B74 /* SoloCompassApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassApp.swift; sourceTree = "<group>"; };
 		E7E69F3EF6F0100CFA47DAFE /* AISynthesisCacheRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISynthesisCacheRecord.swift; sourceTree = "<group>"; };
 		EB579F3F4EBBA014AA306DD1 /* SoloScoreBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloScoreBadge.swift; sourceTree = "<group>"; };
@@ -208,6 +218,7 @@
 				A1F76E8EBB87A2F70FEA1BB0 /* ExploreCacheRecord.swift */,
 				23043E51C493093CF7244629 /* MicroSurveyRecord.swift */,
 				5CA0BAEC05B72704552C0906 /* PendingCheckInRecord.swift */,
+				81A92E0AE1868C3A165F3E95 /* PendingSyncRecord.swift */,
 				9748B0A808BC06F6EDED3C3B /* RecentExploreRegion.swift */,
 				B3CC4BB6965F17D1B62F01A1 /* UserCompletionRecord.swift */,
 				791CBEDE09220728AD52AAAD /* UserFavoriteRecord.swift */,
@@ -239,12 +250,15 @@
 				F4814DBCEAB5975B6338558D /* AIService.swift */,
 				CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */,
 				12F087E4FA7161529378098C /* ExperienceService.swift */,
+				79B73212B8F704EABD27EF5B /* FeatureFlags.swift */,
 				6556C23BF1B228BF686C5500 /* KeychainStore.swift */,
 				2C7919EAFDE363B49C4B4C47 /* LocationService.swift */,
 				C215AE07BA32182A887226F9 /* NotificationService.swift */,
 				67173C74F1A76C3CE5C38C0A /* OverpassService.swift */,
 				64BDF8B4B7CC82F3845C5068 /* ReverseGeocodeService.swift */,
 				33B8A80F048D74BEDB8C1132 /* SubscriptionService.swift */,
+				E406C379247653B4AA5A3E0E /* SupabaseClient.swift */,
+				6163572F4644BF852B35FDA4 /* SyncService.swift */,
 				120FC7465285714C5FA8F96D /* VoiceService.swift */,
 			);
 			path = Services;
@@ -304,6 +318,7 @@
 			children = (
 				4442EDB5CE3602DA3EA32725 /* Assets.xcassets */,
 				D4C10384834D53FE83113D51 /* Configuration.storekit */,
+				409FB4B0922C4A1D8AAEB1D1 /* FeatureFlags.plist */,
 				BC185539C95D5D940693BCB7 /* Info.plist */,
 				349E26E71AF3FA04CA5CC24C /* JSON */,
 				80020844C0A45A5993333741 /* Localizable.strings */,
@@ -420,6 +435,7 @@
 			files = (
 				E0DDDA434921159DDD70F035 /* Assets.xcassets in Resources */,
 				15A48470CBEBB6D31C2201D9 /* Configuration.storekit in Resources */,
+				C735986DAC69807F27CC0E39 /* FeatureFlags.plist in Resources */,
 				BAC775E6105DD571F71ACBC1 /* Localizable.strings in Resources */,
 				D7CC906B358ED5337880A942 /* seed_experiences.json in Resources */,
 			);
@@ -458,6 +474,7 @@
 				E7B5B022519434F7C07818CF /* ExperienceService.swift in Sources */,
 				1BF34EAE036021423C1ACE2D /* ExploreCacheRecord.swift in Sources */,
 				E881A71769542A7C58CF5D10 /* FavoritesListView.swift in Sources */,
+				18D372538603D7A46EE6C86F /* FeatureFlags.swift in Sources */,
 				297541149234668D12EAF272 /* FilterBarView.swift in Sources */,
 				48DF93F42CDDB1329B038865 /* KeychainStore.swift in Sources */,
 				31F9538643C362D7EEF64C6B /* LocationService.swift in Sources */,
@@ -471,6 +488,7 @@
 				193FE8EBE03520DF740EE78D /* PaywallView.swift in Sources */,
 				AA75B3147A29FDA55E61B24A /* PendingCheckInBanner.swift in Sources */,
 				ACBA4CEE6B78AA04DBD26709 /* PendingCheckInRecord.swift in Sources */,
+				641D80BD116D6F255A9ED26A /* PendingSyncRecord.swift in Sources */,
 				9C8CC563D33FDBB3DF57A841 /* RecentExploreRegion.swift in Sources */,
 				EF2003CC07F7787C25847BDF /* ReportIssueSheet.swift in Sources */,
 				62BB74EC16B92899A9A6A44C /* ReverseGeocodeService.swift in Sources */,
@@ -479,6 +497,8 @@
 				13E5AEAEE5194DDB79AE92AC /* SoloCompassModelContainer.swift in Sources */,
 				86F4628473C2D520D4C2FFFB /* SoloScoreBadge.swift in Sources */,
 				BCD734EA6E4D5CE922D0621D /* SubscriptionService.swift in Sources */,
+				EC5A75D4BC8E0C767D06C424 /* SupabaseClient.swift in Sources */,
+				B478C92BB2249C0D5009AABD /* SyncService.swift in Sources */,
 				219718C8521B1013D17AE22F /* UserCompletionRecord.swift in Sources */,
 				D53E53A5AA9AE6F77EF82418 /* UserFavoriteRecord.swift in Sources */,
 				C2C0AF72D709EDC17C6ED874 /* UserPreferences.swift in Sources */,

--- a/apps/ios/SoloCompass/App/SoloCompassApp.swift
+++ b/apps/ios/SoloCompass/App/SoloCompassApp.swift
@@ -36,6 +36,12 @@ struct SoloCompassApp: App {
                         await subscriptionService.loadProducts()
                         await subscriptionService.refreshEntitlement()
                     }
+                    // Bootstrap anonymous Supabase session (Epic E US-028).
+                    // No-op when FF_BACKEND_SYNC is off.
+                    Task { await DeviceIdentityService.shared.bootstrap() }
+                    // Start the outbox sync timer (Epic E US-029).
+                    // Idempotent across re-renders.
+                    SyncService.shared.start()
                 }
         }
         .modelContainer(SoloCompassModelContainer.shared)

--- a/apps/ios/SoloCompass/Persistence/ExperienceRepository.swift
+++ b/apps/ios/SoloCompass/Persistence/ExperienceRepository.swift
@@ -157,6 +157,22 @@ public final class ExperienceRepository {
     public func recordCompletion(experienceId: String, at date: Date = Date()) {
         context.insert(UserCompletionRecord(experienceId: experienceId, completedAt: date))
         try? context.save()
+        // Epic E US-029: queue an upsert to user_completions. The
+        // outbox is durable; if FF_BACKEND_SYNC is off this still
+        // records the row so we can flush historical data once the
+        // flag flips on.
+        if let userId = SupabaseClient.shared.currentSession?.userId {
+            SyncService.shared.enqueue(
+                tableName: "user_completions",
+                operation: "upsert",
+                payload: SyncCompletionPayload(
+                    user_id: userId,
+                    experience_id: experienceId,
+                    completed_at: date
+                ),
+                context: context
+            )
+        }
     }
 
     public func completionCount(experienceId: String) -> Int {
@@ -183,15 +199,32 @@ public final class ExperienceRepository {
             predicate: #Predicate { $0.experienceId == id }
         )
         let existing = (try? context.fetch(descriptor)) ?? []
+        let nowFavorited: Bool
         if let row = existing.first {
             context.delete(row)
             try? context.save()
-            return false
+            nowFavorited = false
         } else {
             context.insert(UserFavoriteRecord(experienceId: experienceId, favoritedAt: date))
             try? context.save()
-            return true
+            nowFavorited = true
         }
+        // Epic E US-029: queue the favorite mutation. We send an
+        // upsert with a `removed_at` flag the server interprets as
+        // tombstone vs active, so a single table handles both states.
+        if let userId = SupabaseClient.shared.currentSession?.userId {
+            SyncService.shared.enqueue(
+                tableName: "user_favorites",
+                operation: "upsert",
+                payload: SyncFavoritePayload(
+                    user_id: userId,
+                    experience_id: experienceId,
+                    favorited_at: nowFavorited ? date : nil
+                ),
+                context: context
+            )
+        }
+        return nowFavorited
     }
 
     public func allFavorites() -> [String] {
@@ -340,4 +373,24 @@ public final class ExperienceRepository {
         let descriptor = FetchDescriptor<ExperienceRecord>()
         return (try? context.fetch(descriptor)) ?? []
     }
+}
+
+// MARK: - Sync payloads (Epic E US-029)
+
+/// Sent to Supabase `user_completions` table on every completion mutation.
+/// snake_case field names match the Postgres column names exactly so the
+/// JSON body serializes 1:1 with no remap.
+struct SyncCompletionPayload: Encodable {
+    let user_id: String
+    let experience_id: String
+    let completed_at: Date
+}
+
+/// Sent to Supabase `user_favorites`. `favorited_at` is nil when the row
+/// represents an unfavorite (the server's RLS + check constraint allow
+/// the null + we treat null as tombstone in nightly cleanup).
+struct SyncFavoritePayload: Encodable {
+    let user_id: String
+    let experience_id: String
+    let favorited_at: Date?
 }

--- a/apps/ios/SoloCompass/Persistence/Models/PendingSyncRecord.swift
+++ b/apps/ios/SoloCompass/Persistence/Models/PendingSyncRecord.swift
@@ -1,0 +1,40 @@
+import Foundation
+import SwiftData
+
+/// Outbox row for the SyncService (Epic E US-029). Every local
+/// mutation that needs to reach Supabase is enqueued as one of these;
+/// `SyncService.flush()` drains them in createdAt order.
+///
+/// `payloadJSON` is the body of the upsert (or delete query params,
+/// depending on `operation`). Storing the body verbatim means the
+/// outbox survives changes to upstream model shapes — replay just
+/// re-sends what was queued.
+@Model
+public final class PendingSyncRecord {
+    @Attribute(.unique) public var id: UUID
+    public var tableName: String
+    /// "upsert" or "delete". Service uses Supabase Prefer:
+    /// resolution=merge-duplicates for upsert idempotency.
+    public var operation: String
+    public var payloadJSON: Data
+    public var createdAt: Date
+    /// Bumped on every flush attempt so we can backoff/dead-letter
+    /// later if a row stays stuck.
+    public var retryCount: Int
+
+    public init(
+        id: UUID = UUID(),
+        tableName: String,
+        operation: String,
+        payloadJSON: Data,
+        createdAt: Date = Date(),
+        retryCount: Int = 0
+    ) {
+        self.id = id
+        self.tableName = tableName
+        self.operation = operation
+        self.payloadJSON = payloadJSON
+        self.createdAt = createdAt
+        self.retryCount = retryCount
+    }
+}

--- a/apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift
+++ b/apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift
@@ -25,6 +25,7 @@ public enum SoloCompassSchemaV1: VersionedSchema {
             DiscoveredCityRecord.self,
             RecentExploreRegion.self,
             AIUsageRecord.self,
+            PendingSyncRecord.self,
         ]
     }
 }

--- a/apps/ios/SoloCompass/Resources/FeatureFlags.plist
+++ b/apps/ios/SoloCompass/Resources/FeatureFlags.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FF_BACKEND_SYNC</key>
+    <false/>
+    <key>FF_ROUTE_AI_THROUGH_EDGE</key>
+    <false/>
+</dict>
+</plist>

--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -348,6 +348,25 @@ public final class AIService {
             return capped.map { Self.skeletonExperience(from: $0, cityCode: cityCode) }
         }
 
+        // Epic E US-031: route through Supabase Edge Function instead
+        // of direct Anthropic when the flag is on. This is the path
+        // that lets us remove ANTHROPIC_API_KEY from the iOS bundle.
+        if FeatureFlags.routeAIThroughEdge && FeatureFlags.backendSync {
+            do {
+                let experiences = try await synthesizeViaEdge(
+                    pois: capped, cityCode: cityCode, locale: locale, cacheKey: cacheKey
+                )
+                await incrementQuota(kind: .synthesis)
+                await writeCachedSynthesis(
+                    cacheKey: cacheKey, experiences: experiences, modelName: modelName
+                )
+                return experiences
+            } catch {
+                // Edge Function failed — skeleton fallback (no cache write).
+                return capped.map { Self.skeletonExperience(from: $0, cityCode: cityCode) }
+            }
+        }
+
         let prompt = Self.synthesisPrompt(pois: capped, cityCode: cityCode, locale: locale)
         do {
             let raw = try await sendMessage(prompt: prompt, kind: .synthesis)
@@ -364,6 +383,118 @@ public final class AIService {
             // transient network blip doesn't poison the cache for 30
             // days.
             return capped.map { Self.skeletonExperience(from: $0, cityCode: cityCode) }
+        }
+    }
+
+    // MARK: - Edge Function path (Epic E US-031)
+
+    private func synthesizeViaEdge(
+        pois: [OverpassService.POI],
+        cityCode: String,
+        locale: Locale,
+        cacheKey: String
+    ) async throws -> [Experience] {
+        struct EdgePOI: Encodable {
+            let osmId: Int64
+            let name: String
+            let nameEn: String?
+            let lat: Double
+            let lon: Double
+            let tags: [String: String]
+        }
+        struct EdgeRequest: Encodable {
+            let pois: [EdgePOI]
+            let cityCode: String
+            let locale: String
+            let cacheKey: String
+        }
+        let body = EdgeRequest(
+            pois: pois.map { EdgePOI(osmId: $0.osmId, name: $0.name, nameEn: $0.nameEn,
+                                     lat: $0.lat, lon: $0.lon, tags: $0.tags) },
+            cityCode: cityCode,
+            locale: locale.identifier,
+            cacheKey: cacheKey
+        )
+        let bodyData = try JSONEncoder().encode(body)
+        let result = await SupabaseClient.shared.invoke(function: "synthesize-experiences", body: bodyData)
+        switch result {
+        case .success(let data):
+            // Edge response shape: {"experiences": [item, ...], "cached": bool}
+            struct EdgeResponse: Decodable {
+                let experiences: [EdgeItem]
+                let cached: Bool?
+            }
+            struct EdgeItem: Decodable {
+                let osmId: Int64
+                let title: String
+                let oneLiner: String
+                let whyItMatters: String
+                let category: String
+                let bestStartHour: Int?
+                let bestEndHour: Int?
+                let durationMinMinutes: Int?
+                let durationMaxMinutes: Int?
+                let howTo: [String]?
+                let soloHint: String?
+                let soloOverall: Double?
+            }
+            let decoded = try JSONDecoder().decode(EdgeResponse.self, from: data)
+            let poiById = Dictionary(uniqueKeysWithValues: pois.map { ($0.osmId, $0) })
+            let now = Date()
+            return decoded.experiences.compactMap { item -> Experience? in
+                guard let poi = poiById[item.osmId] else { return nil }
+                let category = ExperienceCategory(rawValue: item.category) ?? OverpassService.category(for: poi.tags)
+                let startHour = item.bestStartHour.map { max(0, min(23, $0)) } ?? 9
+                let endHour = item.bestEndHour.map { max(0, min(23, $0)) } ?? 21
+                let dMin = item.durationMinMinutes ?? 30
+                let dMax = max(dMin, item.durationMaxMinutes ?? 90)
+                let overall = max(6.0, min(9.5, item.soloOverall ?? 7.0))
+                let breakdown = SoloScore.Breakdown(
+                    seatingFriendly: overall, soloPatronRatio: overall, staffPressure: overall,
+                    soloPortioning: overall, ambianceFit: overall, safety: overall
+                )
+                let howTo = (item.howTo ?? []).enumerated().map { HowToStep(order: $0.offset + 1, text: $0.element) }
+                return Experience(
+                    id: "exp_osm_\(poi.osmId)",
+                    title: item.title,
+                    oneLiner: item.oneLiner,
+                    whyItMatters: item.whyItMatters,
+                    category: category,
+                    location: ExperienceLocation(
+                        coordinates: [poi.lon, poi.lat],
+                        cityCode: cityCode,
+                        addressHint: nil,
+                        placeNameLocal: poi.name,
+                        placeNameRomanized: poi.nameEn
+                    ),
+                    bestTimes: [TimeWindow(startHour: startHour, endHour: endHour)],
+                    durationMinutes: .init(min: dMin, max: dMax),
+                    howTo: howTo,
+                    realInconveniences: [],
+                    soloScore: SoloScore(overall: overall, breakdown: breakdown, hint: item.soloHint, basedOnCount: 0),
+                    sources: [
+                        InformationSource(
+                            type: .user,
+                            url: URL(string: "https://www.openstreetmap.org/node/\(poi.osmId)"),
+                            attribution: "© OpenStreetMap contributors + AI",
+                            verifiedAt: now
+                        )
+                    ],
+                    confidence: Confidence(
+                        level: 1,
+                        lastVerifiedAt: now,
+                        reason: "AI-synthesized via Edge Function, unverified",
+                        signals: .init(aiScrapeAgeDays: 0, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)
+                    ),
+                    nearbyExperienceIds: [],
+                    stats: .init(completionCount: 0, averageRating: 0),
+                    status: .candidate,
+                    createdAt: now,
+                    updatedAt: now
+                )
+            }
+        case .failure(let err):
+            throw err
         }
     }
 

--- a/apps/ios/SoloCompass/Services/DeviceIdentityService.swift
+++ b/apps/ios/SoloCompass/Services/DeviceIdentityService.swift
@@ -24,6 +24,20 @@ public final class DeviceIdentityService {
         return new
     }
 
+    /// Bootstrap the device identity + Supabase anonymous session
+    /// (Epic E US-028). Called from `SoloCompassApp.onAppear`. When
+    /// `FF_BACKEND_SYNC` is off this is a fast no-op (the
+    /// SupabaseClient short-circuits to `.failure(.backendDisabled)`).
+    /// When on, idempotent: re-runs return the existing session if
+    /// not yet expired.
+    public func bootstrap() async {
+        // Touch deviceID so the keychain row is created on first launch.
+        _ = self.deviceID
+        // Best-effort: anonymous Supabase sign-in. We never block the
+        // UI on this — the local-first app must work without a session.
+        _ = await SupabaseClient.shared.signInAnonymously()
+    }
+
     // MARK: - Keychain
 
     private func readFromKeychain() -> String? {

--- a/apps/ios/SoloCompass/Services/FeatureFlags.swift
+++ b/apps/ios/SoloCompass/Services/FeatureFlags.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Build-time feature flags for staging Epic E rollout.
+///
+/// Flags are read from `Resources/FeatureFlags.plist`; missing keys
+/// fall back to the defaults defined here. Override per-build by
+/// editing the plist or setting the matching env var prefixed `FF_`.
+public enum FeatureFlags {
+    /// Master switch for all Supabase-backed code paths (auth, sync,
+    /// Edge Functions). When false, every backend call is a no-op
+    /// returning empty / .success — the app must remain fully usable
+    /// (PRD G7 local-first invariant).
+    ///
+    /// Default: false in beta.1, will flip to true in beta.3.
+    public static var backendSync: Bool {
+        readBool("FF_BACKEND_SYNC", default: false)
+    }
+
+    /// When true, AIService.synthesizeExperiences calls the Supabase
+    /// Edge Function instead of Anthropic directly. Requires
+    /// backendSync to also be true. Off in beta.1 so QA can still
+    /// hit Anthropic via the local key for prompt-tuning.
+    public static var routeAIThroughEdge: Bool {
+        readBool("FF_ROUTE_AI_THROUGH_EDGE", default: false)
+    }
+
+    // MARK: - Internals
+
+    static func readBool(_ key: String, default fallback: Bool) -> Bool {
+        if let env = ProcessInfo.processInfo.environment[key] {
+            return env == "1" || env.lowercased() == "true"
+        }
+        guard let url = Bundle.main.url(forResource: "FeatureFlags", withExtension: "plist"),
+              let data = try? Data(contentsOf: url),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        else { return fallback }
+        return (plist[key] as? Bool) ?? fallback
+    }
+}

--- a/apps/ios/SoloCompass/Services/SubscriptionService.swift
+++ b/apps/ios/SoloCompass/Services/SubscriptionService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import StoreKit
 import Observation
+import SwiftData
 
 /// StoreKit 2 wrapper. The single source of truth for "is this user
 /// Pro?" is `Transaction.currentEntitlements`. Everything else
@@ -91,9 +92,11 @@ public final class SubscriptionService {
     /// entitlement. Updates `entitlement` and writes through to Keychain.
     public func refreshEntitlement() async {
         var resolved: Entitlement = .free
+        var latestTransaction: Transaction?
         for await result in Transaction.currentEntitlements {
             guard case .verified(let txn) = result else { continue }
             guard Self.allProductIDs.contains(txn.productID) else { continue }
+            latestTransaction = txn
             // If revoked or refunded, skip — never count as Pro.
             if txn.revocationDate != nil { continue }
             // Expired transactions count as proExpired only if we don't
@@ -123,7 +126,14 @@ public final class SubscriptionService {
                 }
             }
         }
+        let prior = entitlement
         setEntitlement(resolved)
+        // Epic E US-032: emit a subscription_events row when the
+        // resolved entitlement changes. Routed through the SyncService
+        // outbox so it survives offline boots; FF-off path is a no-op.
+        if prior != resolved, let txn = latestTransaction {
+            emitSubscriptionEvent(prior: prior, current: resolved, transaction: txn)
+        }
     }
 
     /// Initiate a purchase. Returns true on successful verification +
@@ -190,4 +200,55 @@ public final class SubscriptionService {
     public func _setEntitlementForTesting(_ value: Entitlement) {
         setEntitlement(value)
     }
+
+    // MARK: - Subscription event emission (Epic E US-032)
+
+    private func emitSubscriptionEvent(
+        prior: Entitlement,
+        current: Entitlement,
+        transaction: Transaction
+    ) {
+        let eventType: String
+        switch (prior, current) {
+        case (.free, .proTrial), (.free, .pro), (.proExpired, .proTrial), (.proExpired, .pro):
+            eventType = "subscribed"
+        case (.pro, .proExpired), (.proTrial, .proExpired):
+            eventType = "expired"
+        default:
+            eventType = "upgraded"
+        }
+        let payload = SubscriptionEventPayload(
+            user_id: SupabaseClient.shared.currentSession?.userId,
+            event_type: eventType,
+            product_id: transaction.productID,
+            original_purchase_date: transaction.originalPurchaseDate,
+            expires_date: transaction.expirationDate,
+            is_in_trial_period: current == .proTrial,
+            device_id: DeviceIdentityService.shared.deviceID
+        )
+        // No PII (no email, no Apple ID). user_id is anonymous Supabase
+        // UUID; device_id is the random per-device anon UUID.
+        let context = ModelContext(SoloCompassModelContainer.shared)
+        SyncService.shared.enqueue(
+            tableName: "subscription_events",
+            operation: "upsert",
+            payload: payload,
+            context: context
+        )
+        #if DEBUG
+        print("[SubscriptionService] emitted \(eventType) for \(transaction.productID)")
+        #endif
+    }
+}
+
+/// Wire payload for subscription_events. snake_case so PostgREST maps
+/// directly to the column names.
+struct SubscriptionEventPayload: Encodable {
+    let user_id: String?
+    let event_type: String
+    let product_id: String
+    let original_purchase_date: Date?
+    let expires_date: Date?
+    let is_in_trial_period: Bool
+    let device_id: String
 }

--- a/apps/ios/SoloCompass/Services/SupabaseClient.swift
+++ b/apps/ios/SoloCompass/Services/SupabaseClient.swift
@@ -1,0 +1,214 @@
+import Foundation
+
+/// Minimal Supabase REST client using URLSession — no third-party SDK.
+///
+/// This keeps the iOS bundle dep-free (project rule: zero deps where
+/// reasonable) and lets us ship the same API surface no matter which
+/// version of supabase-swift is current. The trade-off: realtime
+/// subscriptions and storage are not wrapped here. We don't need them
+/// for v1.1 (sync is poll-based, not realtime).
+///
+/// All methods are gated by `FeatureFlags.backendSync`. When the flag
+/// is off (default in beta.1), every method short-circuits to a
+/// "do nothing" path that returns the empty / success equivalent. This
+/// preserves PRD G7 (local-first invariant): the app stays fully
+/// usable when the backend is unreachable.
+@MainActor
+public final class SupabaseClient {
+    public static let shared = SupabaseClient()
+
+    public enum SupabaseError: Error, LocalizedError, Sendable {
+        case missingConfig
+        case requestFailed(status: Int, body: String)
+        case decoding(String)
+        case notSignedIn
+        case backendDisabled
+
+        public var errorDescription: String? {
+            switch self {
+            case .missingConfig:        return "Supabase URL/key missing"
+            case .requestFailed(let s, let b): return "Supabase HTTP \(s): \(b)"
+            case .decoding(let m):      return "Supabase decode failed: \(m)"
+            case .notSignedIn:          return "No active Supabase session"
+            case .backendDisabled:      return "Backend sync feature flag is off"
+            }
+        }
+    }
+
+    public struct Session: Codable, Sendable {
+        public let userId: String
+        public let accessToken: String
+        public let refreshToken: String
+        public let expiresAt: Date
+
+        public var isExpired: Bool { expiresAt <= Date() }
+    }
+
+    /// Read the active session from Keychain. May return nil if the
+    /// user has never signed in or the session was cleared.
+    public var currentSession: Session? {
+        guard let blob = KeychainStore.read(account: Self.sessionKey),
+              let data = blob.data(using: .utf8),
+              let s = try? JSONDecoder.iso8601Decoder.decode(Session.self, from: data)
+        else { return nil }
+        return s
+    }
+
+    private static let sessionKey = "sc.supabase.session"
+
+    private let urlSession: URLSession
+    public init(urlSession: URLSession = .shared) {
+        self.urlSession = urlSession
+    }
+
+    // MARK: - Config
+
+    private struct Config {
+        let url: URL
+        let anonKey: String
+    }
+
+    private static func loadConfig() -> Config? {
+        let envURL = ProcessInfo.processInfo.environment["SUPABASE_URL"]
+        let envKey = ProcessInfo.processInfo.environment["SUPABASE_ANON_KEY"]
+            ?? ProcessInfo.processInfo.environment["SUPABASE_KEY"]
+        let urlString = envURL ?? readSecretsString("SUPABASE_URL")
+        let key = envKey ?? readSecretsString("SUPABASE_ANON_KEY") ?? readSecretsString("SUPABASE_KEY")
+        guard let urlString, let url = URL(string: urlString), let key, !key.isEmpty else {
+            return nil
+        }
+        return Config(url: url, anonKey: key)
+    }
+
+    private static func readSecretsString(_ key: String) -> String? {
+        guard let url = Bundle.main.url(forResource: "Secrets", withExtension: "plist"),
+              let data = try? Data(contentsOf: url),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        else { return nil }
+        return plist[key] as? String
+    }
+
+    // MARK: - Auth
+
+    /// Anonymous sign-in. Persists the session to Keychain; subsequent
+    /// `currentSession` reads return it. Returns `.failure(.backendDisabled)`
+    /// when `FF_BACKEND_SYNC` is off — callers should treat that as a
+    /// no-op, not a real error.
+    @discardableResult
+    public func signInAnonymously() async -> Result<Session, SupabaseError> {
+        guard FeatureFlags.backendSync else {
+            return .failure(.backendDisabled)
+        }
+        if let s = currentSession, !s.isExpired {
+            return .success(s)
+        }
+        guard let cfg = Self.loadConfig() else { return .failure(.missingConfig) }
+
+        var req = URLRequest(url: cfg.url.appendingPathComponent("/auth/v1/signup"))
+        req.httpMethod = "POST"
+        req.setValue(cfg.anonKey, forHTTPHeaderField: "apikey")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        // Supabase anonymous signup: empty body + apikey is enough.
+        req.httpBody = "{}".data(using: .utf8)
+
+        do {
+            let (data, response) = try await urlSession.data(for: req)
+            guard let http = response as? HTTPURLResponse else {
+                return .failure(.requestFailed(status: 0, body: ""))
+            }
+            guard (200..<300).contains(http.statusCode) else {
+                return .failure(.requestFailed(status: http.statusCode,
+                                               body: String(data: data, encoding: .utf8) ?? ""))
+            }
+            struct AuthResponse: Decodable {
+                let access_token: String
+                let refresh_token: String
+                let expires_in: Int
+                let user: AuthUser
+            }
+            struct AuthUser: Decodable { let id: String }
+            let resp = try JSONDecoder().decode(AuthResponse.self, from: data)
+            let s = Session(
+                userId: resp.user.id,
+                accessToken: resp.access_token,
+                refreshToken: resp.refresh_token,
+                expiresAt: Date().addingTimeInterval(TimeInterval(resp.expires_in))
+            )
+            persist(s)
+            return .success(s)
+        } catch {
+            return .failure(.requestFailed(status: 0, body: error.localizedDescription))
+        }
+    }
+
+    /// Clear the local session. Does not invalidate it server-side
+    /// (Supabase anonymous sessions don't have a sign-out endpoint
+    /// per se; we just discard the token).
+    public func signOut() {
+        _ = KeychainStore.delete(account: Self.sessionKey)
+    }
+
+    // MARK: - REST helpers (used by SyncService US-029)
+
+    /// Generic POST to a PostgREST table. Returns response body bytes
+    /// on success. Returns `.success(empty Data)` when FF_BACKEND_SYNC
+    /// is off so callers can treat sync as best-effort fire-and-forget.
+    public func post(table: String, body: Data) async -> Result<Data, SupabaseError> {
+        guard FeatureFlags.backendSync else { return .success(Data()) }
+        guard let cfg = Self.loadConfig() else { return .failure(.missingConfig) }
+        guard let token = currentSession?.accessToken else { return .failure(.notSignedIn) }
+
+        var req = URLRequest(url: cfg.url.appendingPathComponent("/rest/v1/\(table)"))
+        req.httpMethod = "POST"
+        req.setValue(cfg.anonKey, forHTTPHeaderField: "apikey")
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        // Prefer: resolution=merge-duplicates so upsert semantics match
+        // SyncService's outbox idempotency.
+        req.setValue("resolution=merge-duplicates", forHTTPHeaderField: "Prefer")
+        req.httpBody = body
+
+        return await sendREST(req)
+    }
+
+    /// Invoke a Supabase Edge Function with the user's bearer token.
+    /// Returns `.success(empty Data)` when FF_BACKEND_SYNC is off.
+    public func invoke(function: String, body: Data) async -> Result<Data, SupabaseError> {
+        guard FeatureFlags.backendSync else { return .success(Data()) }
+        guard let cfg = Self.loadConfig() else { return .failure(.missingConfig) }
+        guard let token = currentSession?.accessToken else { return .failure(.notSignedIn) }
+
+        var req = URLRequest(url: cfg.url.appendingPathComponent("/functions/v1/\(function)"))
+        req.httpMethod = "POST"
+        req.setValue(cfg.anonKey, forHTTPHeaderField: "apikey")
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = body
+
+        return await sendREST(req)
+    }
+
+    // MARK: - Internals
+
+    private func sendREST(_ request: URLRequest) async -> Result<Data, SupabaseError> {
+        do {
+            let (data, response) = try await urlSession.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                return .failure(.requestFailed(status: 0, body: ""))
+            }
+            guard (200..<300).contains(http.statusCode) else {
+                return .failure(.requestFailed(status: http.statusCode,
+                                               body: String(data: data, encoding: .utf8) ?? ""))
+            }
+            return .success(data)
+        } catch {
+            return .failure(.requestFailed(status: 0, body: error.localizedDescription))
+        }
+    }
+
+    private func persist(_ s: Session) {
+        guard let data = try? JSONEncoder.iso8601Encoder.encode(s),
+              let str = String(data: data, encoding: .utf8) else { return }
+        _ = KeychainStore.write(account: Self.sessionKey, value: str)
+    }
+}

--- a/apps/ios/SoloCompass/Services/SyncService.swift
+++ b/apps/ios/SoloCompass/Services/SyncService.swift
@@ -1,0 +1,132 @@
+import Foundation
+import SwiftData
+import Observation
+import UIKit
+
+/// Outbox sync (Epic E US-029). Local mutations enqueue
+/// `PendingSyncRecord` rows; this service drains them to Supabase
+/// every 30 seconds while in foreground and on willEnterForeground.
+///
+/// Design choices:
+/// - The outbox is the single source of truth for "what needs to
+///   reach the server." Direct sync calls aren't allowed; everything
+///   goes through `enqueue(...)`. This makes the sync layer fully
+///   resumable across app kills.
+/// - When `FF_BACKEND_SYNC` is off, `enqueue` still records rows
+///   (cheap; lets us flip the flag on later without losing pre-flag
+///   activity) but `flush` is a no-op.
+/// - Failures bump retryCount; we never throw out a row from the
+///   outbox in v1.0 (dead-letter handling is post-launch).
+@MainActor
+@Observable
+public final class SyncService {
+    public static let shared = SyncService()
+
+    public private(set) var isFlushing: Bool = false
+    public private(set) var lastFlushAt: Date?
+    public private(set) var pendingCount: Int = 0
+
+    nonisolated(unsafe) private var foregroundTimer: Timer?
+    nonisolated(unsafe) private var foregroundObserver: NSObjectProtocol?
+
+    private init() {}
+
+    deinit {
+        foregroundTimer?.invalidate()
+        if let observer = foregroundObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    /// Wire up the 30-second timer + foreground observer. Idempotent.
+    /// Called once from `SoloCompassApp.onAppear`.
+    public func start() {
+        guard foregroundTimer == nil else { return }
+        foregroundTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { _ in
+            Task { @MainActor [weak self] in await self?.flush() }
+        }
+        foregroundObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil, queue: .main
+        ) { _ in
+            Task { @MainActor [weak self] in await self?.flush() }
+        }
+    }
+
+    // MARK: - Enqueue
+
+    /// Enqueue a payload for `tableName`. Caller is responsible for
+    /// constructing a body the PostgREST endpoint understands. The
+    /// payload is stored verbatim (no re-serialization on flush).
+    public func enqueue(
+        tableName: String,
+        operation: String,
+        payload: any Encodable,
+        context: ModelContext
+    ) {
+        guard let data = try? JSONEncoder.iso8601Encoder.encode(AnyEncodable(payload)) else {
+            return
+        }
+        context.insert(
+            PendingSyncRecord(tableName: tableName, operation: operation, payloadJSON: data)
+        )
+        try? context.save()
+        refreshCount(context: context)
+    }
+
+    // MARK: - Flush
+
+    /// Drain the outbox. Returns the number of rows successfully
+    /// sent + deleted. No-op when `FF_BACKEND_SYNC` is off.
+    @discardableResult
+    public func flush(context override: ModelContext? = nil) async -> Int {
+        guard FeatureFlags.backendSync else { return 0 }
+        guard !isFlushing else { return 0 }
+        isFlushing = true
+        defer { isFlushing = false; lastFlushAt = Date() }
+
+        let context = override ?? ModelContext(SoloCompassModelContainer.shared)
+        let descriptor = FetchDescriptor<PendingSyncRecord>(
+            sortBy: [SortDescriptor(\.createdAt, order: .forward)]
+        )
+        guard let rows = try? context.fetch(descriptor), !rows.isEmpty else {
+            refreshCount(context: context)
+            return 0
+        }
+
+        var sent = 0
+        for row in rows {
+            let result: Result<Data, SupabaseClient.SupabaseError>
+            switch row.operation {
+            case "upsert":
+                result = await SupabaseClient.shared.post(table: row.tableName, body: row.payloadJSON)
+            default:
+                row.retryCount += 1
+                continue
+            }
+            switch result {
+            case .success:
+                context.delete(row)
+                sent += 1
+            case .failure:
+                row.retryCount += 1
+            }
+        }
+        try? context.save()
+        refreshCount(context: context)
+        return sent
+    }
+
+    private func refreshCount(context: ModelContext) {
+        let count = (try? context.fetchCount(FetchDescriptor<PendingSyncRecord>())) ?? 0
+        self.pendingCount = count
+    }
+}
+
+// MARK: - AnyEncodable wrapper for heterogeneous payloads
+
+private struct AnyEncodable: Encodable {
+    let value: any Encodable
+    init(_ value: any Encodable) { self.value = value }
+    func encode(to encoder: Encoder) throws { try value.encode(to: encoder) }
+}

--- a/infra/supabase/README.md
+++ b/infra/supabase/README.md
@@ -1,0 +1,89 @@
+# Supabase infrastructure
+
+> Source of truth for the Solo Compass backend schema. Apply migrations
+> to a fresh project via the Supabase CLI; each migration is forward-only.
+
+## Required env
+
+Copy from `.env.example` at the repo root and fill in real values:
+
+```
+SUPABASE_URL=https://xxxxx.supabase.co
+SUPABASE_ANON_KEY=eyJ...           # public, ships with iOS / web bundles
+SUPABASE_SERVICE_ROLE_KEY=eyJ...   # server-only, NEVER ships to clients
+ANTHROPIC_API_KEY=sk-ant-...       # used only by Edge Functions (Epic E US-030)
+```
+
+The anon key is what iOS sends as the `apikey` header. The service role
+key bypasses RLS and is used by Edge Functions only — never by the
+client.
+
+## Apply migrations
+
+Once the founder has provisioned the production project (PRD US-I2):
+
+```bash
+brew install supabase/tap/supabase
+supabase login
+supabase link --project-ref <project-ref>
+
+cd infra/supabase
+supabase db push
+```
+
+For a fresh remote project, `0001_init.sql` runs first and creates every
+table and RLS policy.
+
+## Schema overview
+
+Three groups of tables:
+
+1. **User-scoped data** (RLS = `auth.uid() = user_id`):
+   - `profiles` — entitlement tier, anonymous flag
+   - `user_completions` — append-only per visit
+   - `user_favorites` — toggle (composite PK)
+   - `micro_surveys` — 1–5 ratings + recommend
+   - `subscription_events` — StoreKit lifecycle telemetry
+   - `recent_explore_regions` — last N explored regions for offline mode
+
+2. **Shared community cache** (read-public, write-service-role):
+   - `osm_pois` — canonical OSM POI metadata
+   - `synthesized_experiences` — AI-enriched Experience JSON, dedupable
+     by `source_cache_key`. Stores `aggregated_solo_score` (refreshed
+     nightly) so all users benefit from one paying user's exploration.
+   - `solo_score_signals` — raw signal rows; aggregated nightly into
+     `synthesized_experiences.aggregated_solo_score`. RLS lets users
+     read their own only (privacy).
+
+3. **Internal accounting** (service-role only writes):
+   - `sc_function_calls` — Edge Function rate-limit accounting
+
+## RLS smoke test
+
+After applying migrations:
+
+```bash
+cd infra/supabase
+deno run --allow-net --allow-env test_rls.ts
+```
+
+The test connects with both anon and service-role keys, creates two
+synthetic users, then asserts:
+
+- anon CANNOT read `user_completions` belonging to either user
+- user A authenticated CANNOT read user B's `user_completions`
+- anon CAN read `synthesized_experiences` (public-read)
+- service-role CAN write to `synthesized_experiences` (write boundary)
+
+A non-zero exit means the RLS posture has regressed; do not deploy.
+
+## Edge Functions
+
+Live in `infra/supabase/functions/<name>/index.ts`. Deploy with:
+
+```bash
+supabase functions deploy <name>
+supabase secrets set ANTHROPIC_API_KEY=sk-ant-...
+```
+
+See each function's local README for specifics.

--- a/infra/supabase/functions/synthesize-experiences/README.md
+++ b/infra/supabase/functions/synthesize-experiences/README.md
@@ -1,0 +1,52 @@
+# synthesize-experiences
+
+Server-side AI synthesis. Removes the Anthropic API key from the iOS bundle (PRD US-030 / FR-19).
+
+## Deploy
+
+```bash
+supabase functions deploy synthesize-experiences
+
+supabase secrets set ANTHROPIC_API_KEY=sk-ant-...
+# SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are auto-injected.
+```
+
+## Test
+
+```bash
+JWT=<paste a real Supabase user access token from the iOS app>
+PROJECT=<your-project-ref>
+
+cd infra/supabase/functions/synthesize-experiences
+JWT="$JWT" PROJECT="$PROJECT" ./test.sh
+```
+
+Expected response on cache hit / miss:
+
+```json
+{
+  "experiences": [...],
+  "cached": true
+}
+```
+
+Quota / entitlement errors:
+
+| Status | Meaning |
+|---|---|
+| 401 | Bearer token missing / invalid |
+| 402 | Caller's profiles.entitlement_tier is `free` or `pro_expired` |
+| 429 | Caller has used today's 30-call quota |
+| 502 | Anthropic upstream failure or invalid JSON |
+
+## Environment
+
+- `ANTHROPIC_API_KEY` — required, set via `supabase secrets set`
+- `SUPABASE_URL` — auto-injected at runtime
+- `SUPABASE_SERVICE_ROLE_KEY` — auto-injected; used to read profiles + write synthesized_experiences (bypasses RLS)
+
+## Cost guardrails
+
+- Daily quota 30 / Pro user, enforced via `sc_function_calls`
+- Cache hits do NOT increment the quota counter
+- Anthropic Console hard cap $200/month is the final safety net

--- a/infra/supabase/functions/synthesize-experiences/README.md
+++ b/infra/supabase/functions/synthesize-experiences/README.md
@@ -32,12 +32,12 @@ Expected response on cache hit / miss:
 
 Quota / entitlement errors:
 
-| Status | Meaning |
-|---|---|
-| 401 | Bearer token missing / invalid |
-| 402 | Caller's profiles.entitlement_tier is `free` or `pro_expired` |
-| 429 | Caller has used today's 30-call quota |
-| 502 | Anthropic upstream failure or invalid JSON |
+| Status | Meaning                                                       |
+| ------ | ------------------------------------------------------------- |
+| 401    | Bearer token missing / invalid                                |
+| 402    | Caller's profiles.entitlement_tier is `free` or `pro_expired` |
+| 429    | Caller has used today's 30-call quota                         |
+| 502    | Anthropic upstream failure or invalid JSON                    |
 
 ## Environment
 

--- a/infra/supabase/functions/synthesize-experiences/index.ts
+++ b/infra/supabase/functions/synthesize-experiences/index.ts
@@ -1,0 +1,204 @@
+// Edge Function: synthesize-experiences
+// Epic E US-030 — server-side AI synthesis so the iOS bundle never
+// contains an Anthropic API key.
+//
+// Flow:
+//   1. Verify Supabase JWT from Authorization header.
+//   2. Look up profiles.entitlement_tier; free tier rejected with 402.
+//   3. Rate-limit: count today's calls in sc_function_calls; cap at 30.
+//   4. Read SHA256 cache key from body; if synthesized_experiences row
+//      exists, return it without calling Anthropic.
+//   5. Call Anthropic Sonnet 4.6 with the prompt + POI batch.
+//   6. Validate response shape, write to synthesized_experiences,
+//      return to client.
+//
+// Deploy: `supabase functions deploy synthesize-experiences`
+// Required secrets: ANTHROPIC_API_KEY, SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
+const MODEL = "claude-sonnet-4-6";
+const DAILY_QUOTA_PRO = 30;
+
+interface POI {
+  osmId: number;
+  name: string;
+  nameEn?: string | null;
+  lat: number;
+  lon: number;
+  tags: Record<string, string>;
+}
+
+interface RequestBody {
+  pois: POI[];
+  cityCode: string;
+  locale: string;
+  cacheKey: string;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  // 1. Auth: extract user_id from JWT in Authorization header.
+  const authHeader = req.headers.get("Authorization") ?? "";
+  const jwt = authHeader.replace(/^Bearer /i, "");
+  if (!jwt) return json({ error: "missing bearer token" }, 401);
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const anthropicKey = Deno.env.get("ANTHROPIC_API_KEY");
+  if (!anthropicKey) return json({ error: "server misconfigured" }, 500);
+
+  const admin = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false },
+  });
+
+  // Verify JWT and extract user_id.
+  const { data: userData, error: userErr } = await admin.auth.getUser(jwt);
+  if (userErr || !userData.user) return json({ error: "invalid jwt" }, 401);
+  const userId = userData.user.id;
+
+  // 2. Entitlement check.
+  const { data: profile } = await admin
+    .from("profiles")
+    .select("entitlement_tier")
+    .eq("user_id", userId)
+    .maybeSingle();
+  const tier = profile?.entitlement_tier ?? "free";
+  if (tier === "free" || tier === "pro_expired") {
+    return json({ error: "subscription required" }, 402);
+  }
+
+  // 3. Rate-limit: today's call count.
+  const dayStart = new Date();
+  dayStart.setUTCHours(0, 0, 0, 0);
+  const { count } = await admin
+    .from("sc_function_calls")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", userId)
+    .eq("function_name", "synthesize-experiences")
+    .gte("called_at", dayStart.toISOString());
+  if ((count ?? 0) >= DAILY_QUOTA_PRO) {
+    return json({ error: "daily quota exceeded", quota: DAILY_QUOTA_PRO }, 429);
+  }
+
+  // 4. Parse + cache check.
+  let body: RequestBody;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "invalid json" }, 400);
+  }
+  if (!body.cacheKey || !Array.isArray(body.pois) || body.pois.length === 0) {
+    return json({ error: "cacheKey + non-empty pois required" }, 400);
+  }
+  if (body.pois.length > 15) {
+    return json({ error: "max 15 POIs per call" }, 400);
+  }
+
+  const { data: cached } = await admin
+    .from("synthesized_experiences")
+    .select("payload")
+    .eq("source_cache_key", body.cacheKey)
+    .limit(1)
+    .maybeSingle();
+  if (cached?.payload) {
+    return json({ experiences: cached.payload, cached: true });
+  }
+
+  // 5. Call Anthropic.
+  const prompt = buildPrompt(body);
+  const anthropicReq = await fetch(ANTHROPIC_URL, {
+    method: "POST",
+    headers: {
+      "x-api-key": anthropicKey,
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: 2048,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+  if (!anthropicReq.ok) {
+    const text = await anthropicReq.text();
+    return json(
+      { error: `anthropic error ${anthropicReq.status}: ${text}` },
+      502,
+    );
+  }
+  const anthropicJson = await anthropicReq.json();
+  const text: string = anthropicJson?.content?.[0]?.text ?? "";
+
+  // 6. Validate response shape.
+  const start = text.indexOf("[");
+  const end = text.lastIndexOf("]");
+  if (start === -1 || end === -1) {
+    return json({ error: "anthropic returned no JSON array" }, 502);
+  }
+  let items: unknown;
+  try {
+    items = JSON.parse(text.substring(start, end + 1));
+  } catch {
+    return json({ error: "anthropic returned invalid JSON" }, 502);
+  }
+  if (!Array.isArray(items)) {
+    return json({ error: "anthropic returned non-array" }, 502);
+  }
+  for (const item of items as Record<string, unknown>[]) {
+    if (
+      typeof item.osmId !== "number" ||
+      typeof item.title !== "string" ||
+      typeof item.oneLiner !== "string" ||
+      typeof item.whyItMatters !== "string" ||
+      typeof item.category !== "string"
+    ) {
+      return json({ error: "anthropic item missing required fields" }, 502);
+    }
+  }
+
+  // Write to cache and accounting tables.
+  await admin.from("synthesized_experiences").upsert({
+    id: `exp_osm_${(items as Record<string, unknown>[])[0].osmId}`,
+    city_code: body.cityCode,
+    payload: items,
+    model_name: MODEL,
+    source_cache_key: body.cacheKey,
+  });
+  await admin.from("sc_function_calls").insert({
+    user_id: userId,
+    function_name: "synthesize-experiences",
+  });
+
+  return json({ experiences: items, cached: false });
+});
+
+function buildPrompt(body: RequestBody): string {
+  const lines = body.pois.map((p) =>
+    `- osmId=${p.osmId} name="${p.name}" nameEn="${p.nameEn ?? p.name}" lat=${p.lat} lon=${p.lon} tags=${JSON.stringify(p.tags)}`
+  ).join("\n");
+  return `You are writing solo-traveler-focused entries for real OpenStreetMap places.
+
+CRITICAL: Use ONLY the provided OSM tags. Do NOT invent menu items, hours, prices, owner backstories, or seating positions.
+
+For each POI, return a JSON object with: osmId(int), title, oneLiner, whyItMatters, category(food|coffee|culture|nature|work|wellness|nightlife|hidden), bestStartHour(0-23), bestEndHour(0-23), durationMinMinutes(int), durationMaxMinutes(int), howTo(string[] navigation only), soloHint, soloOverall(6.0-9.5).
+
+Output a JSON array, one object per POI, in input order. No prose, no markdown fences.
+
+Output language: ${body.locale}.
+City code: ${body.cityCode}.
+
+POIs:
+${lines}`;
+}
+
+function json(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/infra/supabase/functions/synthesize-experiences/index.ts
+++ b/infra/supabase/functions/synthesize-experiences/index.ts
@@ -126,10 +126,7 @@ Deno.serve(async (req: Request) => {
   });
   if (!anthropicReq.ok) {
     const text = await anthropicReq.text();
-    return json(
-      { error: `anthropic error ${anthropicReq.status}: ${text}` },
-      502,
-    );
+    return json({ error: `anthropic error ${anthropicReq.status}: ${text}` }, 502);
   }
   const anthropicJson = await anthropicReq.json();
   const text: string = anthropicJson?.content?.[0]?.text ?? "";
@@ -178,9 +175,12 @@ Deno.serve(async (req: Request) => {
 });
 
 function buildPrompt(body: RequestBody): string {
-  const lines = body.pois.map((p) =>
-    `- osmId=${p.osmId} name="${p.name}" nameEn="${p.nameEn ?? p.name}" lat=${p.lat} lon=${p.lon} tags=${JSON.stringify(p.tags)}`
-  ).join("\n");
+  const lines = body.pois
+    .map(
+      (p) =>
+        `- osmId=${p.osmId} name="${p.name}" nameEn="${p.nameEn ?? p.name}" lat=${p.lat} lon=${p.lon} tags=${JSON.stringify(p.tags)}`,
+    )
+    .join("\n");
   return `You are writing solo-traveler-focused entries for real OpenStreetMap places.
 
 CRITICAL: Use ONLY the provided OSM tags. Do NOT invent menu items, hours, prices, owner backstories, or seating positions.

--- a/infra/supabase/functions/synthesize-experiences/test.sh
+++ b/infra/supabase/functions/synthesize-experiences/test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Curl-based integration smoke test. Requires JWT (Supabase user
+# access token) and PROJECT (project ref) in env.
+
+set -euo pipefail
+
+: "${JWT:?Set JWT to a valid Supabase user access token}"
+: "${PROJECT:?Set PROJECT to your Supabase project ref}"
+
+URL="https://${PROJECT}.functions.supabase.co/synthesize-experiences"
+
+# A two-POI sample request. cacheKey would normally be the SHA256 of
+# the canonical input batch from iOS; here it's a synthetic value so
+# we can verify the cache hit path on a second invocation.
+BODY=$(cat <<'JSON'
+{
+  "pois": [
+    {
+      "osmId": 999000001,
+      "name": "Test Cafe",
+      "nameEn": "Test Cafe",
+      "lat": 21.0285,
+      "lon": 105.8542,
+      "tags": {"amenity": "cafe"}
+    }
+  ],
+  "cityCode": "vn-hanoi",
+  "locale": "en",
+  "cacheKey": "test-cache-key-do-not-collide"
+}
+JSON
+)
+
+echo "→ POST $URL"
+curl -fsSL "$URL" \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  --data "$BODY" | python3 -m json.tool

--- a/infra/supabase/migrations/0001_init.sql
+++ b/infra/supabase/migrations/0001_init.sql
@@ -1,0 +1,241 @@
+-- Solo Compass — initial Supabase schema (Epic E US-026)
+--
+-- Apply with `supabase db push` after `supabase link --project-ref <ref>`.
+-- Tables fall into three groups:
+--   1. User-scoped data (profiles, completions, favorites, surveys,
+--      subscription events, recent regions) — RLS enforces
+--      user_id = auth.uid() per row.
+--   2. Shared cache (synthesized_experiences, osm_pois, solo_score_signals
+--      aggregates) — read-public, write-service-role only.
+--   3. Function call accounting (sc_function_calls) — internal, read by
+--      Edge Functions for rate limiting.
+
+begin;
+
+-- ─── 1. User-scoped tables ──────────────────────────────────────────────
+
+create table if not exists public.profiles (
+  user_id            uuid          primary key references auth.users(id) on delete cascade,
+  is_anonymous       boolean       not null default true,
+  entitlement_tier   text          not null default 'free' check (entitlement_tier in ('free', 'pro_trial', 'pro', 'pro_expired')),
+  created_at         timestamptz   not null default now(),
+  updated_at         timestamptz   not null default now()
+);
+
+create table if not exists public.user_completions (
+  id              uuid          primary key default gen_random_uuid(),
+  user_id         uuid          not null references auth.users(id) on delete cascade,
+  experience_id   text          not null,
+  completed_at    timestamptz   not null default now(),
+  updated_at      timestamptz   not null default now()
+);
+create index if not exists user_completions_user_idx on public.user_completions(user_id);
+create index if not exists user_completions_exp_idx  on public.user_completions(experience_id);
+
+create table if not exists public.user_favorites (
+  user_id         uuid          not null references auth.users(id) on delete cascade,
+  experience_id   text          not null,
+  favorited_at    timestamptz   not null default now(),
+  updated_at      timestamptz   not null default now(),
+  primary key (user_id, experience_id)
+);
+
+create table if not exists public.micro_surveys (
+  id              uuid          primary key default gen_random_uuid(),
+  user_id         uuid          not null references auth.users(id) on delete cascade,
+  experience_id   text          not null,
+  comfort         smallint      not null check (comfort between 1 and 5),
+  pressure        smallint      not null check (pressure between 1 and 5),
+  recommend       text          not null check (recommend in ('yes', 'depends', 'no')),
+  submitted_at    timestamptz   not null default now(),
+  updated_at      timestamptz   not null default now()
+);
+create index if not exists micro_surveys_exp_idx on public.micro_surveys(experience_id);
+
+create table if not exists public.subscription_events (
+  id                       uuid          primary key default gen_random_uuid(),
+  user_id                  uuid          not null references auth.users(id) on delete cascade,
+  event_type               text          not null check (event_type in ('subscribed', 'expired', 'in_grace_period', 'revoked', 'upgraded')),
+  product_id               text          not null,
+  original_purchase_date   timestamptz,
+  expires_date             timestamptz,
+  is_in_trial_period       boolean       not null default false,
+  device_id                text,
+  created_at               timestamptz   not null default now(),
+  updated_at               timestamptz   not null default now()
+);
+create index if not exists subscription_events_user_idx on public.subscription_events(user_id);
+
+create table if not exists public.recent_explore_regions (
+  id              uuid          primary key default gen_random_uuid(),
+  user_id         uuid          not null references auth.users(id) on delete cascade,
+  center_lat      double precision not null,
+  center_lon      double precision not null,
+  radius_meters   integer       not null,
+  explored_at     timestamptz   not null default now(),
+  updated_at      timestamptz   not null default now()
+);
+create index if not exists recent_regions_user_idx on public.recent_explore_regions(user_id);
+
+-- ─── 2. Shared (community) cache ────────────────────────────────────────
+
+create table if not exists public.osm_pois (
+  osm_id          bigint        primary key,
+  name            text          not null,
+  name_en         text,
+  lat             double precision not null,
+  lon             double precision not null,
+  tags            jsonb         not null default '{}'::jsonb,
+  fetched_at      timestamptz   not null default now(),
+  updated_at      timestamptz   not null default now()
+);
+create index if not exists osm_pois_geo_idx on public.osm_pois(lat, lon);
+
+create table if not exists public.synthesized_experiences (
+  id                          text          primary key, -- "exp_osm_<osmId>"
+  city_code                   text          not null,
+  payload                     jsonb         not null,    -- full Experience JSON
+  model_name                  text          not null,
+  source_cache_key            text          not null,    -- SHA256 of canonical input batch
+  -- aggregate refreshed nightly; null until enough signals.
+  aggregated_solo_score       double precision,
+  signal_count                integer       not null default 0,
+  synthesized_at              timestamptz   not null default now(),
+  updated_at                  timestamptz   not null default now()
+);
+create index if not exists synth_exp_city_idx     on public.synthesized_experiences(city_code);
+create index if not exists synth_exp_cachekey_idx on public.synthesized_experiences(source_cache_key);
+
+create table if not exists public.solo_score_signals (
+  id              uuid          primary key default gen_random_uuid(),
+  user_id         uuid          references auth.users(id) on delete set null,
+  experience_id   text          not null,
+  comfort         smallint      not null check (comfort between 1 and 5),
+  pressure        smallint      not null check (pressure between 1 and 5),
+  recommend       text          not null check (recommend in ('yes', 'depends', 'no')),
+  submitted_at    timestamptz   not null default now()
+);
+create index if not exists solo_signals_exp_idx on public.solo_score_signals(experience_id);
+
+-- ─── 3. Internal accounting ─────────────────────────────────────────────
+
+create table if not exists public.sc_function_calls (
+  id              uuid          primary key default gen_random_uuid(),
+  user_id         uuid          not null references auth.users(id) on delete cascade,
+  function_name   text          not null,
+  called_at       timestamptz   not null default now()
+);
+create index if not exists sc_function_calls_user_day_idx
+  on public.sc_function_calls(user_id, called_at desc);
+
+-- ─── RLS: per-user data tables ──────────────────────────────────────────
+
+alter table public.profiles                enable row level security;
+alter table public.user_completions        enable row level security;
+alter table public.user_favorites          enable row level security;
+alter table public.micro_surveys           enable row level security;
+alter table public.subscription_events     enable row level security;
+alter table public.recent_explore_regions  enable row level security;
+alter table public.sc_function_calls       enable row level security;
+
+-- profiles: each user reads/writes their own row only.
+create policy "profiles self-select" on public.profiles
+  for select using (auth.uid() = user_id);
+create policy "profiles self-upsert" on public.profiles
+  for insert with check (auth.uid() = user_id);
+create policy "profiles self-update" on public.profiles
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+-- user_completions: standard CRUD scoped to auth.uid().
+create policy "completions self-select" on public.user_completions
+  for select using (auth.uid() = user_id);
+create policy "completions self-insert" on public.user_completions
+  for insert with check (auth.uid() = user_id);
+create policy "completions self-update" on public.user_completions
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "completions self-delete" on public.user_completions
+  for delete using (auth.uid() = user_id);
+
+create policy "favorites self-select" on public.user_favorites
+  for select using (auth.uid() = user_id);
+create policy "favorites self-insert" on public.user_favorites
+  for insert with check (auth.uid() = user_id);
+create policy "favorites self-update" on public.user_favorites
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "favorites self-delete" on public.user_favorites
+  for delete using (auth.uid() = user_id);
+
+create policy "surveys self-select" on public.micro_surveys
+  for select using (auth.uid() = user_id);
+create policy "surveys self-insert" on public.micro_surveys
+  for insert with check (auth.uid() = user_id);
+create policy "surveys self-update" on public.micro_surveys
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "surveys self-delete" on public.micro_surveys
+  for delete using (auth.uid() = user_id);
+
+create policy "sub_events self-select" on public.subscription_events
+  for select using (auth.uid() = user_id);
+create policy "sub_events self-insert" on public.subscription_events
+  for insert with check (auth.uid() = user_id);
+
+create policy "regions self-select" on public.recent_explore_regions
+  for select using (auth.uid() = user_id);
+create policy "regions self-insert" on public.recent_explore_regions
+  for insert with check (auth.uid() = user_id);
+create policy "regions self-update" on public.recent_explore_regions
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "regions self-delete" on public.recent_explore_regions
+  for delete using (auth.uid() = user_id);
+
+-- sc_function_calls: users can read their own (for self-quotas display)
+-- but never insert. Service role bypasses RLS to insert.
+create policy "func_calls self-select" on public.sc_function_calls
+  for select using (auth.uid() = user_id);
+
+-- ─── RLS: shared cache (read-public) ────────────────────────────────────
+
+alter table public.osm_pois                   enable row level security;
+alter table public.synthesized_experiences    enable row level security;
+alter table public.solo_score_signals         enable row level security;
+
+create policy "osm_pois public-read" on public.osm_pois
+  for select using (true);
+
+create policy "synth_exp public-read" on public.synthesized_experiences
+  for select using (true);
+
+-- solo_score_signals: only signal-owner can SELECT (privacy);
+-- aggregated_solo_score lives on synthesized_experiences (public).
+create policy "signals self-select" on public.solo_score_signals
+  for select using (auth.uid() = user_id);
+create policy "signals self-insert" on public.solo_score_signals
+  for insert with check (auth.uid() = user_id);
+
+-- Note: writes to osm_pois and synthesized_experiences happen ONLY via
+-- the service-role key inside Edge Functions. Service role bypasses
+-- RLS, so no public INSERT/UPDATE/DELETE policies exist here on
+-- purpose — that's the security boundary.
+
+-- ─── updated_at touch trigger ──────────────────────────────────────────
+
+create or replace function public.sc_touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger sc_profiles_touch                before update on public.profiles                for each row execute function public.sc_touch_updated_at();
+create trigger sc_completions_touch             before update on public.user_completions        for each row execute function public.sc_touch_updated_at();
+create trigger sc_favorites_touch               before update on public.user_favorites          for each row execute function public.sc_touch_updated_at();
+create trigger sc_surveys_touch                 before update on public.micro_surveys           for each row execute function public.sc_touch_updated_at();
+create trigger sc_sub_events_touch              before update on public.subscription_events     for each row execute function public.sc_touch_updated_at();
+create trigger sc_regions_touch                 before update on public.recent_explore_regions  for each row execute function public.sc_touch_updated_at();
+create trigger sc_osm_pois_touch                before update on public.osm_pois                for each row execute function public.sc_touch_updated_at();
+create trigger sc_synth_exp_touch               before update on public.synthesized_experiences for each row execute function public.sc_touch_updated_at();
+
+commit;

--- a/infra/supabase/test_rls.ts
+++ b/infra/supabase/test_rls.ts
@@ -1,0 +1,127 @@
+// RLS smoke test — Epic E US-026.
+//
+// Verifies four invariants of the schema's row-level-security posture:
+//   1. anon cannot read user-scoped tables of any user
+//   2. user A authenticated cannot read user B's user-scoped tables
+//   3. anon CAN read synthesized_experiences (public-read)
+//   4. service-role CAN write synthesized_experiences (write boundary)
+//
+// Run: `deno run --allow-net --allow-env test_rls.ts`
+// Requires env: SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY
+// Exits 0 on PASS, 1 on FAIL.
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY");
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !SUPABASE_SERVICE_ROLE_KEY) {
+  console.error("Missing env. Set SUPABASE_URL / SUPABASE_ANON_KEY / SUPABASE_SERVICE_ROLE_KEY.");
+  Deno.exit(1);
+}
+
+const failures: string[] = [];
+function assert(cond: unknown, label: string) {
+  if (!cond) failures.push(label);
+  console.log(`${cond ? "PASS" : "FAIL"} — ${label}`);
+}
+
+const anonClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+const serviceClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: { persistSession: false },
+});
+
+// --- 1. anon cannot read user_completions ----------------------------------
+
+{
+  const { data, error } = await anonClient
+    .from("user_completions")
+    .select("id")
+    .limit(1);
+  // RLS denies — Supabase returns empty array (no rows match policy), not an error.
+  assert(
+    !error && Array.isArray(data) && data.length === 0,
+    "anon select on user_completions returns 0 rows (RLS denies)"
+  );
+}
+
+// --- 2. cross-user isolation -----------------------------------------------
+
+const userA = await anonClient.auth.signInAnonymously();
+const userB = await anonClient.auth.signInAnonymously();
+assert(!!userA.data.user, "user A anonymous sign-in succeeded");
+assert(!!userB.data.user, "user B anonymous sign-in succeeded");
+
+if (userA.data.user && userB.data.user) {
+  // user A inserts a completion as themselves.
+  const aClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  await aClient.auth.setSession({
+    access_token: userA.data.session!.access_token,
+    refresh_token: userA.data.session!.refresh_token,
+  });
+  const { error: insertErr } = await aClient
+    .from("user_completions")
+    .insert({ user_id: userA.data.user.id, experience_id: "exp_test_rls" });
+  assert(!insertErr, `user A insert succeeds: ${insertErr?.message ?? "ok"}`);
+
+  // user B should NOT see user A's row.
+  const bClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  await bClient.auth.setSession({
+    access_token: userB.data.session!.access_token,
+    refresh_token: userB.data.session!.refresh_token,
+  });
+  const { data: leakCheck } = await bClient
+    .from("user_completions")
+    .select("id")
+    .eq("user_id", userA.data.user.id);
+  assert(
+    Array.isArray(leakCheck) && leakCheck.length === 0,
+    "user B cannot see user A's completions (RLS isolation)"
+  );
+
+  // Cleanup with service role.
+  await serviceClient.from("user_completions").delete()
+    .or(`user_id.eq.${userA.data.user.id},user_id.eq.${userB.data.user.id}`);
+  await serviceClient.auth.admin.deleteUser(userA.data.user.id).catch(() => {});
+  await serviceClient.auth.admin.deleteUser(userB.data.user.id).catch(() => {});
+}
+
+// --- 3. anon CAN read synthesized_experiences ------------------------------
+
+{
+  const { error } = await anonClient
+    .from("synthesized_experiences")
+    .select("id")
+    .limit(1);
+  assert(!error, `anon select on synthesized_experiences succeeds: ${error?.message ?? "ok"}`);
+}
+
+// --- 4. service-role CAN write synthesized_experiences ---------------------
+
+{
+  const probeId = `exp_test_${Date.now()}`;
+  const { error: insertErr } = await serviceClient
+    .from("synthesized_experiences")
+    .insert({
+      id: probeId,
+      city_code: "test-city",
+      payload: {},
+      model_name: "test",
+      source_cache_key: "test-key",
+    });
+  assert(!insertErr, `service-role insert succeeds: ${insertErr?.message ?? "ok"}`);
+
+  await serviceClient.from("synthesized_experiences").delete().eq("id", probeId);
+}
+
+// --- Result ----------------------------------------------------------------
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} failure(s):`);
+  for (const f of failures) console.error(`  - ${f}`);
+  Deno.exit(1);
+} else {
+  console.log("\nAll RLS invariants hold.");
+  Deno.exit(0);
+}

--- a/infra/supabase/test_rls.ts
+++ b/infra/supabase/test_rls.ts
@@ -35,14 +35,11 @@ const serviceClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
 // --- 1. anon cannot read user_completions ----------------------------------
 
 {
-  const { data, error } = await anonClient
-    .from("user_completions")
-    .select("id")
-    .limit(1);
+  const { data, error } = await anonClient.from("user_completions").select("id").limit(1);
   // RLS denies — Supabase returns empty array (no rows match policy), not an error.
   assert(
     !error && Array.isArray(data) && data.length === 0,
-    "anon select on user_completions returns 0 rows (RLS denies)"
+    "anon select on user_completions returns 0 rows (RLS denies)",
   );
 }
 
@@ -77,11 +74,13 @@ if (userA.data.user && userB.data.user) {
     .eq("user_id", userA.data.user.id);
   assert(
     Array.isArray(leakCheck) && leakCheck.length === 0,
-    "user B cannot see user A's completions (RLS isolation)"
+    "user B cannot see user A's completions (RLS isolation)",
   );
 
   // Cleanup with service role.
-  await serviceClient.from("user_completions").delete()
+  await serviceClient
+    .from("user_completions")
+    .delete()
     .or(`user_id.eq.${userA.data.user.id},user_id.eq.${userB.data.user.id}`);
   await serviceClient.auth.admin.deleteUser(userA.data.user.id).catch(() => {});
   await serviceClient.auth.admin.deleteUser(userB.data.user.id).catch(() => {});
@@ -90,10 +89,7 @@ if (userA.data.user && userB.data.user) {
 // --- 3. anon CAN read synthesized_experiences ------------------------------
 
 {
-  const { error } = await anonClient
-    .from("synthesized_experiences")
-    .select("id")
-    .limit(1);
+  const { error } = await anonClient.from("synthesized_experiences").select("id").limit(1);
   assert(!error, `anon select on synthesized_experiences succeeds: ${error?.message ?? "ok"}`);
 }
 
@@ -101,15 +97,13 @@ if (userA.data.user && userB.data.user) {
 
 {
   const probeId = `exp_test_${Date.now()}`;
-  const { error: insertErr } = await serviceClient
-    .from("synthesized_experiences")
-    .insert({
-      id: probeId,
-      city_code: "test-city",
-      payload: {},
-      model_name: "test",
-      source_cache_key: "test-key",
-    });
+  const { error: insertErr } = await serviceClient.from("synthesized_experiences").insert({
+    id: probeId,
+    city_code: "test-city",
+    payload: {},
+    model_name: "test",
+    source_cache_key: "test-key",
+  });
   assert(!insertErr, `service-role insert succeeds: ${insertErr?.message ?? "ok"}`);
 
   await serviceClient.from("synthesized_experiences").delete().eq("id", probeId);


### PR DESCRIPTION
## Summary

The cross-device-sync layer + the path that removes \`ANTHROPIC_API_KEY\` from the iOS bundle. All 7 stories of Epic E from \`tasks/prd-paid-app-foundation.md\`, gated behind \`FF_BACKEND_SYNC=false\` so this PR can land without affecting beta.1 testers.

## Stories

| Story | Subject |
|---|---|
| US-026 | Supabase schema + RLS migration |
| US-027 | SupabaseClient + FF_BACKEND_SYNC feature flag |
| US-028 | Anonymous sign-in on first launch |
| US-029 | SyncService outbox for completions/favorites |
| US-030 | Edge Function synthesize-experiences (Deno/TS) |
| US-031 | Route iOS AIService through Edge Function |
| US-032 | Subscription event telemetry to Supabase |

## Highlights

- **Local-first invariant preserved.** \`FF_BACKEND_SYNC=false\` (default in beta.1) makes every backend call a no-op. The app stays fully usable offline.
- **No SDK dependency.** \`SupabaseClient\` uses URLSession directly — keeps the project's "zero deps" rule.
- **Outbox durable across kills.** Local mutations enqueue \`PendingSyncRecord\` rows; \`SyncService.flush()\` drains them every 30s + on foreground.
- **Edge Function holds the Anthropic key.** Once \`FF_ROUTE_AI_THROUGH_EDGE\` flips on, the iOS bundle no longer needs the Anthropic key.
- **Defense in depth.** Three independent quota caps: local AIUsageRecord (Epic B), Edge Function rate-limit (this PR), Anthropic Console hard cap.

## Tests

61/61 passing on iPhone 17 / iOS 26.4. RLS smoke test (\`test_rls.ts\`) is meant to be run against a real Supabase project; it's documented but not part of the unit suite.

## Test plan

- [x] \`xcodebuild build\`
- [x] \`xcodebuild test\` 61/61
- [ ] Manual (when @cubxxw provisions Supabase prod): \`supabase db push\` then \`deno run test_rls.ts\` confirms 4 RLS invariants
- [ ] Manual: deploy Edge Function, run \`test.sh\` with a real JWT
- [ ] Manual: flip FF_BACKEND_SYNC=true in dev, complete an Experience, watch outbox drain
- [ ] Manual: flip FF_ROUTE_AI_THROUGH_EDGE=true, tap Explore, confirm zero direct-Anthropic calls

## Stacked on

Epic A (#75), Epic B (#76), Epic C (#77), Epic D (#78) — all merged.