### PR TITLE
fix(ios): add @MainActor to UserPreferences.isFavorited/isCompleted

### DIFF
--- a/apps/ios/SoloCompass/Models/UserPreferences.swift
+++ b/apps/ios/SoloCompass/Models/UserPreferences.swift
@@ -375,6 +375,7 @@ public final class UserPreferences {
 
     /// Read-through to SwiftData when the repository is wired; falls back
     /// to the in-memory set for previews and tests that skip `attachRepository`.
+    @MainActor
     public func isFavorited(_ id: String) -> Bool {
         if let repo = experienceRepository { return repo.isFavorited(experienceId: id) }
         return favoritedExperiences.contains(id)
@@ -382,6 +383,7 @@ public final class UserPreferences {
 
     /// Read-through to SwiftData when the repository is wired; falls back
     /// to the in-memory set for previews and tests that skip `attachRepository`.
+    @MainActor
     public func isCompleted(_ id: String) -> Bool {
         if let repo = experienceRepository { return repo.isCompleted(experienceId: id) }
         return completedExperiences.contains(id)


### PR DESCRIPTION
Fixes iOS CI build failure on main after #87 merge.

**Root cause:** ExperienceRepository methods are @MainActor-isolated, but UserPreferences.isFavorited() and isCompleted() call them without @MainActor annotation.

**Error:**
```
UserPreferences.swift:379:58: error: call to main actor-isolated instance method 'isFavorited(experienceId:)' in a synchronous nonisolated context
UserPreferences.swift:386:58: error: call to main actor-isolated instance method 'isCompleted(experienceId:)' in a synchronous nonisolated context
```

**Fix:** Add @MainActor to both methods — all callers (MapViewModel, ExperienceDetailViewModel) are already @MainActor.