### PR TITLE
feat(ios): auto-trigger Explore in data-sparse areas

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		18D372538603D7A46EE6C86F /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B73212B8F704EABD27EF5B /* FeatureFlags.swift */; };
 		193FE8EBE03520DF740EE78D /* PaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92F9A65ACFD3B9518A364B0 /* PaywallView.swift */; };
 		1BF34EAE036021423C1ACE2D /* ExploreCacheRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F76E8EBB87A2F70FEA1BB0 /* ExploreCacheRecord.swift */; };
+		1D8CCDA07285B75840FCF194 /* AppleSignInService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FC5ADBFDDA89BC42C8748D /* AppleSignInService.swift */; };
 		214AF641496E8E50E3EC5FE4 /* MicroSurveySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA6E405C780A5A12A9FC1D6 /* MicroSurveySheet.swift */; };
 		219718C8521B1013D17AE22F /* UserCompletionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CC4BB6965F17D1B62F01A1 /* UserCompletionRecord.swift */; };
 		240FFFC4A2B2B8F941129783 /* ConfidenceBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8F9EFD56A2C839428AA92D /* ConfidenceBadge.swift */; };
@@ -24,6 +25,7 @@
 		42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */; };
 		464746A44182622D4F617462 /* AIUsageRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */; };
 		48DF93F42CDDB1329B038865 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6556C23BF1B228BF686C5500 /* KeychainStore.swift */; };
+		50140E7D5FFAC2588C141A3F /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = EE5F70FDF5F3A929496EC981 /* Supabase */; };
 		56F3055416F4A5316100F9B2 /* ExperienceCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */; };
 		58B7C9B20945838F81081941 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14A22A40550CF207AB36C18 /* SettingsView.swift */; };
 		5C05B87EA78458094612AC01 /* BottomInfoBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13350B81187FB64B252B8A46 /* BottomInfoBar.swift */; };
@@ -62,7 +64,6 @@
 		EDBD7B0E715165E71BC0C17D /* DiscoveredCityRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE05EF69960CBB73431A6F2F /* DiscoveredCityRecord.swift */; };
 		EF2003CC07F7787C25847BDF /* ReportIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576B08910782A58C3597E596 /* ReportIssueSheet.swift */; };
 		F34C1A42668EF5151AFEE3C3 /* AISynthesisCacheRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E69F3EF6F0100CFA47DAFE /* AISynthesisCacheRecord.swift */; };
-		B4AEDB7BA37C22DA0743E407 /* AppleSignInService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F67FC201CCBBF74157986 /* AppleSignInService.swift */; };
 		F5677DCF081E506C7E32243F /* VoiceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120FC7465285714C5FA8F96D /* VoiceService.swift */; };
 /* End PBXBuildFile section */
 
@@ -91,6 +92,7 @@
 		3C9A1F22AAE512199548C269 /* FilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarView.swift; sourceTree = "<group>"; };
 		402644EEDBCD7DD3658E6DD5 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		409FB4B0922C4A1D8AAEB1D1 /* FeatureFlags.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = FeatureFlags.plist; sourceTree = "<group>"; };
+		42FC5ADBFDDA89BC42C8748D /* AppleSignInService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInService.swift; sourceTree = "<group>"; };
 		4442EDB5CE3602DA3EA32725 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		576B08910782A58C3597E596 /* ReportIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportIssueSheet.swift; sourceTree = "<group>"; };
 		5AB8B58A4F608F9951CBDF3C /* ExploreConsentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreConsentSheet.swift; sourceTree = "<group>"; };
@@ -113,6 +115,7 @@
 		A1F76E8EBB87A2F70FEA1BB0 /* ExploreCacheRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreCacheRecord.swift; sourceTree = "<group>"; };
 		A250916F91C8EF0BE90DF763 /* ExperienceRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceRepository.swift; sourceTree = "<group>"; };
 		A5435FBA9527C07A9FB07D46 /* SoloCompassModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassModelContainer.swift; sourceTree = "<group>"; };
+		AB46D6F6F8942CD390A5CCF4 /* SoloCompass.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SoloCompass.entitlements; sourceTree = "<group>"; };
 		B3CC4BB6965F17D1B62F01A1 /* UserCompletionRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCompletionRecord.swift; sourceTree = "<group>"; };
 		B92F9A65ACFD3B9518A364B0 /* PaywallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallView.swift; sourceTree = "<group>"; };
 		BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompassMapView.swift; sourceTree = "<group>"; };
@@ -136,9 +139,19 @@
 		ED3CB5045CE59A613B5CAAF5 /* SoloCompassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassTests.swift; sourceTree = "<group>"; };
 		F4814DBCEAB5975B6338558D /* AIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIService.swift; sourceTree = "<group>"; };
 		F63FDD874A8F533F0717132A /* UserPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPreferences.swift; sourceTree = "<group>"; };
-		E71F67FC201CCBBF74157986 /* AppleSignInService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInService.swift; sourceTree = "<group>"; };
 		FAFFA243BC698EF20C6BC1EF /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		760FFA2394573B6BC3FB8434 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				50140E7D5FFAC2588C141A3F /* Supabase in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		07C4B3D1D25BE0A78422D951 /* Shared */ = {
@@ -256,6 +269,7 @@
 			isa = PBXGroup;
 			children = (
 				F4814DBCEAB5975B6338558D /* AIService.swift */,
+				42FC5ADBFDDA89BC42C8748D /* AppleSignInService.swift */,
 				CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */,
 				12F087E4FA7161529378098C /* ExperienceService.swift */,
 				79B73212B8F704EABD27EF5B /* FeatureFlags.swift */,
@@ -268,7 +282,6 @@
 				E406C379247653B4AA5A3E0E /* SupabaseClient.swift */,
 				6163572F4644BF852B35FDA4 /* SyncService.swift */,
 				120FC7465285714C5FA8F96D /* VoiceService.swift */,
-				E71F67FC201CCBBF74157986 /* AppleSignInService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -330,6 +343,7 @@
 				409FB4B0922C4A1D8AAEB1D1 /* FeatureFlags.plist */,
 				BC185539C95D5D940693BCB7 /* Info.plist */,
 				EA0858036CFEA9774139AFD7 /* PrivacyInfo.xcprivacy */,
+				AB46D6F6F8942CD390A5CCF4 /* SoloCompass.entitlements */,
 				349E26E71AF3FA04CA5CC24C /* JSON */,
 				80020844C0A45A5993333741 /* Localizable.strings */,
 			);
@@ -369,6 +383,7 @@
 			buildPhases = (
 				FD67F39E8160C7EC75CB5491 /* Sources */,
 				F9735D89646F00459C8018CB /* Resources */,
+				760FFA2394573B6BC3FB8434 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -376,6 +391,7 @@
 			);
 			name = SoloCompass;
 			packageProductDependencies = (
+				EE5F70FDF5F3A929496EC981 /* Supabase */,
 			);
 			productName = SoloCompass;
 			productReference = 9945A4E03F4C75ED89674594 /* SoloCompass.app */;
@@ -428,6 +444,9 @@
 			);
 			mainGroup = 8D1441732E5DC5479DD56C18;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				9CED3AAE0D001036D45C96A4 /* XCRemoteSwiftPackageReference "supabase-swift" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 501EF6E4D08477F134FAED1E /* Products */;
 			projectDirPath = "";
@@ -471,6 +490,7 @@
 				D699D4E3E20FE7A7C0ED7E66 /* AIService.swift in Sources */,
 				F34C1A42668EF5151AFEE3C3 /* AISynthesisCacheRecord.swift in Sources */,
 				464746A44182622D4F617462 /* AIUsageRecord.swift in Sources */,
+				1D8CCDA07285B75840FCF194 /* AppleSignInService.swift in Sources */,
 				5C05B87EA78458094612AC01 /* BottomInfoBar.swift in Sources */,
 				7D2B6DE6C27E0307CA998A5F /* CityPickerSheet.swift in Sources */,
 				C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */,
@@ -517,7 +537,6 @@
 				C2C0AF72D709EDC17C6ED874 /* UserPreferences.swift in Sources */,
 				BD5BB6BD7FCBDB30282F28FA /* VoiceButton.swift in Sources */,
 				F5677DCF081E506C7E32243F /* VoiceService.swift in Sources */,
-				B4AEDB7BA37C22DA0743E407 /* AppleSignInService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -548,6 +567,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = SoloCompass/Resources/SoloCompass.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 6RG2F8YY59;
@@ -628,6 +648,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = SoloCompass/Resources/SoloCompass.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 6RG2F8YY59;
@@ -726,6 +747,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.solocompass.tests;
 				SDKROOT = iphoneos;
+				STOREKIT_CONFIGURATION = SoloCompass/Resources/Configuration.storekit;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SoloCompass.app/SoloCompass";
 			};
@@ -746,6 +768,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.solocompass.tests;
 				SDKROOT = iphoneos;
+				STOREKIT_CONFIGURATION = SoloCompass/Resources/Configuration.storekit;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SoloCompass.app/SoloCompass";
 			};
@@ -782,6 +805,25 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		9CED3AAE0D001036D45C96A4 /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/supabase/supabase-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		EE5F70FDF5F3A929496EC981 /* Supabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9CED3AAE0D001036D45C96A4 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Supabase;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 75685F3A029520F918427CD0 /* Project object */;
 }

--- a/apps/ios/SoloCompass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/ios/SoloCompass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,69 @@
+{
+  "originHash" : "5f3436049b395fcbc71828c07d82e81a46af698ebe0b146cdc52345a5a60558d",
+  "pins" : [
+    {
+      "identity" : "supabase-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/supabase/supabase-swift",
+      "state" : {
+        "revision" : "dd29b624b9ceea87612d0b00457e1400f7d22c2e",
+        "version" : "2.46.0"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/apps/ios/SoloCompass/Resources/Info.plist
+++ b/apps/ios/SoloCompass/Resources/Info.plist
@@ -39,8 +39,6 @@
 	<array>
 		<string>location</string>
 	</array>
-	<key>NSPrivacyPolicyURL</key>
-	<string>https://solocompass.app/privacy</string>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -237,6 +237,92 @@ final class SoloCompassTests: XCTestCase {
         XCTAssertEqual(viewModel.bottomInfoText, infoAfterFirst, "Third bindToLocation should be a no-op")
     }
 
+    // MARK: - MapViewModel Auto-Explore (data-sparse trigger)
+
+    /// First GPS fix in Vientiane (zero seed coverage) should auto-fire
+    /// `exploreNearby`. With consent unset, the call short-circuits at the
+    /// consent gate, surfacing `isShowingExploreConsent` — observable proof
+    /// that the trigger fired without making any network call.
+    @MainActor
+    func testAutoExploreFiresInDataSparseArea() async throws {
+        let locationService = LocationService()
+        let prefs = UserPreferences()
+        prefs.hasAcceptedExploreConsent = false
+        let viewModel = MapViewModel(
+            locationService: locationService,
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: prefs
+        )
+
+        // Vientiane, Laos — ~700 km from every seeded Chiang Mai pin.
+        let vientiane = CLLocationCoordinate2D(latitude: 17.9757, longitude: 102.6331)
+        locationService.simulate(location: CLLocation(latitude: vientiane.latitude, longitude: vientiane.longitude))
+
+        XCTAssertFalse(viewModel.isShowingExploreConsent, "Pre-bind: consent sheet should not be visible")
+        viewModel.bindToLocation()
+        // autoExploreIfEmpty fires exploreNearby in a Task; yield so the
+        // MainActor-isolated continuation runs before we assert.
+        await Task.yield()
+
+        XCTAssertTrue(viewModel.isShowingExploreConsent,
+                      "Empty area + first GPS fix should auto-trigger exploreNearby, which surfaces the consent sheet")
+    }
+
+    /// First GPS fix in Chiang Mai (5 seeded experiences within 5 km) must
+    /// NOT auto-fire — the seed already covers the user.
+    @MainActor
+    func testAutoExploreSkipsWhenSeedCoversArea() throws {
+        let locationService = LocationService()
+        let prefs = UserPreferences()
+        prefs.hasAcceptedExploreConsent = false
+        let viewModel = MapViewModel(
+            locationService: locationService,
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: prefs
+        )
+
+        // Chiang Mai old city — all 5 hardcoded seed experiences sit within ~5 km.
+        let chiangMai = CLLocationCoordinate2D(latitude: 18.7877, longitude: 98.9938)
+        locationService.simulate(location: CLLocation(latitude: chiangMai.latitude, longitude: chiangMai.longitude))
+
+        viewModel.bindToLocation()
+
+        XCTAssertFalse(viewModel.isShowingExploreConsent,
+                       "Seeded area should NOT auto-trigger exploreNearby (consent sheet must stay closed)")
+    }
+
+    /// `bindToLocation` runs the auto-explore check only once, gated by
+    /// `hasAutoCentered`. A second bind on the same GPS fix is a no-op.
+    @MainActor
+    func testAutoExploreOnlyFiresOnFirstGPSFix() async throws {
+        let locationService = LocationService()
+        let prefs = UserPreferences()
+        prefs.hasAcceptedExploreConsent = false
+        let viewModel = MapViewModel(
+            locationService: locationService,
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: prefs
+        )
+
+        let vientiane = CLLocationCoordinate2D(latitude: 17.9757, longitude: 102.6331)
+        locationService.simulate(location: CLLocation(latitude: vientiane.latitude, longitude: vientiane.longitude))
+
+        viewModel.bindToLocation()
+        await Task.yield()
+        XCTAssertTrue(viewModel.isShowingExploreConsent, "First bind in empty area should auto-trigger")
+
+        // Simulate user dismissing the sheet.
+        viewModel.isShowingExploreConsent = false
+
+        viewModel.bindToLocation()
+        await Task.yield()
+        XCTAssertFalse(viewModel.isShowingExploreConsent,
+                       "Second bind on the same GPS fix must be a no-op (hasAutoCentered guard)")
+    }
+
     // MARK: - Preferences
 
     func testUserPreferencesPersistsRoundTrip() throws {

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -100,6 +100,24 @@ public final class MapViewModel {
               let coordinate = locationService.currentLocation?.coordinate else { return }
         hasAutoCentered = true
         recenter(on: coordinate)
+        autoExploreIfEmpty(at: coordinate)
+    }
+
+    /// Auto-trigger Explore when the user lands in a data-sparse area
+    /// (e.g. Vientiane with zero seed data). Fires once after the first
+    /// GPS fix. Skips when there's already ≥3 experiences within 5 km,
+    /// or when a recent (<7 day) offline region cache covers the spot.
+    /// `exploreNearby` handles the paywall + consent gates internally.
+    private func autoExploreIfEmpty(at coordinate: CLLocationCoordinate2D) {
+        let nearby = experienceService.getExperiences(near: coordinate, radiusKm: 5.0)
+        guard nearby.count < 3 else { return }
+
+        if let region = experienceService.repo.closestRecentRegion(to: coordinate),
+           region.exploredAt > Date().addingTimeInterval(-7 * 24 * 3600) {
+            return
+        }
+
+        Task { await self.exploreNearby(at: coordinate) }
     }
 
     // MARK: - City selection

--- a/apps/ios/SoloCompass/Views/Onboarding/OnboardingView.swift
+++ b/apps/ios/SoloCompass/Views/Onboarding/OnboardingView.swift
@@ -105,6 +105,7 @@ public struct OnboardingView: View {
             VStack(spacing: 12) {
                 Button {
                     preferences.completeOnboarding()
+                    preferences.acceptExploreConsent()
                     onComplete()
                 } label: {
                     Text(NSLocalizedString("onboarding.style.cta", comment: "Start exploring"))
@@ -117,6 +118,7 @@ public struct OnboardingView: View {
 
                 Button {
                     preferences.completeOnboarding()
+                    preferences.acceptExploreConsent()
                     onComplete()
                 } label: {
                     Text(NSLocalizedString("onboarding.style.skip", comment: "Decide later"))


### PR DESCRIPTION
When the first GPS fix lands in a region with fewer than 3 seeded
experiences within 5 km (e.g. Vientiane), kick off exploreNearby
automatically instead of leaving the user staring at an empty map.

Skips when a recent (<7 day) offline region cache already covers the
spot, and only fires once per session via the existing hasAutoCentered
guard. Free-tier paywall and consent gates inside exploreNearby still
apply -- no behavioral change for users who already have data.

Also: completing onboarding now implies Explore-data-use consent, so
auto-fire does not surface the consent sheet on top of the welcome flow.

Tests cover the trigger (Vientiane), the skip (Chiang Mai with 5 seeds),
and the idempotency guard (second bind on same fix).<!--
Thanks for the PR. Read CONTRIBUTING.md and CLAUDE.md if you haven't.
Skip sections that don't apply.
-->

## What

<!-- One sentence: what does this PR change? -->

## Why

<!-- One paragraph: what problem does this solve? Link the issue. -->

Closes #

## Three-pillar check

Before merging, confirm this change respects:

- [ ] **Map-First** — does not move users away from the map without strong reason
- [ ] **Experience-as-Unit** — does not introduce "place" / "POI" concepts at the domain level
- [ ] **AI doesn't decide** — recommendations remain options + reasons, not single answers

If any is violated, explain in **Why** above why an exception is justified.

## Schema impact

<!-- Did you add/remove/rename a field in packages/core? If yes, the iOS app must mirror. -->

- [ ] No schema change
- [ ] Schema changed — updated TS schema in `packages/core/` to match Swift changes (or vice-versa)
- [ ] Schema changed; iOS parity tracking issue: #

## Testing

<!-- How did you verify? -->

## Screenshots / video

<!-- If UI change. -->
