### PR TITLE
fix(ci): pre-seed GeneratedSecrets.swift before xcodegen

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -168,6 +168,17 @@ jobs:
           ruby -c fastlane/Fastfile
           bundle exec fastlane lanes > /dev/null
 
+      # ── 4b. Pre-seed GeneratedSecrets.swift so xcodegen sees it ──────────
+      # The Xcode preBuildScript that emits GeneratedSecrets.swift only runs
+      # at archive time; xcodegen builds the project's sources list before
+      # that. If the file isn't on disk when xcodegen runs, it's never added
+      # to the project and Swift compile fails with "cannot find 'Secrets' in
+      # scope". The script has a no-.env placeholder fallback, so this is
+      # safe to run before Create .env from secrets — the real values are
+      # written later when the preBuildScript re-runs during archive.
+      - name: Pre-seed GeneratedSecrets.swift
+        run: bash scripts/generate_secrets.sh
+
       # ── 5. Generate .xcodeproj from project.yml ──────────────────────────
       - name: Install XcodeGen
         run: brew install xcodegen


### PR DESCRIPTION
## Summary
- TestFlight workflow has failed on every push to `main` since #93 with `cannot find 'Secrets' in scope` errors in `AIService.swift`.
- Root cause: `xcodegen` builds the `.xcodeproj`'s sources list at project-generation time. `GeneratedSecrets.swift` (which defines `enum Secrets`) is gitignored and only emitted by the Xcode `preBuildScript`, which runs at archive time — too late. `xcodegen` never sees the file, and `Secrets` is missing from the compiled module.
- Fix: run `scripts/generate_secrets.sh` once before `xcodegen`. The script's no-`.env` placeholder fallback handles this case (all fields = empty string). The later `Create .env from secrets` step plus the Xcode `preBuildScript` re-running during archive overwrite the file with real secret values.

## Why this didn't fail before #93
PR #93 introduced the secrets generation system (DeepSeek migration). The signing-fix run that just landed exposed this latent bug for the first time, because before that the workflow died earlier (provisioning profile mismatch).

## Test plan
- [x] Confirmed locally that running `bash scripts/generate_secrets.sh` with no `.env` writes a valid Swift file with `enum Secrets`.
- [ ] CI on this PR runs `ios-ci` + `secret-scan` (testflight only runs on `main` push); watch those pass.
- [ ] After merge, monitor `Deploy to TestFlight` on `main` to confirm full archive succeeds.