### PR TITLE
feat(ai): US-MR-03 synthesisLimit 60 + distance-aware prompt

### DIFF
--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -331,9 +331,12 @@ public final class AIService {
 
     // MARK: - Synthesize from OSM POIs (Explore Here)
 
-    /// Maximum POIs sent to the model in one call. Keeps prompt size and cost
-    /// predictable, and matches the product cap of 15 generated experiences.
-    public static let synthesisLimit = 15
+    /// Maximum POIs sent to the model in one call. Sized to accommodate the
+    /// merged output of a 4-ring Pro radial Explore (≈60 POIs after dedupe)
+    /// so the entire ring stack can share a single synthesis call rather
+    /// than burning 4× the daily quota. See docs/PRD/pro-radial-explore.md
+    /// (US-MR-03 / option B).
+    public static let synthesisLimit = 60
 
     /// Convert a batch of OSM POIs into Experiences. The hot path:
     /// 1. Cache hit (SHA256 of inputs + model name + 30-day TTL) →
@@ -735,6 +738,8 @@ public final class AIService {
         - howTo must contain navigation/orientation steps only. Do NOT write "order the X", "try the X", "ask for X", "sit at the bar/window/back".
         - Avoid the phrases: "menu", "specialty", "best seat", "the owner", "opens at", "closes at", "price", "order the", "try the".
         - Solo Score should be a conservative 7.0–8.5 unless tags clearly indicate something exceptional (e.g. tourism=viewpoint with a name → up to 9.0).
+
+        DISTANCE AWARENESS: The POI list may span 0–12 km from the user (a Pro radial Explore covers 4 rings: 1.5/3/6/12 km). Infer approximate distance from each POI's lat/lon relative to the others; closer POIs should lean toward in-the-moment framings (walk-up, sidewalk), farther POIs toward half-day-out framings (worth a transit ride). Do NOT mention distances or rings explicitly in the output — just let the framing reflect the proximity.
 
         Examples of GOOD output (tag-derived, generic):
         - title: "Sit with locals at a Hanoi café"

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -429,7 +429,10 @@ final class SoloCompassTests: XCTestCase {
     func testSynthesisLimitCapsInputs() async throws {
         unsetenv("DEEPSEEK_API_KEY")
         let ai = AIService()
-        let many: [OverpassService.POI] = (0..<25).map {
+        // Always supply more POIs than the cap so this test stays meaningful
+        // when synthesisLimit changes (15 → 60 in US-MR-03, may grow again).
+        let count = AIService.synthesisLimit + 10
+        let many: [OverpassService.POI] = (0..<count).map {
             .init(osmId: Int64(1000 + $0), name: "Spot \($0)", nameEn: nil,
                   lat: 0, lon: 0, tags: ["amenity": "restaurant"])
         }


### PR DESCRIPTION
## Summary

Implements **US-MR-03** from [docs/PRD/pro-radial-explore.md](./docs/PRD/pro-radial-explore.md). Smallest independent slice of the Pro multi-ring Explore work — sets up the synthesis pipeline so that **one DeepSeek call can absorb the merged output of all 4 rings** (option B), rather than burning 4× the daily quota.

## Changes

| File | Change |
|---|---|
| `apps/ios/SoloCompass/Services/AIService.swift` | `synthesisLimit` 15 → 60; new "DISTANCE AWARENESS" instruction block in `synthesisPrompt` telling the model that inputs may span 0–12 km with framing guidance (near → walk-up, far → transit-out); explicitly forbids mentioning distances/rings in output |
| `apps/ios/SoloCompass/Tests/SoloCompassTests.swift` | `testSynthesisLimitCapsInputs`: input count now `synthesisLimit + 10` so the assertion stays meaningful when the constant moves |

## Why option B (recap from PRD)

| Option | Pro Explores/day | Token cost | Picked? |
|---|---|---|---|
| A: 4 separate syntheses, raise quota to 100 | 25 | ~4× | ❌ token economics |
| **B: share one synthesis across all rings** | **30** | **~2.5×** | ✅ |
| C: keep 30 quota, show countdown | 7 | 1× | ❌ rationing kills UX |

## Test plan

- [x] `xcodebuild test` on iPhone 17 / iOS 26.4 — 4 synthesis tests:
  - `testSynthesisLimitCapsInputs` (input=70, limit=60) passed 6.090s
  - `testSynthesisCacheHitDoesNotIncrementQuota` passed
  - `testSynthesisCacheTwoCallsOneHTTPIdenticalResults` passed
  - `testSynthesisRequestBodyContainsSonnetModel` passed
  - **TEST SUCCEEDED**

## Out of scope (deferred to US-MR-01)

- Multi-ring Overpass scheduling in `MapViewModel.exploreNearby`
- Per-POI distance field in the prompt (needs query-center plumbing)
- DeepSeek Edge Function POI cap sync (`supabase/functions/synthesize-experiences`)

## Notes for reviewers

- This PR is purely a capacity + prompt change; no UI, no `MapViewModel` changes, no quota/billing changes.
- The 60-POI prompt grows the average input by ~3× (≈3-5K tokens). DeepSeek context budget is fine, but if the latency on real devices regresses we may revisit (PRD §7).
- After this PR, calling `synthesizeExperiences` with 16-60 POIs works as expected; ≤15 behaviour is identical to before (cap not hit).