### PR TITLE
feat(overpass): US-MR-02 cross-ring dedupe utility

### DIFF
--- a/apps/ios/SoloCompass/Services/OverpassService.swift
+++ b/apps/ios/SoloCompass/Services/OverpassService.swift
@@ -134,6 +134,25 @@ public final class OverpassService {
     /// Deterministic key for a (lat, lon, radius) cell. Rounding to
     /// 0.01° (~1.1 km) means small map pans still hit the same cache
     /// row.
+    /// Flatten a list of per-ring POI batches into a single deduplicated
+    /// list, keyed by `osmId`. Earlier batches (inner rings) win — when a
+    /// POI appears in both R1 and R2 we keep the R1 copy. Preserves input
+    /// order within each batch.
+    ///
+    /// Used by the Pro multi-ring Explore (US-MR-02) to merge the outputs
+    /// of 4 concurrent Overpass calls before handing the result to a
+    /// single AI synthesis. See docs/PRD/pro-radial-explore.md.
+    public static func dedupe(across batches: [[POI]]) -> [POI] {
+        var seen = Set<Int64>()
+        var result: [POI] = []
+        for batch in batches {
+            for poi in batch where seen.insert(poi.osmId).inserted {
+                result.append(poi)
+            }
+        }
+        return result
+    }
+
     public static func regionKey(lat: Double, lon: Double, radiusMeters: Int) -> String {
         let roundedLat = (lat * 100).rounded() / 100
         let roundedLon = (lon * 100).rounded() / 100

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -883,6 +883,47 @@ final class SoloCompassTests: XCTestCase {
         XCTAssertEqual(key, "21.03_105.85_3000", "rounding to 0.01° + radius suffix")
     }
 
+    // MARK: - US-MR-02 cross-ring dedupe
+
+    /// Helper: make a stub POI for dedupe tests. Real coordinates / tags
+    /// are irrelevant — only osmId matters for dedupe semantics.
+    private func makePOI(_ osmId: Int64, name: String = "Spot") -> OverpassService.POI {
+        OverpassService.POI(osmId: osmId, name: name, nameEn: nil, lat: 0, lon: 0, tags: [:])
+    }
+
+    func testDedupeKeepsInnerRingOnOverlap() {
+        // R1 (inner) and R2 (outer) overlap at osmId 2 and 3. R1 wins —
+        // and the kept POI carries R1's name, proving inner-first semantics.
+        let r1 = [makePOI(1, name: "R1-1"), makePOI(2, name: "R1-2"), makePOI(3, name: "R1-3")]
+        let r2 = [makePOI(2, name: "R2-2"), makePOI(3, name: "R2-3"), makePOI(4, name: "R2-4")]
+
+        let merged = OverpassService.dedupe(across: [r1, r2])
+
+        XCTAssertEqual(merged.map(\.osmId), [1, 2, 3, 4],
+                       "merged list preserves R1 order then appends R2-only entries")
+        XCTAssertEqual(merged.first { $0.osmId == 2 }?.name, "R1-2",
+                       "R1 wins when an osmId overlaps")
+        XCTAssertEqual(merged.first { $0.osmId == 3 }?.name, "R1-3",
+                       "R1 wins for all overlaps, not just the first")
+    }
+
+    func testDedupeHandlesEmptyAndAllOverlap() {
+        // Empty input, mixed empties, and 100%-overlap rings — all edge
+        // cases the 4-ring Pro Explore can plausibly hit.
+        XCTAssertTrue(OverpassService.dedupe(across: []).isEmpty)
+        XCTAssertTrue(OverpassService.dedupe(across: [[], [], []]).isEmpty)
+
+        let onlyR2 = OverpassService.dedupe(across: [[], [makePOI(7)]])
+        XCTAssertEqual(onlyR2.map(\.osmId), [7])
+
+        let identical = OverpassService.dedupe(across: [
+            [makePOI(1), makePOI(2)],
+            [makePOI(1), makePOI(2)],
+            [makePOI(1), makePOI(2)],
+        ])
+        XCTAssertEqual(identical.map(\.osmId), [1, 2])
+    }
+
     func testOverpassFetchUsesCacheOnSecondCall() async throws {
         // Stub URLProtocol to count requests and return a small valid OSM JSON.
         StubURLProtocol.handler = { _ in


### PR DESCRIPTION
## Summary

Implements **US-MR-02** from [docs/PRD/pro-radial-explore.md](./docs/PRD/pro-radial-explore.md). Adds the pure dedup function that the upcoming multi-ring `MapViewModel.exploreNearby` (US-MR-01) will use to merge 4 concurrent Overpass results before handing the union to one AI synthesis call.

## What's in the PR

```swift
// OverpassService.swift
public static func dedupe(across batches: [[POI]]) -> [POI]
```

- Keyed by `osmId`
- **Inner ring wins** on overlap (earlier batch retained, later duplicates dropped)
- Preserves input order within each batch
- Pure — no instance state, no IO

## Tests

| Test | What it covers |
|---|---|
| `testDedupeKeepsInnerRingOnOverlap` | R1 ∩ R2 overlaps on osmId 2 and 3 → R1 wins. Verified via `name` field, not just osmId order, so a future bug that returned the right id but wrong copy would still fail. |
| `testDedupeHandlesEmptyAndAllOverlap` | `[]`, `[[],[],[]]`, partial empties, 100% identical rings — all the edge shapes a real 4-ring Explore can produce. |

Both pass locally on iPhone 17 / iOS 26.4 (combined ~4ms).

## Test plan

- [x] `xcodebuild test` on the new test targets passes
- [ ] CI green (will know in ~7 min)

## Out of scope

- Calling `dedupe` from `MapViewModel.exploreNearby` — that's US-MR-01
- Cross-batch field merging (e.g. picking the most-tagged copy on overlap) — current semantics are intentionally "first wins" for predictability