### PR TITLE
feat(map): US-MR-01 Pro multi-ring exploreNearby schedule

### DIFF
--- a/apps/ios/SoloCompass/Services/FeatureFlags.swift
+++ b/apps/ios/SoloCompass/Services/FeatureFlags.swift
@@ -42,6 +42,18 @@ public enum FeatureFlags {
         readBool("FF_FORCE_REVIEW_PROMPT", default: false)
     }
 
+    /// When true and the user is Pro, `MapViewModel.exploreNearby` runs the
+    /// 4-ring radial schedule (1.5 / 3 / 6 / 12 km) instead of the single
+    /// 3 km query, then merges results through `OverpassService.dedupe` and
+    /// feeds them to a single AI synthesis call. Pro users without the flag
+    /// still get the original 1-ring behaviour. Free users are unaffected
+    /// regardless. See docs/PRD/pro-radial-explore.md (US-MR-01).
+    ///
+    /// Default off in beta — flip to true after staged 10% rollout review.
+    public static var proMultiRingExplore: Bool {
+        readBool("FF_PRO_MULTI_RING_EXPLORE", default: false)
+    }
+
     // MARK: - Internals
 
     static func readBool(_ key: String, default fallback: Bool) -> Bool {

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -924,6 +924,149 @@ final class SoloCompassTests: XCTestCase {
         XCTAssertEqual(identical.map(\.osmId), [1, 2])
     }
 
+    // MARK: - US-MR-01 multi-ring exploreNearby schedule
+
+    /// Build an OverpassService backed by StubURLProtocol that returns
+    /// one POI per ring, keyed by the `radius=` value in the request URL.
+    /// `failedRadii` lets a test mark specific rings as 5xx so we can
+    /// assert partial-failure tolerance.
+    @MainActor
+    private func makeMultiRingOverpass(failedRadii: Set<Int> = []) -> OverpassService {
+        StubURLProtocol.requestCount = 0
+        StubURLProtocol.handler = { request in
+            // Overpass query lives in the POST body. Parse the radius
+            // from `around:<radius>,<lat>,<lon>` so each ring gets a
+            // distinct osmId — that's how dedupe + counting works.
+            let body = StubURLProtocol.readBody(from: request.httpBodyStream)
+                ?? request.httpBody
+                ?? Data()
+            let bodyString = String(data: body, encoding: .utf8) ?? ""
+            // Extract integer after "around:".
+            var radius = 0
+            if let range = bodyString.range(of: "around:") {
+                let after = bodyString[range.upperBound...]
+                let digits = after.prefix { $0.isNumber }
+                radius = Int(digits) ?? 0
+            }
+            if failedRadii.contains(radius) {
+                let resp = HTTPURLResponse(
+                    url: request.url!, statusCode: 503,
+                    httpVersion: nil, headerFields: nil
+                )!
+                return (resp, Data())
+            }
+            // One node per ring; osmId = radius so dedupe distinguishes
+            // them and the test can assert which rings landed.
+            let json = """
+            {"elements":[{"type":"node","id":\(radius),"lat":0,"lon":0,"tags":{"name":"R\(radius)","amenity":"cafe"}}]}
+            """
+            let resp = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (resp, Data(json.utf8))
+        }
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        let session = URLSession(configuration: config)
+        // useSharedCache:false so test doesn't write through to SwiftData.
+        return OverpassService(session: session, maxResults: 30, repository: nil)
+    }
+
+    @MainActor
+    private func makeMapViewModelForMultiRing(
+        overpass: OverpassService
+    ) -> MapViewModel {
+        MapViewModel(
+            locationService: LocationService(),
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: UserPreferences(),
+            overpassService: overpass
+        )
+    }
+
+    @MainActor
+    func testFetchExplorePOIsMultiRingAllSuccessReturnsDedupedUnion() async throws {
+        setenv("FF_PRO_MULTI_RING_EXPLORE", "1", 1)
+        defer { unsetenv("FF_PRO_MULTI_RING_EXPLORE") }
+
+        let vm = makeMapViewModelForMultiRing(overpass: makeMultiRingOverpass())
+        let (pois, effectiveRadius) = try await vm.fetchExplorePOIs(
+            near: CLLocationCoordinate2D(latitude: 21.0, longitude: 105.8),
+            singleRingRadius: 3000
+        )
+
+        // 4 rings, 1 unique POI each (osmId = ring radius) → 4 POIs out.
+        XCTAssertEqual(pois.count, MapViewModel.multiRingRadii.count,
+                       "all rings present in merged output")
+        XCTAssertEqual(
+            Set(pois.map(\.osmId)),
+            Set(MapViewModel.multiRingRadii.map(Int64.init)),
+            "each ring contributed exactly one POI"
+        )
+        XCTAssertEqual(effectiveRadius, MapViewModel.multiRingRadii.last,
+                       "effectiveRadius records the outermost ring for offline cache")
+        XCTAssertEqual(StubURLProtocol.requestCount, MapViewModel.multiRingRadii.count,
+                       "exactly one HTTP request per ring")
+    }
+
+    @MainActor
+    func testFetchExplorePOIsMultiRingTolerateSingleRingFailure() async throws {
+        setenv("FF_PRO_MULTI_RING_EXPLORE", "1", 1)
+        defer { unsetenv("FF_PRO_MULTI_RING_EXPLORE") }
+
+        // Fail R3 (6000m). Expect 3 POIs from R1/R2/R4, no throw.
+        let overpass = makeMultiRingOverpass(failedRadii: [6000])
+        let vm = makeMapViewModelForMultiRing(overpass: overpass)
+
+        let (pois, _) = try await vm.fetchExplorePOIs(
+            near: CLLocationCoordinate2D(latitude: 21.0, longitude: 105.8),
+            singleRingRadius: 3000
+        )
+
+        let ids = Set(pois.map(\.osmId))
+        XCTAssertEqual(ids, [1500, 3000, 12000],
+                       "surviving rings still land; R3 (6000) is missing")
+    }
+
+    @MainActor
+    func testFetchExplorePOIsMultiRingAllFailedThrows() async {
+        setenv("FF_PRO_MULTI_RING_EXPLORE", "1", 1)
+        defer { unsetenv("FF_PRO_MULTI_RING_EXPLORE") }
+
+        let overpass = makeMultiRingOverpass(failedRadii: [1500, 3000, 6000, 12000])
+        let vm = makeMapViewModelForMultiRing(overpass: overpass)
+
+        do {
+            _ = try await vm.fetchExplorePOIs(
+                near: CLLocationCoordinate2D(latitude: 21.0, longitude: 105.8),
+                singleRingRadius: 3000
+            )
+            XCTFail("expected an error when all rings fail so the outer catch can offer offline fallback")
+        } catch {
+            // Pass: any error is acceptable; the outer `exploreNearby`
+            // catch only needs *some* throw to trigger the offline branch.
+        }
+    }
+
+    @MainActor
+    func testFetchExplorePOIsFlagOffUsesSingleRing() async throws {
+        // Flag off → behave exactly like pre-MR-01: one Overpass call at
+        // singleRingRadius, effectiveRadius == that radius.
+        unsetenv("FF_PRO_MULTI_RING_EXPLORE")
+
+        let vm = makeMapViewModelForMultiRing(overpass: makeMultiRingOverpass())
+        let (pois, effectiveRadius) = try await vm.fetchExplorePOIs(
+            near: CLLocationCoordinate2D(latitude: 21.0, longitude: 105.8),
+            singleRingRadius: 2500
+        )
+
+        XCTAssertEqual(StubURLProtocol.requestCount, 1, "exactly one HTTP request")
+        XCTAssertEqual(effectiveRadius, 2500, "effectiveRadius matches the requested radius")
+        XCTAssertEqual(pois.map(\.osmId), [2500], "single ring at 2500m")
+    }
+
     func testOverpassFetchUsesCacheOnSecondCall() async throws {
         // Stub URLProtocol to count requests and return a small valid OSM JSON.
         StubURLProtocol.handler = { _ in

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -653,7 +653,14 @@ public final class MapViewModel {
         aiService.isProTier = isProUser
 
         do {
-            let pois = try await overpassService.fetchPOIs(near: coordinate, radiusMeters: radiusMeters)
+            // US-MR-01: Pro multi-ring schedule (4 rings, dedup'd, single
+            // synthesis). Falls back to a 1-ring fetch when the flag is off
+            // or the user isn't on Pro. Returns the radius we should record
+            // for offline fallback (PRD §7: outermost ring only).
+            let (pois, effectiveRadius) = try await fetchExplorePOIs(
+                near: coordinate,
+                singleRingRadius: radiusMeters
+            )
             guard !pois.isEmpty else {
                 lastExploreError = NSLocalizedString("explore.error.nothingFound", comment: "No POIs found nearby")
                 return
@@ -684,10 +691,12 @@ public final class MapViewModel {
             lastExploreAddedCount = added
 
             // US-022: record a successful region so offline fallback can reuse it.
+            // For multi-ring runs this is the outermost ring (12 km) so the
+            // cached set has maximum coverage with one entry.
             experienceService.repo.recordRecentExploreRegion(
                 centerLat: coordinate.latitude,
                 centerLon: coordinate.longitude,
-                radiusMeters: radiusMeters
+                radiusMeters: effectiveRadius
             )
 
             // US-015: surface quota banner if AIService just degraded.
@@ -744,6 +753,82 @@ public final class MapViewModel {
             }
             lastExploreError = error.localizedDescription
         }
+    }
+
+    /// Pro multi-ring radii in meters (PRD docs/PRD/pro-radial-explore.md §3.1).
+    /// Inner-first order matters for dedupe semantics — nearer POIs win
+    /// when an osmId appears in two rings.
+    static let multiRingRadii: [Int] = [1_500, 3_000, 6_000, 12_000]
+
+    /// Pull OSM POIs for `exploreNearby`. When the Pro multi-ring flag is
+    /// on AND the user is Pro, fans out 4 concurrent Overpass calls and
+    /// merges via `OverpassService.dedupe`. Otherwise falls back to a
+    /// single-ring query at `singleRingRadius` (preserves pre-MR-01 behaviour).
+    ///
+    /// Returns `(pois, effectiveRadius)`. `effectiveRadius` is the radius
+    /// to record in `recordRecentExploreRegion` — outermost ring for
+    /// multi-ring runs, the caller's requested radius otherwise.
+    ///
+    /// Throws only when EVERY ring failed (multi-ring) or the single ring
+    /// failed (single). Partial ring failures are swallowed so the outer
+    /// catch in `exploreNearby` only fires when there's literally nothing
+    /// to show.
+    ///
+    /// `internal` rather than `private` so tests in the same module can
+    /// drive each ring scenario (full success / one ring fails / all fail)
+    /// without going through the whole `exploreNearby` pipeline.
+    func fetchExplorePOIs(
+        near coordinate: CLLocationCoordinate2D,
+        singleRingRadius: Int
+    ) async throws -> (pois: [OverpassService.POI], effectiveRadius: Int) {
+        // Single-ring legacy path. Used when:
+        //   - the flag is off, OR
+        //   - the user isn't Pro (free-tier never gets here, but defence)
+        guard FeatureFlags.proMultiRingExplore, isProUser else {
+            let pois = try await overpassService.fetchPOIs(
+                near: coordinate, radiusMeters: singleRingRadius
+            )
+            return (pois, singleRingRadius)
+        }
+
+        // Multi-ring: fan out 4 concurrent Overpass fetches. Each ring
+        // independently catches errors so one slow/failed ring doesn't
+        // tank the whole Explore. Order in the returned array matches
+        // `multiRingRadii` so inner rings win in dedupe.
+        let service = overpassService
+        var batches: [[OverpassService.POI]] = Array(
+            repeating: [], count: Self.multiRingRadii.count
+        )
+        var failedRings = 0
+
+        await withTaskGroup(of: (Int, [OverpassService.POI]).self) { group in
+            for (index, radius) in Self.multiRingRadii.enumerated() {
+                group.addTask { @MainActor in
+                    do {
+                        let pois = try await service.fetchPOIs(
+                            near: coordinate, radiusMeters: radius
+                        )
+                        return (index, pois)
+                    } catch {
+                        return (index, [])
+                    }
+                }
+            }
+            for await (index, pois) in group {
+                batches[index] = pois
+                if pois.isEmpty { failedRings += 1 }
+            }
+        }
+
+        // If every ring came back empty / failed, surface as a single
+        // throw so the outer catch can hit the offline fallback branch.
+        if failedRings == Self.multiRingRadii.count {
+            throw OverpassService.OverpassError.requestFailed(status: 0)
+        }
+
+        let merged = OverpassService.dedupe(across: batches)
+        let outermost = Self.multiRingRadii.last ?? singleRingRadius
+        return (merged, outermost)
     }
 
     /// Free-tier OSM-only explore: fetches Overpass POIs and converts them


### PR DESCRIPTION
## Summary

Last code story for **Pro Radial Explore**. Stacks on top of [US-MR-03](https://github.com/getyak/solo-compass/pull/99) (synthesisLimit 60) and [US-MR-02](https://github.com/getyak/solo-compass/pull/100) (cross-ring dedupe).

With this PR, a Pro user with `FF_PRO_MULTI_RING_EXPLORE` on triggers:

1. 4 concurrent Overpass fetches (1.5 / 3 / 6 / 12 km) via `TaskGroup`
2. `OverpassService.dedupe(across:)` → ≤60 unique POIs
3. one `AIService.synthesizeExperiences` call (cap 60, distance-aware prompt)
4. `recordRecentExploreRegion` writes the **outermost ring** so one cache entry covers everything (PRD §7)

## What changed

| File | Change |
|---|---|
| `Services/FeatureFlags.swift` | new `proMultiRingExplore` flag (default off) |
| `ViewModels/MapViewModel.swift` | new `static multiRingRadii` + internal `fetchExplorePOIs(near:singleRingRadius:)`; routes between single-ring and multi-ring inside `exploreNearby`; partial ring failures swallowed; effective-radius bubbles up for offline cache |
| `Tests/SoloCompassTests.swift` | 4 new tests covering all branches |

`exploreNearby` public signature is unchanged. Pre-MR-01 behaviour is preserved when the flag is off OR the user is free-tier.

## Tests (all pass on iPhone 17 / iOS 26.4)

| Test | Scenario | Time |
|---|---|---|
| `testFetchExplorePOIsMultiRingAllSuccessReturnsDedupedUnion` | 4 rings succeed → 4 POIs, effectiveRadius=12000, 4 HTTP calls | 0.145s |
| `testFetchExplorePOIsMultiRingTolerateSingleRingFailure` | R3 → 503; R1/R2/R4 still land | 5.333s |
| `testFetchExplorePOIsMultiRingAllFailedThrows` | every ring 503 → throws so outer catch offers offline fallback | 1.212s |
| `testFetchExplorePOIsFlagOffUsesSingleRing` | flag off → identical single-ring path, 1 HTTP call | 0.389s |

## How to enable for testing

```bash
# Run with multi-ring on
DEEPSEEK_API_KEY=... FF_PRO_MULTI_RING_EXPLORE=1 \
  xcodebuild -scheme SoloCompass -destination 'platform=iOS Simulator,name=iPhone 17' build
```

Or set `FF_PRO_MULTI_RING_EXPLORE = YES` in `Resources/FeatureFlags.plist`.

## Out of scope

- Edge Function POI cap sync (`supabase/functions/synthesize-experiences`) — follow-up PR
- UI progress states (`ExploreProgress` enum, ring-completion haptics) — **US-MR-04**
- Analytics event `explore_multi_ring_completed` — **US-MR-05**

## Test plan

- [x] `xcodebuild test` passes for all 4 new tests
- [ ] CI green
- [ ] Manual smoke: with `FF_PRO_MULTI_RING_EXPLORE=1` on a Pro account, tap "Explore Here" and verify >15 places land (cap is now 60 not 15)