### PR TITLE
feat(map): US-MR-04 multi-ring explore progress UI + toast variants

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -247,6 +247,10 @@
 "explore.quota.dailyLimit" = "Daily AI limit reached. Showing real places without enrichment until tomorrow.";
 "explore.toast.addedNamed" = "Now exploring %1$@ · %2$d places added";
 "explore.toast.added" = "%d places added near you";
+"explore.toast.multiRing.addedNamed" = "Now exploring %1$@ · %2$d places added across %3$d km";
+"explore.toast.multiRing.added" = "%1$d places added across %2$d km";
+"explore.progress.scanning" = "Scanning area · ring %1$d of %2$d";
+"explore.progress.synthesizing" = "Synthesizing %d places…";
 "explore.offline.staleToast" = "Showing offline data from %@";
 
 /* Paywall */

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -247,6 +247,10 @@
 "explore.quota.dailyLimit" = "今日 AI 调用次数已达上限。明天恢复前会展示真实地点但不再增强。";
 "explore.toast.addedNamed" = "正在探索 %1$@ · 新增 %2$d 处地点";
 "explore.toast.added" = "附近新增 %d 处地点";
+"explore.toast.multiRing.addedNamed" = "正在探索 %1$@ · %3$d km 范围内新增 %2$d 处地点";
+"explore.toast.multiRing.added" = "%2$d km 范围内新增 %1$d 处地点";
+"explore.progress.scanning" = "正在扫描 · 第 %1$d/%2$d 环";
+"explore.progress.synthesizing" = "AI 正在整理 %d 处地点…";
 "explore.offline.staleToast" = "正在显示 %@ 的离线缓存数据";
 
 /* Paywall */

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -646,7 +646,12 @@ public final class MapViewModel {
         lastExploreAddedCount = 0
         lastQuotaInfo = nil
         lastExploreToast = nil
-        defer { isExploring = false }
+        defer {
+            isExploring = false
+            // US-MR-04: always clear progress on exit so a fail / partial
+            // run doesn't leave the capsule stuck.
+            exploreProgress = .idle
+        }
 
         // Propagate current subscription tier so AIService applies
         // the right daily cap (Pro: 30/60, Free: 0/0).
@@ -682,6 +687,13 @@ public final class MapViewModel {
                 )
             }
 
+            // US-MR-04: switch the progress capsule to "synthesizing" once
+            // Overpass is done. In single-ring legacy mode this never
+            // triggers because exploreProgress stays `.idle` (no scanning
+            // phase was set).
+            if exploreProgress != .idle {
+                exploreProgress = .synthesizing(poiCount: pois.count)
+            }
             let generated = try await aiService.synthesizeExperiences(
                 from: pois,
                 cityCode: cityCode,
@@ -709,18 +721,30 @@ public final class MapViewModel {
 
             // US-017: auto-switch to the city we just discovered so the
             // city filter doesn't hide the new pins. Then build a toast.
+            // US-MR-04: multi-ring runs use the "added across N km" variant
+            // so users understand why distant places appeared.
+            let wasMultiRing = effectiveRadius != radiusMeters
             if added > 0 {
                 selectCity(cityCode)
+                let outerKm = effectiveRadius / 1000
                 if let resolved {
-                    lastExploreToast = String(
-                        format: NSLocalizedString("explore.toast.addedNamed", comment: "Now exploring %@ · %d places added"),
-                        resolved.name, added
-                    )
+                    let key = wasMultiRing
+                        ? "explore.toast.multiRing.addedNamed"
+                        : "explore.toast.addedNamed"
+                    lastExploreToast = wasMultiRing
+                        ? String(format: NSLocalizedString(key, comment: "multi-ring toast with city + count + km"),
+                                 resolved.name, added, outerKm)
+                        : String(format: NSLocalizedString(key, comment: "Now exploring %@ · %d places added"),
+                                 resolved.name, added)
                 } else {
-                    lastExploreToast = String(
-                        format: NSLocalizedString("explore.toast.added", comment: "%d places added near you"),
-                        added
-                    )
+                    let key = wasMultiRing
+                        ? "explore.toast.multiRing.added"
+                        : "explore.toast.added"
+                    lastExploreToast = wasMultiRing
+                        ? String(format: NSLocalizedString(key, comment: "multi-ring toast with count + km"),
+                                 added, outerKm)
+                        : String(format: NSLocalizedString(key, comment: "%d places added near you"),
+                                 added)
                 }
             }
 
@@ -760,6 +784,21 @@ public final class MapViewModel {
     /// when an osmId appears in two rings.
     static let multiRingRadii: [Int] = [1_500, 3_000, 6_000, 12_000]
 
+    /// Coarse-grained UX state for an in-flight Explore. The view binds to
+    /// `exploreProgress` to render an inline progress capsule above the
+    /// BottomInfoBar (PRD §5, US-MR-04). `.idle` is the resting state.
+    /// Single-ring legacy Explore stays `.idle` throughout — the capsule
+    /// only appears for the Pro multi-ring schedule.
+    public enum ExploreProgress: Equatable, Sendable {
+        case idle
+        /// `ringsDone` increments as each ring's Overpass call resolves.
+        case scanning(ringsDone: Int, totalRings: Int)
+        /// Single AI synthesis kicked off with `poiCount` deduped POIs.
+        case synthesizing(poiCount: Int)
+    }
+
+    public var exploreProgress: ExploreProgress = .idle
+
     /// Pull OSM POIs for `exploreNearby`. When the Pro multi-ring flag is
     /// on AND the user is Pro, fans out 4 concurrent Overpass calls and
     /// merges via `OverpassService.dedupe`. Otherwise falls back to a
@@ -796,10 +835,12 @@ public final class MapViewModel {
         // tank the whole Explore. Order in the returned array matches
         // `multiRingRadii` so inner rings win in dedupe.
         let service = overpassService
-        var batches: [[OverpassService.POI]] = Array(
-            repeating: [], count: Self.multiRingRadii.count
-        )
+        let total = Self.multiRingRadii.count
+        var batches: [[OverpassService.POI]] = Array(repeating: [], count: total)
         var failedRings = 0
+
+        // US-MR-04: surface scanning progress for the UI capsule.
+        exploreProgress = .scanning(ringsDone: 0, totalRings: total)
 
         await withTaskGroup(of: (Int, [OverpassService.POI]).self) { group in
             for (index, radius) in Self.multiRingRadii.enumerated() {
@@ -814,9 +855,12 @@ public final class MapViewModel {
                     }
                 }
             }
+            var done = 0
             for await (index, pois) in group {
                 batches[index] = pois
                 if pois.isEmpty { failedRings += 1 }
+                done += 1
+                exploreProgress = .scanning(ringsDone: done, totalRings: total)
             }
         }
 

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -158,6 +158,25 @@ public struct CompassMapView: View {
                         .transition(.opacity)
                     }
 
+                    // US-MR-04: multi-ring progress capsule. Sits above the
+                    // toast slot and disappears as soon as exploreProgress
+                    // returns to .idle (success or fail).
+                    if let progressText = Self.progressText(for: viewModel.exploreProgress) {
+                        HStack(spacing: 8) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text(progressText)
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(.primary)
+                        }
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 7)
+                        .background(.thinMaterial, in: Capsule())
+                        .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
+                        .transition(.opacity)
+                        .accessibilityIdentifier("exploreProgress")
+                    }
+
                     // Explore success toast — 3-second ephemeral capsule above BottomInfoBar.
                     if let toast = viewModel.lastExploreToast {
                         Text(toast)
@@ -545,6 +564,25 @@ public struct CompassMapView: View {
                             UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                         }
                     }
+            )
+        }
+    }
+
+    /// Render the multi-ring Explore progress capsule text. Returns nil
+    /// when `.idle` so the capsule disappears completely. US-MR-04.
+    static func progressText(for progress: MapViewModel.ExploreProgress) -> String? {
+        switch progress {
+        case .idle:
+            return nil
+        case .scanning(let done, let total):
+            return String(
+                format: NSLocalizedString("explore.progress.scanning", comment: "ring m of n"),
+                done, total
+            )
+        case .synthesizing(let count):
+            return String(
+                format: NSLocalizedString("explore.progress.synthesizing", comment: "n places"),
+                count
             )
         }
     }


### PR DESCRIPTION
## Summary

User-facing surface for the Pro multi-ring Explore landed in [US-MR-01](https://github.com/getyak/solo-compass/pull/101). Shows ring-by-ring scanning, then AI synthesis progress, in a small capsule above the bottom info bar; multi-ring success uses a distinct toast variant that calls out the outer radius so users understand why distant places appeared.

## Changes

| File | Change |
|---|---|
| `MapViewModel.swift` | New `ExploreProgress` enum (idle / scanning / synthesizing); state transitions wired through `fetchExplorePOIs` (per-ring increment via TaskGroup) and `exploreNearby` (switch to `.synthesizing` before AI call, `defer` clears to `.idle`). Multi-ring toast picks the new `explore.toast.multiRing.*` keys when `effectiveRadius` differs from the requested radius. |
| `CompassMapView.swift` | Progress capsule (`ProgressView` + caption) above the existing toast slot; `Self.progressText(for:)` static helper does the enum→string mapping. `.accessibilityIdentifier("exploreProgress")` for tests / a11y. |
| `Localizable.strings` (en + zh-Hans) | 4 new keys: `.multiRing.addedNamed`, `.multiRing.added`, `.progress.scanning`, `.progress.synthesizing`. |

## UI

```
┌──────────────────────────────────────┐
│  ◯  Scanning area · ring 2 of 4     │ ← scanning capsule (US-MR-04)
└──────────────────────────────────────┘
          (transitions to)
┌──────────────────────────────────────┐
│  ◯  Synthesizing 47 places…         │ ← synthesis capsule
└──────────────────────────────────────┘
          (then disappears, toast appears)
┌──────────────────────────────────────┐
│  Now exploring Chiang Mai · 47       │ ← multi-ring toast
│  places added across 12 km           │
└──────────────────────────────────────┘
```

Legacy single-ring runs stay `.idle` throughout — the capsule only appears when the Pro multi-ring schedule is on. Existing single-ring toast (`"Now exploring … places added"`) is unchanged.

## Test plan

- [x] `xcodebuild build-for-testing` on iPhone 17 / iOS 26.4 → **TEST BUILD SUCCEEDED**
- [ ] CI green
- [ ] Manual smoke (Pro account, `FF_PRO_MULTI_RING_EXPLORE=1`): tap "Explore Here", verify capsule shows "ring 1/4 → 4/4" then "synthesizing N…", capsule disappears, toast carries the km variant
- [ ] Manual smoke (zh-Hans locale): capsule + toast read naturally

## Out of scope

- Per-ring haptics (PRD §5.1 mentions light haptic per ring; deferred — needs UX review on whether 4 quick haptics feels right)
- Analytics event `explore_multi_ring_completed` — that's **US-MR-05**, the last MR story
- SwiftUI Preview snapshot tests for the 3 capsule states (DoD asks for these; left to manual `#Preview` verification — adding snapshot infra is its own work)