### PR TITLE
feat(ios): in-app language switcher + US-MR-05 multi-ring analytics

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		7D2B6DE6C27E0307CA998A5F /* CityPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873ACB737A9B43254C17B238 /* CityPickerSheet.swift */; };
 		86F4628473C2D520D4C2FFFB /* SoloScoreBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB579F3F4EBBA014AA306DD1 /* SoloScoreBadge.swift */; };
 		8B4F2A6E8F3C6EAD0F9A8E32 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = EA0858036CFEA9774139AFD7 /* PrivacyInfo.xcprivacy */; };
+		953C7BD48AF4AF55608145A6 /* LanguageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87002BB6D344B384A3FDFBFD /* LanguageService.swift */; };
 		9C8CC563D33FDBB3DF57A841 /* RecentExploreRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9748B0A808BC06F6EDED3C3B /* RecentExploreRegion.swift */; };
 		A84320715E7CBDA91FC3F26F /* ExperienceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */; };
 		AA75B3147A29FDA55E61B24A /* PendingCheckInBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */; };
@@ -111,6 +112,7 @@
 		791CBEDE09220728AD52AAAD /* UserFavoriteRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFavoriteRecord.swift; sourceTree = "<group>"; };
 		79B73212B8F704EABD27EF5B /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
 		81A92E0AE1868C3A165F3E95 /* PendingSyncRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingSyncRecord.swift; sourceTree = "<group>"; };
+		87002BB6D344B384A3FDFBFD /* LanguageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageService.swift; sourceTree = "<group>"; };
 		873ACB737A9B43254C17B238 /* CityPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityPickerSheet.swift; sourceTree = "<group>"; };
 		8FDFA5F3503B8ABC4B5CB086 /* SoloCompassTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SoloCompassTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9748B0A808BC06F6EDED3C3B /* RecentExploreRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentExploreRegion.swift; sourceTree = "<group>"; };
@@ -288,6 +290,7 @@
 				12F087E4FA7161529378098C /* ExperienceService.swift */,
 				79B73212B8F704EABD27EF5B /* FeatureFlags.swift */,
 				6556C23BF1B228BF686C5500 /* KeychainStore.swift */,
+				87002BB6D344B384A3FDFBFD /* LanguageService.swift */,
 				2C7919EAFDE363B49C4B4C47 /* LocationService.swift */,
 				C215AE07BA32182A887226F9 /* NotificationService.swift */,
 				67173C74F1A76C3CE5C38C0A /* OverpassService.swift */,
@@ -549,6 +552,7 @@
 				297541149234668D12EAF272 /* FilterBarView.swift in Sources */,
 				391D6B5C48997AD74F367C0C /* GeneratedSecrets.swift in Sources */,
 				48DF93F42CDDB1329B038865 /* KeychainStore.swift in Sources */,
+				953C7BD48AF4AF55608145A6 /* LanguageService.swift in Sources */,
 				31F9538643C362D7EEF64C6B /* LocationService.swift in Sources */,
 				CE1A6A1D5EB25B2BEA5B29DA /* MapViewModel.swift in Sources */,
 				28E3EB1BFFB0A73A1C56FD54 /* MarkerIconView.swift in Sources */,

--- a/apps/ios/SoloCompass/App/SoloCompassApp.swift
+++ b/apps/ios/SoloCompass/App/SoloCompassApp.swift
@@ -9,6 +9,7 @@ struct SoloCompassApp: App {
     @State private var preferences = UserPreferences()
     @State private var notificationService = NotificationService.shared
     @State private var subscriptionService = SubscriptionService()
+    @State private var languageService = LanguageService.shared
     private let supabaseClient = SupabaseClient.shared
 
     var body: some Scene {
@@ -20,6 +21,7 @@ struct SoloCompassApp: App {
                 .environment(preferences)
                 .environment(notificationService)
                 .environment(subscriptionService)
+                .environment(languageService)
                 .environment(supabaseClient)
                 .onAppear {
                     locationService.preferences = preferences

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -297,3 +297,13 @@
 "explore.consent.bullet.no_pii" = "We never collect contacts, photos, or browsing history. Nothing is shared with advertisers.";
 "explore.consent.accept" = "Got it — explore";
 "explore.consent.cancel" = "Not now";
+
+/* In-app language switcher */
+"settings.language" = "Language";
+"settings.language.footer" = "Choose the language Solo Compass speaks. The app restarts to apply your choice.";
+"settings.language.system" = "Follow system";
+"settings.language.english" = "English";
+"settings.language.zh-Hans" = "简体中文";
+"settings.language.restart.title" = "Restart required";
+"settings.language.restart.message" = "Quit and reopen Solo Compass to finish switching languages.";
+"settings.language.restart.ok" = "OK";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -297,3 +297,13 @@
 "explore.consent.bullet.no_pii" = "我们不收集通讯录、相册、浏览记录。绝不与广告商共享。";
 "explore.consent.accept" = "了解了 — 开始探索";
 "explore.consent.cancel" = "暂不";
+
+/* In-app language switcher */
+"settings.language" = "语言";
+"settings.language.footer" = "选择 Solo Compass 显示的语言。切换后需重启应用生效。";
+"settings.language.system" = "跟随系统";
+"settings.language.english" = "English";
+"settings.language.zh-Hans" = "简体中文";
+"settings.language.restart.title" = "需要重启";
+"settings.language.restart.message" = "请退出并重新打开 Solo Compass 以完成语言切换。";
+"settings.language.restart.ok" = "好的";

--- a/apps/ios/SoloCompass/Services/LanguageService.swift
+++ b/apps/ios/SoloCompass/Services/LanguageService.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Observation
+
+/// In-app language switcher.
+///
+/// iOS apps normally inherit the system language. We override that by writing
+/// to the `AppleLanguages` UserDefaults key — the value is read by `Bundle`
+/// on next launch to pick the matching `.lproj`. A relaunch is required for
+/// the change to take effect (a hard iOS constraint without bundle swizzling).
+@MainActor
+@Observable
+public final class LanguageService {
+    public enum Option: String, CaseIterable, Identifiable, Sendable {
+        case system
+        case english = "en"
+        case simplifiedChinese = "zh-Hans"
+
+        public var id: String { rawValue }
+
+        /// `nil` for `.system` — fall back to `Locale.current`.
+        public var locale: Locale? {
+            switch self {
+            case .system:            return nil
+            case .english:           return Locale(identifier: "en")
+            case .simplifiedChinese: return Locale(identifier: "zh-Hans")
+            }
+        }
+    }
+
+    public static let shared = LanguageService()
+
+    /// UserDefaults key honoured by `Bundle` to pick the active `.lproj`.
+    static let appleLanguagesKey = "AppleLanguages"
+    /// Our own override marker so we can distinguish "user picked system"
+    /// from "AppleLanguages happens to match the system language".
+    static let overrideKey = "SoloCompass.LanguageOverride"
+
+    public private(set) var current: Option
+
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let raw = defaults.string(forKey: Self.overrideKey),
+           let option = Option(rawValue: raw) {
+            self.current = option
+        } else {
+            self.current = .system
+        }
+    }
+
+    /// Effective locale to pass to AI / formatters. Falls back to system
+    /// when the user picked `.system`.
+    public var effectiveLocale: Locale {
+        current.locale ?? .current
+    }
+
+    /// Persist the user's choice. Returns `true` when a relaunch is needed
+    /// for UI strings to actually swap (always true except for no-op writes).
+    @discardableResult
+    public func setLanguage(_ option: Option) -> Bool {
+        guard option != current else { return false }
+        current = option
+
+        switch option {
+        case .system:
+            defaults.removeObject(forKey: Self.overrideKey)
+            defaults.removeObject(forKey: Self.appleLanguagesKey)
+        case .english, .simplifiedChinese:
+            defaults.set(option.rawValue, forKey: Self.overrideKey)
+            defaults.set([option.rawValue], forKey: Self.appleLanguagesKey)
+        }
+        return true
+    }
+}

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -1050,6 +1050,41 @@ final class SoloCompassTests: XCTestCase {
         }
     }
 
+    // MARK: - US-MR-05 multi-ring analytics
+
+    @MainActor
+    func testMultiRingMetricsShapeIsStableAndEmittable() {
+        // Lock the field set + types so future analytics-transport work
+        // can wire to the same shape the PRD specifies (US-MR-05).
+        let m = MapViewModel.ExploreMetrics(
+            addedCount: 47,
+            maxRadiusMeters: 12_000,
+            failedRings: 1,
+            totalRings: 4,
+            durationMs: 5_234
+        )
+        XCTAssertEqual(m.addedCount, 47)
+        XCTAssertEqual(m.maxRadiusMeters, 12_000)
+        XCTAssertEqual(m.failedRings, 1)
+        XCTAssertEqual(m.totalRings, 4)
+        XCTAssertEqual(m.durationMs, 5_234)
+
+        // Equatable + Sendable conformances are part of the public contract.
+        let copy = MapViewModel.ExploreMetrics(
+            addedCount: 47, maxRadiusMeters: 12_000,
+            failedRings: 1, totalRings: 4, durationMs: 5_234
+        )
+        XCTAssertEqual(m, copy)
+
+        // emitMultiRingCompleted must not crash on a populated payload.
+        MapViewModel.emitMultiRingCompleted(m)
+        // Also must handle the all-failed edge (addedCount=0, failedRings=totalRings).
+        MapViewModel.emitMultiRingCompleted(.init(
+            addedCount: 0, maxRadiusMeters: 12_000,
+            failedRings: 4, totalRings: 4, durationMs: 1_200
+        ))
+    }
+
     @MainActor
     func testFetchExplorePOIsFlagOffUsesSingleRing() async throws {
         // Flag off → behave exactly like pre-MR-01: one Overpass call at
@@ -2420,5 +2455,73 @@ final class MockSupabaseClient: SupabaseClientProtocol {
 
     var isAnonymous: Bool {
         get async { false }
+    }
+}
+
+// MARK: - LanguageService
+
+@MainActor
+final class LanguageServiceTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "LanguageServiceTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testDefaultsToSystemWhenNoOverride() {
+        let svc = LanguageService(defaults: defaults)
+        XCTAssertEqual(svc.current, .system)
+        XCTAssertNil(LanguageService.Option.system.locale)
+    }
+
+    func testSetEnglishPersistsAppleLanguages() {
+        let svc = LanguageService(defaults: defaults)
+        let changed = svc.setLanguage(.english)
+        XCTAssertTrue(changed)
+        XCTAssertEqual(svc.current, .english)
+        XCTAssertEqual(defaults.stringArray(forKey: LanguageService.appleLanguagesKey), ["en"])
+        XCTAssertEqual(defaults.string(forKey: LanguageService.overrideKey), "en")
+        XCTAssertEqual(svc.effectiveLocale.identifier, "en")
+    }
+
+    func testSetZhHansPersistsAppleLanguages() {
+        let svc = LanguageService(defaults: defaults)
+        XCTAssertTrue(svc.setLanguage(.simplifiedChinese))
+        XCTAssertEqual(defaults.stringArray(forKey: LanguageService.appleLanguagesKey), ["zh-Hans"])
+        XCTAssertEqual(svc.effectiveLocale.identifier, "zh-Hans")
+    }
+
+    func testSettingSameLanguageReturnsFalse() {
+        let svc = LanguageService(defaults: defaults)
+        XCTAssertTrue(svc.setLanguage(.english))
+        XCTAssertFalse(svc.setLanguage(.english))
+    }
+
+    func testSettingSystemClearsOverride() {
+        let svc = LanguageService(defaults: defaults)
+        _ = svc.setLanguage(.simplifiedChinese)
+        XCTAssertTrue(svc.setLanguage(.system))
+        // override marker is what we own — once cleared, `Bundle` will fall
+        // back to the system language even though UserDefaults may still
+        // surface a system-wide value for `AppleLanguages`.
+        XCTAssertNil(defaults.string(forKey: LanguageService.overrideKey))
+        XCTAssertEqual(svc.current, .system)
+        XCTAssertNil(LanguageService.Option.system.locale)
+    }
+
+    func testInitRestoresPersistedOverride() {
+        defaults.set("zh-Hans", forKey: LanguageService.overrideKey)
+        let svc = LanguageService(defaults: defaults)
+        XCTAssertEqual(svc.current, .simplifiedChinese)
     }
 }

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -646,6 +646,8 @@ public final class MapViewModel {
         lastExploreAddedCount = 0
         lastQuotaInfo = nil
         lastExploreToast = nil
+        // US-MR-05: stamp wall-clock start; emitted via durationMs.
+        let exploreStart = Date()
         defer {
             isExploring = false
             // US-MR-04: always clear progress on exit so a fail / partial
@@ -697,7 +699,7 @@ public final class MapViewModel {
             let generated = try await aiService.synthesizeExperiences(
                 from: pois,
                 cityCode: cityCode,
-                locale: .current
+                locale: LanguageService.shared.effectiveLocale
             )
             let added = experienceService.appendGenerated(generated)
             lastExploreAddedCount = added
@@ -724,6 +726,23 @@ public final class MapViewModel {
             // US-MR-04: multi-ring runs use the "added across N km" variant
             // so users understand why distant places appeared.
             let wasMultiRing = effectiveRadius != radiusMeters
+
+            // US-MR-05: emit analytics for multi-ring runs even when
+            // added == 0 (a "we tried and got nothing" event is still
+            // signal worth tracking).
+            if wasMultiRing {
+                let durationMs = Int(Date().timeIntervalSince(exploreStart) * 1000)
+                let metrics = ExploreMetrics(
+                    addedCount: added,
+                    maxRadiusMeters: effectiveRadius,
+                    failedRings: pendingFailedRings,
+                    totalRings: Self.multiRingRadii.count,
+                    durationMs: durationMs
+                )
+                lastMultiRingMetrics = metrics
+                Self.emitMultiRingCompleted(metrics)
+            }
+
             if added > 0 {
                 selectCity(cityCode)
                 let outerKm = effectiveRadius / 1000
@@ -799,6 +818,26 @@ public final class MapViewModel {
 
     public var exploreProgress: ExploreProgress = .idle
 
+    /// Telemetry from the most recent multi-ring Explore. Populated only
+    /// when the Pro multi-ring schedule runs; nil after a single-ring
+    /// fetch or before the first Explore. Bound by tests; in production
+    /// it's also emitted as `explore_multi_ring_completed` via the
+    /// DEBUG-print analytics shim below until a real AnalyticsService
+    /// lands. US-MR-05.
+    public struct ExploreMetrics: Equatable, Sendable {
+        public let addedCount: Int
+        public let maxRadiusMeters: Int
+        public let failedRings: Int
+        public let totalRings: Int
+        public let durationMs: Int
+    }
+
+    public private(set) var lastMultiRingMetrics: ExploreMetrics?
+    /// Mutable within `fetchExplorePOIs` (multi-ring path) to plumb
+    /// failed-ring count up to `exploreNearby` without changing the
+    /// existing tuple return signature (which is covered by tests).
+    private var pendingFailedRings: Int = 0
+
     /// Pull OSM POIs for `exploreNearby`. When the Pro multi-ring flag is
     /// on AND the user is Pro, fans out 4 concurrent Overpass calls and
     /// merges via `OverpassService.dedupe`. Otherwise falls back to a
@@ -841,6 +880,8 @@ public final class MapViewModel {
 
         // US-MR-04: surface scanning progress for the UI capsule.
         exploreProgress = .scanning(ringsDone: 0, totalRings: total)
+        // US-MR-05: reset analytics counter before this run.
+        pendingFailedRings = 0
 
         await withTaskGroup(of: (Int, [OverpassService.POI]).self) { group in
             for (index, radius) in Self.multiRingRadii.enumerated() {
@@ -863,6 +904,10 @@ public final class MapViewModel {
                 exploreProgress = .scanning(ringsDone: done, totalRings: total)
             }
         }
+
+        // US-MR-05: stash counters so exploreNearby can emit
+        // `explore_multi_ring_completed` after appendGenerated.
+        pendingFailedRings = failedRings
 
         // If every ring came back empty / failed, surface as a single
         // throw so the outer catch can hit the offline fallback branch.
@@ -913,7 +958,7 @@ public final class MapViewModel {
             let generated = try await aiService.synthesizeExperiences(
                 from: pois,
                 cityCode: cityCode,
-                locale: .current
+                locale: LanguageService.shared.effectiveLocale
             )
             let added = experienceService.appendGenerated(generated)
             lastExploreAddedCount = added
@@ -960,5 +1005,28 @@ public final class MapViewModel {
         // so we use a heuristic — average reports/30d divided down.
         let signals = experiences.reduce(0) { $0 + $1.confidence.signals.passiveGpsHits30d }
         return max(0, signals / 30) // per-day estimate
+    }
+
+    // MARK: - US-MR-05 analytics shim
+    //
+    // Until a real AnalyticsService lands, emit `explore_multi_ring_completed`
+    // as a one-line JSON dictionary visible in the Xcode console under DEBUG.
+    // The shape matches the PRD field names so the eventual transport (Edge
+    // Function / RudderStack / etc.) can wire it through without renames.
+    static func emitMultiRingCompleted(_ metrics: ExploreMetrics) {
+        #if DEBUG
+        let payload: [String: Any] = [
+            "event": "explore_multi_ring_completed",
+            "addedCount": metrics.addedCount,
+            "maxRadiusMeters": metrics.maxRadiusMeters,
+            "failedRings": metrics.failedRings,
+            "totalRings": metrics.totalRings,
+            "durationMs": metrics.durationMs
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let line = String(data: data, encoding: .utf8) {
+            print("[Analytics] \(line)")
+        }
+        #endif
     }
 }

--- a/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
@@ -8,6 +8,7 @@ public struct SettingsView: View {
     @Environment(UserPreferences.self) private var preferences
     @Environment(NotificationService.self) private var notificationService
     @Environment(SubscriptionService.self) private var subscriptionService
+    @Environment(LanguageService.self) private var languageService
     @Environment(\.modelContext) private var modelContext
     var onClose: () -> Void
     var onShowFavorites: (() -> Void)?
@@ -15,6 +16,7 @@ public struct SettingsView: View {
     @State private var showingClearConfirm = false
     @State private var restoreToast: String?
     @State private var restoreInFlight = false
+    @State private var showingLanguageRestartAlert = false
 
     // Admin / tester email unlock — bypasses StoreKit for allow-listed
     // emails so internal testers and the project owner can reach Pro
@@ -41,6 +43,7 @@ public struct SettingsView: View {
                 dislikedCategoriesSection
                 distanceSection
                 notificationsSection
+                languageSection
                 subscriptionSection
                 statsSection
                 dataSection
@@ -189,6 +192,56 @@ public struct SettingsView: View {
             Text(NSLocalizedString("settings.notifications.header", comment: "Notifications section header"))
         } footer: {
             Text(NSLocalizedString("settings.notifications.footer", comment: "Notifications footer"))
+        }
+    }
+
+    // MARK: - Language
+
+    private var languageSection: some View {
+        Section {
+            ForEach(LanguageService.Option.allCases) { option in
+                HStack {
+                    Image(systemName: "globe")
+                        .frame(width: 28)
+                        .foregroundStyle(.blue)
+                    Text(languageOptionLabel(option))
+                    Spacer()
+                    if languageService.current == option {
+                        Image(systemName: "checkmark")
+                            .foregroundStyle(.blue)
+                            .fontWeight(.semibold)
+                    }
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    if languageService.setLanguage(option) {
+                        showingLanguageRestartAlert = true
+                    }
+                }
+            }
+        } header: {
+            Text(NSLocalizedString("settings.language", comment: "Language section header"))
+        } footer: {
+            Text(NSLocalizedString("settings.language.footer", comment: "Language footer"))
+        }
+        .alert(
+            NSLocalizedString("settings.language.restart.title", comment: "Restart required"),
+            isPresented: $showingLanguageRestartAlert
+        ) {
+            Button(NSLocalizedString("settings.language.restart.ok", comment: "OK")) {}
+        } message: {
+            Text(NSLocalizedString("settings.language.restart.message", comment: "Restart message"))
+        }
+    }
+
+    private func languageOptionLabel(_ option: LanguageService.Option) -> String {
+        switch option {
+        case .system:
+            return NSLocalizedString("settings.language.system", comment: "Follow system")
+        case .english:
+            return NSLocalizedString("settings.language.english", comment: "English")
+        case .simplifiedChinese:
+            return NSLocalizedString("settings.language.zh-Hans", comment: "Simplified Chinese")
         }
     }
 
@@ -464,4 +517,5 @@ extension UserPreferences.SoloTravelStyle {
 #Preview {
     SettingsView()
         .environment(UserPreferences())
+        .environment(LanguageService())
 }


### PR DESCRIPTION
## Summary

This PR bundles two changes that were committed together:

### 1. In-app language switcher (i18n verification follow-through)

New `LanguageService` that overrides `AppleLanguages` via UserDefaults so users can pick System / English / 简体中文 in Settings, independent of the device language. AI synthesis prompts now use the user's selected locale rather than `Locale.current`, so generated content speaks the chosen language too.

- `Services/LanguageService.swift` — Option enum, persistence, `effectiveLocale`
- `Views/Settings/SettingsView.swift` — language section + restart-required alert
- `ViewModels/MapViewModel.swift` — routes synthesis through `LanguageService.effectiveLocale`
- `Resources/Localizable.strings` (en + zh-Hans) — 8 picker / alert keys
- 6 unit tests on `LanguageService` (default state, set/clear, restore)

A relaunch alert is shown after switching because iOS only re-reads localized bundles on next app launch (hard iOS constraint without bundle swizzling).

### 2. US-MR-05 multi-ring analytics (closes Pro multi-ring PRD)

Last story of `docs/PRD/pro-radial-explore.md`. Adds telemetry for multi-ring Explore runs.

- `MapViewModel.ExploreMetrics` — new nested struct with `addedCount`, `maxRadiusMeters`, `failedRings`, `totalRings`, `durationMs`
- `lastMultiRingMetrics` — published property so tests / future surfaces can observe
- `emitMultiRingCompleted(_:)` — DEBUG-only JSON-line print of `explore_multi_ring_completed` until a real `AnalyticsService` lands; field names match the PRD so the transport plug-in won't need renames
- Wall-clock duration stamped at start of `exploreNearby`, `pendingFailedRings` plumbed up from `fetchExplorePOIs`
- 1 unit test locking the metrics shape + `emit*` no-crash on populated + all-failed payloads

## Why bundled

The MR-05 work and the language switcher landed in the same commit during a working-tree consolidation. Splitting them now would mean a rebase + re-test cycle for no real reviewer benefit since they touch overlapping files (`MapViewModel`, `Tests`, `Localizable.strings`).

## Test plan

- [x] `xcodebuild build-for-testing` on iPhone 17 / iOS 26.4 → **TEST BUILD SUCCEEDED**
- [ ] CI runs the test suite (local sim was flaky earlier — pre-existing issue with `simctl shutdown all` mid-test; CI runs clean from scratch each time)
- [ ] Manual smoke: Settings → switch to 简体中文 → restart → UI in Chinese → trigger Explore → AI text in Chinese
- [ ] Manual smoke: with `FF_PRO_MULTI_RING_EXPLORE=1`, run Explore → console shows `[Analytics] {"event":"explore_multi_ring_completed", …}`

## Out of scope

- Real AnalyticsService transport (Edge Function / RudderStack) — replaces the DEBUG print
- Bundle-swizzling for hot language switch (no restart required) — intentionally not done; iOS-blessed path is restart