### PR TITLE
feat(voice): US-VA-01 VoiceAgentSession state model

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		BCD734EA6E4D5CE922D0621D /* SubscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B8A80F048D74BEDB8C1132 /* SubscriptionService.swift */; };
 		BD5BB6BD7FCBDB30282F28FA /* VoiceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8ABF85EEFDF9969C94B441 /* VoiceButton.swift */; };
 		C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */; };
+		C220FEC091B645D82519465E /* VoiceAgentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112319E8315F5F6961C95264 /* VoiceAgentSession.swift */; };
 		C2C0AF72D709EDC17C6ED874 /* UserPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63FDD874A8F533F0717132A /* UserPreferences.swift */; };
 		C53DB60CA9E95907A2CBF2C0 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C215AE07BA32182A887226F9 /* NotificationService.swift */; };
 		C735986DAC69807F27CC0E39 /* FeatureFlags.plist in Resources */ = {isa = PBXBuildFile; fileRef = 409FB4B0922C4A1D8AAEB1D1 /* FeatureFlags.plist */; };
@@ -83,6 +84,7 @@
 /* Begin PBXFileReference section */
 		001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIUsageRecord.swift; sourceTree = "<group>"; };
 		0E0157D30FF53B21FF31D519 /* MarkerIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerIconView.swift; sourceTree = "<group>"; };
+		112319E8315F5F6961C95264 /* VoiceAgentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAgentSession.swift; sourceTree = "<group>"; };
 		120FC7465285714C5FA8F96D /* VoiceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceService.swift; sourceTree = "<group>"; };
 		12F087E4FA7161529378098C /* ExperienceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceService.swift; sourceTree = "<group>"; };
 		130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingCheckInBanner.swift; sourceTree = "<group>"; };
@@ -298,6 +300,7 @@
 				33B8A80F048D74BEDB8C1132 /* SubscriptionService.swift */,
 				E406C379247653B4AA5A3E0E /* SupabaseClient.swift */,
 				6163572F4644BF852B35FDA4 /* SyncService.swift */,
+				112319E8315F5F6961C95264 /* VoiceAgentSession.swift */,
 				120FC7465285714C5FA8F96D /* VoiceService.swift */,
 			);
 			path = Services;
@@ -579,6 +582,7 @@
 				219718C8521B1013D17AE22F /* UserCompletionRecord.swift in Sources */,
 				D53E53A5AA9AE6F77EF82418 /* UserFavoriteRecord.swift in Sources */,
 				C2C0AF72D709EDC17C6ED874 /* UserPreferences.swift in Sources */,
+				C220FEC091B645D82519465E /* VoiceAgentSession.swift in Sources */,
 				BD5BB6BD7FCBDB30282F28FA /* VoiceButton.swift in Sources */,
 				F5677DCF081E506C7E32243F /* VoiceService.swift in Sources */,
 			);

--- a/apps/ios/SoloCompass/Services/VoiceAgentSession.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentSession.swift
@@ -1,0 +1,288 @@
+import Foundation
+import Observation
+
+/// State + message history for one multi-turn voice agent conversation.
+///
+/// US-VA-01: pure model layer. No UI, no network, no SwiftData. Sequence:
+///   1. `appendUser(_:)` after speech-to-text resolves a phrase.
+///   2. Transition to `.thinking` while DeepSeek runs (US-VA-02 will own
+///      the actual HTTP call).
+///   3. If the model returns `tool_calls`, switch to `.toolExecuting`,
+///      run them locally, then `appendToolResult(...)` for each and loop.
+///   4. When the model returns plain `content`, `appendAssistant(...)`
+///      and transition to `.speaking`, then back to `.idle` (or
+///      `.listening` for the next turn).
+///
+/// All transitions and message bookkeeping happen on the main actor so
+/// the @Observable bindings the UI consumes never cross actor boundaries.
+@MainActor
+@Observable
+public final class VoiceAgentSession {
+
+    // MARK: - Hard limits (PRD §5.1)
+    //
+    // Pinned as `static let` so US-VA-06 (loop orchestration) and tests
+    // can reference the same numbers without reaching into the PRD.
+
+    /// Maximum messages kept in `messages` before `compactIfNeeded()`
+    /// summarises the oldest pairs into a single system note. Includes
+    /// the initial system prompt; PRD §5.1 spec is 10 + system, here
+    /// we count system in the limit for simplicity (so 11 effective).
+    public static let messagesMaxCount = 11
+
+    /// Maximum `tool_calls` we will execute from a single assistant
+    /// turn. DeepSeek can return more; we reject the surplus to keep
+    /// runtime bounded.
+    public static let toolCallsMaxPerTurn = 5
+
+    /// Maximum `thinking ↔ toolExecuting` recursion within one user
+    /// turn. After this many loops the agent must produce plain
+    /// content or the turn aborts.
+    public static let recursionDepthMax = 3
+
+    /// Wall-clock ceiling per user turn (transcribe + thinks + tools).
+    public static let turnTimeoutSeconds: TimeInterval = 30
+
+    /// How many `visibleExperiences` summaries to inject in the
+    /// per-turn system continuation (PRD §6.2).
+    public static let visibleExperiencesInjected = 5
+
+    // MARK: - Types
+
+    /// OpenAI-compatible role. We model `.tool` separately from
+    /// `.assistant` because DeepSeek requires the `tool_call_id` field
+    /// only on `tool` rows.
+    public enum Role: String, Codable, Sendable {
+        case system
+        case user
+        case assistant
+        case tool
+    }
+
+    /// A pending tool call returned by the model. Arguments stay as
+    /// raw JSON text because the router (US-VA-03) decodes them per
+    /// tool — every tool has its own argument schema.
+    public struct ToolCall: Equatable, Sendable, Identifiable {
+        public let id: String
+        public let name: String
+        public let argumentsJSON: String
+
+        public init(id: String, name: String, argumentsJSON: String) {
+            self.id = id
+            self.name = name
+            self.argumentsJSON = argumentsJSON
+        }
+    }
+
+    /// Single entry in the conversation. Only one of `content` /
+    /// `toolCalls` is set for an assistant row; tool rows always have
+    /// `content` (the JSON result) + `toolCallId`.
+    public struct Message: Equatable, Sendable, Identifiable {
+        public let id: UUID
+        public let role: Role
+        public let content: String?
+        public let toolCalls: [ToolCall]
+        public let toolCallId: String?
+        /// For tool rows: name of the tool that produced this result.
+        /// Optional because OpenAI's tool message spec accepts it but
+        /// doesn't require it.
+        public let name: String?
+
+        public init(
+            id: UUID = UUID(),
+            role: Role,
+            content: String? = nil,
+            toolCalls: [ToolCall] = [],
+            toolCallId: String? = nil,
+            name: String? = nil
+        ) {
+            self.id = id
+            self.role = role
+            self.content = content
+            self.toolCalls = toolCalls
+            self.toolCallId = toolCallId
+            self.name = name
+        }
+    }
+
+    /// Agent loop states (PRD §5.1 diagram).
+    public enum State: Equatable, Sendable {
+        case idle
+        case listening
+        case transcribing
+        case thinking
+        case toolExecuting(toolCount: Int)
+        case speaking
+    }
+
+    /// Why a session ended. The view binds to this to decide what to
+    /// show after the sheet closes.
+    public enum EndReason: String, Sendable {
+        case userClose
+        case timeout
+        case error
+        case quotaExceeded
+    }
+
+    // MARK: - Observable state
+
+    public private(set) var state: State = .idle
+    public private(set) var messages: [Message] = []
+    public private(set) var turnCount: Int = 0
+    /// Recursion depth within the current user turn (thinking →
+    /// toolExecuting → thinking …). Reset by `beginUserTurn()`.
+    public private(set) var recursionDepth: Int = 0
+    /// Set after `end(reason:)`. Sticky — the session is done.
+    public private(set) var endReason: EndReason?
+
+    // MARK: - Init
+
+    public init() {}
+
+    // MARK: - Public transitions
+    //
+    // All transitions are deliberately gated through these methods so a
+    // future test can verify "you cannot go from .idle directly to
+    // .toolExecuting", etc.
+
+    /// Seed the conversation with a system prompt. Call once at the
+    /// start of a session, before any `beginUserTurn()`.
+    public func seedSystem(_ prompt: String) {
+        precondition(messages.isEmpty, "system prompt must be first")
+        messages.append(Message(role: .system, content: prompt))
+    }
+
+    /// Transition .idle → .listening. Caller is the long-press gesture.
+    public func beginListening() {
+        guard endReason == nil else { return }
+        state = .listening
+    }
+
+    /// Transition .listening → .transcribing once the mic is released
+    /// and speech-to-text starts producing a final transcript.
+    public func beginTranscribing() {
+        guard state == .listening else { return }
+        state = .transcribing
+    }
+
+    /// Start a new user turn. Appends the user transcript, resets
+    /// recursion depth, increments `turnCount`, transitions to
+    /// `.thinking`. Compacts history if it would overflow.
+    public func beginUserTurn(transcript: String) {
+        guard endReason == nil else { return }
+        guard !transcript.isEmpty else { return }
+        messages.append(Message(role: .user, content: transcript))
+        turnCount += 1
+        recursionDepth = 0
+        state = .thinking
+        compactIfNeeded()
+    }
+
+    /// Append an assistant turn. If `toolCalls` is non-empty the agent
+    /// must transition to `.toolExecuting`; otherwise to `.speaking`.
+    /// Returns the resulting state so the caller can chain on it.
+    @discardableResult
+    public func appendAssistantTurn(
+        content: String?,
+        toolCalls: [ToolCall]
+    ) -> State {
+        let capped = Array(toolCalls.prefix(Self.toolCallsMaxPerTurn))
+        messages.append(Message(role: .assistant, content: content, toolCalls: capped))
+        if capped.isEmpty {
+            state = .speaking
+        } else {
+            recursionDepth += 1
+            state = .toolExecuting(toolCount: capped.count)
+        }
+        return state
+    }
+
+    /// Append one tool result. The view-model fans these in once for
+    /// every entry in the prior assistant turn's `toolCalls`.
+    public func appendToolResult(
+        toolCallId: String,
+        name: String,
+        resultJSON: String
+    ) {
+        messages.append(Message(
+            role: .tool, content: resultJSON,
+            toolCallId: toolCallId, name: name
+        ))
+    }
+
+    /// All tool results for this round are in — go back to `.thinking`
+    /// so the next DeepSeek call can react to them.
+    public func resumeThinkingAfterTools() {
+        guard case .toolExecuting = state else { return }
+        state = .thinking
+    }
+
+    /// Final assistant text shown; transition to .speaking → .idle so
+    /// the UI can render the reply and wait for the next turn.
+    public func finishSpeakingTurn() {
+        guard state == .speaking else { return }
+        state = .idle
+    }
+
+    /// Terminate the session. Idempotent — only the first call wins.
+    public func end(reason: EndReason) {
+        guard endReason == nil else { return }
+        endReason = reason
+        state = .idle
+    }
+
+    // MARK: - Predicates
+
+    /// True when we've spent the recursion budget for the current
+    /// user turn; the next assistant response MUST be plain content
+    /// (no tool_calls) or the orchestrator aborts.
+    public var hasExceededRecursionBudget: Bool {
+        recursionDepth >= Self.recursionDepthMax
+    }
+
+    /// True when the session has ended for any reason.
+    public var isEnded: Bool { endReason != nil }
+
+    // MARK: - History compaction (PRD §5.2)
+
+    /// If `messages.count` exceeds `messagesMaxCount`, replace the
+    /// middle slice with a synthesised system summary, keeping:
+    /// - the original system prompt (index 0, if present)
+    /// - the two most recent user/assistant pairs
+    /// This is a lossy compression for cost; the orchestrator should
+    /// avoid relying on long-distance pronoun resolution.
+    func compactIfNeeded() {
+        guard messages.count > Self.messagesMaxCount else { return }
+
+        // Pull the leading system prompt aside if there is one.
+        var head: [Message] = []
+        var rest = messages
+        if let first = rest.first, first.role == .system {
+            head.append(first)
+            rest.removeFirst()
+        }
+
+        // Keep the most recent 4 messages (~2 user/assistant pairs).
+        let tailKeep = 4
+        guard rest.count > tailKeep else { return }
+        let dropping = rest.dropLast(tailKeep)
+        let tail = Array(rest.suffix(tailKeep))
+
+        // Build a coarse summary. We pull at most 3 user turns for
+        // the summary; verbosity here costs tokens forever.
+        let userSnippets = dropping
+            .filter { $0.role == .user }
+            .compactMap { $0.content }
+            .suffix(3)
+        let summary: String
+        if userSnippets.isEmpty {
+            summary = "Earlier turns omitted to stay within the model context budget."
+        } else {
+            summary = "Earlier user turns (summarised): "
+                + userSnippets.joined(separator: " | ")
+        }
+
+        let summaryMsg = Message(role: .system, content: summary)
+        messages = head + [summaryMsg] + tail
+    }
+}

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -2318,6 +2318,148 @@ final class SoloCompassTests: XCTestCase {
             "userId must NOT be persisted when FF_BACKEND_SYNC is off"
         )
     }
+
+    // MARK: - US-VA-01 VoiceAgentSession state model
+
+    func testVoiceAgentSessionStartsIdleAndEmpty() {
+        let session = VoiceAgentSession()
+        XCTAssertEqual(session.state, .idle)
+        XCTAssertTrue(session.messages.isEmpty)
+        XCTAssertEqual(session.turnCount, 0)
+        XCTAssertEqual(session.recursionDepth, 0)
+        XCTAssertNil(session.endReason)
+        XCTAssertFalse(session.isEnded)
+    }
+
+    func testVoiceAgentSessionHappyPathSingleTurn() {
+        // user → assistant (no tools) → end-of-turn back to idle.
+        let session = VoiceAgentSession()
+        session.seedSystem("You are an assistant.")
+        XCTAssertEqual(session.messages.count, 1)
+
+        session.beginUserTurn(transcript: "find me a quiet café")
+        XCTAssertEqual(session.state, .thinking)
+        XCTAssertEqual(session.turnCount, 1)
+        XCTAssertEqual(session.messages.last?.role, .user)
+
+        // Plain assistant content, no tool_calls → .speaking → .idle.
+        let resulting = session.appendAssistantTurn(
+            content: "There are 3 within walking distance.",
+            toolCalls: []
+        )
+        XCTAssertEqual(resulting, .speaking)
+        XCTAssertEqual(session.recursionDepth, 0,
+                       "no recursion increment when there are no tool calls")
+
+        session.finishSpeakingTurn()
+        XCTAssertEqual(session.state, .idle)
+    }
+
+    func testVoiceAgentSessionToolCallRoundTrip() {
+        // user → assistant (tool_calls) → toolExecuting → tool result
+        // → thinking → assistant content → speaking.
+        let session = VoiceAgentSession()
+        session.beginUserTurn(transcript: "filter to coffee")
+
+        let call = VoiceAgentSession.ToolCall(
+            id: "call_1", name: "filter_by_category",
+            argumentsJSON: #"{"category":"coffee"}"#
+        )
+        session.appendAssistantTurn(content: nil, toolCalls: [call])
+        XCTAssertEqual(session.state, .toolExecuting(toolCount: 1))
+        XCTAssertEqual(session.recursionDepth, 1)
+
+        session.appendToolResult(
+            toolCallId: "call_1",
+            name: "filter_by_category",
+            resultJSON: #"{"ok":true,"visible_count":7}"#
+        )
+        let last = session.messages.last
+        XCTAssertEqual(last?.role, .tool)
+        XCTAssertEqual(last?.toolCallId, "call_1")
+
+        session.resumeThinkingAfterTools()
+        XCTAssertEqual(session.state, .thinking)
+
+        session.appendAssistantTurn(
+            content: "Filtered to 7 coffee spots.", toolCalls: []
+        )
+        XCTAssertEqual(session.state, .speaking)
+    }
+
+    func testVoiceAgentSessionCapsToolCallsPerTurn() {
+        let session = VoiceAgentSession()
+        session.beginUserTurn(transcript: "do everything")
+        let many = (1...10).map { i in
+            VoiceAgentSession.ToolCall(
+                id: "call_\(i)", name: "noop",
+                argumentsJSON: "{}"
+            )
+        }
+        session.appendAssistantTurn(content: nil, toolCalls: many)
+        XCTAssertEqual(
+            session.messages.last?.toolCalls.count,
+            VoiceAgentSession.toolCallsMaxPerTurn,
+            "extra tool_calls beyond the cap are dropped"
+        )
+        if case let .toolExecuting(count) = session.state {
+            XCTAssertEqual(count, VoiceAgentSession.toolCallsMaxPerTurn)
+        } else {
+            XCTFail("expected .toolExecuting after capped tool_calls")
+        }
+    }
+
+    func testVoiceAgentSessionRecursionBudget() {
+        let session = VoiceAgentSession()
+        session.beginUserTurn(transcript: "do recursive things")
+        for i in 1...VoiceAgentSession.recursionDepthMax {
+            session.appendAssistantTurn(
+                content: nil,
+                toolCalls: [.init(id: "c\(i)", name: "noop", argumentsJSON: "{}")]
+            )
+            session.appendToolResult(toolCallId: "c\(i)", name: "noop", resultJSON: "{}")
+            session.resumeThinkingAfterTools()
+        }
+        XCTAssertTrue(
+            session.hasExceededRecursionBudget,
+            "after recursionDepthMax loops the orchestrator must stop"
+        )
+    }
+
+    func testVoiceAgentSessionEndIsSticky() {
+        let session = VoiceAgentSession()
+        session.beginUserTurn(transcript: "hi")
+        session.end(reason: .userClose)
+        XCTAssertTrue(session.isEnded)
+        XCTAssertEqual(session.endReason, .userClose)
+        // Subsequent end(_:) should not overwrite the first reason.
+        session.end(reason: .timeout)
+        XCTAssertEqual(session.endReason, .userClose)
+        // Further transitions are no-ops.
+        session.beginListening()
+        XCTAssertEqual(session.state, .idle)
+    }
+
+    func testVoiceAgentSessionCompactsLongHistory() {
+        let session = VoiceAgentSession()
+        session.seedSystem("system prompt")
+        // Push the conversation past the cap. messagesMaxCount = 11
+        // counting the system prompt; we want noticeably more.
+        for i in 1...8 {
+            session.beginUserTurn(transcript: "user turn \(i)")
+            session.appendAssistantTurn(content: "reply \(i)", toolCalls: [])
+            session.finishSpeakingTurn()
+        }
+        XCTAssertLessThanOrEqual(
+            session.messages.count,
+            VoiceAgentSession.messagesMaxCount,
+            "compactIfNeeded must bound the history at messagesMaxCount"
+        )
+        XCTAssertEqual(session.messages.first?.role, .system,
+                       "the leading system prompt survives compaction")
+        // Last 4 should still be intact (PRD §5.2 keeps the recent tail).
+        XCTAssertEqual(session.messages.suffix(2).first?.role, .user)
+    }
 }
 
 // MARK: - URLProtocol stub for HTTP-mocked tests


### PR DESCRIPTION
## Summary

First story of the [voice-agent PRD](./docs/PRD/voice-agent.md). Pure model layer — no UI, no network — so the orchestration / DeepSeek tools / UI stories (US-VA-02..07) can build on a stable foundation.

## What's in

`apps/ios/SoloCompass/Services/VoiceAgentSession.swift` — `@MainActor @Observable` class.

**Types**

| Type | Purpose |
|---|---|
| `Role` | system / user / assistant / tool (OpenAI-compatible) |
| `ToolCall` | id + name + raw arguments JSON (US-VA-03 decodes per-tool) |
| `Message` | content / toolCalls / toolCallId / name (covers all 4 row shapes) |
| `State` | idle / listening / transcribing / thinking / toolExecuting / speaking |
| `EndReason` | userClose / timeout / error / quotaExceeded |

**Pinned limits (PRD §5.1)**

| Constant | Value |
|---|---|
| `messagesMaxCount` | 11 (includes system) |
| `toolCallsMaxPerTurn` | 5 |
| `recursionDepthMax` | 3 |
| `turnTimeoutSeconds` | 30 |
| `visibleExperiencesInjected` | 5 |

**Public transition API**

`seedSystem` · `beginListening` · `beginTranscribing` · `beginUserTurn` · `appendAssistantTurn` · `appendToolResult` · `resumeThinkingAfterTools` · `finishSpeakingTurn` · `end(reason:)` (sticky).

**History compaction (PRD §5.2)**

When `messages.count` exceeds `messagesMaxCount`, keep the system prompt + the most recent 4 messages and replace the middle with a synthesised system summary of the last 3 user turns.

## Tests (7 new, all pass)

| Test | What it locks down |
|---|---|
| `StartsIdleAndEmpty` | initial state contract |
| `HappyPathSingleTurn` | user → assistant content → speaking → idle |
| `ToolCallRoundTrip` | assistant tool_call → tool result → thinking → assistant content → speaking |
| `CapsToolCallsPerTurn` | surplus tool_calls beyond 5 dropped, state shows capped count |
| `RecursionBudget` | `hasExceededRecursionBudget` flips after 3 loops |
| `EndIsSticky` | first `end(_:)` wins, later transitions are no-ops |
| `CompactsLongHistory` | bounded message count, system + tail preserved |

All pass on iPhone 17 / iOS 26.4 (~0.02s combined).

## Out of scope (deferred to later stories)

- DeepSeek HTTP integration → **US-VA-02**
- Tool router + 5 tools → **US-VA-03**
- ConversationSheet UI → **US-VA-04**
- Long-press mic gesture → **US-VA-05**
- Agent loop orchestration → **US-VA-06**
- Quota + analytics + error degradation → **US-VA-07**

## Test plan

- [x] `xcodebuild test` for the 7 new tests passes locally
- [ ] CI green
- [ ] No regressions in existing test suite (touched only new file + Tests insert)