### PR TITLE
feat(ai): US-VA-02 sendAgentMessage with DeepSeek tools protocol

### DIFF
--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -194,6 +194,168 @@ public final class AIService {
         }
     }
 
+    // MARK: - Voice agent (US-VA-02)
+
+    /// Function-calling tool definition sent to DeepSeek. The `parameters`
+    /// payload is the raw OpenAI-style JSON Schema for the tool's
+    /// arguments — callers (the router in US-VA-03) own its shape.
+    public struct AgentTool: Sendable {
+        public let name: String
+        public let description: String
+        /// JSON Schema as a JSON string ready to drop into the
+        /// `parameters` slot of `{"type":"function","function":{...}}`.
+        public let parametersJSON: String
+
+        public init(name: String, description: String, parametersJSON: String) {
+            self.name = name
+            self.description = description
+            self.parametersJSON = parametersJSON
+        }
+    }
+
+    /// What `sendAgentMessage` hands back. Mirrors the OpenAI shape:
+    /// when the model decides to call tools, `content` is nil and
+    /// `toolCalls` is populated; when it's done, `content` carries the
+    /// final assistant text.
+    public struct AgentResponse: Equatable, Sendable {
+        public let content: String?
+        public let toolCalls: [VoiceAgentSession.ToolCall]
+
+        public init(content: String?, toolCalls: [VoiceAgentSession.ToolCall]) {
+            self.content = content
+            self.toolCalls = toolCalls
+        }
+    }
+
+    /// POST a full message history + tool catalog to DeepSeek and return
+    /// either tool calls or final content. Stateless — the caller (the
+    /// voice agent orchestrator in US-VA-06) owns the conversation.
+    ///
+    /// Routes through `.voice` config for now (model + auth + quota);
+    /// US-VA-07 may carve out a dedicated `.voiceAgent` kind once we
+    /// have per-session quotas to enforce.
+    public func sendAgentMessage(
+        messages: [VoiceAgentSession.Message],
+        tools: [AgentTool]
+    ) async throws -> AgentResponse {
+        guard let key = Self.resolveAPIKey() else { throw AIError.missingAPIKey }
+        guard let apiURL else { throw AIError.requestFailed(status: 0, body: "bad URL") }
+
+        await MainActor.run { self.isProcessing = true }
+        defer { Task { @MainActor [weak self] in self?.isProcessing = false } }
+
+        var request = URLRequest(url: apiURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 30  // tighter than synthesis: agent turn budget is 30s total
+
+        let body: [String: Any] = [
+            "model": Self.modelName(for: .voice),
+            "messages": Self.serializeAgentMessages(messages),
+            "tools": Self.serializeAgentTools(tools),
+            "tool_choice": "auto",
+            "parallel_tool_calls": true,
+            "max_tokens": 512,
+            "temperature": 0.3,
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw AIError.requestFailed(status: 0, body: "no response")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let bodyText = String(data: data, encoding: .utf8) ?? ""
+            throw AIError.requestFailed(status: http.statusCode, body: bodyText)
+        }
+
+        return try Self.parseAgentResponse(data)
+    }
+
+    /// Serialise the conversation as the array DeepSeek wants. We map
+    /// each Role / Message field by hand so the wire shape stays
+    /// decoupled from the in-memory model.
+    static func serializeAgentMessages(_ messages: [VoiceAgentSession.Message]) -> [[String: Any]] {
+        messages.map { msg -> [String: Any] in
+            var row: [String: Any] = ["role": msg.role.rawValue]
+            if let content = msg.content {
+                row["content"] = content
+            } else {
+                // OpenAI requires "content" key even when null on assistant
+                // tool-call rows. NSNull renders as JSON null.
+                row["content"] = NSNull()
+            }
+            if !msg.toolCalls.isEmpty {
+                row["tool_calls"] = msg.toolCalls.map { call -> [String: Any] in
+                    [
+                        "id": call.id,
+                        "type": "function",
+                        "function": [
+                            "name": call.name,
+                            "arguments": call.argumentsJSON,
+                        ],
+                    ]
+                }
+            }
+            if let toolCallId = msg.toolCallId {
+                row["tool_call_id"] = toolCallId
+            }
+            if let name = msg.name {
+                row["name"] = name
+            }
+            return row
+        }
+    }
+
+    static func serializeAgentTools(_ tools: [AgentTool]) -> [[String: Any]] {
+        tools.compactMap { tool -> [String: Any]? in
+            guard
+                let data = tool.parametersJSON.data(using: .utf8),
+                let parametersDict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else {
+                return nil
+            }
+            return [
+                "type": "function",
+                "function": [
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": parametersDict,
+                ],
+            ]
+        }
+    }
+
+    static func parseAgentResponse(_ data: Data) throws -> AgentResponse {
+        guard
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let choices = json["choices"] as? [[String: Any]],
+            let first = choices.first,
+            let message = first["message"] as? [String: Any]
+        else {
+            throw AIError.decodingFailed("Unexpected agent response shape")
+        }
+
+        // tool_calls path
+        if let rawCalls = message["tool_calls"] as? [[String: Any]], !rawCalls.isEmpty {
+            let calls: [VoiceAgentSession.ToolCall] = rawCalls.compactMap { entry in
+                guard
+                    let id = entry["id"] as? String,
+                    let fn = entry["function"] as? [String: Any],
+                    let name = fn["name"] as? String
+                else { return nil }
+                let args = fn["arguments"] as? String ?? "{}"
+                return VoiceAgentSession.ToolCall(id: id, name: name, argumentsJSON: args)
+            }
+            return AgentResponse(content: nil, toolCalls: calls)
+        }
+
+        // plain content path
+        let content = message["content"] as? String
+        return AgentResponse(content: content.map(Self.stripMarkdownFences), toolCalls: [])
+    }
+
     // MARK: - HTTP
 
     /// POST a single user prompt to DeepSeek (`/chat/completions`) and return

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -2440,6 +2440,158 @@ final class SoloCompassTests: XCTestCase {
         XCTAssertEqual(session.state, .idle)
     }
 
+    // MARK: - US-VA-02 sendAgentMessage HTTP integration
+
+    /// Helper: build an AIService backed by StubURLProtocol so each test
+    /// can inspect the outgoing request body + control the response.
+    @MainActor
+    private func makeAgentTestAIService() -> AIService {
+        setenv("DEEPSEEK_API_KEY", "stub-key", 1)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        let session = URLSession(configuration: config)
+        return AIService(session: session, modelContext: nil)
+    }
+
+    func testSendAgentMessageSerialisesToolsAndMessagesCorrectly() async throws {
+        nonisolated(unsafe) var capturedBody: [String: Any] = [:]
+        StubURLProtocol.handler = { request in
+            let body = StubURLProtocol.readBody(from: request.httpBodyStream)
+                ?? request.httpBody
+                ?? Data()
+            if let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any] {
+                capturedBody = json
+            }
+            // Plain content response is fine for this serialisation test.
+            let json = #"{"choices":[{"message":{"role":"assistant","content":"ok"}}]}"#
+            let resp = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (resp, Data(json.utf8))
+        }
+
+        let ai = await makeAgentTestAIService()
+        let messages: [VoiceAgentSession.Message] = [
+            .init(role: .system, content: "you are an assistant"),
+            .init(role: .user, content: "find coffee"),
+            .init(role: .assistant, content: nil, toolCalls: [
+                .init(id: "call_x", name: "filter_by_category",
+                      argumentsJSON: #"{"category":"coffee"}"#),
+            ]),
+            .init(role: .tool, content: #"{"ok":true}"#,
+                  toolCallId: "call_x", name: "filter_by_category"),
+        ]
+        let tools = [
+            AIService.AgentTool(
+                name: "filter_by_category",
+                description: "filter visible experiences by category",
+                parametersJSON: #"{"type":"object","required":["category"],"properties":{"category":{"type":"string"}}}"#
+            )
+        ]
+
+        _ = try await ai.sendAgentMessage(messages: messages, tools: tools)
+
+        // tool_choice + parallel_tool_calls flow through
+        XCTAssertEqual(capturedBody["tool_choice"] as? String, "auto")
+        XCTAssertEqual(capturedBody["parallel_tool_calls"] as? Bool, true)
+
+        // tools array serialises as OpenAI function shape
+        let toolsArray = try XCTUnwrap(capturedBody["tools"] as? [[String: Any]])
+        XCTAssertEqual(toolsArray.count, 1)
+        let firstTool = try XCTUnwrap(toolsArray.first)
+        XCTAssertEqual(firstTool["type"] as? String, "function")
+        let fn = try XCTUnwrap(firstTool["function"] as? [String: Any])
+        XCTAssertEqual(fn["name"] as? String, "filter_by_category")
+        XCTAssertNotNil(fn["parameters"] as? [String: Any],
+                        "parameters JSON must be a dict, not a string")
+
+        // messages array carries 4 rows with correct role+field mapping
+        let rows = try XCTUnwrap(capturedBody["messages"] as? [[String: Any]])
+        XCTAssertEqual(rows.map { $0["role"] as? String },
+                       ["system", "user", "assistant", "tool"])
+        // assistant row has tool_calls
+        let assistantRow = rows[2]
+        let toolCalls = try XCTUnwrap(assistantRow["tool_calls"] as? [[String: Any]])
+        XCTAssertEqual(toolCalls.first?["id"] as? String, "call_x")
+        // tool row has tool_call_id (not just name)
+        let toolRow = rows[3]
+        XCTAssertEqual(toolRow["tool_call_id"] as? String, "call_x")
+        XCTAssertEqual(toolRow["name"] as? String, "filter_by_category")
+    }
+
+    func testSendAgentMessageParsesToolCallsResponse() async throws {
+        StubURLProtocol.handler = { request in
+            // Mimic OpenAI tool_calls shape.
+            let json = """
+            {"choices":[{"message":{"role":"assistant","content":null,"tool_calls":[
+              {"id":"call_a","type":"function","function":{"name":"filter_by_category","arguments":"{\\"category\\":\\"coffee\\"}"}},
+              {"id":"call_b","type":"function","function":{"name":"show_details","arguments":"{\\"experience_id\\":\\"exp_1\\"}"}}
+            ]}}]}
+            """
+            let resp = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (resp, Data(json.utf8))
+        }
+
+        let ai = await makeAgentTestAIService()
+        let result = try await ai.sendAgentMessage(messages: [
+            .init(role: .system, content: "system"),
+            .init(role: .user, content: "do two things"),
+        ], tools: [])
+
+        XCTAssertNil(result.content, "no plain content when model decides to call tools")
+        XCTAssertEqual(result.toolCalls.count, 2)
+        XCTAssertEqual(result.toolCalls[0].id, "call_a")
+        XCTAssertEqual(result.toolCalls[0].name, "filter_by_category")
+        XCTAssertEqual(result.toolCalls[0].argumentsJSON, #"{"category":"coffee"}"#)
+        XCTAssertEqual(result.toolCalls[1].name, "show_details")
+    }
+
+    func testSendAgentMessageParsesPlainContentResponse() async throws {
+        StubURLProtocol.handler = { request in
+            let json = #"{"choices":[{"message":{"role":"assistant","content":"Filtered to 7 coffee spots."}}]}"#
+            let resp = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (resp, Data(json.utf8))
+        }
+
+        let ai = await makeAgentTestAIService()
+        let result = try await ai.sendAgentMessage(messages: [
+            .init(role: .system, content: "system"),
+            .init(role: .user, content: "hi"),
+        ], tools: [])
+
+        XCTAssertEqual(result.content, "Filtered to 7 coffee spots.")
+        XCTAssertTrue(result.toolCalls.isEmpty)
+    }
+
+    func testSendAgentMessageThrowsOnHTTPError() async {
+        StubURLProtocol.handler = { request in
+            let resp = HTTPURLResponse(
+                url: request.url!, statusCode: 500,
+                httpVersion: nil, headerFields: nil
+            )!
+            return (resp, Data("boom".utf8))
+        }
+
+        let ai = await makeAgentTestAIService()
+        do {
+            _ = try await ai.sendAgentMessage(messages: [
+                .init(role: .user, content: "hi"),
+            ], tools: [])
+            XCTFail("expected throw on 500 response")
+        } catch AIService.AIError.requestFailed(let status, _) {
+            XCTAssertEqual(status, 500)
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+    }
+
     func testVoiceAgentSessionCompactsLongHistory() {
         let session = VoiceAgentSession()
         session.seedSystem("system prompt")


### PR DESCRIPTION
> **Stacked on [#105 (US-VA-01)](https://github.com/getyak/solo-compass/pull/105)** — base is the VA-01 branch, not main. Will rebase to main once #105 lands.

## Summary

Second voice-agent story. Adds an OpenAI-compatible tools-protocol HTTP method on `AIService` so the orchestrator (US-VA-06) can hand DeepSeek a full message history + a tool catalog and get back either tool calls or final assistant content.

## What's in

| Type | Purpose |
|---|---|
| `AIService.AgentTool` | `{ name, description, parametersJSON }` — caller-owned JSON Schema dropped into the OpenAI `function` payload |
| `AIService.AgentResponse` | `{ content?, toolCalls: [VoiceAgentSession.ToolCall] }` — mirrors the OpenAI shape |
| `AIService.sendAgentMessage(messages:tools:) async throws -> AgentResponse` | Stateless POST; caller owns the conversation |
| `serializeAgentMessages` / `serializeAgentTools` / `parseAgentResponse` | Internal helpers (split out so tests don't have to hit HTTP for every shape concern) |

Routes through `.voice` `ModelKind` for now; **US-VA-07** may split out `.voiceAgent` if per-session quotas need separate accounting.

## Tests (4 new, all pass on iPhone 17 / iOS 26.4)

| Test | What it locks down |
|---|---|
| `SerialisesToolsAndMessagesCorrectly` | HTTP body has `tool_choice=auto`, `parallel_tool_calls=true`, `tools.function.parameters` is a JSON dict (not a string), and all 4 role rows (system/user/assistant/tool) serialise with the right fields (`tool_call_id` on tool rows, `tool_calls` array on assistant rows) |
| `ParsesToolCallsResponse` | `{ content: null, tool_calls: [...] }` → `AgentResponse` with nil content + 2 `ToolCall`s in order |
| `ParsesPlainContentResponse` | model returns content string → response carries content + empty `toolCalls` |
| `ThrowsOnHTTPError` | 500 → `AIError.requestFailed(status: 500, ...)` |

## Out of scope (later stories)

- `ModelKind.voiceAgent` + per-session quota → **US-VA-07**
- The 5 actual tools (router) → **US-VA-03**
- Orchestration loop calling `sendAgentMessage` in a `thinking ↔ tools` cycle → **US-VA-06**

## Test plan

- [x] `xcodebuild test` for the 4 new tests passes locally
- [ ] CI green (note: macOS runner has been slow on the parent PR #105 — may take longer than usual)
- [ ] No regressions in existing test suite