### PR TITLE
feat(voice): US-VA-03 VoiceAgentToolRouter + 5 tools

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		464746A44182622D4F617462 /* AIUsageRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */; };
 		48DF93F42CDDB1329B038865 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6556C23BF1B228BF686C5500 /* KeychainStore.swift */; };
 		50140E7D5FFAC2588C141A3F /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = EE5F70FDF5F3A929496EC981 /* Supabase */; };
+		54952646C79E8F29AF89F4D6 /* VoiceAgentToolRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20208D92E4F564C474E8AEED /* VoiceAgentToolRouter.swift */; };
 		56F3055416F4A5316100F9B2 /* ExperienceCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */; };
 		58B7C9B20945838F81081941 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14A22A40550CF207AB36C18 /* SettingsView.swift */; };
 		5C05B87EA78458094612AC01 /* BottomInfoBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13350B81187FB64B252B8A46 /* BottomInfoBar.swift */; };
@@ -90,6 +91,7 @@
 		130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingCheckInBanner.swift; sourceTree = "<group>"; };
 		13350B81187FB64B252B8A46 /* BottomInfoBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomInfoBar.swift; sourceTree = "<group>"; };
 		1FA8C8BF234F3C74D0D8A9BD /* SecretsRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretsRuntime.swift; sourceTree = "<group>"; };
+		20208D92E4F564C474E8AEED /* VoiceAgentToolRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAgentToolRouter.swift; sourceTree = "<group>"; };
 		23043E51C493093CF7244629 /* MicroSurveyRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicroSurveyRecord.swift; sourceTree = "<group>"; };
 		2C7919EAFDE363B49C4B4C47 /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 		2DA6E405C780A5A12A9FC1D6 /* MicroSurveySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicroSurveySheet.swift; sourceTree = "<group>"; };
@@ -301,6 +303,7 @@
 				E406C379247653B4AA5A3E0E /* SupabaseClient.swift */,
 				6163572F4644BF852B35FDA4 /* SyncService.swift */,
 				112319E8315F5F6961C95264 /* VoiceAgentSession.swift */,
+				20208D92E4F564C474E8AEED /* VoiceAgentToolRouter.swift */,
 				120FC7465285714C5FA8F96D /* VoiceService.swift */,
 			);
 			path = Services;
@@ -583,6 +586,7 @@
 				D53E53A5AA9AE6F77EF82418 /* UserFavoriteRecord.swift in Sources */,
 				C2C0AF72D709EDC17C6ED874 /* UserPreferences.swift in Sources */,
 				C220FEC091B645D82519465E /* VoiceAgentSession.swift in Sources */,
+				54952646C79E8F29AF89F4D6 /* VoiceAgentToolRouter.swift in Sources */,
 				BD5BB6BD7FCBDB30282F28FA /* VoiceButton.swift in Sources */,
 				F5677DCF081E506C7E32243F /* VoiceService.swift in Sources */,
 			);

--- a/apps/ios/SoloCompass/Services/VoiceAgentToolRouter.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentToolRouter.swift
@@ -1,0 +1,277 @@
+import Foundation
+import CoreLocation
+
+/// Maps DeepSeek `tool_calls` to concrete app actions.
+///
+/// US-VA-03: 5 tools defined in docs/PRD/voice-agent.md §4 — explore_nearby,
+/// filter_by_category, show_details, save_to_favorites, dismiss_recommendation.
+/// Each `execute(...)` returns a JSON string suitable for feeding back to
+/// DeepSeek as a `tool` role message (the orchestrator in US-VA-06 wraps it
+/// with `VoiceAgentSession.appendToolResult(...)`).
+///
+/// Held weakly by the orchestrator so the router can't keep the view model
+/// alive past sheet dismissal.
+@MainActor
+public final class VoiceAgentToolRouter {
+
+    public enum RouterError: Error, LocalizedError {
+        case unknownTool(String)
+        case invalidArguments(tool: String, reason: String)
+        case experienceNotFound(String)
+        case underlying(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .unknownTool(let name):
+                return "Unknown tool: \(name)"
+            case .invalidArguments(let tool, let reason):
+                return "Bad arguments for \(tool): \(reason)"
+            case .experienceNotFound(let id):
+                return "Experience not found: \(id)"
+            case .underlying(let msg):
+                return msg
+            }
+        }
+    }
+
+    private weak var mapViewModel: MapViewModel?
+    private let preferences: UserPreferences
+
+    public init(mapViewModel: MapViewModel, preferences: UserPreferences) {
+        self.mapViewModel = mapViewModel
+        self.preferences = preferences
+    }
+
+    // MARK: - Tool catalog
+
+    /// Tool defs handed to `AIService.sendAgentMessage(...)`. JSON Schemas
+    /// mirror the PRD verbatim so the model gets the same contract spec'd
+    /// in docs/PRD/voice-agent.md §4.
+    public static let allTools: [AIService.AgentTool] = [
+        .init(
+            name: "explore_nearby",
+            description: "Fetch real OSM POIs near a coordinate and enrich them with AI. Use when the user wants new places not in the current visible set, or moves to a new area. Returns the count of newly added experiences.",
+            parametersJSON: #"""
+            {
+              "type": "object",
+              "properties": {
+                "latitude":  {"type": "number"},
+                "longitude": {"type": "number"},
+                "radius_meters": {"type": "integer", "minimum": 500, "maximum": 8000, "default": 3000}
+              }
+            }
+            """#
+        ),
+        .init(
+            name: "filter_by_category",
+            description: "Filter visible experiences on the map to a single category. Use this whenever the user asks for a specific type of place (coffee, food, etc).",
+            parametersJSON: #"""
+            {
+              "type": "object",
+              "required": ["category"],
+              "properties": {
+                "category": {
+                  "type": "string",
+                  "enum": ["culture","nature","food","coffee","work","wellness","nightlife","hidden"]
+                }
+              }
+            }
+            """#
+        ),
+        .init(
+            name: "show_details",
+            description: "Open the full detail sheet for one experience. Use when the user asks 'tell me more about X' or refers to a specific item by its position ('the second one').",
+            parametersJSON: #"""
+            {
+              "type": "object",
+              "required": ["experience_id"],
+              "properties": {
+                "experience_id": {"type": "string"}
+              }
+            }
+            """#
+        ),
+        .init(
+            name: "save_to_favorites",
+            description: "Add or remove an experience from the user's favorites. Toggle semantics — call again to un-favorite.",
+            parametersJSON: #"""
+            {
+              "type": "object",
+              "required": ["experience_id"],
+              "properties": {
+                "experience_id": {"type": "string"}
+              }
+            }
+            """#
+        ),
+        .init(
+            name: "dismiss_recommendation",
+            description: "Temporarily hide one experience from the current visible set. Does NOT persist — refreshes will bring it back. Use when the user says 'not that one' or 'skip this'.",
+            parametersJSON: #"""
+            {
+              "type": "object",
+              "required": ["experience_id"],
+              "properties": {
+                "experience_id": {"type": "string"}
+              }
+            }
+            """#
+        ),
+    ]
+
+    // MARK: - Execution
+
+    /// Route one DeepSeek `tool_call` to the matching app action. Returns
+    /// a JSON string that the orchestrator feeds back as the `tool` row
+    /// content. Failures are represented as `{"ok":false,"error":"…"}`
+    /// rather than thrown so the agent can recover via the model.
+    public func execute(_ call: VoiceAgentSession.ToolCall) async -> String {
+        do {
+            switch call.name {
+            case "explore_nearby":
+                return try await executeExploreNearby(args: call.argumentsJSON)
+            case "filter_by_category":
+                return try executeFilterByCategory(args: call.argumentsJSON)
+            case "show_details":
+                return try executeShowDetails(args: call.argumentsJSON)
+            case "save_to_favorites":
+                return try executeSaveToFavorites(args: call.argumentsJSON)
+            case "dismiss_recommendation":
+                return try executeDismissRecommendation(args: call.argumentsJSON)
+            default:
+                throw RouterError.unknownTool(call.name)
+            }
+        } catch {
+            return Self.errorJSON(error)
+        }
+    }
+
+    // MARK: - Per-tool handlers
+
+    private struct ExploreNearbyArgs: Decodable {
+        let latitude: Double?
+        let longitude: Double?
+        let radius_meters: Int?
+    }
+
+    private func executeExploreNearby(args: String) async throws -> String {
+        let parsed: ExploreNearbyArgs = try Self.decode(args, tool: "explore_nearby")
+        guard let vm = mapViewModel else {
+            throw RouterError.underlying("map view model deallocated")
+        }
+        // Fall back to the default center when the model omits coords —
+        // matches the PRD's "Omit to use the user's current GPS location".
+        let coord = CLLocationCoordinate2D(
+            latitude: parsed.latitude ?? MapViewModel.defaultCenter.latitude,
+            longitude: parsed.longitude ?? MapViewModel.defaultCenter.longitude
+        )
+        let radius = parsed.radius_meters ?? 3000
+        await vm.exploreNearby(at: coord, radiusMeters: radius)
+        return Self.successJSON([
+            "added_count": vm.lastExploreAddedCount,
+            "radius_meters": radius,
+        ])
+    }
+
+    private struct FilterByCategoryArgs: Decodable {
+        let category: String
+    }
+
+    private func executeFilterByCategory(args: String) throws -> String {
+        let parsed: FilterByCategoryArgs = try Self.decode(args, tool: "filter_by_category")
+        guard let category = ExperienceCategory(rawValue: parsed.category) else {
+            throw RouterError.invalidArguments(
+                tool: "filter_by_category",
+                reason: "unknown category '\(parsed.category)'"
+            )
+        }
+        guard let vm = mapViewModel else {
+            throw RouterError.underlying("map view model deallocated")
+        }
+        vm.selectCategory(category)
+        return Self.successJSON([
+            "category": category.rawValue,
+            "visible_count": vm.visibleExperiences.count,
+        ])
+    }
+
+    private struct ExperienceIDArgs: Decodable {
+        let experience_id: String
+    }
+
+    private func executeShowDetails(args: String) throws -> String {
+        let parsed: ExperienceIDArgs = try Self.decode(args, tool: "show_details")
+        guard let vm = mapViewModel else {
+            throw RouterError.underlying("map view model deallocated")
+        }
+        // PRD: AI must only reference experience_ids it saw in the
+        // VISIBLE_EXPERIENCES injection. We hard-fail unknown ids so
+        // hallucinated ones round-trip back to the model as
+        // `unknown_experience_id` and it can self-correct.
+        guard let exp = vm.visibleExperiences.first(where: { $0.id == parsed.experience_id }) else {
+            throw RouterError.experienceNotFound(parsed.experience_id)
+        }
+        vm.selectExperience(exp)
+        vm.isShowingDetail = true
+        return Self.successJSON(["experience_id": exp.id, "title": exp.title])
+    }
+
+    private func executeSaveToFavorites(args: String) throws -> String {
+        let parsed: ExperienceIDArgs = try Self.decode(args, tool: "save_to_favorites")
+        let wasFavorited = preferences.isFavorited(parsed.experience_id)
+        preferences.toggleFavorite(parsed.experience_id)
+        return Self.successJSON([
+            "experience_id": parsed.experience_id,
+            "now_favorited": !wasFavorited,
+        ])
+    }
+
+    private func executeDismissRecommendation(args: String) throws -> String {
+        let parsed: ExperienceIDArgs = try Self.decode(args, tool: "dismiss_recommendation")
+        guard let vm = mapViewModel else {
+            throw RouterError.underlying("map view model deallocated")
+        }
+        vm.dismissFromVisible(parsed.experience_id)
+        return Self.successJSON([
+            "experience_id": parsed.experience_id,
+            "visible_count": vm.visibleExperiences.count,
+        ])
+    }
+
+    // MARK: - Codec helpers
+
+    private static func decode<T: Decodable>(_ argsJSON: String, tool: String) throws -> T {
+        guard let data = argsJSON.data(using: .utf8) else {
+            throw RouterError.invalidArguments(tool: tool, reason: "arguments not valid UTF-8")
+        }
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw RouterError.invalidArguments(
+                tool: tool, reason: error.localizedDescription
+            )
+        }
+    }
+
+    private static func successJSON(_ fields: [String: Any]) -> String {
+        var payload = fields
+        payload["ok"] = true
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let s = String(data: data, encoding: .utf8) {
+            return s
+        }
+        return #"{"ok":true}"#
+    }
+
+    private static func errorJSON(_ error: Error) -> String {
+        let payload: [String: Any] = [
+            "ok": false,
+            "error": (error as? LocalizedError)?.errorDescription ?? "\(error)",
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let s = String(data: data, encoding: .utf8) {
+            return s
+        }
+        return #"{"ok":false,"error":"unknown"}"#
+    }
+}

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -2592,6 +2592,156 @@ final class SoloCompassTests: XCTestCase {
         }
     }
 
+    // MARK: - US-VA-03 VoiceAgentToolRouter
+
+    /// Build a router + MapViewModel pre-seeded with two visible
+    /// experiences so the show_details / save_to_favorites / dismiss
+    /// tools have real ids to target.
+    @MainActor
+    private func makeRouterTestRig() -> (
+        router: VoiceAgentToolRouter,
+        vm: MapViewModel,
+        prefs: UserPreferences,
+        seededIds: [String]
+    ) {
+        let prefs = UserPreferences()
+        let vm = MapViewModel(
+            locationService: LocationService(),
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: prefs
+        )
+        let seeded = vm.visibleExperiences.prefix(2).map(\.id)
+        let router = VoiceAgentToolRouter(mapViewModel: vm, preferences: prefs)
+        return (router, vm, prefs, Array(seeded))
+    }
+
+    func testToolRouterAllToolsAreWellFormedSchemas() {
+        // Each PRD tool def must have a parseable JSON Schema in
+        // parametersJSON; otherwise sendAgentMessage will silently drop it.
+        for tool in VoiceAgentToolRouter.allTools {
+            XCTAssertFalse(tool.name.isEmpty)
+            XCTAssertFalse(tool.description.isEmpty)
+            let data = tool.parametersJSON.data(using: .utf8)!
+            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            XCTAssertNotNil(obj, "tool \(tool.name) parametersJSON must be valid JSON")
+            XCTAssertEqual(obj?["type"] as? String, "object",
+                           "tool \(tool.name) schema must declare type:object")
+        }
+        XCTAssertEqual(VoiceAgentToolRouter.allTools.count, 5,
+                       "PRD spec is exactly 5 tools (US-VA-03)")
+    }
+
+    func testToolRouterFilterByCategoryHappyPath() async throws {
+        let rig = makeRouterTestRig()
+        let result = await rig.router.execute(.init(
+            id: "c1", name: "filter_by_category",
+            argumentsJSON: #"{"category":"coffee"}"#
+        ))
+        let parsed = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(result.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(parsed["ok"] as? Bool, true)
+        XCTAssertEqual(parsed["category"] as? String, "coffee")
+        XCTAssertEqual(rig.vm.selectedCategory, .coffee,
+                       "filter_by_category must drive selectedCategory")
+    }
+
+    func testToolRouterFilterByCategoryRejectsUnknownCategory() async {
+        let rig = makeRouterTestRig()
+        let result = await rig.router.execute(.init(
+            id: "c1", name: "filter_by_category",
+            argumentsJSON: #"{"category":"not-a-real-cat"}"#
+        ))
+        // Error path must round-trip back to the model as {"ok":false}
+        XCTAssertTrue(result.contains(#""ok":false"#))
+        XCTAssertTrue(result.contains("unknown category"))
+    }
+
+    func testToolRouterShowDetailsHappyPath() async throws {
+        let rig = makeRouterTestRig()
+        guard let firstId = rig.seededIds.first else {
+            XCTFail("seed expected at least 1 experience")
+            return
+        }
+        let result = await rig.router.execute(.init(
+            id: "c1", name: "show_details",
+            argumentsJSON: #"{"experience_id":"\#(firstId)"}"#
+        ))
+        XCTAssertTrue(result.contains(#""ok":true"#))
+        XCTAssertEqual(rig.vm.selectedExperience?.id, firstId)
+        XCTAssertTrue(rig.vm.isShowingDetail)
+    }
+
+    func testToolRouterShowDetailsRejectsUnknownId() async {
+        let rig = makeRouterTestRig()
+        let result = await rig.router.execute(.init(
+            id: "c1", name: "show_details",
+            argumentsJSON: #"{"experience_id":"definitely-not-here"}"#
+        ))
+        XCTAssertTrue(result.contains(#""ok":false"#))
+        XCTAssertTrue(result.contains("not found"))
+    }
+
+    func testToolRouterSaveToFavoritesTogglesPersistence() async throws {
+        let rig = makeRouterTestRig()
+        guard let firstId = rig.seededIds.first else {
+            XCTFail("seed expected at least 1 experience")
+            return
+        }
+        XCTAssertFalse(rig.prefs.isFavorited(firstId))
+
+        let result = await rig.router.execute(.init(
+            id: "c1", name: "save_to_favorites",
+            argumentsJSON: #"{"experience_id":"\#(firstId)"}"#
+        ))
+        XCTAssertTrue(result.contains(#""now_favorited":true"#))
+        XCTAssertTrue(rig.prefs.isFavorited(firstId))
+
+        // Toggle off
+        let result2 = await rig.router.execute(.init(
+            id: "c2", name: "save_to_favorites",
+            argumentsJSON: #"{"experience_id":"\#(firstId)"}"#
+        ))
+        XCTAssertTrue(result2.contains(#""now_favorited":false"#))
+        XCTAssertFalse(rig.prefs.isFavorited(firstId))
+    }
+
+    func testToolRouterDismissRemovesFromVisible() async throws {
+        let rig = makeRouterTestRig()
+        guard let firstId = rig.seededIds.first else {
+            XCTFail("seed expected at least 1 experience")
+            return
+        }
+        let before = rig.vm.visibleExperiences.count
+        let result = await rig.router.execute(.init(
+            id: "c1", name: "dismiss_recommendation",
+            argumentsJSON: #"{"experience_id":"\#(firstId)"}"#
+        ))
+        XCTAssertTrue(result.contains(#""ok":true"#))
+        XCTAssertEqual(rig.vm.visibleExperiences.count, before - 1)
+        XCTAssertFalse(rig.vm.visibleExperiences.contains { $0.id == firstId })
+    }
+
+    func testToolRouterUnknownToolReturnsStructuredError() async {
+        let rig = makeRouterTestRig()
+        let result = await rig.router.execute(.init(
+            id: "c1", name: "fly_to_mars",
+            argumentsJSON: "{}"
+        ))
+        XCTAssertTrue(result.contains(#""ok":false"#))
+        XCTAssertTrue(result.contains("Unknown tool"))
+    }
+
+    func testToolRouterRejectsInvalidArgumentsJSON() async {
+        let rig = makeRouterTestRig()
+        let result = await rig.router.execute(.init(
+            id: "c1", name: "filter_by_category",
+            argumentsJSON: "not actually JSON"
+        ))
+        XCTAssertTrue(result.contains(#""ok":false"#))
+    }
+
     func testVoiceAgentSessionCompactsLongHistory() {
         let session = VoiceAgentSession()
         session.seedSystem("system prompt")

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -371,6 +371,19 @@ public final class MapViewModel {
         isShowingDetail = false
     }
 
+    /// US-VA-03 tool `dismiss_recommendation`: hide one experience from
+    /// `visibleExperiences` without touching SwiftData. The next refresh
+    /// (filter change, new explore, app relaunch) brings it back —
+    /// dismissal is intentionally ephemeral so the AI can't permanently
+    /// blackhole results the user might want later.
+    public func dismissFromVisible(_ id: String) {
+        visibleExperiences.removeAll { $0.id == id }
+        if selectedExperience?.id == id {
+            selectedExperience = nil
+            isShowingDetail = false
+        }
+    }
+
     /// Recenter the camera and refresh experiences for the given coordinate.
     /// Use this for explicit recentering (e.g. "locate me" button), NOT for
     /// reacting to user pan/zoom — that would create a feedback loop where


### PR DESCRIPTION
> **Stacked PR**: base is [#106 (US-VA-02)](https://github.com/getyak/solo-compass/pull/106) → [#105 (US-VA-01)](https://github.com/getyak/solo-compass/pull/105) → main. Will rebase to main once the parents land.

## Summary

Third voice-agent story. Maps every DeepSeek `tool_call` returned by `sendAgentMessage` (US-VA-02) to a concrete app action and returns a JSON string the orchestrator (US-VA-06) feeds back as the next `tool` row.

## What's in

**`Services/VoiceAgentToolRouter.swift`** — `@MainActor` class, weak `MapViewModel` + `UserPreferences` refs.

`static let allTools` matches PRD §4 verbatim:

| Tool | Args | Action |
|---|---|---|
| `explore_nearby` | `latitude?` / `longitude?` / `radius_meters?` | `MapViewModel.exploreNearby(at:radiusMeters:)` |
| `filter_by_category` | `category` (enum) | `MapViewModel.selectCategory(_:)` |
| `show_details` | `experience_id` | `selectExperience` + `isShowingDetail = true`; rejects unknown ids |
| `save_to_favorites` | `experience_id` | `UserPreferences.toggleFavorite(_:)` |
| `dismiss_recommendation` | `experience_id` | New `MapViewModel.dismissFromVisible(_:)` — purely in-memory; refresh brings it back per PRD §4.5 |

`execute(_:)` routes by tool name. Every error path returns `{"ok":false,"error":"..."}` so the agent can self-correct instead of the loop crashing.

**`MapViewModel.dismissFromVisible(_:)`** — purely in-memory removal from `visibleExperiences`; also clears `selectedExperience` / `isShowingDetail` if dismissing the currently shown card.

## Tests (9 new, all pass on iPhone 17 / iOS 26.4)

| Test | What it covers |
|---|---|
| `AllToolsAreWellFormedSchemas` | every `parametersJSON` parses; exactly 5 tools |
| `FilterByCategoryHappyPath` | drives `MapViewModel.selectedCategory` |
| `FilterByCategoryRejectsUnknownCategory` | returns `{"ok":false}` |
| `ShowDetailsHappyPath` | `selectedExperience` + `isShowingDetail = true` |
| `ShowDetailsRejectsUnknownId` | enforces "only visible ids" per PRD |
| `SaveToFavoritesTogglesPersistence` | hits real `UserPreferences` both directions |
| `DismissRemovesFromVisible` | count drops by 1 |
| `UnknownToolReturnsStructuredError` | garbage tool name → `ok:false` |
| `RejectsInvalidArgumentsJSON` | non-JSON args → `ok:false` |

## Out of scope

- Wiring the router into the agent loop → **US-VA-06**
- `VISIBLE_EXPERIENCES` injection in the system message → **US-VA-06**
- per-tool latency / failure metrics → **US-VA-07**

## Test plan

- [x] 9 new tests pass locally
- [ ] CI green (note: macOS runner has been slow on parent PRs — may take longer)