### PR TITLE
feat(voice): US-VA-04 ConversationSheet UI

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		240FFFC4A2B2B8F941129783 /* ConfidenceBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8F9EFD56A2C839428AA92D /* ConfidenceBadge.swift */; };
 		28E3EB1BFFB0A73A1C56FD54 /* MarkerIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E0157D30FF53B21FF31D519 /* MarkerIconView.swift */; };
 		297541149234668D12EAF272 /* FilterBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9A1F22AAE512199548C269 /* FilterBarView.swift */; };
+		2B48B67ACB86F5ECDDDAF999 /* ConversationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCB9264712588AB26CB1337 /* ConversationSheet.swift */; };
 		31F9538643C362D7EEF64C6B /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7919EAFDE363B49C4B4C47 /* LocationService.swift */; };
 		391D6B5C48997AD74F367C0C /* GeneratedSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5642EDC714993C8EE0ECDD83 /* GeneratedSecrets.swift */; };
 		42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */; };
@@ -91,6 +92,7 @@
 		13350B81187FB64B252B8A46 /* BottomInfoBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomInfoBar.swift; sourceTree = "<group>"; };
 		1FA8C8BF234F3C74D0D8A9BD /* SecretsRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretsRuntime.swift; sourceTree = "<group>"; };
 		23043E51C493093CF7244629 /* MicroSurveyRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicroSurveyRecord.swift; sourceTree = "<group>"; };
+		2BCB9264712588AB26CB1337 /* ConversationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationSheet.swift; sourceTree = "<group>"; };
 		2C7919EAFDE363B49C4B4C47 /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 		2DA6E405C780A5A12A9FC1D6 /* MicroSurveySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicroSurveySheet.swift; sourceTree = "<group>"; };
 		33B8A80F048D74BEDB8C1132 /* SubscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionService.swift; sourceTree = "<group>"; };
@@ -343,6 +345,7 @@
 				F041AA40AC029B779843B5D4 /* Paywall */,
 				8FF93171FFB8E00CD1BDF550 /* Settings */,
 				07C4B3D1D25BE0A78422D951 /* Shared */,
+				E45C3A8BE30C9DCD0C3AD62F /* Voice */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -384,6 +387,14 @@
 				C660F7996B1E4387C37720B3 /* OnboardingView.swift */,
 			);
 			path = Onboarding;
+			sourceTree = "<group>";
+		};
+		E45C3A8BE30C9DCD0C3AD62F /* Voice */ = {
+			isa = PBXGroup;
+			children = (
+				2BCB9264712588AB26CB1337 /* ConversationSheet.swift */,
+			);
+			path = Voice;
 			sourceTree = "<group>";
 		};
 		F041AA40AC029B779843B5D4 /* Paywall */ = {
@@ -539,6 +550,7 @@
 				7D2B6DE6C27E0307CA998A5F /* CityPickerSheet.swift in Sources */,
 				C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */,
 				240FFFC4A2B2B8F941129783 /* ConfidenceBadge.swift in Sources */,
+				2B48B67ACB86F5ECDDDAF999 /* ConversationSheet.swift in Sources */,
 				42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */,
 				EDBD7B0E715165E71BC0C17D /* DiscoveredCityRecord.swift in Sources */,
 				0A830B26D4A18948D16F3A42 /* Experience.swift in Sources */,

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -307,3 +307,15 @@
 "settings.language.restart.title" = "Restart required";
 "settings.language.restart.message" = "Quit and reopen Solo Compass to finish switching languages.";
 "settings.language.restart.ok" = "OK";
+
+/* Voice agent conversation sheet (US-VA-04) */
+"conversation.header.turn" = "Conversation · turn %d";
+"conversation.state.idle" = "Idle";
+"conversation.state.listening" = "Listening…";
+"conversation.state.transcribing" = "Transcribing…";
+"conversation.state.thinking" = "Thinking…";
+"conversation.state.toolExecuting" = "Running tools…";
+"conversation.state.speaking" = "Reply ready";
+"conversation.input.placeholder" = "Type a message…";
+"conversation.input.mic.a11y" = "Hold to speak";
+"conversation.input.send.a11y" = "Send message";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -307,3 +307,15 @@
 "settings.language.restart.title" = "需要重启";
 "settings.language.restart.message" = "请退出并重新打开 Solo Compass 以完成语言切换。";
 "settings.language.restart.ok" = "好的";
+
+/* Voice agent conversation sheet (US-VA-04) */
+"conversation.header.turn" = "对话 · 第 %d 轮";
+"conversation.state.idle" = "待机";
+"conversation.state.listening" = "正在聆听…";
+"conversation.state.transcribing" = "正在转写…";
+"conversation.state.thinking" = "正在思考…";
+"conversation.state.toolExecuting" = "正在执行工具…";
+"conversation.state.speaking" = "回复已就绪";
+"conversation.input.placeholder" = "输入消息…";
+"conversation.input.mic.a11y" = "按住说话";
+"conversation.input.send.a11y" = "发送消息";

--- a/apps/ios/SoloCompass/Views/Voice/ConversationSheet.swift
+++ b/apps/ios/SoloCompass/Views/Voice/ConversationSheet.swift
@@ -1,0 +1,308 @@
+import SwiftUI
+
+/// Multi-turn voice agent conversation surface (US-VA-04).
+///
+/// Bound to a `VoiceAgentSession` from the environment. Renders:
+/// - top status bar with turn count + close button
+/// - scrollable message list (user right, assistant left, tool muted)
+/// - bottom input row (mic + text field) — text input is wired here
+///   but the mic gesture lands in US-VA-05.
+///
+/// The orchestrator (US-VA-06) drives the session; this view is read-only
+/// for state and only emits two intents: `onClose` and `onSubmitText(_:)`.
+public struct ConversationSheet: View {
+    @Environment(VoiceAgentSession.self) private var session
+
+    /// Called when the user dismisses the sheet (× button or down-drag).
+    public var onClose: () -> Void
+
+    /// Called when the user submits a typed message (the fallback path
+    /// when voice isn't available or for accessibility).
+    public var onSubmitText: (String) -> Void
+
+    @State private var textDraft: String = ""
+
+    public init(
+        onClose: @escaping () -> Void = {},
+        onSubmitText: @escaping (String) -> Void = { _ in }
+    ) {
+        self.onClose = onClose
+        self.onSubmitText = onSubmitText
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            messageList
+            Divider()
+            inputBar
+        }
+        .background(Color(.systemBackground))
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            statusDot
+            VStack(alignment: .leading, spacing: 0) {
+                Text(headerTitle)
+                    .font(.subheadline.weight(.semibold))
+                Text(stateLabel)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("conversationStateLabel")
+            }
+            Spacer()
+            Button(action: onClose) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title2)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityLabel(NSLocalizedString("common.close", comment: "Close"))
+            .accessibilityIdentifier("conversationCloseButton")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var headerTitle: String {
+        String(
+            format: NSLocalizedString("conversation.header.turn", comment: "Conversation · turn %d"),
+            max(session.turnCount, 1)
+        )
+    }
+
+    private var stateLabel: String {
+        switch session.state {
+        case .idle:          return NSLocalizedString("conversation.state.idle", comment: "")
+        case .listening:     return NSLocalizedString("conversation.state.listening", comment: "")
+        case .transcribing:  return NSLocalizedString("conversation.state.transcribing", comment: "")
+        case .thinking:      return NSLocalizedString("conversation.state.thinking", comment: "")
+        case .toolExecuting: return NSLocalizedString("conversation.state.toolExecuting", comment: "")
+        case .speaking:      return NSLocalizedString("conversation.state.speaking", comment: "")
+        }
+    }
+
+    @ViewBuilder
+    private var statusDot: some View {
+        switch session.state {
+        case .idle:
+            Image(systemName: "circle.fill")
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary.opacity(0.5))
+        case .listening:
+            Image(systemName: "mic.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(.red)
+        case .transcribing, .thinking:
+            ProgressView().controlSize(.small)
+        case .toolExecuting:
+            Image(systemName: "gearshape.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(.blue)
+        case .speaking:
+            Image(systemName: "text.bubble.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(.green)
+        }
+    }
+
+    // MARK: - Message list
+
+    private var messageList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 12) {
+                    ForEach(session.messages.filter { $0.role != .system }) { message in
+                        messageRow(message)
+                            .id(message.id)
+                    }
+                    if session.state == .thinking {
+                        thinkingBubble.id("thinking")
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 14)
+            }
+            .onChange(of: session.messages.count) {
+                // Pin the most recent bubble in view as new content lands.
+                if let last = session.messages.last {
+                    withAnimation(.easeOut(duration: 0.18)) {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func messageRow(_ msg: VoiceAgentSession.Message) -> some View {
+        switch msg.role {
+        case .user:
+            HStack {
+                Spacer(minLength: 40)
+                userBubble(msg.content ?? "")
+            }
+        case .assistant:
+            VStack(alignment: .leading, spacing: 6) {
+                if let content = msg.content, !content.isEmpty {
+                    HStack {
+                        assistantBubble(content)
+                        Spacer(minLength: 40)
+                    }
+                }
+                ForEach(msg.toolCalls) { call in
+                    toolCallChip(call)
+                }
+            }
+        case .tool:
+            HStack(spacing: 6) {
+                Image(systemName: "checkmark.seal")
+                    .font(.caption2)
+                Text(toolResultSummary(msg))
+                    .font(.caption2)
+                    .lineLimit(1)
+            }
+            .foregroundStyle(.secondary)
+            .padding(.leading, 8)
+        case .system:
+            EmptyView()
+        }
+    }
+
+    private func userBubble(_ text: String) -> some View {
+        Text(text)
+            .font(.subheadline)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Color.accentColor.opacity(0.92), in: RoundedRectangle(cornerRadius: 14))
+            .foregroundStyle(.white)
+            .accessibilityIdentifier("userBubble")
+    }
+
+    private func assistantBubble(_ text: String) -> some View {
+        Text(text)
+            .font(.subheadline)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14))
+            .accessibilityIdentifier("assistantBubble")
+    }
+
+    private func toolCallChip(_ call: VoiceAgentSession.ToolCall) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "gearshape.fill")
+                .font(.caption2)
+            Text(call.name)
+                .font(.caption2.weight(.medium))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(Color(.tertiarySystemBackground), in: Capsule())
+        .foregroundStyle(.secondary)
+        .accessibilityIdentifier("toolCallChip")
+    }
+
+    private var thinkingBubble: some View {
+        HStack(spacing: 8) {
+            ProgressView().controlSize(.small)
+            Text(NSLocalizedString("conversation.state.thinking", comment: ""))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Short label for a tool-result row — we don't want to dump full
+    /// JSON in the conversation view, so we strip to the most useful
+    /// hint: either the tool's `name` field if present, or a count.
+    private func toolResultSummary(_ msg: VoiceAgentSession.Message) -> String {
+        let name = msg.name ?? "tool"
+        if let content = msg.content,
+           let data = content.data(using: .utf8),
+           let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let ok = obj["ok"] as? Bool, !ok, let err = obj["error"] as? String {
+                return "\(name): \(err)"
+            }
+            return name
+        }
+        return name
+    }
+
+    // MARK: - Input bar
+
+    private var inputBar: some View {
+        HStack(spacing: 10) {
+            // Mic button — long-press gesture wiring lands in US-VA-05.
+            Image(systemName: "mic.circle.fill")
+                .font(.system(size: 36))
+                .foregroundStyle(Color.accentColor)
+                .accessibilityIdentifier("conversationMicButton")
+                .accessibilityLabel(NSLocalizedString("conversation.input.mic.a11y", comment: ""))
+
+            TextField(
+                NSLocalizedString("conversation.input.placeholder", comment: ""),
+                text: $textDraft,
+                axis: .vertical
+            )
+            .textFieldStyle(.roundedBorder)
+            .lineLimit(1...3)
+            .submitLabel(.send)
+            .onSubmit { submitText() }
+
+            Button {
+                submitText()
+            } label: {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 28))
+                    .foregroundStyle(textDraft.isEmpty ? Color.secondary : Color.accentColor)
+            }
+            .disabled(textDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .accessibilityLabel(NSLocalizedString("conversation.input.send.a11y", comment: ""))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+    }
+
+    private func submitText() {
+        let trimmed = textDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        onSubmitText(trimmed)
+        textDraft = ""
+    }
+}
+
+// MARK: - Preview helpers
+//
+// PRD US-VA-04 DoD: three #Preview states (thinking, tool_executing, idle).
+
+#Preview("idle (empty)") {
+    let session = VoiceAgentSession()
+    return ConversationSheet()
+        .environment(session)
+}
+
+#Preview("thinking") {
+    let session = VoiceAgentSession()
+    session.seedSystem("system prompt")
+    session.beginUserTurn(transcript: "Find me a quiet café in the old quarter.")
+    return ConversationSheet()
+        .environment(session)
+}
+
+#Preview("tool_executing") {
+    let session = VoiceAgentSession()
+    session.seedSystem("system prompt")
+    session.beginUserTurn(transcript: "Filter to coffee, then show details for the closest one.")
+    session.appendAssistantTurn(content: nil, toolCalls: [
+        .init(id: "c1", name: "filter_by_category",
+              argumentsJSON: #"{"category":"coffee"}"#),
+        .init(id: "c2", name: "show_details",
+              argumentsJSON: #"{"experience_id":"exp_demo"}"#),
+    ])
+    session.appendToolResult(toolCallId: "c1", name: "filter_by_category",
+                             resultJSON: #"{"ok":true}"#)
+    return ConversationSheet()
+        .environment(session)
+}


### PR DESCRIPTION
## Summary

SwiftUI surface for the voice-agent conversation, spec'd in [PRD §3.2](./docs/PRD/voice-agent.md). Independent of the network / orchestration stories — binds to `VoiceAgentSession` read-only and emits two intents (`onClose`, `onSubmitText`).

## What's in

**`Views/Voice/ConversationSheet.swift`** — new file.

| Region | Content |
|---|---|
| Header | Status dot (icon varies by state) · "Conversation · turn N" · state label · close button |
| Message list | User bubbles right-aligned · assistant bubbles left-aligned · tool results as muted single-line summaries · `tool_call` chips below assistant content · auto-scrolls to newest |
| Input bar | Mic icon (long-press wiring → US-VA-05) · text field (axis: vertical, 1–3 lines) · send button (disabled when empty) |

**10 new `Localizable.strings` keys** in `en` + `zh-Hans`: header turn label, 6 state labels (idle/listening/transcribing/thinking/toolExecuting/speaking), placeholder, 2 a11y labels.

## 3 `#Preview` blocks (PRD DoD)

- `idle (empty)` — fresh session, no messages
- `thinking` — one user turn, in `.thinking` state
- `tool_executing` — assistant returned 2 tool_calls, one result already landed

## Test plan

- [x] `xcodebuild build-for-testing` on iPhone 17 / iOS 26.4 → **TEST BUILD SUCCEEDED**
- [ ] CI green
- [ ] Manual: open each `#Preview` in Xcode and verify all three render distinct UI without crashes

## Out of scope

- Long-press mic gesture wiring → **US-VA-05**
- Sheet presentation from `CompassMapView` (`.sheet(isPresented:)`) → **US-VA-05** / **US-VA-06**
- Orchestration that actually drives the session → **US-VA-06**

## Notes for reviewers

- View is intentionally inert. The session is `@Environment`-injected so the orchestrator can drive it; the view never mutates state itself except the local `textDraft` `@State`.
- Tool-result rows show only `name` + (on failure) `error` — the full JSON would be noise in the bubble stream.
- LSP may report "type 'ShapeStyle' has no member 'accent'" — that was a real compile error before I switched to `Color.accentColor`. Current code compiles clean.