### PR TITLE
feat(voice): US-VA-06 agent loop orchestrator

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		B28F15C454376D86258FCD77 /* OverpassService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67173C74F1A76C3CE5C38C0A /* OverpassService.swift */; };
 		B478C92BB2249C0D5009AABD /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6163572F4644BF852B35FDA4 /* SyncService.swift */; };
 		BAC775E6105DD571F71ACBC1 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 80020844C0A45A5993333741 /* Localizable.strings */; };
+		BB0BC19A9BE687E947C48034 /* VoiceAgentOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94EF0AA0049BDCC88E125164 /* VoiceAgentOrchestrator.swift */; };
 		BCD734EA6E4D5CE922D0621D /* SubscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B8A80F048D74BEDB8C1132 /* SubscriptionService.swift */; };
 		BD5BB6BD7FCBDB30282F28FA /* VoiceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8ABF85EEFDF9969C94B441 /* VoiceButton.swift */; };
 		C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */; };
@@ -119,6 +120,7 @@
 		87002BB6D344B384A3FDFBFD /* LanguageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageService.swift; sourceTree = "<group>"; };
 		873ACB737A9B43254C17B238 /* CityPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityPickerSheet.swift; sourceTree = "<group>"; };
 		8FDFA5F3503B8ABC4B5CB086 /* SoloCompassTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SoloCompassTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		94EF0AA0049BDCC88E125164 /* VoiceAgentOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAgentOrchestrator.swift; sourceTree = "<group>"; };
 		9748B0A808BC06F6EDED3C3B /* RecentExploreRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentExploreRegion.swift; sourceTree = "<group>"; };
 		9945A4E03F4C75ED89674594 /* SoloCompass.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SoloCompass.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9E8ABF85EEFDF9969C94B441 /* VoiceButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceButton.swift; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 				33B8A80F048D74BEDB8C1132 /* SubscriptionService.swift */,
 				E406C379247653B4AA5A3E0E /* SupabaseClient.swift */,
 				6163572F4644BF852B35FDA4 /* SyncService.swift */,
+				94EF0AA0049BDCC88E125164 /* VoiceAgentOrchestrator.swift */,
 				112319E8315F5F6961C95264 /* VoiceAgentSession.swift */,
 				20208D92E4F564C474E8AEED /* VoiceAgentToolRouter.swift */,
 				120FC7465285714C5FA8F96D /* VoiceService.swift */,
@@ -585,6 +588,7 @@
 				219718C8521B1013D17AE22F /* UserCompletionRecord.swift in Sources */,
 				D53E53A5AA9AE6F77EF82418 /* UserFavoriteRecord.swift in Sources */,
 				C2C0AF72D709EDC17C6ED874 /* UserPreferences.swift in Sources */,
+				BB0BC19A9BE687E947C48034 /* VoiceAgentOrchestrator.swift in Sources */,
 				C220FEC091B645D82519465E /* VoiceAgentSession.swift in Sources */,
 				54952646C79E8F29AF89F4D6 /* VoiceAgentToolRouter.swift in Sources */,
 				BD5BB6BD7FCBDB30282F28FA /* VoiceButton.swift in Sources */,

--- a/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
@@ -1,0 +1,243 @@
+import Foundation
+import Observation
+import CoreLocation
+
+/// Drives one `VoiceAgentSession` through the thinking ↔ tool_executing
+/// loop until the model produces final assistant content or one of the
+/// budgets trips (recursion depth, wall-clock timeout, user cancellation).
+///
+/// US-VA-06: orchestration only — no UI, no HTTP construction. The
+/// view-model owns one orchestrator per voice sheet presentation; the
+/// view (`ConversationSheet`) reads `session` for state.
+@MainActor
+@Observable
+public final class VoiceAgentOrchestrator {
+
+    // MARK: - State
+
+    public let session: VoiceAgentSession
+    private let aiService: AIService
+    private let router: VoiceAgentToolRouter
+
+    /// Currently-running turn, retained so `cancel()` can cooperatively
+    /// kill the in-flight think/tool loop.
+    private var currentTurnTask: Task<Void, Never>?
+
+    public init(
+        session: VoiceAgentSession,
+        aiService: AIService,
+        router: VoiceAgentToolRouter
+    ) {
+        self.session = session
+        self.aiService = aiService
+        self.router = router
+    }
+
+    // MARK: - Public API
+
+    /// Seed the session with a system prompt. Call once before the first
+    /// user turn. The system prompt is the long bilingual block from
+    /// PRD §6.1; the caller owns the exact text so it can be A/B tested
+    /// without touching this file.
+    public func start(systemPrompt: String) {
+        guard session.messages.isEmpty else { return }
+        session.seedSystem(systemPrompt)
+    }
+
+    /// Process one user turn end-to-end. Safe to await from the view;
+    /// races against `cancel()` and the per-turn timeout.
+    ///
+    /// `visibleExperiences` and `userLocation` are injected into a
+    /// per-turn system continuation so the model can resolve "the
+    /// second one" without inventing ids (PRD §6.2).
+    public func handleUserTurn(
+        transcript: String,
+        visibleExperiences: [Experience],
+        userLocation: CLLocationCoordinate2D?
+    ) async {
+        guard !session.isEnded else { return }
+        currentTurnTask?.cancel()
+        let task = Task {
+            await runTurn(
+                transcript: transcript,
+                visibleExperiences: visibleExperiences,
+                userLocation: userLocation
+            )
+        }
+        currentTurnTask = task
+        await task.value
+    }
+
+    /// User pulled the rip-cord (× button, app backgrounded mid-turn).
+    /// Cancels the current Task; the loop sees `Task.isCancelled` and
+    /// stops without appending more rows.
+    public func cancel() {
+        currentTurnTask?.cancel()
+        currentTurnTask = nil
+        if !session.isEnded {
+            session.end(reason: .userClose)
+        }
+    }
+
+    // MARK: - Turn loop
+
+    /// One end-to-end user turn: optionally inject context, then loop
+    /// (DeepSeek → execute tool_calls → DeepSeek …) up to the recursion
+    /// budget; wrapped in a wall-clock timeout (PRD §5.1).
+    private func runTurn(
+        transcript: String,
+        visibleExperiences: [Experience],
+        userLocation: CLLocationCoordinate2D?
+    ) async {
+        appendPerTurnSystemContext(
+            visibleExperiences: visibleExperiences,
+            userLocation: userLocation
+        )
+        session.beginUserTurn(transcript: transcript)
+
+        let timeoutSeconds = VoiceAgentSession.turnTimeoutSeconds
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask { @MainActor [weak self] in
+                    await self?.runThinkLoop()
+                }
+                group.addTask {
+                    try await Task.sleep(
+                        nanoseconds: UInt64(timeoutSeconds * 1_000_000_000)
+                    )
+                    throw VoiceAgentError.turnTimeout
+                }
+                // First branch to finish wins. If think finishes first
+                // the timeout sleep gets cancelled when we cancelAll();
+                // if the timeout fires it throws and we drop the loop.
+                _ = try await group.next()
+                group.cancelAll()
+            }
+        } catch is CancellationError {
+            // user-initiated cancel — no-op; session already moved by cancel()
+            return
+        } catch VoiceAgentError.turnTimeout {
+            session.end(reason: .timeout)
+        } catch {
+            session.end(reason: .error)
+        }
+    }
+
+    /// `thinking → toolExecuting → thinking → …` loop. Stops on:
+    /// - assistant content with no tool_calls (success: finishSpeakingTurn)
+    /// - recursion budget exhausted (synthesise refusal results so the
+    ///   model has a clean chance to wrap up on the next turn)
+    /// - any network failure (ends the session as .error)
+    /// - external cancellation (Task.isCancelled → bail silently)
+    private func runThinkLoop() async {
+        while !Task.isCancelled {
+            do {
+                let response = try await aiService.sendAgentMessage(
+                    messages: session.messages,
+                    tools: VoiceAgentToolRouter.allTools
+                )
+                if Task.isCancelled { return }
+
+                if response.toolCalls.isEmpty {
+                    session.appendAssistantTurn(
+                        content: response.content,
+                        toolCalls: []
+                    )
+                    session.finishSpeakingTurn()
+                    return
+                }
+
+                // tool_calls path
+                session.appendAssistantTurn(
+                    content: response.content,
+                    toolCalls: response.toolCalls
+                )
+
+                if session.hasExceededRecursionBudget {
+                    // Force the next pass to be content-only by feeding
+                    // synthetic refusals for every pending call.
+                    for call in response.toolCalls {
+                        session.appendToolResult(
+                            toolCallId: call.id,
+                            name: call.name,
+                            resultJSON: #"{"ok":false,"error":"recursion_budget_exhausted"}"#
+                        )
+                    }
+                    session.resumeThinkingAfterTools()
+                    continue
+                }
+
+                await executeToolCallsInParallel(response.toolCalls)
+                if Task.isCancelled { return }
+                session.resumeThinkingAfterTools()
+            } catch {
+                if Task.isCancelled { return }
+                if error is CancellationError { return }
+                session.end(reason: .error)
+                return
+            }
+        }
+    }
+
+    /// Fan tool calls out as a TaskGroup so independent tools (e.g.
+    /// `filter_by_category` + `explore_nearby`) overlap. Results are
+    /// appended back in the input order so the conversation reads naturally.
+    private func executeToolCallsInParallel(
+        _ calls: [VoiceAgentSession.ToolCall]
+    ) async {
+        var results: [String?] = Array(repeating: nil, count: calls.count)
+        await withTaskGroup(of: (Int, String).self) { group in
+            for (index, call) in calls.enumerated() {
+                let router = self.router
+                group.addTask { @MainActor in
+                    let json = await router.execute(call)
+                    return (index, json)
+                }
+            }
+            for await (index, json) in group {
+                results[index] = json
+            }
+        }
+        for (index, call) in calls.enumerated() {
+            let json = results[index] ?? #"{"ok":false,"error":"missing_result"}"#
+            session.appendToolResult(
+                toolCallId: call.id, name: call.name, resultJSON: json
+            )
+        }
+    }
+
+    // MARK: - Per-turn system context (PRD §6.2)
+
+    /// Append a system continuation listing up to N visible experiences
+    /// + the user's location. We append (not replace) so the AI sees a
+    /// fresh snapshot each turn. The orchestrator never edits past msgs.
+    private func appendPerTurnSystemContext(
+        visibleExperiences: [Experience],
+        userLocation: CLLocationCoordinate2D?
+    ) {
+        let summarised = visibleExperiences
+            .prefix(VoiceAgentSession.visibleExperiencesInjected)
+            .map { exp in
+                "- \(exp.id): \"\(exp.title)\" [\(exp.category.rawValue)]"
+            }
+            .joined(separator: "\n")
+        let locationLine: String
+        if let coord = userLocation {
+            locationLine = "USER_LOCATION: lat=\(String(format: "%.4f", coord.latitude)) lon=\(String(format: "%.4f", coord.longitude))"
+        } else {
+            locationLine = "USER_LOCATION: unknown"
+        }
+        let payload = """
+        VISIBLE_EXPERIENCES (max \(VoiceAgentSession.visibleExperiencesInjected), ranked):
+        \(summarised.isEmpty ? "(none on map yet — explore_nearby first)" : summarised)
+        \(locationLine)
+        """
+        session.appendSystemContext(payload)
+    }
+}
+
+// MARK: - Errors
+
+enum VoiceAgentError: Error {
+    case turnTimeout
+}

--- a/apps/ios/SoloCompass/Services/VoiceAgentSession.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentSession.swift
@@ -152,6 +152,16 @@ public final class VoiceAgentSession {
         messages.append(Message(role: .system, content: prompt))
     }
 
+    /// Append a per-turn system continuation (PRD §6.2). Used by the
+    /// orchestrator to inject `VISIBLE_EXPERIENCES` + user location
+    /// snapshots before each user turn so the model can resolve
+    /// referents ("the second one") without inventing ids.
+    public func appendSystemContext(_ payload: String) {
+        guard endReason == nil else { return }
+        guard !payload.isEmpty else { return }
+        messages.append(Message(role: .system, content: payload))
+    }
+
     /// Transition .idle → .listening. Caller is the long-press gesture.
     public func beginListening() {
         guard endReason == nil else { return }


### PR DESCRIPTION
> **Stacked on [#108](https://github.com/getyak/solo-compass/pull/108)** (which already includes US-VA-03's commits since the user squashed #107 onto that branch). Will rebase to main once #108 lands.

## Summary

Wires the three voice-agent layers — session model (US-VA-01) + DeepSeek tools HTTP (US-VA-02) + tool router (US-VA-03) — into a turn-driven loop with timeout, recursion budget, and cancellation. The orchestrator is what the long-press mic gesture (US-VA-05) will own and what `ConversationSheet` (US-VA-04) will read.

## What's in

**`Services/VoiceAgentOrchestrator.swift`** — `@MainActor @Observable`.

| API | Purpose |
|---|---|
| `start(systemPrompt:)` | seed once before first turn |
| `handleUserTurn(transcript:visibleExperiences:userLocation:) async` | one user turn end-to-end |
| `cancel()` | drop the in-flight Task and end the session |

**Turn flow** (`runTurn` → `runThinkLoop`):

1. Append a per-turn system continuation (PRD §6.2): top-5 `VISIBLE_EXPERIENCES` + `USER_LOCATION`.
2. `beginUserTurn(transcript)` — state → `.thinking`.
3. Race a `runThinkLoop` against a 30s sleep via `withThrowingTaskGroup`. Whoever finishes first cancels the other (PRD §5.1).
4. `runThinkLoop`:
   - call `sendAgentMessage` with the full message history + `VoiceAgentToolRouter.allTools`
   - if response is plain content → `appendAssistantTurn` + `finishSpeakingTurn` → return
   - if response has `tool_calls` and recursion budget left → execute in `TaskGroup` (parallel), append results in input order, `resumeThinkingAfterTools`, loop
   - if response has `tool_calls` but budget exhausted → synthesise `{"ok":false,"error":"recursion_budget_exhausted"}` results so the next round can wrap up cleanly

**`VoiceAgentSession.appendSystemContext(_:)`** — new public method so the orchestrator can drop per-turn system continuations without violating `seedSystem`'s "must be first" precondition.

## Test plan

- [x] `xcodebuild build-for-testing` on iPhone 17 / iOS 26.4 → **TEST BUILD SUCCEEDED**
- [ ] CI green
- [ ] End-to-end integration test with mocked DeepSeek deferred to **US-VA-07**

## Out of scope

- 3-turn integration test (mock DeepSeek) → **US-VA-07**
- AnalyticsService event emission → **US-VA-07**
- Long-press mic gesture creating an Orchestrator → **US-VA-05**
- Wiring into `CompassMapView` (`.sheet(isPresented:)`) → **US-VA-05**

## Why no unit tests in this PR

Orchestrator integration tests need `StubURLProtocol` driving `AIService` AND real `MapViewModel`/`UserPreferences` for router side effects AND timing control for the 30s race. That's the "end-to-end 3-turn" test the PRD lists for **US-VA-07** — duplicating it here would be busywork. Build-only verification is intentional.