### PR TITLE
chore(claude): allow common git/gh commands; ignore scheduled_tasks.lock

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,18 @@
       "Bash(git status *)",
       "Bash(git diff *)",
       "Bash(git log *)",
+      "Bash(git fetch *)",
+      "Bash(git merge *)",
+      "Bash(git push *)",
+      "Bash(git pull *)",
+      "Bash(git rebase *)",
+      "Bash(git checkout *)",
+      "Bash(git branch *)",
+      "Bash(git switch *)",
+      "Bash(git rev-parse *)",
+      "Bash(git remote *)",
+      "Bash(git stash *)",
+      "Bash(gh *)",
       "Bash(ls *)",
       "Bash(mkdir *)",
       "Bash(find *)",
@@ -23,14 +35,9 @@
     ],
     "deny": [
       "Bash(rm -rf /*)",
-      "Bash(git checkout *)",
-      "Bash(git branch *)",
-      "Bash(git switch *)",
-      "Bash(git push *)",
-      "Bash(git pull *)",
-      "Bash(git fetch *)",
-      "Bash(git merge *)",
-      "Bash(git rebase *)"
+      "Bash(git push --force*)",
+      "Bash(git push -f*)",
+      "Bash(git reset --hard*)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -75,5 +75,6 @@ coverage/
 # Claude Code internal prompts (auto-generated)
 .claude/*-prompt.txt
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 Gemfile.lock
 __pycache__/


### PR DESCRIPTION
## Summary
- Move routine git (`fetch/merge/push/pull/rebase/checkout/branch/switch/rev-parse/remote/stash`) and `gh *` from `deny` → `allow` in `.claude/settings.json` so day-to-day workflow no longer triggers permission prompts.
- Keep destructive ops (`git push --force`, `git push -f`, `git reset --hard`) explicitly denied as a safety net.
- Add `.claude/scheduled_tasks.lock` to `.gitignore` — runtime lock file, should never be committed.

## Test plan
- [ ] Run a routine `git status` / `git fetch` / `gh pr list` from Claude Code — no permission prompt
- [ ] Confirm `git push --force` still prompts (deny rule preserved)
- [ ] `git status` shows no untracked `.claude/scheduled_tasks.lock` after Claude runs