### PR TITLE
feat(ios): tap location address → open Maps for navigation

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -124,9 +124,15 @@ public struct ExperienceDetailView: View {
 
             if let local = viewModel.experience.location.placeNameLocal, !local.isEmpty {
                 let romanized = viewModel.experience.location.placeNameRomanized
-                Text(romanized?.isEmpty == false ? "\(local) · \(romanized ?? "")" : local)
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
+                let label = romanized?.isEmpty == false ? "\(local) · \(romanized ?? "")" : local
+                Button {
+                    openInMaps(viewModel.experience)
+                } label: {
+                    Label(label, systemImage: "map")
+                        .font(.caption)
+                        .foregroundStyle(.blue)
+                }
+                .buttonStyle(.plain)
             }
         }
     }
@@ -402,6 +408,15 @@ public struct ExperienceDetailView: View {
 
     private func format(window: TimeWindow) -> String {
         String(format: "%02d:00 – %02d:00", window.startHour, window.endHour)
+    }
+
+    private func openInMaps(_ experience: Experience) {
+        guard let coord = experience.location.clCoordinate else { return }
+        let placeName = experience.location.placeNameLocal ?? experience.title
+        let encoded = placeName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "Location"
+        let urlString = "maps://?ll=\(coord.latitude),\(coord.longitude)&q=\(encoded)"
+        guard let url = URL(string: urlString) else { return }
+        UIApplication.shared.open(url)
     }
 }
 


### PR DESCRIPTION
## 功能

ExperienceDetailView 中的地点名称现在可点击，点击后用 `maps://` URL scheme 打开三方导航 App。

### 改动
- 位置文本从 `Text` → `Button + Label`（蓝色 + map icon）
- 新增 `openInMaps()` 方法：取坐标 + 地名 → maps:// URL
- 兼容 Apple Maps / Google Maps / 高德等所有支持 maps:// 的导航 App

### Before
位置是灰色纯文本，无法交互

### After  
位置显示为蓝色可点击链接，带 🗺️ 图标，点击打开导航