### PR TITLE
feat(ios): add voice processing feedback indicator

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "info.night" = "The night is winding down. %d places still open.";
 
 /* Voice */
+"voice.processing" = "Thinking: %@";
 "voice.button" = "Voice input";
 "voice.permission.title" = "Microphone access needed";
 "voice.permission.message" = "Solo Compass needs microphone and speech permission to take voice input.";

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -230,6 +230,11 @@ public final class MapViewModel {
     // True when a "Now" filter is active (best-now experiences only).
     public var isNowFilter: Bool = false
 
+    // MARK: - Voice processing feedback
+
+    public var isProcessingVoiceIntent: Bool = false
+    public var currentVoiceTranscript: String = ""
+
     // MARK: - Settings
 
     public var isShowingSettings: Bool = false
@@ -597,8 +602,12 @@ public final class MapViewModel {
             return
         }
         let coordinate = locationService.currentLocation?.coordinate ?? Self.defaultCenter
+        isProcessingVoiceIntent = true
+        currentVoiceTranscript = transcript
+        defer { isProcessingVoiceIntent = false }
         do {
             let response = try await aiService.processVoiceIntent(transcript: transcript, near: coordinate)
+            currentVoiceTranscript = ""
             aiExplanation = response.explanation
             if let suggestion = response.filterSuggestion {
                 selectCategory(suggestion)

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -162,6 +162,26 @@ public struct CompassMapView: View {
                     // ExploreProgressBar which hides itself when .idle.
                     ExploreProgressBar(progress: viewModel.exploreProgress)
 
+                    // Voice intent processing indicator — shown while AI handles the transcript.
+                    if viewModel.isProcessingVoiceIntent {
+                        HStack(spacing: 8) {
+                            ProgressView()
+                                .scaleEffect(0.8)
+                            Text(String(
+                                format: NSLocalizedString("voice.processing", comment: "AI is thinking about your request"),
+                                viewModel.currentVoiceTranscript.truncated(limit: 30)
+                            ))
+                            .font(.caption)
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+                        }
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .background(.thinMaterial, in: Capsule())
+                        .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
+                        .transition(.opacity.combined(with: .scale(scale: 0.95)))
+                    }
+
                     // Explore success toast — 3-second ephemeral capsule above BottomInfoBar.
                     if let toast = viewModel.lastExploreToast {
                         Text(toast)
@@ -579,6 +599,13 @@ public struct CompassMapView: View {
         .environment(ExperienceService())
         .environment(AIService())
         .environment(UserPreferences())
+}
+
+private extension String {
+    func truncated(limit: Int) -> String {
+        guard count > limit else { return self }
+        return String(prefix(limit)) + "…"
+    }
 }
 
 private struct EmptyStateOverlay: View {


### PR DESCRIPTION
## Problem

Voice button on the map (bottom-right) had a dead zone in UX: after user releases the mic, the transcript disappears and there's zero feedback while the AI processes the voice command — user doesn't know if anything is happening.

## Fix

Added a processing indicator pill that bridges the gap between "user finished speaking" and "AI response received":

- `MapViewModel`: new `isProcessingVoiceIntent` + `currentVoiceTranscript` state properties
- `CompassMapView`: processing capsule (`ProgressView` + "Thinking: …" truncated transcript) shown above the bottom bar
- `Localizable.strings`: localization key for the new string

### Flow

1. Long-press mic → red pulse + live transcript (unchanged)
2. Release → transcript fades, **processing pill appears**: "🔄 Thinking: 推荐附近的咖啡馆…"
3. AI response → pill disappears, results shown
4. Error → pill disappears, error banner shown (existing behavior)

Uses `defer` to guarantee cleanup on both success and error paths.