### PR TITLE
feat(ios): context-aware voice intent + result toast UX

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -67,6 +67,9 @@
 /* Voice */
 "voice.processing" = "Thinking: %@";
 "voice.button" = "Voice input";
+"voice.result.found" = "Found %d matching places";
+"voice.result.filtered" = "Showing %@ nearby";
+"voice.result.none" = "No matching places nearby — try a different search";
 "voice.permission.title" = "Microphone access needed";
 "voice.permission.message" = "Solo Compass needs microphone and speech permission to take voice input.";
 

--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -176,11 +176,34 @@ public final class AIService {
         }
     }
 
-    public func processVoiceIntent(transcript: String, near coordinate: CLLocationCoordinate2D) async throws -> AIResponse {
+    public func processVoiceIntent(
+        transcript: String,
+        near coordinate: CLLocationCoordinate2D,
+        nearbyExperiences: [Experience] = []
+    ) async throws -> AIResponse {
+        let nearbyContext: String
+        if nearbyExperiences.isEmpty {
+            nearbyContext = "There are no curated experiences within 10km."
+        } else {
+            nearbyContext = nearbyExperiences.prefix(20).map { exp in
+                "  [\(exp.id)] \(exp.title) — \(exp.category.rawValue) — \(String(format: "%.1f", exp.soloScore.overall))/10"
+            }.joined(separator: "\n")
+        }
+
         let prompt = """
-        A solo traveler said: \"\(transcript)\".
-        Their current coordinates are \(coordinate.latitude), \(coordinate.longitude).
-        Respond as JSON: {"recommendedIds":[],"explanation":"...","filterSuggestion":"culture|nature|food|coffee|work|wellness|nightlife|hidden|null"}
+        A solo traveler said: "\(transcript)".
+        Their location: \(coordinate.latitude), \(coordinate.longitude).
+
+        Nearby curated experiences (use these exact IDs to recommend):
+        \(nearbyContext)
+
+        Respond as JSON:
+        {
+          "recommendedIds": ["id1","id2"],
+          "explanation": "A warm, one-sentence response to the user. If no matches, suggest what kind of place they might look for.",
+          "filterSuggestion": "culture|nature|food|coffee|work|wellness|nightlife|hidden|null"
+        }
+        Only include IDs that match the user request. If nothing matches, use empty array and explain.
         """
         do {
             let raw = try await sendMessage(prompt: prompt, kind: .voice)

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -234,6 +234,8 @@ public final class MapViewModel {
 
     public var isProcessingVoiceIntent: Bool = false
     public var currentVoiceTranscript: String = ""
+    /// Ephemeral toast shown after voice AI resolves. Nil when not active.
+    public var voiceResultToast: String? = nil
 
     // MARK: - Settings
 
@@ -602,11 +604,21 @@ public final class MapViewModel {
             return
         }
         let coordinate = locationService.currentLocation?.coordinate ?? Self.defaultCenter
+        let nearby = experienceService.allExperiences.filter { exp in
+            guard let expCoord = exp.coordinate else { return false }
+            let loc = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+            let expLoc = CLLocation(latitude: expCoord.latitude, longitude: expCoord.longitude)
+            return expLoc.distance(from: loc) < 10_000
+        }
         isProcessingVoiceIntent = true
         currentVoiceTranscript = transcript
         defer { isProcessingVoiceIntent = false }
         do {
-            let response = try await aiService.processVoiceIntent(transcript: transcript, near: coordinate)
+            let response = try await aiService.processVoiceIntent(
+                transcript: transcript,
+                near: coordinate,
+                nearbyExperiences: nearby
+            )
             currentVoiceTranscript = ""
             aiExplanation = response.explanation
             if let suggestion = response.filterSuggestion {
@@ -618,6 +630,35 @@ public final class MapViewModel {
             }
             bottomInfoText = response.explanation
             lastAIError = nil
+
+            if !response.recommendedIds.isEmpty {
+                voiceResultToast = String(
+                    format: NSLocalizedString("voice.result.found", comment: ""),
+                    response.recommendedIds.count
+                )
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
+                Task {
+                    try? await Task.sleep(for: .seconds(3))
+                    voiceResultToast = nil
+                }
+            } else if let suggestion = response.filterSuggestion {
+                voiceResultToast = String(
+                    format: NSLocalizedString("voice.result.filtered", comment: ""),
+                    NSLocalizedString("category.\(suggestion.rawValue)", comment: "")
+                )
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
+                Task {
+                    try? await Task.sleep(for: .seconds(3))
+                    voiceResultToast = nil
+                }
+            } else {
+                voiceResultToast = NSLocalizedString("voice.result.none", comment: "No matching places found nearby")
+                UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                Task {
+                    try? await Task.sleep(for: .seconds(4))
+                    voiceResultToast = nil
+                }
+            }
         } catch {
             // Keep current state on error; record for UI to optionally surface.
             lastAIError = error.localizedDescription

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -158,9 +158,24 @@ public struct CompassMapView: View {
                         .transition(.opacity)
                     }
 
-                    // US-MR-04: multi-ring progress capsule. Delegates to
-                    // ExploreProgressBar which hides itself when .idle.
-                    ExploreProgressBar(progress: viewModel.exploreProgress)
+                    // US-MR-04: multi-ring progress capsule — inlined to
+                    // avoid cross-file CI build error (ExploreProgressBar).
+                    if let progressText = CompassMapView.progressText(for: viewModel.exploreProgress) {
+                        HStack(spacing: 8) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text(progressText)
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(.primary)
+                        }
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 7)
+                        .background(.thinMaterial, in: Capsule())
+                        .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
+                        .transition(.opacity)
+                        .accessibilityIdentifier("exploreProgress")
+                        .accessibilityLabel(Text(progressText))
+                    }
 
                     // Voice intent processing indicator — shown while AI handles the transcript.
                     if viewModel.isProcessingVoiceIntent {

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -513,7 +513,7 @@ private struct MapOverlayView: View {
                         ? "magnifyingglass" : "checkmark.circle.fill")
                         .font(.caption)
                         .foregroundStyle(toast == NSLocalizedString("voice.result.none", comment: "No matching places found nearby")
-                            ? .secondary : .green)
+                            ? Color.secondary : Color.green)
                     Text(toast)
                         .font(.caption.weight(.medium))
                         .foregroundStyle(.primary)

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -182,6 +182,26 @@ public struct CompassMapView: View {
                         .transition(.opacity.combined(with: .scale(scale: 0.95)))
                     }
 
+                    // Voice result toast — shown after AI resolves a voice intent.
+                    if let toast = viewModel.voiceResultToast {
+                        HStack(spacing: 8) {
+                            Image(systemName: toast == NSLocalizedString("voice.result.none", comment: "No matching places found nearby")
+                                ? "magnifyingglass" : "checkmark.circle.fill")
+                                .font(.caption)
+                                .foregroundStyle(toast == NSLocalizedString("voice.result.none", comment: "No matching places found nearby")
+                                    ? .secondary : .green)
+                            Text(toast)
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(.primary)
+                        }
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 7)
+                        .background(.thinMaterial, in: Capsule())
+                        .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
+                        .transition(.opacity.combined(with: .scale(scale: 0.95)))
+                        .accessibilityIdentifier("voiceResultToast")
+                    }
+
                     // Explore success toast — 3-second ephemeral capsule above BottomInfoBar.
                     if let toast = viewModel.lastExploreToast {
                         Text(toast)

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -31,227 +31,14 @@ public struct CompassMapView: View {
                 mapLayer(viewModel: viewModel)
                     .ignoresSafeArea()
 
-                VStack {
-                    HStack {
-                        cityPill(viewModel: viewModel)
-                            .padding(.leading, 12)
-                            .padding(.top, 8)
-                        Spacer()
-                    }
-
-                    FilterBarView(
-                        selectedCategory: viewModel.selectedCategory,
-                        isNowSelected: viewModel.isNowFilter,
-                        onSelectNow: { viewModel.selectNowFilter() },
-                        onSelectAll: { viewModel.clearFilters() },
-                        onSelectCategory: { viewModel.selectCategory($0) }
-                    )
-                    .padding(.top, 4)
-
-                    // AI / voice error banner — dismissible, shown below filter bar.
-                    if let errorText = viewModel.lastAIError, errorText != dismissedAIError {
-                        HStack(spacing: 8) {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .foregroundStyle(.orange)
-                            Text(errorText)
-                                .font(.caption)
-                                .foregroundStyle(.primary)
-                                .lineLimit(2)
-                            Spacer()
-                            Button {
-                                dismissedAIError = errorText
-                            } label: {
-                                Image(systemName: "xmark")
-                                    .font(.caption.bold())
-                                    .foregroundStyle(.secondary)
-                            }
-                            .accessibilityLabel(Text(NSLocalizedString("common.dismiss", comment: "Dismiss error")))
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 8)
-                        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
-                        .padding(.horizontal, 12)
-                        .transition(.move(edge: .top).combined(with: .opacity))
-                        .accessibilityElement(children: .combine)
-                        .accessibilityLabel(Text(errorText))
-                    }
-
-                    // Explore error banner — orange, dismissible, below filter bar.
-                    if let exploreError = viewModel.lastExploreError, exploreError != dismissedExploreError {
-                        HStack(spacing: 8) {
-                            Image(systemName: "airplane.slash")
-                                .foregroundStyle(.orange)
-                            Text(exploreError)
-                                .font(.caption)
-                                .foregroundStyle(.primary)
-                                .lineLimit(2)
-                            Spacer()
-                            Button {
-                                dismissedExploreError = exploreError
-                            } label: {
-                                Image(systemName: "xmark")
-                                    .font(.caption.bold())
-                                    .foregroundStyle(.secondary)
-                            }
-                            .accessibilityLabel(Text(NSLocalizedString("common.dismiss", comment: "Dismiss error")))
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 8)
-                        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
-                        .padding(.horizontal, 12)
-                        .transition(.move(edge: .top).combined(with: .opacity))
-                        .accessibilityElement(children: .combine)
-                        .accessibilityLabel(Text(exploreError))
-                        .accessibilityIdentifier("exploreErrorBanner")
-                    }
-
-                    // Quota banner — yellow, persistent until the next UTC day.
-                    if let quotaInfo = viewModel.lastQuotaInfo, quotaInfo != dismissedQuotaInfo {
-                        HStack(spacing: 8) {
-                            Image(systemName: "clock.badge.exclamationmark")
-                                .foregroundStyle(Color(red: 0.8, green: 0.6, blue: 0))
-                            Text(quotaInfo)
-                                .font(.caption)
-                                .foregroundStyle(.primary)
-                                .lineLimit(2)
-                            Spacer()
-                            Button {
-                                dismissedQuotaInfo = quotaInfo
-                            } label: {
-                                Image(systemName: "xmark")
-                                    .font(.caption.bold())
-                                    .foregroundStyle(.secondary)
-                            }
-                            .accessibilityLabel(Text(NSLocalizedString("common.dismiss", comment: "Dismiss banner")))
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 8)
-                        .background(
-                            Color(red: 1, green: 0.95, blue: 0.7).opacity(0.9),
-                            in: RoundedRectangle(cornerRadius: 12)
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .strokeBorder(Color(red: 0.8, green: 0.6, blue: 0).opacity(0.5), lineWidth: 1)
-                        )
-                        .padding(.horizontal, 12)
-                        .transition(.move(edge: .top).combined(with: .opacity))
-                        .accessibilityElement(children: .combine)
-                        .accessibilityLabel(Text(quotaInfo))
-                        .accessibilityIdentifier("quotaBanner")
-                    }
-
-                    Spacer()
-
-                    // AI processing indicator — shown above the bottom info bar.
-                    if aiService.isProcessing {
-                        HStack(spacing: 6) {
-                            ProgressView()
-                                .scaleEffect(0.8)
-                            Text(NSLocalizedString("ai.processing", comment: "AI is processing"))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
-                        .background(.thinMaterial, in: Capsule())
-                        .transition(.opacity)
-                    }
-
-                    // US-MR-04: multi-ring progress capsule — inlined to
-                    // avoid cross-file CI build error (ExploreProgressBar).
-                    if let progressText = CompassMapView.progressText(for: viewModel.exploreProgress) {
-                        HStack(spacing: 8) {
-                            ProgressView()
-                                .controlSize(.small)
-                            Text(progressText)
-                                .font(.caption.weight(.medium))
-                                .foregroundStyle(.primary)
-                        }
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 7)
-                        .background(.thinMaterial, in: Capsule())
-                        .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
-                        .transition(.opacity)
-                        .accessibilityIdentifier("exploreProgress")
-                        .accessibilityLabel(Text(progressText))
-                    }
-
-                    // Voice intent processing indicator — shown while AI handles the transcript.
-                    if viewModel.isProcessingVoiceIntent {
-                        HStack(spacing: 8) {
-                            ProgressView()
-                                .scaleEffect(0.8)
-                            Text(String(
-                                format: NSLocalizedString("voice.processing", comment: "AI is thinking about your request"),
-                                viewModel.currentVoiceTranscript.truncated(limit: 30)
-                            ))
-                            .font(.caption)
-                            .foregroundStyle(.primary)
-                            .lineLimit(1)
-                        }
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 8)
-                        .background(.thinMaterial, in: Capsule())
-                        .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
-                        .transition(.opacity.combined(with: .scale(scale: 0.95)))
-                    }
-
-                    // Voice result toast — shown after AI resolves a voice intent.
-                    if let toast = viewModel.voiceResultToast {
-                        HStack(spacing: 8) {
-                            Image(systemName: toast == NSLocalizedString("voice.result.none", comment: "No matching places found nearby")
-                                ? "magnifyingglass" : "checkmark.circle.fill")
-                                .font(.caption)
-                                .foregroundStyle(toast == NSLocalizedString("voice.result.none", comment: "No matching places found nearby")
-                                    ? .secondary : .green)
-                            Text(toast)
-                                .font(.caption.weight(.medium))
-                                .foregroundStyle(.primary)
-                        }
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 7)
-                        .background(.thinMaterial, in: Capsule())
-                        .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
-                        .transition(.opacity.combined(with: .scale(scale: 0.95)))
-                        .accessibilityIdentifier("voiceResultToast")
-                    }
-
-                    // Explore success toast — 3-second ephemeral capsule above BottomInfoBar.
-                    if let toast = viewModel.lastExploreToast {
-                        Text(toast)
-                            .font(.caption.weight(.medium))
-                            .foregroundStyle(.primary)
-                            .padding(.horizontal, 14)
-                            .padding(.vertical, 7)
-                            .background(.thinMaterial, in: Capsule())
-                            .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
-                            .transition(.opacity.combined(with: .scale(scale: 0.95)))
-                            .accessibilityIdentifier("exploreToast")
-                            .onAppear {
-                                Task {
-                                    try? await Task.sleep(for: .seconds(3))
-                                    withAnimation(.easeOut(duration: 0.3)) {
-                                        viewModel.lastExploreToast = nil
-                                    }
-                                }
-                            }
-                    }
-
-                    BottomInfoBar(text: viewModel.bottomInfoText, nearbySoloCount: viewModel.nearbySoloCount)
-                        .padding(.bottom, 8)
-
-                    // Pending check-in banner (geofence fired while user was nearby)
-                    if let pending = viewModel.pendingCheckIn {
-                        PendingCheckInBanner(
-                            experienceTitle: pending.title,
-                            onConfirm: { viewModel.confirmCheckIn() },
-                            onDismiss: { viewModel.dismissCheckIn() }
-                        )
-                        .padding(.bottom, 4)
-                        .animation(.spring(response: 0.4), value: viewModel.pendingCheckIn != nil)
-                    }
-                }
+                MapOverlayView(
+                    viewModel: viewModel,
+                    isAIProcessing: aiService.isProcessing,
+                    isShowingCityPicker: $isShowingCityPicker,
+                    dismissedAIError: $dismissedAIError,
+                    dismissedExploreError: $dismissedExploreError,
+                    dismissedQuotaInfo: $dismissedQuotaInfo
+                )
 
                 VStack {
                     Spacer()
@@ -503,36 +290,6 @@ public struct CompassMapView: View {
         }
     }
 
-    // MARK: - City pill
-
-    @ViewBuilder
-    private func cityPill(viewModel: MapViewModel) -> some View {
-        let cityName: String = {
-            if let code = viewModel.selectedCity,
-               let city = viewModel.availableCities.first(where: { $0.code == code }) {
-                return city.name
-            }
-            return NSLocalizedString("city.all", comment: "All cities option")
-        }()
-
-        Button {
-            isShowingCityPicker = true
-        } label: {
-            HStack(spacing: 4) {
-                Text(cityName)
-                    .font(.subheadline.weight(.medium))
-                Image(systemName: "chevron.down")
-                    .font(.caption.weight(.semibold))
-            }
-            .foregroundStyle(.primary)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background(.regularMaterial, in: Capsule())
-        }
-        .accessibilityLabel(Text(cityName))
-        .accessibilityHint(Text(NSLocalizedString("city.picker.title", comment: "City picker sheet title")))
-    }
-
     @ViewBuilder
     private func mapLayer(viewModel: MapViewModel) -> some View {
         let bindingCamera = Binding<MapCameraPosition>(
@@ -640,6 +397,221 @@ private extension String {
     func truncated(limit: Int) -> String {
         guard count > limit else { return self }
         return String(prefix(limit)) + "…"
+    }
+}
+
+private struct MapOverlayView: View {
+    var viewModel: MapViewModel
+    var isAIProcessing: Bool
+    @Binding var isShowingCityPicker: Bool
+    @Binding var dismissedAIError: String?
+    @Binding var dismissedExploreError: String?
+    @Binding var dismissedQuotaInfo: String?
+
+    var body: some View {
+        VStack {
+            HStack {
+                cityPill
+                    .padding(.leading, 12)
+                    .padding(.top, 8)
+                Spacer()
+            }
+
+            FilterBarView(
+                selectedCategory: viewModel.selectedCategory,
+                isNowSelected: viewModel.isNowFilter,
+                onSelectNow: { viewModel.selectNowFilter() },
+                onSelectAll: { viewModel.clearFilters() },
+                onSelectCategory: { viewModel.selectCategory($0) }
+            )
+            .padding(.top, 4)
+
+            if let errorText = viewModel.lastAIError, errorText != dismissedAIError {
+                DismissibleBanner(
+                    systemImage: "exclamationmark.triangle.fill",
+                    text: errorText,
+                    color: .orange,
+                    onDismiss: { dismissedAIError = errorText }
+                )
+            }
+
+            if let exploreError = viewModel.lastExploreError, exploreError != dismissedExploreError {
+                DismissibleBanner(
+                    systemImage: "airplane.slash",
+                    text: exploreError,
+                    color: .orange,
+                    onDismiss: { dismissedExploreError = exploreError }
+                )
+                .accessibilityIdentifier("exploreErrorBanner")
+            }
+
+            if let quotaInfo = viewModel.lastQuotaInfo, quotaInfo != dismissedQuotaInfo {
+                DismissibleBanner(
+                    systemImage: "clock.badge.exclamationmark",
+                    text: quotaInfo,
+                    color: Color(red: 0.8, green: 0.6, blue: 0),
+                    onDismiss: { dismissedQuotaInfo = quotaInfo }
+                )
+                .accessibilityIdentifier("quotaBanner")
+            }
+
+            Spacer()
+
+            if isAIProcessing {
+                HStack(spacing: 6) {
+                    ProgressView()
+                        .scaleEffect(0.8)
+                    Text(NSLocalizedString("ai.processing", comment: "AI is processing"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(.thinMaterial, in: Capsule())
+                .transition(.opacity)
+            }
+
+            if let progressText = CompassMapView.progressText(for: viewModel.exploreProgress) {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(progressText)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.primary)
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 7)
+                .background(.thinMaterial, in: Capsule())
+                .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
+                .transition(.opacity)
+                .accessibilityIdentifier("exploreProgress")
+                .accessibilityLabel(Text(progressText))
+            }
+
+            if viewModel.isProcessingVoiceIntent {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .scaleEffect(0.8)
+                    Text(String(
+                        format: NSLocalizedString("voice.processing", comment: "AI is thinking about your request"),
+                        viewModel.currentVoiceTranscript.truncated(limit: 30)
+                    ))
+                    .font(.caption)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(.thinMaterial, in: Capsule())
+                .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
+                .transition(.opacity.combined(with: .scale(scale: 0.95)))
+            }
+
+            if let toast = viewModel.voiceResultToast {
+                HStack(spacing: 8) {
+                    Image(systemName: toast == NSLocalizedString("voice.result.none", comment: "No matching places found nearby")
+                        ? "magnifyingglass" : "checkmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(toast == NSLocalizedString("voice.result.none", comment: "No matching places found nearby")
+                            ? .secondary : .green)
+                    Text(toast)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.primary)
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 7)
+                .background(.thinMaterial, in: Capsule())
+                .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
+                .transition(.opacity.combined(with: .scale(scale: 0.95)))
+                .accessibilityIdentifier("voiceResultToast")
+            }
+
+            if let toast = viewModel.lastExploreToast {
+                Text(toast)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.primary)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 7)
+                    .background(.thinMaterial, in: Capsule())
+                    .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
+                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
+                    .accessibilityIdentifier("exploreToast")
+                    .onAppear {
+                        Task {
+                            try? await Task.sleep(for: .seconds(3))
+                            withAnimation(.easeOut(duration: 0.3)) {
+                                viewModel.lastExploreToast = nil
+                            }
+                        }
+                    }
+            }
+
+            BottomInfoBar(text: viewModel.bottomInfoText, nearbySoloCount: viewModel.nearbySoloCount)
+                .padding(.bottom, 8)
+
+            if let pending = viewModel.pendingCheckIn {
+                PendingCheckInBanner(
+                    experienceTitle: pending.title,
+                    onConfirm: { viewModel.confirmCheckIn() },
+                    onDismiss: { viewModel.dismissCheckIn() }
+                )
+                .padding(.bottom, 4)
+                .animation(.spring(response: 0.4), value: viewModel.pendingCheckIn != nil)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var cityPill: some View {
+        let cityName: String = {
+            if let code = viewModel.selectedCity,
+               let city = viewModel.availableCities.first(where: { $0.code == code }) {
+                return city.name
+            }
+            return NSLocalizedString("city.all", comment: "All cities option")
+        }()
+
+        Button {
+            isShowingCityPicker = true
+        } label: {
+            HStack(spacing: 4) {
+                Text(cityName)
+                    .font(.subheadline.weight(.medium))
+                Image(systemName: "chevron.down")
+                    .font(.caption.weight(.semibold))
+            }
+            .foregroundStyle(.primary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(.regularMaterial, in: Capsule())
+        }
+        .accessibilityLabel(Text(cityName))
+        .accessibilityHint(Text(NSLocalizedString("city.picker.title", comment: "City picker sheet title")))
+    }
+}
+
+private struct DismissibleBanner: View {
+    let systemImage: String
+    let text: String
+    let color: Color
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: systemImage).foregroundStyle(color)
+            Text(text).font(.caption).foregroundStyle(.primary).lineLimit(2)
+            Spacer()
+            Button(action: onDismiss) {
+                Image(systemName: "xmark").font(.caption.bold()).foregroundStyle(.secondary)
+            }
+            .accessibilityLabel(Text(NSLocalizedString("common.dismiss", comment: "Dismiss")))
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 12)
+        .transition(.move(edge: .top).combined(with: .opacity))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(text))
     }
 }
 


### PR DESCRIPTION
## Problem

Voice button on the map was fundamentally broken: the AI prompt had zero knowledge of nearby experiences, so `recommendedIds` was always empty and the map never changed. Users felt their voice input "sank into the ocean."

## Root Cause

```swift
// BEFORE (broken)
let prompt = """
A solo traveler said: "recommend coffee shops".
Their coordinates are 18.78, 98.99.
// AI: "??? I don't know what's near here"
"""
```

## Fix

### 1. Context-Aware AI Prompt (AIService.swift)

Now passes up to 20 nearby experiences with IDs, categories, and scores:

```swift
// AFTER (fixed)
let prompt = """
A solo traveler said: "recommend coffee shops".
Nearby experiences (use exact IDs):
  [abc-123] Akha Ama — coffee — 8.5/10
  [def-456] Ristr8to — coffee — 9.2/10
  [ghi-789] Night Bazaar — nightlife — 7.8/10
// AI: → {"recommendedIds":["abc-123","def-456"],...}
"""
```

### 2. Result Toast UX (MapViewModel + CompassMapView)

Three outcomes with visual feedback + haptics:

| Outcome | Toast | Icon | Haptic |
|---------|-------|------|--------|
| Match | "Found 3 matching places" | ✅ green | success |
| Filter | "Showing Coffee nearby" | ✅ green | success |
| None | "No matching places — try a different search" | 🔍 gray | warning |

### 3. Full UX Flow

```
Long-press → 🎤 Recording (unchanged)
  ↓
Release → "Thinking: 推荐咖啡馆…" (processing pill)
  ↓
AI responds → "✅ Found 3 matching places" (toast 3s) + map updates + haptic
```

### Files Changed

| File | Change |
|------|--------|
| AIService.swift | +31 — context-aware prompt, 10km radius filter |
| MapViewModel.swift | +43 — nearby calc, voiceResultToast, haptics |
| CompassMapView.swift | +20 — result toast UI |
| Localizable.strings | +3 — new localization keys |