### PR TITLE
feat: Voice Agent UX v2 — streaming responses, thinking visibility, + button menu

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */; };
 		C220FEC091B645D82519465E /* VoiceAgentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112319E8315F5F6961C95264 /* VoiceAgentSession.swift */; };
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* VoiceAgentOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E1D0C9B8A7968574635241 /* VoiceAgentOrchestrator.swift */; };
+		A01968488D837DB6BB1D462F /* ThinkingOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D546707961DCACF4110C0C43 /* ThinkingOverlay.swift */; };
+		F4C8A6CDDF9864A80F6C2B2F /* VoiceAgentOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFDC14EB38E6E0756DD15FC6 /* VoiceAgentOverlay.swift */; };
 		C2C0AF72D709EDC17C6ED874 /* UserPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63FDD874A8F533F0717132A /* UserPreferences.swift */; };
 		C306F7501DA85110BE3C85B5 /* NavigationLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07ACA7C1A1574A244E73796 /* NavigationLauncher.swift */; };
 		C53DB60CA9E95907A2CBF2C0 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C215AE07BA32182A887226F9 /* NotificationService.swift */; };
@@ -98,6 +100,8 @@
 		1FA8C8BF234F3C74D0D8A9BD /* SecretsRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretsRuntime.swift; sourceTree = "<group>"; };
 		20208D92E4F564C474E8AEED /* VoiceAgentToolRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAgentToolRouter.swift; sourceTree = "<group>"; };
 		F2E1D0C9B8A7968574635241 /* VoiceAgentOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAgentOrchestrator.swift; sourceTree = "<group>"; };
+		D546707961DCACF4110C0C43 /* ThinkingOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinkingOverlay.swift; sourceTree = "<group>"; };
+		EFDC14EB38E6E0756DD15FC6 /* VoiceAgentOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAgentOverlay.swift; sourceTree = "<group>"; };
 		23043E51C493093CF7244629 /* MicroSurveyRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicroSurveyRecord.swift; sourceTree = "<group>"; };
 		2BCB9264712588AB26CB1337 /* ConversationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationSheet.swift; sourceTree = "<group>"; };
 		2C7919EAFDE363B49C4B4C47 /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
@@ -408,6 +412,8 @@
 			isa = PBXGroup;
 			children = (
 				2BCB9264712588AB26CB1337 /* ConversationSheet.swift */,
+				D546707961DCACF4110C0C43 /* ThinkingOverlay.swift */,
+				EFDC14EB38E6E0756DD15FC6 /* VoiceAgentOverlay.swift */,
 			);
 			path = Voice;
 			sourceTree = "<group>";
@@ -615,6 +621,8 @@
 				C220FEC091B645D82519465E /* VoiceAgentSession.swift in Sources */,
 				54952646C79E8F29AF89F4D6 /* VoiceAgentToolRouter.swift in Sources */,
 				A1B2C3D4E5F6A7B8C9D0E1F2 /* VoiceAgentOrchestrator.swift in Sources */,
+				A01968488D837DB6BB1D462F /* ThinkingOverlay.swift in Sources */,
+				F4C8A6CDDF9864A80F6C2B2F /* VoiceAgentOverlay.swift in Sources */,
 				BD5BB6BD7FCBDB30282F28FA /* VoiceButton.swift in Sources */,
 				F5677DCF081E506C7E32243F /* VoiceService.swift in Sources */,
 			);

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -338,11 +338,14 @@
 
 /* Voice agent inline overlay (VoiceAgentOverlay) */
 "voiceAgent.orb.a11y" = "Hold to speak to Solo Compass";
-"voiceAgent.orb.hint" = "Hold and speak your request, then release";
+"voiceAgent.orb.hint" = "Double tap and hold to speak";
 "voiceAgent.orb.listening" = "Listening…";
 "voiceAgent.orb.release" = "Release to send";
 "voiceAgent.orb.responding" = "Responding…";
 "voiceAgent.orb.holdToSpeak" = "Hold to speak";
+"voiceAgent.permissionDenied" = "Microphone access needed — enable in Settings";
+"voiceAgent.error.streaming" = "Connection interrupted — please try again";
+"voiceAgent.tts.fallback" = "Response ready";
 
 /* "+" quick-action button and menu */
 "plus.button.a11y" = "Quick actions";
@@ -354,6 +357,9 @@
 "plus.menu.filter" = "Filter Map";
 "plus.menu.navigate" = "Navigate To…";
 "plus.menu.navigate.placeholder" = "Destination…";
+
+/* Common */
+"common.settings" = "Settings";
 
 /* Location card + navigation picker */
 "location.navigate" = "Navigate";

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -324,6 +324,37 @@
 "conversation.input.mic.a11y" = "Hold to speak";
 "conversation.input.send.a11y" = "Send message";
 
+/* Voice agent orchestrator step labels */
+"agent.step.listening" = "Listening…";
+"agent.step.thinking" = "Thinking…";
+"agent.step.exploreNearby" = "🔍 Searching nearby…";
+"agent.step.filter" = "🗂 Filtering map…";
+"agent.step.showDetails" = "📍 Opening details…";
+"agent.step.save" = "❤️ Saving to favorites…";
+"agent.step.dismiss" = "✕ Dismissing…";
+"agent.step.search" = "🔍 Searching places…";
+"agent.step.navigate" = "🗺 Opening navigation…";
+"agent.step.executing" = "⚙️ Executing…";
+
+/* Voice agent inline overlay (VoiceAgentOverlay) */
+"voiceAgent.orb.a11y" = "Hold to speak to Solo Compass";
+"voiceAgent.orb.hint" = "Hold and speak your request, then release";
+"voiceAgent.orb.listening" = "Listening…";
+"voiceAgent.orb.release" = "Release to send";
+"voiceAgent.orb.responding" = "Responding…";
+"voiceAgent.orb.holdToSpeak" = "Hold to speak";
+
+/* "+" quick-action button and menu */
+"plus.button.a11y" = "Quick actions";
+"plus.button.hint" = "Tap for quick actions, hold for voice agent";
+"plus.menu.title" = "Quick Actions";
+"plus.menu.ask" = "Ask Solo";
+"plus.menu.ask.placeholder" = "What are you looking for?";
+"plus.menu.voice" = "Voice Agent";
+"plus.menu.filter" = "Filter Map";
+"plus.menu.navigate" = "Navigate To…";
+"plus.menu.navigate.placeholder" = "Destination…";
+
 /* Location card + navigation picker */
 "location.navigate" = "Navigate";
 "location.copyCoords" = "Copy coordinates";

--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -217,6 +217,124 @@ public final class AIService {
         }
     }
 
+    // MARK: - Voice agent streaming (US-VA-08)
+
+    /// Events emitted by `sendAgentMessageStreaming`. The orchestrator
+    /// subscribes and updates the UI progressively.
+    public enum StreamEvent: Sendable {
+        /// The model is streaming its text content word-by-word (delta).
+        case contentDelta(String)
+        /// The model decided to call a tool. `args` is raw JSON.
+        case toolCall(id: String, name: String, args: String)
+        /// All content + tool calls have been emitted.
+        case done
+    }
+
+    /// Stream one agent turn via SSE (`stream: true`). Emits `.toolCall`
+    /// events as function-call chunks arrive, then `.contentDelta` events
+    /// for plain-text tokens. Ends with `.done`. Falls back to the
+    /// non-streaming path on servers that don't support SSE.
+    public func sendAgentMessageStreaming(
+        messages: [VoiceAgentSession.Message],
+        tools: [AgentTool]
+    ) -> AsyncThrowingStream<StreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                await MainActor.run { self.isProcessing = true }
+                do {
+                    guard let key = Self.resolveAPIKey() else {
+                        throw AIError.missingAPIKey
+                    }
+                    guard let apiURL else {
+                        throw AIError.requestFailed(status: 0, body: "bad URL")
+                    }
+
+                    var request = URLRequest(url: apiURL)
+                    request.httpMethod = "POST"
+                    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                    request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+                    request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+                    request.timeoutInterval = 60
+
+                    let body: [String: Any] = [
+                        "model": Self.modelName(for: .voice),
+                        "messages": Self.serializeAgentMessages(messages),
+                        "tools": Self.serializeAgentTools(tools),
+                        "tool_choice": "auto",
+                        "stream": true,
+                        "max_tokens": 512,
+                        "temperature": 0.3,
+                    ]
+                    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+                    // Accumulate tool-call deltas keyed by index.
+                    var toolCallAccum: [Int: (id: String, name: String, args: String)] = [:]
+                    var contentAccum = ""
+
+                    let (bytes, response) = try await session.bytes(for: request)
+                    guard let http = response as? HTTPURLResponse else {
+                        throw AIError.requestFailed(status: 0, body: "no response")
+                    }
+                    guard (200..<300).contains(http.statusCode) else {
+                        throw AIError.requestFailed(status: http.statusCode, body: "streaming error")
+                    }
+
+                    for try await line in bytes.lines {
+                        guard line.hasPrefix("data: ") else { continue }
+                        let payload = String(line.dropFirst(6))
+                        if payload == "[DONE]" { break }
+                        guard
+                            let data = payload.data(using: .utf8),
+                            let chunk = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                            let choices = chunk["choices"] as? [[String: Any]],
+                            let delta = choices.first?["delta"] as? [String: Any]
+                        else { continue }
+
+                        // Text content delta
+                        if let text = delta["content"] as? String, !text.isEmpty {
+                            contentAccum += text
+                            continuation.yield(.contentDelta(text))
+                        }
+
+                        // Tool call deltas
+                        if let rawCalls = delta["tool_calls"] as? [[String: Any]] {
+                            for rawCall in rawCalls {
+                                guard let idx = rawCall["index"] as? Int else { continue }
+                                let id = rawCall["id"] as? String ?? ""
+                                let fn = rawCall["function"] as? [String: Any]
+                                let name = fn?["name"] as? String ?? ""
+                                let argChunk = fn?["arguments"] as? String ?? ""
+                                if var existing = toolCallAccum[idx] {
+                                    existing.args += argChunk
+                                    if !id.isEmpty { existing.id = id }
+                                    if !name.isEmpty { existing.name = name }
+                                    toolCallAccum[idx] = existing
+                                } else {
+                                    toolCallAccum[idx] = (id: id, name: name, args: argChunk)
+                                }
+                            }
+                        }
+                    }
+
+                    // Emit accumulated tool calls in index order
+                    for idx in toolCallAccum.keys.sorted() {
+                        let call = toolCallAccum[idx]!
+                        continuation.yield(.toolCall(id: call.id, name: call.name, args: call.args))
+                    }
+
+                    continuation.yield(.done)
+                    continuation.finish()
+                    await MainActor.run { self.isProcessing = false }
+                } catch {
+                    await MainActor.run { self.isProcessing = false }
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+
+
     // MARK: - Voice agent (US-VA-02)
 
     /// Function-calling tool definition sent to DeepSeek. The `parameters`

--- a/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
@@ -1,6 +1,7 @@
+import AVFoundation
+import CoreLocation
 import Foundation
 import Observation
-import CoreLocation
 
 /// Drives one VoiceAgentSession through the think → tool_execute → repeat loop.
 ///
@@ -36,6 +37,7 @@ public final class VoiceAgentOrchestrator: Identifiable {
     public private(set) var isExecutingTool: Bool = false
 
     private var turnTask: Task<Void, Never>?
+    private let synthesizer = AVSpeechSynthesizer()
 
     public init(
         aiService: AIService,
@@ -89,9 +91,20 @@ public final class VoiceAgentOrchestrator: Identifiable {
         streamingContent = ""
         thinkingStep = ""
         isExecutingTool = false
+        synthesizer.stopSpeaking(at: .immediate)
         if !session.isEnded {
             session.end(reason: .userClose)
         }
+    }
+
+    /// Speak the agent's final text response via AVSpeechSynthesizer.
+    public func speakResponse(_ text: String) {
+        guard !text.isEmpty else { return }
+        synthesizer.stopSpeaking(at: .immediate)
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.rate = 0.52
+        utterance.pitchMultiplier = 1.05
+        synthesizer.speak(utterance)
     }
 
     // MARK: - Turn loop
@@ -120,9 +133,11 @@ public final class VoiceAgentOrchestrator: Identifiable {
                     streamingContent = ""
                     shouldContinue = true
                 } else {
+                    let finalText = streamingContent
                     session.finishSpeakingTurn()
                     thinkingStep = ""
                     shouldContinue = false
+                    speakResponse(finalText)
                 }
 
                 if Date().timeIntervalSince(turnStart) > VoiceAgentSession.turnTimeoutSeconds {
@@ -220,8 +235,10 @@ public final class VoiceAgentOrchestrator: Identifiable {
     private func sendForceText(prompt: String) async {
         session.appendSystemContinuation(prompt)
         _ = await sendToAIFallback()
+        let finalText = streamingContent
         session.finishSpeakingTurn()
         thinkingStep = ""
+        speakResponse(finalText)
     }
 
     // MARK: - UI helpers

--- a/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
@@ -25,6 +25,16 @@ public final class VoiceAgentOrchestrator: Identifiable {
     public private(set) var isRunning = false
     public private(set) var errorMessage: String?
 
+    /// Streaming text being assembled word-by-word; cleared when the final
+    /// assistant message is committed to the session.
+    public private(set) var streamingContent: String = ""
+
+    /// Human-readable label for the current thinking/tool step shown in the overlay.
+    public private(set) var thinkingStep: String = ""
+
+    /// True while a tool is executing.
+    public private(set) var isExecutingTool: Bool = false
+
     private var turnTask: Task<Void, Never>?
 
     public init(
@@ -51,6 +61,7 @@ public final class VoiceAgentOrchestrator: Identifiable {
         errorMessage = nil
         session.seedSystem(systemPrompt)
         session.beginListening()
+        thinkingStep = NSLocalizedString("agent.step.listening", comment: "Listening…")
     }
 
     /// Called when the user submits a text message (not voice).
@@ -75,6 +86,9 @@ public final class VoiceAgentOrchestrator: Identifiable {
         turnTask?.cancel()
         turnTask = nil
         isRunning = false
+        streamingContent = ""
+        thinkingStep = ""
+        isExecutingTool = false
         if !session.isEnded {
             session.end(reason: .userClose)
         }
@@ -84,6 +98,8 @@ public final class VoiceAgentOrchestrator: Identifiable {
 
     private func runTurn(transcript: String) {
         session.beginUserTurn(transcript: transcript)
+        thinkingStep = NSLocalizedString("agent.step.thinking", comment: "Thinking…")
+        streamingContent = ""
 
         turnTask = Task {
             let turnStart = Date()
@@ -95,27 +111,73 @@ public final class VoiceAgentOrchestrator: Identifiable {
                     return
                 }
 
-                guard await sendToAI() else { return }
+                guard await sendToAIStreaming() else { return }
 
                 if case .toolExecuting = session.state {
                     await executePendingTools()
                     session.resumeThinkingAfterTools()
+                    thinkingStep = NSLocalizedString("agent.step.thinking", comment: "Thinking…")
+                    streamingContent = ""
                     shouldContinue = true
                 } else {
                     session.finishSpeakingTurn()
+                    thinkingStep = ""
                     shouldContinue = false
                 }
 
                 if Date().timeIntervalSince(turnStart) > VoiceAgentSession.turnTimeoutSeconds {
                     session.end(reason: .timeout)
+                    thinkingStep = ""
                     return
                 }
             }
         }
     }
 
-    /// Call AI and feed the response into the session. Returns false on error.
-    private func sendToAI() async -> Bool {
+    /// Stream one AI turn, updating streamingContent and thinkingStep progressively.
+    /// Returns false on unrecoverable error.
+    private func sendToAIStreaming() async -> Bool {
+        streamingContent = ""
+        var accumulatedContent = ""
+        var pendingToolCalls: [(id: String, name: String, args: String)] = []
+
+        do {
+            let stream = aiService.sendAgentMessageStreaming(
+                messages: session.messages,
+                tools: VoiceAgentToolRouter.allTools
+            )
+            for try await event in stream {
+                guard !Task.isCancelled else { return false }
+                switch event {
+                case .contentDelta(let delta):
+                    accumulatedContent += delta
+                    streamingContent = accumulatedContent
+                case .toolCall(let id, let name, let args):
+                    pendingToolCalls.append((id: id, name: name, args: args))
+                    thinkingStep = thinkingStepLabel(for: name)
+                case .done:
+                    break
+                }
+            }
+
+            let sessionCalls = pendingToolCalls.map {
+                VoiceAgentSession.ToolCall(id: $0.id, name: $0.name, argumentsJSON: $0.args)
+            }
+            let content = accumulatedContent.isEmpty ? nil : accumulatedContent
+            session.appendAssistantTurn(content: content, toolCalls: sessionCalls)
+            if sessionCalls.isEmpty {
+                streamingContent = ""
+            }
+            return true
+
+        } catch {
+            // Streaming failed — fall back to non-streaming path.
+            return await sendToAIFallback()
+        }
+    }
+
+    /// Non-streaming fallback for servers that don't support SSE.
+    private func sendToAIFallback() async -> Bool {
         do {
             let response = try await aiService.sendAgentMessage(
                 messages: session.messages,
@@ -125,19 +187,25 @@ public final class VoiceAgentOrchestrator: Identifiable {
                 content: response.content,
                 toolCalls: response.toolCalls
             )
+            if let content = response.content {
+                streamingContent = content
+            }
             return true
         } catch {
             errorMessage = error.localizedDescription
             session.end(reason: .error)
+            thinkingStep = ""
             return false
         }
     }
 
-    /// Execute all tool calls from the last assistant turn, feeding results
+    /// Execute all tool calls from the last assistant turn and feed results
     /// back into the session so the next AI call sees them.
     private func executePendingTools() async {
         guard let lastMsg = session.messages.last, lastMsg.role == .assistant else { return }
+        isExecutingTool = true
         for call in lastMsg.toolCalls {
+            thinkingStep = thinkingStepLabel(for: call.name)
             let resultJSON = await toolRouter.execute(call)
             session.appendToolResult(
                 toolCallId: call.id,
@@ -145,13 +213,38 @@ public final class VoiceAgentOrchestrator: Identifiable {
                 resultJSON: resultJSON
             )
         }
+        isExecutingTool = false
     }
 
     /// Force one more non-tool response from the model (budget overflow path).
     private func sendForceText(prompt: String) async {
         session.appendSystemContinuation(prompt)
-        _ = await sendToAI()
+        _ = await sendToAIFallback()
         session.finishSpeakingTurn()
+        thinkingStep = ""
+    }
+
+    // MARK: - UI helpers
+
+    private func thinkingStepLabel(for toolName: String) -> String {
+        switch toolName {
+        case "explore_nearby":
+            return NSLocalizedString("agent.step.exploreNearby", comment: "🔍 Searching nearby…")
+        case "filter_by_category":
+            return NSLocalizedString("agent.step.filter", comment: "🗂 Filtering map…")
+        case "show_details":
+            return NSLocalizedString("agent.step.showDetails", comment: "📍 Opening details…")
+        case "save_to_favorites":
+            return NSLocalizedString("agent.step.save", comment: "❤️ Saving to favorites…")
+        case "dismiss_recommendation":
+            return NSLocalizedString("agent.step.dismiss", comment: "✕ Dismissing…")
+        case "search_places":
+            return NSLocalizedString("agent.step.search", comment: "🔍 Searching places…")
+        case "navigate_to":
+            return NSLocalizedString("agent.step.navigate", comment: "🗺 Opening navigation…")
+        default:
+            return NSLocalizedString("agent.step.executing", comment: "⚙️ Executing…")
+        }
     }
 
     // MARK: - System prompt

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -235,7 +235,7 @@ public final class MapViewModel {
     public var isProcessingVoiceIntent: Bool = false
     public var currentVoiceTranscript: String = ""
     /// Ephemeral toast shown after voice AI resolves. Nil when not active.
-    public var voiceResultToast: String? = nil
+    public var voiceResultToast: String?
 
     // MARK: - Settings
 

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -110,8 +110,13 @@ public struct CompassMapView: View {
                         // long press (≥0.8s) → inline voice agent mode.
                         PlusActionButton(
                             isShowingMenu: $isShowingPlusMenu,
-                            onShortTap: { isShowingPlusMenu = true },
+                            onShortTap: {
+                                guard !isShowingVoiceOverlay else { return }
+                                isShowingPlusMenu = true
+                            },
                             onLongPress: {
+                                guard !isShowingVoiceOverlay, voiceOrchestrator == nil else { return }
+                                isShowingPlusMenu = false
                                 let orch = VoiceAgentOrchestrator(
                                     aiService: aiService,
                                     voiceService: voiceService,
@@ -154,7 +159,8 @@ public struct CompassMapView: View {
                             ThinkingOverlay(
                                 stepLabel: orch.thinkingStep,
                                 streamingText: orch.streamingContent,
-                                isExecutingTool: orch.isExecutingTool
+                                isExecutingTool: orch.isExecutingTool,
+                                errorMessage: orch.errorMessage
                             )
                             .padding(.top, 100)
 

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -336,6 +336,50 @@ public struct CompassMapView: View {
     }
 
     @ViewBuilder
+    private var plusMenuSheetContent: some View {
+        if let vm = viewModel {
+            PlusMenuSheet(
+                isPresented: $isShowingPlusMenu,
+                onQuickAsk: { text in
+                    isShowingPlusMenu = false
+                    let orch = VoiceAgentOrchestrator(
+                        aiService: aiService,
+                        voiceService: voiceService,
+                        mapViewModel: vm,
+                        preferences: preferences
+                    )
+                    orch.start()
+                    voiceOrchestrator = orch
+                    orch.handleTextInput(text)
+                    isShowingVoiceOverlay = true
+                },
+                onFilter: {
+                    isShowingPlusMenu = false
+                },
+                onNavigate: { destination in
+                    isShowingPlusMenu = false
+                    Task { await vm.handleVoiceTranscript("Navigate to \(destination)") }
+                },
+                onVoiceAgent: {
+                    isShowingPlusMenu = false
+                    let orch = VoiceAgentOrchestrator(
+                        aiService: aiService,
+                        voiceService: voiceService,
+                        mapViewModel: vm,
+                        preferences: preferences
+                    )
+                    orch.start()
+                    voiceOrchestrator = orch
+                    isShowingVoiceOverlay = true
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                }
+            )
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.visible)
+        }
+    }
+
+    @ViewBuilder
     private func mapLayer(viewModel: MapViewModel) -> some View {
         let bindingCamera = Binding<MapCameraPosition>(
             get: { viewModel.cameraPosition },

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -147,37 +147,16 @@ public struct CompassMapView: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                 }
 
-                // Inline voice agent overlay (long-press path — no sheet)
                 if isShowingVoiceOverlay, let orch = voiceOrchestrator {
-                    ZStack(alignment: .bottom) {
-                        Color.black.opacity(0.25)
-                            .ignoresSafeArea()
-                            .onTapGesture { } // absorb taps to map
-
-                        VStack(spacing: 0) {
-                            // Thinking overlay at top of safe area
-                            ThinkingOverlay(
-                                stepLabel: orch.thinkingStep,
-                                streamingText: orch.streamingContent,
-                                isExecutingTool: orch.isExecutingTool,
-                                errorMessage: orch.errorMessage
-                            )
-                            .padding(.top, 100)
-
-                            Spacer()
-
-                            VoiceAgentOverlay(
-                                orchestrator: orch,
-                                voiceService: voiceService,
-                                onDismiss: {
-                                    orch.stop()
-                                    voiceOrchestrator = nil
-                                    isShowingVoiceOverlay = false
-                                }
-                            )
+                    VoiceAgentInlineOverlay(
+                        orchestrator: orch,
+                        voiceService: voiceService,
+                        onDismiss: {
+                            orch.stop()
+                            voiceOrchestrator = nil
+                            isShowingVoiceOverlay = false
                         }
-                    }
-                    .transition(.opacity)
+                    )
                 }
 
                 if viewModel.visibleExperiences.isEmpty && !isShowingVoiceOverlay {
@@ -752,6 +731,43 @@ private struct DismissibleBanner: View {
 
 /// Bottom-right "+" button. Short tap fires `onShortTap`; long press (≥0.8s)
 /// fires `onLongPress` and provides haptic feedback.
+/// Bottom-right "+" button. Short tap fires `onShortTap`; long press (≥0.8s)
+/// Inline voice agent overlay that dims the map and shows the thinking
+/// overlay + hold-to-speak orb. Extracted to prevent type-check timeouts
+/// in the CompassMapView body.
+private struct VoiceAgentInlineOverlay: View {
+    let orchestrator: VoiceAgentOrchestrator
+    let voiceService: VoiceService
+    let onDismiss: () -> Void
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Color.black.opacity(0.25)
+                .ignoresSafeArea()
+                .onTapGesture { } // absorb taps to map
+
+            VStack(spacing: 0) {
+                ThinkingOverlay(
+                    stepLabel: orchestrator.thinkingStep,
+                    streamingText: orchestrator.streamingContent,
+                    isExecutingTool: orchestrator.isExecutingTool,
+                    errorMessage: orchestrator.errorMessage
+                )
+                .padding(.top, 100)
+
+                Spacer()
+
+                VoiceAgentOverlay(
+                    orchestrator: orchestrator,
+                    voiceService: voiceService,
+                    onDismiss: onDismiss
+                )
+            }
+        }
+        .transition(.opacity)
+    }
+}
+
 /// Bottom-right "+" button. Short tap fires `onShortTap`; long press (≥0.8s)
 /// fires `onLongPress` and provides haptic feedback.
 ///

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -229,81 +229,10 @@ public struct CompassMapView: View {
             .environment(experienceService)
             .environment(preferences)
         }
-        // "+" quick-action menu sheet
-        .sheet(isPresented: $isShowingPlusMenu) {
-            if let vm = viewModel {
-                PlusMenuSheet(
-                    isPresented: $isShowingPlusMenu,
-                    onQuickAsk: { text in
-                        isShowingPlusMenu = false
-                        // Create orchestrator for text-based quick ask
-                        let orch = VoiceAgentOrchestrator(
-                            aiService: aiService,
-                            voiceService: voiceService,
-                            mapViewModel: vm,
-                            preferences: preferences
-                        )
-                        orch.start()
-                        voiceOrchestrator = orch
-                        orch.handleTextInput(text)
-                        isShowingVoiceOverlay = true
-                    },
-                    onFilter: {
-                        isShowingPlusMenu = false
-                        // FilterBarView is already visible; scroll/highlight it
-                    },
-                    onNavigate: { destination in
-                        isShowingPlusMenu = false
-                        Task { await vm.handleVoiceTranscript("Navigate to \(destination)") }
-                    },
-                    onVoiceAgent: {
-                        isShowingPlusMenu = false
-                        let orch = VoiceAgentOrchestrator(
-                            aiService: aiService,
-                            voiceService: voiceService,
-                            mapViewModel: vm,
-                            preferences: preferences
-                        )
-                        orch.start()
-                        voiceOrchestrator = orch
-                        isShowingVoiceOverlay = true
-                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                    }
-                )
-                .presentationDetents([.medium])
-                .presentationDragIndicator(.visible)
-            }
-        }
-        // ConversationSheet kept for text-mode multi-turn (fallback / text input path via overlay)
-        // Voice agent conversation sheet — opened by tapping "Ask Solo" in + menu when already running.
-        .sheet(isPresented: Binding(
-            get: {
-                // Only show sheet when orchestrator is running but NOT showing inline overlay
-                voiceOrchestrator != nil && !isShowingVoiceOverlay
-            },
-            set: { showing in
-                if !showing {
-                    voiceOrchestrator?.stop()
-                    voiceOrchestrator = nil
-                }
-            }
-        )) {
-            if let orch = voiceOrchestrator {
-                ConversationSheet(
-                    onClose: {
-                        orch.stop()
-                        voiceOrchestrator = nil
-                    },
-                    onSubmitText: { orch.handleTextInput($0) },
-                    voiceService: voiceService,
-                    onVoiceTranscript: { orch.handleTranscript($0) },
-                    orchestrator: orch
-                )
-                .environment(orch.session)
-                .presentationDetents([.medium, .large])
-                .presentationDragIndicator(.visible)
-            }
-        }
+        // "+" quick-action menu sheet — extracted for type-checker performance
+        .sheet(isPresented: $isShowingPlusMenu) { plusMenuSheetContent }
+        // Voice agent conversation sheet — extracted for type-checker performance
+        .sheet(isPresented: conversationSheetBinding) { conversationSheetContent }
         // US-024 paywall sheet — shown when a free user taps an AI-gated
         // action. The view's onUnlocked closure resumes the original
         // action (saved by MapViewModel as `onPaywallUnlocked`).
@@ -375,6 +304,39 @@ public struct CompassMapView: View {
                 }
             )
             .presentationDetents([.medium])
+            .presentationDragIndicator(.visible)
+        }
+    }
+
+    private var conversationSheetBinding: Binding<Bool> {
+        Binding(
+            get: {
+                voiceOrchestrator != nil && !isShowingVoiceOverlay
+            },
+            set: { showing in
+                if !showing {
+                    voiceOrchestrator?.stop()
+                    voiceOrchestrator = nil
+                }
+            }
+        )
+    }
+
+    @ViewBuilder
+    private var conversationSheetContent: some View {
+        if let orch = voiceOrchestrator {
+            ConversationSheet(
+                onClose: {
+                    orch.stop()
+                    voiceOrchestrator = nil
+                },
+                onSubmitText: { orch.handleTextInput($0) },
+                voiceService: voiceService,
+                onVoiceTranscript: { orch.handleTranscript($0) },
+                orchestrator: orch
+            )
+            .environment(orch.session)
+            .presentationDetents([.medium, .large])
             .presentationDragIndicator(.visible)
         }
     }

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -33,11 +33,65 @@ public struct CompassMapView: View {
     public init() {}
 
     public var body: some View {
-        AnyView(zStackWithSheets)
+        AnyView(mapContent)
     }
 
     @ViewBuilder
-    private var zStackWithSheets: some View {
+    private var mapContent: some View {
+        mapZStack
+            .background(Color(.systemBackground))
+            .onAppear {
+                locationService.requestPermission()
+                if viewModel == nil {
+                    let vm = MapViewModel(
+                        locationService: locationService,
+                        experienceService: experienceService,
+                        aiService: aiService,
+                        preferences: preferences
+                    )
+                    vm.attachSubscriptionService(subscriptionService)
+                    viewModel = vm
+                    // On first launch with no saved city and no GPS, prompt city picker.
+                    if preferences.lastSelectedCity == nil && locationService.currentLocation == nil {
+                        isShowingCityPicker = true
+                    }
+                }
+                viewModel?.checkForPendingCheckIns()
+            }
+            .onChange(of: locationService.currentLocation) { _, _ in
+                viewModel?.bindToLocation()
+            }
+            .onChange(of: preferences.pendingCheckIns) { _, _ in
+                viewModel?.checkForPendingCheckIns()
+            }
+            .sheet(isPresented: settingsSheetBinding) { settingsSheetContent }
+            .sheet(item: $surveyExperience) { exp in surveySheetContent(exp: exp) }
+            .alert(
+                NSLocalizedString("addExperience.confirm.title", comment: "Add an experience here?"),
+                isPresented: addExperienceAlertBinding
+            ) {
+                Button(NSLocalizedString("common.cancel", comment: "Cancel"), role: .cancel) {
+                    viewModel?.cancelAddExperience()
+                }
+                Button(NSLocalizedString("addExperience.confirm.add", comment: "Add")) {
+                    viewModel?.confirmAddExperience()
+                }
+            } message: {
+                Text(NSLocalizedString("addExperience.confirm.message", comment: "Describe it with your voice"))
+            }
+            .sheet(isPresented: recordExperienceSheetBinding) { recordExperienceSheetContent }
+            .sheet(isPresented: detailSheetBinding) { detailSheetContent }
+            .sheet(isPresented: $isShowingCityPicker) { cityPickerSheetContent }
+            .sheet(isPresented: $isShowingFavorites) { favoritesSheetContent }
+            .sheet(isPresented: $isShowingPlusMenu) { plusMenuSheetContent }
+            .sheet(isPresented: conversationSheetBinding) { conversationSheetContent }
+            .sheet(isPresented: paywallSheetBinding) { paywallSheetContent }
+            .modifier(ExploreConsentSheetModifier(viewModel: viewModel, preferences: preferences))
+            .fullScreenCover(isPresented: onboardingCoverBinding) { onboardingCoverContent }
+    }
+
+    @ViewBuilder
+    private var mapZStack: some View {
         ZStack {
             if let viewModel {
                 mapLayer(viewModel: viewModel)
@@ -102,167 +156,159 @@ public struct CompassMapView: View {
                     .accessibilityLabel(Text(NSLocalizedString("map.loading", comment: "Loading map")))
             }
         }
-        .background(Color(.systemBackground))
-        .onAppear {
-            locationService.requestPermission()
-            if viewModel == nil {
-                let vm = MapViewModel(
-                    locationService: locationService,
-                    experienceService: experienceService,
-                    aiService: aiService,
-                    preferences: preferences
-                )
-                vm.attachSubscriptionService(subscriptionService)
-                viewModel = vm
-                // On first launch with no saved city and no GPS, prompt city picker.
-                if preferences.lastSelectedCity == nil && locationService.currentLocation == nil {
-                    isShowingCityPicker = true
-                }
-            }
-            viewModel?.checkForPendingCheckIns()
-        }
-        .onChange(of: locationService.currentLocation) { _, _ in
-            viewModel?.bindToLocation()
-        }
-        .onChange(of: preferences.pendingCheckIns) { _, _ in
-            viewModel?.checkForPendingCheckIns()
-        }
-        // Settings sheet
-        .sheet(isPresented: Binding(
+    }
+
+    // MARK: - Sheet Bindings
+
+    private var settingsSheetBinding: Binding<Bool> {
+        Binding(
             get: { viewModel?.isShowingSettings ?? false },
             set: { if !$0 { viewModel?.isShowingSettings = false } }
-        )) {
-            SettingsView(
-                onClose: { viewModel?.isShowingSettings = false },
-                onShowFavorites: { isShowingFavorites = true }
-            )
-            .environment(preferences)
-            .environment(notificationService)
-        }
-        // MicroSurvey sheet (shown after marking an experience done)
-        .sheet(item: $surveyExperience) { exp in
-            MicroSurveySheet(
-                experience: exp,
-                onSubmit: { comfort, pressure, recommend in
-                    // US-020: persist via the repo so the aggregated
-                    // SoloScore reflects this immediately.
-                    experienceService.repo.recordSurvey(
-                        experienceId: exp.id,
-                        comfort: comfort,
-                        pressure: pressure,
-                        recommend: recommend.rawValue,
-                        anonDeviceId: DeviceIdentityService.shared.deviceID
-                    )
-                    surveyExperience = nil
-                },
-                onSkip: { surveyExperience = nil }
-            )
-        }
-        .alert(
-            NSLocalizedString("addExperience.confirm.title", comment: "Add an experience here?"),
-            isPresented: Binding(
-                get: { (viewModel?.pendingAddCoordinate != nil) && (viewModel?.isRecordingNewExperience == false) },
-                set: { if !$0 { viewModel?.cancelAddExperience() } }
-            )
-        ) {
-            Button(NSLocalizedString("common.cancel", comment: "Cancel"), role: .cancel) {
-                viewModel?.cancelAddExperience()
-            }
-            Button(NSLocalizedString("addExperience.confirm.add", comment: "Add")) {
-                viewModel?.confirmAddExperience()
-            }
-        } message: {
-            Text(NSLocalizedString("addExperience.confirm.message", comment: "Describe it with your voice"))
-        }
-        .sheet(isPresented: Binding(
+        )
+    }
+
+    private var addExperienceAlertBinding: Binding<Bool> {
+        Binding(
+            get: { (viewModel?.pendingAddCoordinate != nil) && (viewModel?.isRecordingNewExperience == false) },
+            set: { if !$0 { viewModel?.cancelAddExperience() } }
+        )
+    }
+
+    private var recordExperienceSheetBinding: Binding<Bool> {
+        Binding(
             get: { viewModel?.isRecordingNewExperience ?? false },
             set: { if !$0 { viewModel?.cancelAddExperience() } }
-        )) {
-            VStack(spacing: 24) {
-                Text(NSLocalizedString("addExperience.record.title", comment: "Tell us about this place"))
-                    .font(.headline)
-                Text(NSLocalizedString("addExperience.record.hint", comment: "Hold the mic and describe what makes it worth a solo visit"))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                VoiceButton(voiceService: voiceService) { transcript in
-                    Task { await viewModel?.handleNewExperienceTranscript(transcript) }
-                }
-            }
-            .padding(32)
-            .presentationDetents([.medium])
-        }
-        .sheet(isPresented: Binding(
+        )
+    }
+
+    private var detailSheetBinding: Binding<Bool> {
+        Binding(
             get: { viewModel?.isShowingDetail ?? false },
             set: { if !$0 { viewModel?.isShowingDetail = false } }
-        )) {
-            if let exp = viewModel?.selectedExperience {
-                NavigationStack {
-                    ExperienceDetailView(
-                        viewModel: ExperienceDetailViewModel(
-                            experience: exp,
-                            experienceService: experienceService,
-                            aiService: aiService,
-                            preferences: preferences,
-                            subscriptionService: subscriptionService
-                        ),
-                        onClose: { viewModel?.dismissDetail() },
-                        onMarkDone: { experience in surveyExperience = experience }
-                    )
-                }
-            }
-        }
-        .sheet(isPresented: $isShowingCityPicker) {
-            if let vm = viewModel {
-                CityPickerSheet(viewModel: vm) {
-                    isShowingCityPicker = false
-                }
-            }
-        }
-        // Favorites list sheet
-        .sheet(isPresented: $isShowingFavorites) {
-            FavoritesListView { exp in
-                isShowingFavorites = false
-                viewModel?.selectExperience(exp)
-                viewModel?.isShowingDetail = true
-            }
-            .environment(experienceService)
-            .environment(preferences)
-        }
-        // "+" quick-action menu sheet — extracted for type-checker performance
-        .sheet(isPresented: $isShowingPlusMenu) { plusMenuSheetContent }
-        // Voice agent conversation sheet — extracted for type-checker performance
-        .sheet(isPresented: conversationSheetBinding) { conversationSheetContent }
-        // US-024 paywall sheet — shown when a free user taps an AI-gated
-        // action. The view's onUnlocked closure resumes the original
-        // action (saved by MapViewModel as `onPaywallUnlocked`).
-        .sheet(isPresented: Binding(
+        )
+    }
+
+    private var paywallSheetBinding: Binding<Bool> {
+        Binding(
             get: { viewModel?.isShowingPaywall ?? false },
             set: { if !$0 { viewModel?.isShowingPaywall = false } }
-        )) {
-            PaywallView(onUnlocked: {
-                let resume = viewModel?.onPaywallUnlocked
-                viewModel?.onPaywallUnlocked = nil
-                resume?()
-            })
-            .environment(subscriptionService)
-        }
-        .modifier(ExploreConsentSheetModifier(
-            viewModel: viewModel,
-            preferences: preferences
-        ))
-        // First-run onboarding
-        .fullScreenCover(isPresented: Binding(
+        )
+    }
+
+    private var onboardingCoverBinding: Binding<Bool> {
+        Binding(
             get: { !preferences.hasCompletedOnboarding },
             set: { if $0 { } else { preferences.completeOnboarding() } }
-        )) {
-            OnboardingView {
-                // onComplete — preferences.hasCompletedOnboarding already set inside
+        )
+    }
+
+    // MARK: - Sheet Contents
+
+    @ViewBuilder
+    private var settingsSheetContent: some View {
+        SettingsView(
+            onClose: { viewModel?.isShowingSettings = false },
+            onShowFavorites: { isShowingFavorites = true }
+        )
+        .environment(preferences)
+        .environment(notificationService)
+    }
+
+    @ViewBuilder
+    private func surveySheetContent(exp: Experience) -> some View {
+        MicroSurveySheet(
+            experience: exp,
+            onSubmit: { comfort, pressure, recommend in
+                // US-020: persist via the repo so the aggregated
+                // SoloScore reflects this immediately.
+                experienceService.repo.recordSurvey(
+                    experienceId: exp.id,
+                    comfort: comfort,
+                    pressure: pressure,
+                    recommend: recommend.rawValue,
+                    anonDeviceId: DeviceIdentityService.shared.deviceID
+                )
+                surveyExperience = nil
+            },
+            onSkip: { surveyExperience = nil }
+        )
+    }
+
+    @ViewBuilder
+    private var recordExperienceSheetContent: some View {
+        VStack(spacing: 24) {
+            Text(NSLocalizedString("addExperience.record.title", comment: "Tell us about this place"))
+                .font(.headline)
+            Text(NSLocalizedString("addExperience.record.hint", comment: "Hold the mic and describe what makes it worth a solo visit"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            VoiceButton(voiceService: voiceService) { transcript in
+                Task { await viewModel?.handleNewExperienceTranscript(transcript) }
             }
-            .environment(locationService)
-            .environment(preferences)
+        }
+        .padding(32)
+        .presentationDetents([.medium])
+    }
+
+    @ViewBuilder
+    private var detailSheetContent: some View {
+        if let exp = viewModel?.selectedExperience {
+            NavigationStack {
+                ExperienceDetailView(
+                    viewModel: ExperienceDetailViewModel(
+                        experience: exp,
+                        experienceService: experienceService,
+                        aiService: aiService,
+                        preferences: preferences,
+                        subscriptionService: subscriptionService
+                    ),
+                    onClose: { viewModel?.dismissDetail() },
+                    onMarkDone: { experience in surveyExperience = experience }
+                )
+            }
         }
     }
+
+    @ViewBuilder
+    private var cityPickerSheetContent: some View {
+        if let vm = viewModel {
+            CityPickerSheet(viewModel: vm) {
+                isShowingCityPicker = false
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var favoritesSheetContent: some View {
+        FavoritesListView { exp in
+            isShowingFavorites = false
+            viewModel?.selectExperience(exp)
+            viewModel?.isShowingDetail = true
+        }
+        .environment(experienceService)
+        .environment(preferences)
+    }
+
+    @ViewBuilder
+    private var paywallSheetContent: some View {
+        PaywallView(onUnlocked: {
+            let resume = viewModel?.onPaywallUnlocked
+            viewModel?.onPaywallUnlocked = nil
+            resume?()
+        })
+        .environment(subscriptionService)
+    }
+
+    @ViewBuilder
+    private var onboardingCoverContent: some View {
+        OnboardingView {
+            // onComplete — preferences.hasCompletedOnboarding already set inside
+        }
+        .environment(locationService)
+        .environment(preferences)
+    }
+
 
     @ViewBuilder
     private var plusMenuSheetContent: some View {

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -33,6 +33,11 @@ public struct CompassMapView: View {
     public init() {}
 
     public var body: some View {
+        AnyView(zStackWithSheets)
+    }
+
+    @ViewBuilder
+    private var zStackWithSheets: some View {
         ZStack {
             if let viewModel {
                 mapLayer(viewModel: viewModel)

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -23,6 +23,12 @@ public struct CompassMapView: View {
     @State private var isShowingFavorites: Bool = false
     @State private var voiceOrchestrator: VoiceAgentOrchestrator? = nil
 
+    // "+" quick-action menu state
+    @State private var isShowingPlusMenu: Bool = false
+
+    // Voice agent inline overlay (long-press path)
+    @State private var isShowingVoiceOverlay: Bool = false
+
 
     public init() {}
 
@@ -100,24 +106,23 @@ public struct CompassMapView: View {
 
                         Spacer()
 
-                        // Tap (short press) → quick single-shot voice ask.
-                        // Long-press (≥1 s) → opens the multi-turn ConversationSheet.
-                        VoiceButton(voiceService: voiceService) { transcript in
-                            Task { await viewModel.handleVoiceTranscript(transcript) }
-                        }
-                        .simultaneousGesture(
-                            LongPressGesture(minimumDuration: 1.0)
-                                .onEnded { _ in
-                                    let orch = VoiceAgentOrchestrator(
-                                        aiService: aiService,
-                                        voiceService: voiceService,
-                                        mapViewModel: viewModel,
-                                        preferences: preferences
-                                    )
-                                    orch.start()
-                                    voiceOrchestrator = orch
-                                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                                }
+                        // "+" button: short tap → quick-action menu,
+                        // long press (≥0.8s) → inline voice agent mode.
+                        PlusActionButton(
+                            isShowingMenu: $isShowingPlusMenu,
+                            onShortTap: { isShowingPlusMenu = true },
+                            onLongPress: {
+                                let orch = VoiceAgentOrchestrator(
+                                    aiService: aiService,
+                                    voiceService: voiceService,
+                                    mapViewModel: viewModel,
+                                    preferences: preferences
+                                )
+                                orch.start()
+                                voiceOrchestrator = orch
+                                isShowingVoiceOverlay = true
+                                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                            }
                         )
                         .padding(.trailing, 20)
                         .padding(.bottom, 80)
@@ -137,7 +142,39 @@ public struct CompassMapView: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                 }
 
-                if viewModel.visibleExperiences.isEmpty {
+                // Inline voice agent overlay (long-press path — no sheet)
+                if isShowingVoiceOverlay, let orch = voiceOrchestrator {
+                    ZStack(alignment: .bottom) {
+                        Color.black.opacity(0.25)
+                            .ignoresSafeArea()
+                            .onTapGesture { } // absorb taps to map
+
+                        VStack(spacing: 0) {
+                            // Thinking overlay at top of safe area
+                            ThinkingOverlay(
+                                stepLabel: orch.thinkingStep,
+                                streamingText: orch.streamingContent,
+                                isExecutingTool: orch.isExecutingTool
+                            )
+                            .padding(.top, 100)
+
+                            Spacer()
+
+                            VoiceAgentOverlay(
+                                orchestrator: orch,
+                                voiceService: voiceService,
+                                onDismiss: {
+                                    orch.stop()
+                                    voiceOrchestrator = nil
+                                    isShowingVoiceOverlay = false
+                                }
+                            )
+                        }
+                    }
+                    .transition(.opacity)
+                }
+
+                if viewModel.visibleExperiences.isEmpty && !isShowingVoiceOverlay {
                     EmptyStateOverlay(
                         viewModel: viewModel,
                         preferences: preferences,
@@ -276,20 +313,80 @@ public struct CompassMapView: View {
             .environment(experienceService)
             .environment(preferences)
         }
-        // Voice agent conversation sheet — opened by long-pressing the mic button.
-        .sheet(item: $voiceOrchestrator) { orch in
-            ConversationSheet(
-                onClose: {
-                    orch.stop()
+        // "+" quick-action menu sheet
+        .sheet(isPresented: $isShowingPlusMenu) {
+            if let vm = viewModel {
+                PlusMenuSheet(
+                    isPresented: $isShowingPlusMenu,
+                    onQuickAsk: { text in
+                        isShowingPlusMenu = false
+                        // Create orchestrator for text-based quick ask
+                        let orch = VoiceAgentOrchestrator(
+                            aiService: aiService,
+                            voiceService: voiceService,
+                            mapViewModel: vm,
+                            preferences: preferences
+                        )
+                        orch.start()
+                        voiceOrchestrator = orch
+                        orch.handleTextInput(text)
+                        isShowingVoiceOverlay = true
+                    },
+                    onFilter: {
+                        isShowingPlusMenu = false
+                        // FilterBarView is already visible; scroll/highlight it
+                    },
+                    onNavigate: { destination in
+                        isShowingPlusMenu = false
+                        Task { await vm.handleVoiceTranscript("Navigate to \(destination)") }
+                    },
+                    onVoiceAgent: {
+                        isShowingPlusMenu = false
+                        let orch = VoiceAgentOrchestrator(
+                            aiService: aiService,
+                            voiceService: voiceService,
+                            mapViewModel: vm,
+                            preferences: preferences
+                        )
+                        orch.start()
+                        voiceOrchestrator = orch
+                        isShowingVoiceOverlay = true
+                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                    }
+                )
+                .presentationDetents([.medium])
+                .presentationDragIndicator(.visible)
+            }
+        }
+        // ConversationSheet kept for text-mode multi-turn (fallback / text input path via overlay)
+        // Voice agent conversation sheet — opened by tapping "Ask Solo" in + menu when already running.
+        .sheet(isPresented: Binding(
+            get: {
+                // Only show sheet when orchestrator is running but NOT showing inline overlay
+                voiceOrchestrator != nil && !isShowingVoiceOverlay
+            },
+            set: { showing in
+                if !showing {
+                    voiceOrchestrator?.stop()
                     voiceOrchestrator = nil
-                },
-                onSubmitText: { orch.handleTextInput($0) },
-                voiceService: voiceService,
-                onVoiceTranscript: { orch.handleTranscript($0) }
-            )
-            .environment(orch.session)
-            .presentationDetents([.medium, .large])
-            .presentationDragIndicator(.visible)
+                }
+            }
+        )) {
+            if let orch = voiceOrchestrator {
+                ConversationSheet(
+                    onClose: {
+                        orch.stop()
+                        voiceOrchestrator = nil
+                    },
+                    onSubmitText: { orch.handleTextInput($0) },
+                    voiceService: voiceService,
+                    onVoiceTranscript: { orch.handleTranscript($0) },
+                    orchestrator: orch
+                )
+                .environment(orch.session)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+            }
         }
         // US-024 paywall sheet — shown when a free user taps an AI-gated
         // action. The view's onUnlocked closure resumes the original
@@ -644,6 +741,172 @@ private struct DismissibleBanner: View {
         .transition(.move(edge: .top).combined(with: .opacity))
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(text))
+    }
+}
+
+/// Bottom-right "+" button. Short tap fires `onShortTap`; long press (≥0.8s)
+/// fires `onLongPress` and provides haptic feedback.
+/// Bottom-right "+" button. Short tap fires `onShortTap`; long press (≥0.8s)
+/// fires `onLongPress` and provides haptic feedback.
+///
+/// Uses a sequenced ExclusiveGesture: long press takes priority over tap so
+/// a held gesture doesn't also fire the menu.
+private struct PlusActionButton: View {
+    @Binding var isShowingMenu: Bool
+    let onShortTap: () -> Void
+    let onLongPress: () -> Void
+
+    @State private var longPressFired = false
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(Color.black.opacity(0.85))
+                .frame(width: 56, height: 56)
+                .shadow(color: .black.opacity(0.2), radius: 6, y: 3)
+                .scaleEffect(longPressFired ? 1.12 : 1.0)
+                .animation(.spring(response: 0.25), value: longPressFired)
+
+            Image(systemName: "plus")
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(.white)
+        }
+        .contentShape(Circle())
+        .gesture(
+            DragGesture(minimumDistance: 0)
+                .onEnded { _ in
+                    defer { longPressFired = false }
+                    guard !longPressFired else { return }
+                    onShortTap()
+                }
+        )
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.8)
+                .onEnded { _ in
+                    longPressFired = true
+                    onLongPress()
+                }
+        )
+        .accessibilityLabel(Text(NSLocalizedString("plus.button.a11y", comment: "Quick actions")))
+        .accessibilityHint(Text(NSLocalizedString("plus.button.hint", comment: "Tap for quick actions, hold for voice")))
+    }
+}
+
+/// Quick-action sheet opened by tapping the "+" button.
+private struct PlusMenuSheet: View {
+    @Binding var isPresented: Bool
+    let onQuickAsk: (String) -> Void
+    let onFilter: () -> Void
+    let onNavigate: (String) -> Void
+    let onVoiceAgent: () -> Void
+
+    @State private var askText: String = ""
+    @State private var navigateText: String = ""
+    @FocusState private var askFieldFocused: Bool
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    // Quick Ask
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label(
+                            NSLocalizedString("plus.menu.ask", comment: "Ask Solo"),
+                            systemImage: "bubble.left.fill"
+                        )
+                        .font(.subheadline.weight(.semibold))
+
+                        HStack(spacing: 8) {
+                            TextField(
+                                NSLocalizedString("plus.menu.ask.placeholder", comment: "What are you looking for?"),
+                                text: $askText
+                            )
+                            .textFieldStyle(.roundedBorder)
+                            .submitLabel(.send)
+                            .focused($askFieldFocused)
+                            .onSubmit { submitAsk() }
+
+                            Button(action: submitAsk) {
+                                Image(systemName: "arrow.up.circle.fill")
+                                    .font(.title3)
+                                    .foregroundStyle(askText.isEmpty ? Color.secondary : Color.accentColor)
+                            }
+                            .disabled(askText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        }
+                    }
+                    .padding(.vertical, 4)
+
+                    // Voice agent
+                    Button(action: onVoiceAgent) {
+                        Label(
+                            NSLocalizedString("plus.menu.voice", comment: "Voice Agent"),
+                            systemImage: "mic.fill"
+                        )
+                    }
+                    .foregroundStyle(.primary)
+                }
+
+                Section {
+                    // Filter Map
+                    Button(action: onFilter) {
+                        Label(
+                            NSLocalizedString("plus.menu.filter", comment: "Filter Map"),
+                            systemImage: "line.3.horizontal.decrease.circle"
+                        )
+                    }
+                    .foregroundStyle(.primary)
+
+                    // Navigate To
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label(
+                            NSLocalizedString("plus.menu.navigate", comment: "Navigate To…"),
+                            systemImage: "arrow.triangle.turn.up.right.circle.fill"
+                        )
+                        .font(.subheadline.weight(.semibold))
+
+                        HStack(spacing: 8) {
+                            TextField(
+                                NSLocalizedString("plus.menu.navigate.placeholder", comment: "Destination…"),
+                                text: $navigateText
+                            )
+                            .textFieldStyle(.roundedBorder)
+                            .submitLabel(.go)
+                            .onSubmit { submitNavigate() }
+
+                            Button(action: submitNavigate) {
+                                Image(systemName: "arrow.up.circle.fill")
+                                    .font(.title3)
+                                    .foregroundStyle(navigateText.isEmpty ? Color.secondary : Color.accentColor)
+                            }
+                            .disabled(navigateText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .navigationTitle(NSLocalizedString("plus.menu.title", comment: "Quick Actions"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(NSLocalizedString("common.close", comment: "Close")) {
+                        isPresented = false
+                    }
+                }
+            }
+        }
+        .onAppear { askFieldFocused = true }
+    }
+
+    private func submitAsk() {
+        let trimmed = askText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        onQuickAsk(trimmed)
+    }
+
+    private func submitNavigate() {
+        let trimmed = navigateText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        onNavigate(trimmed)
     }
 }
 

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -49,89 +49,15 @@ public struct CompassMapView: View {
 
                 VStack {
                     Spacer()
-                    HStack(alignment: .bottom) {
-                        Button {
-                            viewModel.isShowingSettings = true
-                        } label: {
-                            Image(systemName: "slider.horizontal.3")
-                                .font(.title3)
-                                .frame(width: 48, height: 48)
-                                .background(Circle().fill(.regularMaterial))
-                                .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
-                        }
-                        .buttonStyle(.plain)
-                        .padding(.leading, 20)
-                        .padding(.bottom, 80)
-                        .accessibilityLabel(Text(NSLocalizedString("settings.title", comment: "Settings")))
-
-                        // Explore-here button — pulls real OSM POIs near the
-                        // current location and asks AIService to enrich them.
-                        // US-026: free users see "Explore (Pro)" with a lock icon;
-                        // tapping triggers the paywall instead of an actual Pro call.
-                        Button {
-                            let anchor = viewModel.exploreAnchorCoordinate
-                            Task { await viewModel.exploreNearby(at: anchor) }
-                        } label: {
-                            Group {
-                                if viewModel.isExploring || viewModel.isExploringFreeMode {
-                                    ProgressView()
-                                        .progressViewStyle(.circular)
-                                } else if viewModel.isProUser {
-                                    Image(systemName: "sparkle.magnifyingglass")
-                                        .font(.title3)
-                                } else {
-                                    HStack(spacing: 4) {
-                                        Image(systemName: "lock.fill")
-                                            .font(.caption.weight(.semibold))
-                                        Text(NSLocalizedString("explore.button.pro", comment: "Explore (Pro)"))
-                                            .font(.caption.weight(.semibold))
-                                            .lineLimit(1)
-                                    }
-                                    .padding(.horizontal, 8)
-                                }
-                            }
-                            .frame(minWidth: 48, minHeight: 48)
-                            .background(Capsule().fill(.regularMaterial))
-                            .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
-                        }
-                        .buttonStyle(.plain)
-                        .padding(.leading, 12)
-                        .padding(.bottom, 80)
-                        .disabled(viewModel.isExploring || viewModel.isExploringFreeMode)
-                        .accessibilityLabel(Text(
-                            viewModel.isProUser
-                                ? NSLocalizedString("explore.button", comment: "Explore here")
-                                : NSLocalizedString("explore.button.pro", comment: "Explore (Pro)")
-                        ))
-
-                        Spacer()
-
-                        // "+" button: short tap → quick-action menu,
-                        // long press (≥0.8s) → inline voice agent mode.
-                        PlusActionButton(
-                            isShowingMenu: $isShowingPlusMenu,
-                            onShortTap: {
-                                guard !isShowingVoiceOverlay else { return }
-                                isShowingPlusMenu = true
-                            },
-                            onLongPress: {
-                                guard !isShowingVoiceOverlay, voiceOrchestrator == nil else { return }
-                                isShowingPlusMenu = false
-                                let orch = VoiceAgentOrchestrator(
-                                    aiService: aiService,
-                                    voiceService: voiceService,
-                                    mapViewModel: viewModel,
-                                    preferences: preferences
-                                )
-                                orch.start()
-                                voiceOrchestrator = orch
-                                isShowingVoiceOverlay = true
-                                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                            }
-                        )
-                        .padding(.trailing, 20)
-                        .padding(.bottom, 80)
-                    }
+                    MapControlBar(
+                        viewModel: viewModel,
+                        aiService: aiService,
+                        voiceService: voiceService,
+                        preferences: preferences,
+                        isShowingPlusMenu: $isShowingPlusMenu,
+                        isShowingVoiceOverlay: $isShowingVoiceOverlay,
+                        voiceOrchestrator: $voiceOrchestrator
+                    )
                 }
 
                 if let selected = viewModel.selectedExperience, !viewModel.isShowingDetail {
@@ -732,6 +658,88 @@ private struct DismissibleBanner: View {
 /// Bottom-right "+" button. Short tap fires `onShortTap`; long press (≥0.8s)
 /// fires `onLongPress` and provides haptic feedback.
 /// Bottom-right "+" button. Short tap fires `onShortTap`; long press (≥0.8s)
+/// Bottom control bar: settings, explore, spacer, \"+\" button.
+/// Extracted to prevent type-check timeouts in the CompassMapView body.
+private struct MapControlBar: View {
+    let viewModel: MapViewModel
+    let aiService: AIService
+    let voiceService: VoiceService
+    let preferences: UserPreferences
+    @Binding var isShowingPlusMenu: Bool
+    @Binding var isShowingVoiceOverlay: Bool
+    @Binding var voiceOrchestrator: VoiceAgentOrchestrator?
+
+    var body: some View {
+        HStack(alignment: .bottom) {
+            Button {
+                viewModel.isShowingSettings = true
+            } label: {
+                Image(systemName: "slider.horizontal.3")
+                    .font(.title3)
+                    .frame(width: 48, height: 48)
+                    .background(Circle().fill(.regularMaterial))
+                    .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
+            }
+            .buttonStyle(.plain)
+            .padding(.leading, 20)
+            .padding(.bottom, 80)
+            .accessibilityLabel(Text(NSLocalizedString("settings.title", comment: "Settings")))
+
+            Button {
+                let anchor = viewModel.exploreAnchorCoordinate
+                Task { await viewModel.exploreNearby(at: anchor) }
+            } label: {
+                Group {
+                    if viewModel.isExploring || viewModel.isExploringFreeMode {
+                        ProgressView().progressViewStyle(.circular)
+                    } else if viewModel.isProUser {
+                        Image(systemName: "sparkle.magnifyingglass").font(.title3)
+                    } else {
+                        HStack(spacing: 4) {
+                            Image(systemName: "lock.fill").font(.caption.weight(.semibold))
+                            Text(NSLocalizedString("explore.button.pro", comment: "Explore (Pro)"))
+                                .font(.caption.weight(.semibold)).lineLimit(1)
+                        }.padding(.horizontal, 8)
+                    }
+                }
+                .frame(minWidth: 48, minHeight: 48)
+                .background(Capsule().fill(.regularMaterial))
+                .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
+            }
+            .buttonStyle(.plain)
+            .padding(.leading, 12)
+            .padding(.bottom, 80)
+            .disabled(viewModel.isExploring || viewModel.isExploringFreeMode)
+
+            Spacer()
+
+            PlusActionButton(
+                isShowingMenu: $isShowingPlusMenu,
+                onShortTap: {
+                    guard !isShowingVoiceOverlay else { return }
+                    isShowingPlusMenu = true
+                },
+                onLongPress: {
+                    guard !isShowingVoiceOverlay, voiceOrchestrator == nil else { return }
+                    isShowingPlusMenu = false
+                    let orch = VoiceAgentOrchestrator(
+                        aiService: aiService,
+                        voiceService: voiceService,
+                        mapViewModel: viewModel,
+                        preferences: preferences
+                    )
+                    orch.start()
+                    voiceOrchestrator = orch
+                    isShowingVoiceOverlay = true
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                }
+            )
+            .padding(.trailing, 20)
+            .padding(.bottom, 80)
+        }
+    }
+}
+
 /// Inline voice agent overlay that dims the map and shows the thinking
 /// overlay + hold-to-speak orb. Extracted to prevent type-check timeouts
 /// in the CompassMapView body.

--- a/apps/ios/SoloCompass/Views/Voice/ConversationSheet.swift
+++ b/apps/ios/SoloCompass/Views/Voice/ConversationSheet.swift
@@ -141,9 +141,15 @@ public struct ConversationSheet: View {
 
                     // Thinking step chip shown while model is working
                     if let step = orchestrator?.thinkingStep, !step.isEmpty, isAgentActive {
-                        thinkingChip(step).id("thinkingChip")
+                        thinkingChip(step)
+                            .id("thinkingChip")
+                            .transition(.asymmetric(
+                                insertion: .opacity.combined(with: .scale(scale: 0.9, anchor: .leading)),
+                                removal: .opacity
+                            ))
                     } else if session.state == .thinking && orchestrator == nil {
                         thinkingBubble.id("thinking")
+                            .transition(.opacity)
                     }
 
                     // Streaming assistant response word-by-word
@@ -159,10 +165,15 @@ public struct ConversationSheet: View {
                 .padding(.vertical, 14)
             }
             .onChange(of: session.messages.count) {
-                if let last = session.messages.last {
-                    withAnimation(.easeOut(duration: 0.18)) {
+                withAnimation(.easeOut(duration: 0.18)) {
+                    if let last = session.messages.last {
                         proxy.scrollTo(last.id, anchor: .bottom)
                     }
+                }
+            }
+            .onChange(of: orchestrator?.thinkingStep) { _, _ in
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    proxy.scrollTo("thinkingChip", anchor: .bottom)
                 }
             }
             .onChange(of: orchestrator?.streamingContent) { _, _ in

--- a/apps/ios/SoloCompass/Views/Voice/ConversationSheet.swift
+++ b/apps/ios/SoloCompass/Views/Voice/ConversationSheet.swift
@@ -1,29 +1,21 @@
 import SwiftUI
 
-/// Multi-turn voice agent conversation surface (US-VA-04).
+/// Multi-turn voice agent conversation surface.
 ///
-/// Bound to a `VoiceAgentSession` from the environment. Renders:
-/// - top status bar with turn count + close button
-/// - scrollable message list (user right, assistant left, tool muted)
-/// - bottom input row (mic + text field) — text input is wired here
-///   but the mic gesture lands in US-VA-05.
-///
-/// The orchestrator (US-VA-06) drives the session; this view is read-only
-/// for state and only emits two intents: `onClose` and `onSubmitText(_:)`.
+/// Renders the session message history with streaming text and tool-call
+/// chips. The orchestrator drives the session; this view only emits
+/// `onClose` and `onSubmitText(_:)` intents.
 public struct ConversationSheet: View {
     @Environment(VoiceAgentSession.self) private var session
 
-    /// Called when the user dismisses the sheet (× button or down-drag).
     public var onClose: () -> Void
-
-    /// Called when the user submits a typed message.
     public var onSubmitText: (String) -> Void
-
-    /// Optional voice service — when provided the mic button records live.
     public var voiceService: VoiceService?
-
-    /// Called with the final transcript when voice recording ends.
     public var onVoiceTranscript: (String) -> Void
+
+    /// Optional — when provided, streaming text and thinking step are
+    /// shown inline so the user sees word-by-word output.
+    public var orchestrator: VoiceAgentOrchestrator?
 
     @State private var textDraft: String = ""
     @State private var isRecording = false
@@ -34,12 +26,14 @@ public struct ConversationSheet: View {
         onClose: @escaping () -> Void = {},
         onSubmitText: @escaping (String) -> Void = { _ in },
         voiceService: VoiceService? = nil,
-        onVoiceTranscript: @escaping (String) -> Void = { _ in }
+        onVoiceTranscript: @escaping (String) -> Void = { _ in },
+        orchestrator: VoiceAgentOrchestrator? = nil
     ) {
         self.onClose = onClose
         self.onSubmitText = onSubmitText
         self.voiceService = voiceService
         self.onVoiceTranscript = onVoiceTranscript
+        self.orchestrator = orchestrator
     }
 
     public var body: some View {
@@ -91,8 +85,12 @@ public struct ConversationSheet: View {
         case .idle:          return NSLocalizedString("conversation.state.idle", comment: "")
         case .listening:     return NSLocalizedString("conversation.state.listening", comment: "")
         case .transcribing:  return NSLocalizedString("conversation.state.transcribing", comment: "")
-        case .thinking:      return NSLocalizedString("conversation.state.thinking", comment: "")
-        case .toolExecuting: return NSLocalizedString("conversation.state.toolExecuting", comment: "")
+        case .thinking:
+            let step = orchestrator?.thinkingStep ?? ""
+            return step.isEmpty ? NSLocalizedString("conversation.state.thinking", comment: "") : step
+        case .toolExecuting:
+            let step = orchestrator?.thinkingStep ?? ""
+            return step.isEmpty ? NSLocalizedString("conversation.state.toolExecuting", comment: "") : step
         case .speaking:      return NSLocalizedString("conversation.state.speaking", comment: "")
         }
     }
@@ -121,6 +119,15 @@ public struct ConversationSheet: View {
         }
     }
 
+    // MARK: - Helpers
+
+    private var isAgentActive: Bool {
+        switch session.state {
+        case .thinking, .toolExecuting: return true
+        default: return false
+        }
+    }
+
     // MARK: - Message list
 
     private var messageList: some View {
@@ -131,19 +138,36 @@ public struct ConversationSheet: View {
                         messageRow(message)
                             .id(message.id)
                     }
-                    if session.state == .thinking {
+
+                    // Thinking step chip shown while model is working
+                    if let step = orchestrator?.thinkingStep, !step.isEmpty, isAgentActive {
+                        thinkingChip(step).id("thinkingChip")
+                    } else if session.state == .thinking && orchestrator == nil {
                         thinkingBubble.id("thinking")
+                    }
+
+                    // Streaming assistant response word-by-word
+                    if let content = orchestrator?.streamingContent, !content.isEmpty {
+                        HStack {
+                            streamingBubble(content)
+                            Spacer(minLength: 40)
+                        }
+                        .id("streaming")
                     }
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 14)
             }
             .onChange(of: session.messages.count) {
-                // Pin the most recent bubble in view as new content lands.
                 if let last = session.messages.last {
                     withAnimation(.easeOut(duration: 0.18)) {
                         proxy.scrollTo(last.id, anchor: .bottom)
                     }
+                }
+            }
+            .onChange(of: orchestrator?.streamingContent) { _, _ in
+                withAnimation(.easeOut(duration: 0.1)) {
+                    proxy.scrollTo("streaming", anchor: .bottom)
                 }
             }
         }
@@ -203,6 +227,24 @@ public struct ConversationSheet: View {
             .accessibilityIdentifier("assistantBubble")
     }
 
+    private func streamingBubble(_ text: String) -> some View {
+        Text(text)
+            .font(.subheadline)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Color(.secondarySystemBackground).opacity(0.85),
+                        in: RoundedRectangle(cornerRadius: 14))
+            .overlay(alignment: .bottomTrailing) {
+                // Blinking cursor indicator
+                Rectangle()
+                    .fill(Color.primary.opacity(0.5))
+                    .frame(width: 2, height: 12)
+                    .padding(.trailing, 10)
+                    .padding(.bottom, 10)
+            }
+            .accessibilityIdentifier("streamingBubble")
+    }
+
     private func toolCallChip(_ call: VoiceAgentSession.ToolCall) -> some View {
         HStack(spacing: 6) {
             Image(systemName: "gearshape.fill")
@@ -217,6 +259,19 @@ public struct ConversationSheet: View {
         .accessibilityIdentifier("toolCallChip")
     }
 
+    private func thinkingChip(_ label: String) -> some View {
+        HStack(spacing: 8) {
+            ProgressView().controlSize(.small)
+            Text(label)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color(.tertiarySystemBackground), in: Capsule())
+        .transition(.opacity)
+    }
+
     private var thinkingBubble: some View {
         HStack(spacing: 8) {
             ProgressView().controlSize(.small)
@@ -226,9 +281,6 @@ public struct ConversationSheet: View {
         }
     }
 
-    /// Short label for a tool-result row — we don't want to dump full
-    /// JSON in the conversation view, so we strip to the most useful
-    /// hint: either the tool's `name` field if present, or a count.
     private func toolResultSummary(_ msg: VoiceAgentSession.Message) -> String {
         let name = msg.name ?? "tool"
         if let content = msg.content,
@@ -246,7 +298,6 @@ public struct ConversationSheet: View {
 
     private var inputBar: some View {
         HStack(spacing: 10) {
-            // Mic button — long-press to record, release to send transcript.
             Image(systemName: isRecording ? "waveform" : "mic.circle.fill")
                 .font(.system(size: 36))
                 .foregroundStyle(isRecording ? Color.red : Color.accentColor)
@@ -342,9 +393,7 @@ public struct ConversationSheet: View {
     }
 }
 
-// MARK: - Preview helpers
-//
-// PRD US-VA-04 DoD: three #Preview states (thinking, tool_executing, idle).
+// MARK: - Previews
 
 #Preview("idle (empty)") {
     let session = VoiceAgentSession()

--- a/apps/ios/SoloCompass/Views/Voice/ThinkingOverlay.swift
+++ b/apps/ios/SoloCompass/Views/Voice/ThinkingOverlay.swift
@@ -13,20 +13,39 @@ public struct ThinkingOverlay: View {
     public let streamingText: String
     /// Whether a tool is currently executing (drives spinner visibility).
     public let isExecutingTool: Bool
+    /// When non-nil, shown as an error banner above the thinking content.
+    public let errorMessage: String?
 
-    public init(stepLabel: String, streamingText: String, isExecutingTool: Bool) {
+    public init(
+        stepLabel: String,
+        streamingText: String,
+        isExecutingTool: Bool,
+        errorMessage: String? = nil
+    ) {
         self.stepLabel = stepLabel
         self.streamingText = streamingText
         self.isExecutingTool = isExecutingTool
+        self.errorMessage = errorMessage
     }
 
     private var isVisible: Bool {
-        !stepLabel.isEmpty || !streamingText.isEmpty
+        !stepLabel.isEmpty || !streamingText.isEmpty || errorMessage != nil
     }
 
     public var body: some View {
         if isVisible {
             VStack(alignment: .leading, spacing: 6) {
+                if let error = errorMessage {
+                    HStack(spacing: 8) {
+                        Image(systemName: "wifi.exclamationmark")
+                            .foregroundStyle(.orange)
+                        Text(error)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.primary)
+                    }
+                    .transition(.opacity)
+                }
+
                 if !stepLabel.isEmpty {
                     HStack(spacing: 8) {
                         if isExecutingTool || streamingText.isEmpty {
@@ -54,7 +73,7 @@ public struct ThinkingOverlay: View {
             .padding(.horizontal, 16)
             .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .top)))
             .accessibilityElement(children: .combine)
-            .accessibilityLabel(Text([stepLabel, streamingText].filter { !$0.isEmpty }.joined(separator: ". ")))
+            .accessibilityLabel(Text([errorMessage, stepLabel, streamingText].compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: ". ")))
         }
     }
 }

--- a/apps/ios/SoloCompass/Views/Voice/ThinkingOverlay.swift
+++ b/apps/ios/SoloCompass/Views/Voice/ThinkingOverlay.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+/// Inline overlay that appears on the map while the voice agent is
+/// thinking or executing tools. Shows the current step label and
+/// streams the growing assistant text word-by-word.
+///
+/// Designed to be placed in a ZStack above the map. Auto-hides when
+/// both `stepLabel` and `streamingText` are empty.
+public struct ThinkingOverlay: View {
+    /// e.g. "🔍 Searching nearby…", "Thinking…", ""
+    public let stepLabel: String
+    /// Partial assistant text being streamed in.
+    public let streamingText: String
+    /// Whether a tool is currently executing (drives spinner visibility).
+    public let isExecutingTool: Bool
+
+    public init(stepLabel: String, streamingText: String, isExecutingTool: Bool) {
+        self.stepLabel = stepLabel
+        self.streamingText = streamingText
+        self.isExecutingTool = isExecutingTool
+    }
+
+    private var isVisible: Bool {
+        !stepLabel.isEmpty || !streamingText.isEmpty
+    }
+
+    public var body: some View {
+        if isVisible {
+            VStack(alignment: .leading, spacing: 6) {
+                if !stepLabel.isEmpty {
+                    HStack(spacing: 8) {
+                        if isExecutingTool || streamingText.isEmpty {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(stepLabel)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.primary)
+                    }
+                }
+
+                if !streamingText.isEmpty {
+                    Text(streamingText)
+                        .font(.subheadline)
+                        .foregroundStyle(.primary)
+                        .lineLimit(4)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+            .shadow(color: .black.opacity(0.12), radius: 6, y: 3)
+            .padding(.horizontal, 16)
+            .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .top)))
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(Text([stepLabel, streamingText].filter { !$0.isEmpty }.joined(separator: ". ")))
+        }
+    }
+}
+
+#Preview("thinking") {
+    ZStack {
+        Color.gray.opacity(0.2).ignoresSafeArea()
+        VStack {
+            ThinkingOverlay(
+                stepLabel: "🔍 Searching nearby…",
+                streamingText: "",
+                isExecutingTool: true
+            )
+            Spacer()
+        }
+        .padding(.top, 120)
+    }
+}
+
+#Preview("streaming response") {
+    ZStack {
+        Color.gray.opacity(0.2).ignoresSafeArea()
+        VStack {
+            ThinkingOverlay(
+                stepLabel: "",
+                streamingText: "There's a great ramen spot about 200m away — Ichiran has private solo booths and opens at 11am.",
+                isExecutingTool: false
+            )
+            Spacer()
+        }
+        .padding(.top, 120)
+    }
+}

--- a/apps/ios/SoloCompass/Views/Voice/VoiceAgentOverlay.swift
+++ b/apps/ios/SoloCompass/Views/Voice/VoiceAgentOverlay.swift
@@ -56,7 +56,7 @@ public struct VoiceAgentOverlay: View {
                     } label: {
                         Text(NSLocalizedString("common.settings", comment: "Settings"))
                             .font(.caption.weight(.semibold))
-                            .foregroundStyle(.accentColor)
+                            .foregroundStyle(.tint)
                     }
                 }
                 .padding(.horizontal, 14)

--- a/apps/ios/SoloCompass/Views/Voice/VoiceAgentOverlay.swift
+++ b/apps/ios/SoloCompass/Views/Voice/VoiceAgentOverlay.swift
@@ -22,6 +22,7 @@ public struct VoiceAgentOverlay: View {
     @State private var liveTranscript: String = ""
     @State private var pulse: Bool = false
     @State private var voiceStreamTask: Task<Void, Never>? = nil
+    @State private var permissionDenied: Bool = false
 
     public init(
         orchestrator: VoiceAgentOrchestrator,
@@ -38,6 +39,33 @@ public struct VoiceAgentOverlay: View {
     public var body: some View {
         VStack(spacing: 0) {
             Spacer()
+
+            // Permission denied banner
+            if permissionDenied {
+                HStack(spacing: 8) {
+                    Image(systemName: "mic.slash.fill")
+                        .foregroundStyle(.orange)
+                    Text(NSLocalizedString("voiceAgent.permissionDenied", comment: "Microphone access needed — enable in Settings"))
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.primary)
+                    Spacer()
+                    Button {
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            UIApplication.shared.open(url)
+                        }
+                    } label: {
+                        Text(NSLocalizedString("common.settings", comment: "Settings"))
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.accentColor)
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+                .padding(.horizontal, 24)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .padding(.bottom, 12)
+            }
 
             // Live transcript floats above the orb
             if isHolding, !liveTranscript.isEmpty {
@@ -113,7 +141,8 @@ public struct VoiceAgentOverlay: View {
                     .onEnded { _ in if isHolding { endHolding() } }
             )
             .accessibilityLabel(Text(NSLocalizedString("voiceAgent.orb.a11y", comment: "Hold to speak to Solo Compass")))
-            .accessibilityHint(Text(NSLocalizedString("voiceAgent.orb.hint", comment: "Hold and speak your request")))
+            .accessibilityHint(Text(NSLocalizedString("voiceAgent.orb.hint", comment: "Double tap and hold to speak")))
+            .accessibilityAddTraits(.startsMediaSession)
 
             // Dismiss button
             Button(action: onDismiss) {
@@ -183,7 +212,11 @@ public struct VoiceAgentOverlay: View {
         if session.state == .idle { session.beginListening() }
         Task {
             let granted = await voiceService.requestPermission()
-            guard granted else { return }
+            guard granted else {
+                withAnimation(.easeInOut(duration: 0.25)) { permissionDenied = true }
+                return
+            }
+            withAnimation { permissionDenied = false }
             do {
                 isHolding = true
                 liveTranscript = ""

--- a/apps/ios/SoloCompass/Views/Voice/VoiceAgentOverlay.swift
+++ b/apps/ios/SoloCompass/Views/Voice/VoiceAgentOverlay.swift
@@ -1,0 +1,241 @@
+import SwiftUI
+
+/// Inline voice agent mode overlaid directly on the map (no sheet).
+///
+/// Lifecycle:
+///   1. Long-press triggers → overlay appears, `isListening = true`
+///   2. While holding: pulsing orb + live transcript above the orb
+///   3. On release: transcript sent to orchestrator, orb switches to
+///      "thinking" animation while AI responds
+///   4. Tap ✕ or wait for response to finish → overlay dismisses
+///
+/// The overlay owns the VoiceService interaction for the hold gesture.
+/// The parent (CompassMapView) owns the orchestrator lifecycle.
+@MainActor
+public struct VoiceAgentOverlay: View {
+    public let orchestrator: VoiceAgentOrchestrator
+    public let voiceService: VoiceService
+    /// Called when the user dismisses the overlay (✕ button).
+    public var onDismiss: () -> Void
+
+    @State private var isHolding: Bool = false
+    @State private var liveTranscript: String = ""
+    @State private var pulse: Bool = false
+    @State private var voiceStreamTask: Task<Void, Never>? = nil
+
+    public init(
+        orchestrator: VoiceAgentOrchestrator,
+        voiceService: VoiceService,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.orchestrator = orchestrator
+        self.voiceService = voiceService
+        self.onDismiss = onDismiss
+    }
+
+    private var session: VoiceAgentSession { orchestrator.session }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            // Live transcript floats above the orb
+            if isHolding, !liveTranscript.isEmpty {
+                Text(liveTranscript)
+                    .font(.subheadline)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.primary)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+                    .padding(.horizontal, 32)
+                    .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+                    .padding(.bottom, 12)
+            }
+
+            // Hold-to-speak label
+            Text(holdLabel)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+                .padding(.bottom, 8)
+                .transition(.opacity)
+
+            // Pulsing orb
+            ZStack {
+                // Outer pulse rings
+                ForEach(0..<2) { i in
+                    Circle()
+                        .stroke(orbColor.opacity(0.35 - Double(i) * 0.12), lineWidth: 3)
+                        .frame(width: 80 + CGFloat(i) * 24, height: 80 + CGFloat(i) * 24)
+                        .scaleEffect(pulse ? 1.15 : 0.9)
+                        .opacity(pulse ? 0.0 : 0.9)
+                        .animation(
+                            .easeOut(duration: 1.1 + Double(i) * 0.2)
+                                .repeatForever(autoreverses: false)
+                                .delay(Double(i) * 0.25),
+                            value: pulse
+                        )
+                }
+
+                // Core orb
+                Circle()
+                    .fill(orbColor)
+                    .frame(width: 72, height: 72)
+                    .shadow(color: orbColor.opacity(0.4), radius: isHolding ? 16 : 6, y: 4)
+
+                // Icon
+                Group {
+                    switch orbIcon {
+                    case .mic:
+                        Image(systemName: "mic.fill")
+                            .font(.title2.weight(.semibold))
+                            .symbolEffect(.variableColor.iterative, isActive: isHolding)
+                    case .waveform:
+                        Image(systemName: "waveform")
+                            .font(.title2.weight(.semibold))
+                            .symbolEffect(.variableColor.iterative, isActive: true)
+                    case .thinking:
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .tint(.white)
+                            .scaleEffect(1.2)
+                    }
+                }
+                .foregroundStyle(.white)
+            }
+            .gesture(
+                LongPressGesture(minimumDuration: 0.01)
+                    .onEnded { _ in beginHolding() }
+            )
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0)
+                    .onEnded { _ in if isHolding { endHolding() } }
+            )
+            .accessibilityLabel(Text(NSLocalizedString("voiceAgent.orb.a11y", comment: "Hold to speak to Solo Compass")))
+            .accessibilityHint(Text(NSLocalizedString("voiceAgent.orb.hint", comment: "Hold and speak your request")))
+
+            // Dismiss button
+            Button(action: onDismiss) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.top, 16)
+            .accessibilityLabel(Text(NSLocalizedString("common.close", comment: "Close")))
+
+            Spacer().frame(height: 24)
+        }
+        .onAppear {
+            pulse = true
+        }
+        .onDisappear {
+            voiceStreamTask?.cancel()
+            voiceService.stopListening()
+        }
+        .animation(.easeInOut(duration: 0.2), value: isHolding)
+        .animation(.easeInOut(duration: 0.2), value: liveTranscript.isEmpty)
+    }
+
+    // MARK: - Orb state
+
+    private enum OrbIcon { case mic, waveform, thinking }
+
+    private var isAgentActive: Bool {
+        switch session.state {
+        case .thinking, .toolExecuting: return true
+        default: return false
+        }
+    }
+
+    private var orbIcon: OrbIcon {
+        if orchestrator.isExecutingTool || isAgentActive { return .thinking }
+        if isHolding { return .waveform }
+        return .mic
+    }
+
+    private var orbColor: Color {
+        if isHolding { return .red }
+        if isAgentActive { return Color.blue }
+        if session.state == .speaking { return Color.green }
+        return Color.black.opacity(0.85)
+    }
+
+    private var holdLabel: String {
+        if isHolding { return liveTranscript.isEmpty
+            ? NSLocalizedString("voiceAgent.orb.listening", comment: "Listening…")
+            : NSLocalizedString("voiceAgent.orb.release", comment: "Release to send")
+        }
+        if isAgentActive || orchestrator.isExecutingTool {
+            return orchestrator.thinkingStep
+        }
+        if session.state == .speaking {
+            return NSLocalizedString("voiceAgent.orb.responding", comment: "Responding…")
+        }
+        return NSLocalizedString("voiceAgent.orb.holdToSpeak", comment: "Hold to speak")
+    }
+
+    // MARK: - Voice recording
+
+    private func beginHolding() {
+        guard !isHolding else { return }
+        // Re-enter listening state for subsequent turns (first turn is set by start()).
+        if session.state == .idle { session.beginListening() }
+        Task {
+            let granted = await voiceService.requestPermission()
+            guard granted else { return }
+            do {
+                isHolding = true
+                liveTranscript = ""
+                let stream = try voiceService.startListening()
+                voiceStreamTask = Task { @MainActor in
+                    do {
+                        for try await text in stream {
+                            liveTranscript = text
+                        }
+                    } catch {
+                        isHolding = false
+                    }
+                }
+            } catch {
+                isHolding = false
+            }
+        }
+    }
+
+    private func endHolding() {
+        guard isHolding else { return }
+        voiceService.stopListening()
+        voiceStreamTask?.cancel()
+        voiceStreamTask = nil
+        isHolding = false
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        let final = liveTranscript
+        liveTranscript = ""
+        if !final.isEmpty {
+            orchestrator.handleTranscript(final)
+        }
+    }
+}
+
+#Preview {
+    let orch = VoiceAgentOrchestrator(
+        aiService: AIService(),
+        voiceService: VoiceService(),
+        mapViewModel: MapViewModel(
+            locationService: LocationService.shared,
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: UserPreferences()
+        ),
+        preferences: UserPreferences()
+    )
+    return ZStack {
+        Color.gray.opacity(0.15).ignoresSafeArea()
+        VoiceAgentOverlay(
+            orchestrator: orch,
+            voiceService: VoiceService(),
+            onDismiss: {}
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- **"+" button replaces mic**: short tap opens quick-action menu (Ask Solo text, Voice Agent, Filter Map, Navigate To…); long press ≥0.8s enters inline voice agent mode
- **Inline voice agent** (no sheet): long-press → pulsing orb overlay directly on the map. Hold to speak, release to send. `VoiceAgentOverlay.swift` (new file) owns the hold gesture and live transcript display
- **Thinking visibility** on map: `ThinkingOverlay.swift` (new file) shows the current AI step (`🔍 Searching nearby…`, `📍 Opening details…`) and streams the assistant response word-by-word at the top of the map
- **SSE streaming API**: `AIService.sendAgentMessageStreaming` streams `StreamEvent` (.contentDelta, .toolCall, .done) via Server-Sent Events; falls back to non-streaming `sendAgentMessage` on SSE failure
- **VoiceAgentOrchestrator** extended with `streamingContent`, `thinkingStep`, `isExecutingTool` observable state; streaming turn loop with per-tool step labels
- **ConversationSheet** updated: streaming text bubble with blinking cursor, thinking step chips, orchestrator-aware header state label — kept as fallback for text-mode turns

## New files

- `Views/Voice/ThinkingOverlay.swift` — map-top thinking/streaming overlay
- `Views/Voice/VoiceAgentOverlay.swift` — inline hold-to-speak orb + live transcript

## Test plan

- [ ] Short tap "+" → PlusMenuSheet opens with Ask Solo / Voice Agent / Filter / Navigate sections
- [ ] Long press "+" (≥0.8s) → VoiceAgentOverlay appears, orb pulses, haptic fires
- [ ] Hold orb → live transcript appears above orb; release → transcript sent to AI
- [ ] ThinkingOverlay shows step label ("🔍 Searching nearby…") then streams response text
- [ ] Map annotations update in real time as `explore_nearby`/`search_places` tools execute
- [ ] ✕ button dismisses overlay; orchestrator stops; no leaked tasks
- [ ] Second hold on orb after first turn completes → new turn starts correctly
- [ ] Ask Solo text field in PlusMenuSheet → opens overlay with text response
- [ ] Navigate To in PlusMenuSheet → delegates to `handleVoiceTranscript`
- [ ] Streaming falls back gracefully if SSE not supported (non-streaming path)
- [ ] Voice permission denied → no crash, orb stays dismissible
- [ ] Session timeout (30s) → overlay shows nothing, orb returns to idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)