### PR TITLE
fix(ios): unblock pro chat + free map controls from status bar

### DIFF
--- a/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
@@ -68,9 +68,17 @@ public final class VoiceAgentOrchestrator: Identifiable {
     /// Seed with system prompt and begin listening immediately.
     /// US-003: If the resolved API key is empty, short-circuit to .unconfigured
     /// before touching the session — no system prompt is seeded, no mic starts.
+    ///
+    /// Pro users whose traffic goes through the Supabase chat-proxy Edge
+    /// function don't need a local DeepSeek key — the Edge function holds it
+    /// server-side. Skip the local-key guard in that case so the orchestrator
+    /// actually starts and `handleTextInput` / `handleTranscript` can run.
     public func start() {
         guard !isRunning else { return }
-        guard !Secrets.resolvedDeepSeekApiKey.isEmpty else {
+        let routesThroughEdge = FeatureFlags.routeAIThroughEdge
+            && FeatureFlags.backendSync
+            && aiService.isProTier
+        if !routesThroughEdge && Secrets.resolvedDeepSeekApiKey.isEmpty {
             uiState = .unconfigured
             return
         }

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -3773,8 +3773,9 @@ final class LanguageServiceTests: XCTestCase {
 @MainActor
 final class VoiceAgentOrchestratorUnconfiguredTests: XCTestCase {
 
-    /// When resolvedDeepSeekApiKey is empty, start() must set uiState = .unconfigured
-    /// and must NOT set isRunning (no session seeded, no mic started).
+    /// When resolvedDeepSeekApiKey is empty AND the user is not on the Pro
+    /// Edge-routing path, start() must set uiState = .unconfigured and must
+    /// NOT set isRunning (no session seeded, no mic started).
     func testMissingKeyYieldsUnconfiguredState() {
         // Clear any UserDefaults override so resolvedDeepSeekApiKey falls back
         // to the build-time value. In CI the build-time key is empty (""), so
@@ -3796,13 +3797,18 @@ final class VoiceAgentOrchestratorUnconfiguredTests: XCTestCase {
         unsetenv("DEEPSEEK_API_KEY")
         defer { if hadEnvKey { setenv("DEEPSEEK_API_KEY", "", 1) } }
 
+        // Force the non-Edge path: isProTier = false so the local-key guard
+        // is the only thing standing between start() and .unconfigured.
+        let ai = AIService()
+        ai.isProTier = false
+
         let orch = VoiceAgentOrchestrator(
-            aiService: AIService(),
+            aiService: ai,
             voiceService: VoiceService(),
             mapViewModel: MapViewModel(
                 locationService: LocationService(),
                 experienceService: ExperienceService(),
-                aiService: AIService(),
+                aiService: ai,
                 preferences: UserPreferences()
             ),
             preferences: UserPreferences()
@@ -3817,6 +3823,63 @@ final class VoiceAgentOrchestratorUnconfiguredTests: XCTestCase {
                        "start() with empty API key must set uiState = .unconfigured")
         XCTAssertFalse(orch.isRunning,
                        "orchestrator must NOT become running when key is missing")
+    }
+
+    /// Pro users whose traffic is routed through the chat-proxy Edge function
+    /// must not be blocked by an empty local DeepSeek key — the key lives on
+    /// the server. start() should proceed to the listening state even when
+    /// `resolvedDeepSeekApiKey` is empty, provided the Edge-routing flags +
+    /// isProTier are all on.
+    func testProUserSkipsLocalKeyGuardWhenRoutingThroughEdge() {
+        // Force-empty the local key so the only way start() can succeed is
+        // via the Edge-routing bypass.
+        let savedOverride = UserDefaults.standard.string(forKey: Secrets.RuntimeKeys.deepSeekApiKey)
+        UserDefaults.standard.set("", forKey: Secrets.RuntimeKeys.deepSeekApiKey)
+        defer {
+            if let saved = savedOverride {
+                UserDefaults.standard.set(saved, forKey: Secrets.RuntimeKeys.deepSeekApiKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Secrets.RuntimeKeys.deepSeekApiKey)
+            }
+        }
+        let hadEnvKey = getenv("DEEPSEEK_API_KEY") != nil
+        unsetenv("DEEPSEEK_API_KEY")
+        defer { if hadEnvKey { setenv("DEEPSEEK_API_KEY", "", 1) } }
+
+        // Inject Edge-routing flags via env vars (FeatureFlags.readBool reads
+        // env first, then plist). Save+restore so we don't leak into other tests.
+        let savedBackendSync = getenv("FF_BACKEND_SYNC").flatMap { String(cString: $0) }
+        let savedRouteEdge = getenv("FF_ROUTE_AI_THROUGH_EDGE").flatMap { String(cString: $0) }
+        setenv("FF_BACKEND_SYNC", "1", 1)
+        setenv("FF_ROUTE_AI_THROUGH_EDGE", "1", 1)
+        defer {
+            if let v = savedBackendSync { setenv("FF_BACKEND_SYNC", v, 1) } else { unsetenv("FF_BACKEND_SYNC") }
+            if let v = savedRouteEdge { setenv("FF_ROUTE_AI_THROUGH_EDGE", v, 1) } else { unsetenv("FF_ROUTE_AI_THROUGH_EDGE") }
+        }
+        XCTAssertTrue(FeatureFlags.routeAIThroughEdge, "precondition: env override should turn the flag on")
+        XCTAssertTrue(FeatureFlags.backendSync, "precondition: env override should turn the flag on")
+
+        let ai = AIService()
+        ai.isProTier = true
+
+        let orch = VoiceAgentOrchestrator(
+            aiService: ai,
+            voiceService: VoiceService(),
+            mapViewModel: MapViewModel(
+                locationService: LocationService(),
+                experienceService: ExperienceService(),
+                aiService: ai,
+                preferences: UserPreferences()
+            ),
+            preferences: UserPreferences()
+        )
+
+        orch.start()
+
+        XCTAssertNotEqual(orch.uiState, .unconfigured,
+                          "Pro + Edge routing must bypass the empty-key guard")
+        XCTAssertTrue(orch.isRunning,
+                      "orchestrator must enter the running state for Pro users on Edge")
     }
 
     // MARK: - US-010 Pan debounce: single long-lived Task, not N per-frame Tasks

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -101,8 +101,14 @@ public struct CompassMapView: View {
     private var mapZStack: some View {
         ZStack {
             if let viewModel {
-                mapLayer(viewModel: viewModel)
+                // Backing tile bleeds under every edge so the map looks
+                // edge-to-edge, but the actual `Map` view keeps its top
+                // safe-area inset so `.mapControls` (MapCompass +
+                // MapUserLocationButton) don't collide with the status bar.
+                themeService.currentTheme.background
                     .ignoresSafeArea()
+                mapLayer(viewModel: viewModel)
+                    .ignoresSafeArea(edges: [.bottom, .horizontal])
 
                 MapOverlayView(
                     viewModel: viewModel,


### PR DESCRIPTION
## Summary

- **Pro chat was completely broken.** `VoiceAgentOrchestrator.start()` required a local DeepSeek key unconditionally, so Pro users whose traffic goes through the chat-proxy Edge function were stuck in `.unconfigured`. Every text message and voice transcript was silently dropped by the `guard isRunning, isSeeded` checks in `handleTextInput` / `handleTranscript` — UI showed nothing, no AI reply, voice push-to-talk did nothing on release. Skip the local-key guard when `routeAIThroughEdge + backendSync + isProTier` are all on.
- **Map controls collided with the iPhone status bar.** `mapLayer.ignoresSafeArea()` ignored *every* edge, pulling the `Map` view (and its `.mapControls` — `MapCompass`, `MapUserLocationButton`) under the status bar so the user-location arrow overlapped clock / signal icons. Keep the top safe-area inset on the `Map` itself; backing color bleeds behind the status bar so it still feels edge-to-edge.

## Test plan

- [x] `xcodebuild build` — iPhone 17 Pro / iOS 26.4 — clean (only pre-existing Swift 6 concurrency warnings unrelated to this change)
- [x] `testProUserSkipsLocalKeyGuardWhenRoutingThroughEdge` — passes; uses `setenv FF_BACKEND_SYNC=1 FF_ROUTE_AI_THROUGH_EDGE=1` so the bypass path runs even on a build whose default flags are off
- [x] Manual screenshot on iPhone 17 Pro simulator confirms `MapUserLocationButton` sits below status bar after grant of when-in-use location
- [ ] CI: verify `testMissingKeyYieldsUnconfiguredState` passes (it depends on an empty compile-time DeepSeek key — fails locally on dev machines that have one baked in; this is **pre-existing**, not introduced by this PR — confirmed by running the test on a clean `git stash` of `main`)

## Notes

- The failing `testMissingKeyYieldsUnconfiguredState` / `testRepeatedStartWhileUnconfiguredStaysUnconfigured` on dev machines are *not* caused by this PR. They were already failing on `main` whenever the build-time `GeneratedSecrets.deepSeekApiKey` is non-empty. Tracked separately.
- Follow-up P1 work identified during diagnosis but **not** included here: ① experience card AI follow-up entry point, ② empty-filter auto-explore, ③ user-configurable categories.