### PR TITLE
fix: english-first POI naming + smoother map interaction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,10 +99,10 @@ cd apps/ios
 xcodegen                 # regenerate SoloCompass.xcodeproj from project.yml
 xcodebuild build \
   -project SoloCompass.xcodeproj -scheme SoloCompass \
-  -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest'
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest'
 xcodebuild test \
   -project SoloCompass.xcodeproj -scheme SoloCompass \
-  -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest'
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest'
 
 # Ralph autonomous dev
 cd scripts/ralph && ./ralph.sh --tool claude 12
@@ -117,7 +117,7 @@ cd scripts/ralph && ./ralph.sh --tool claude 12
 
 ## Testing
 
-**iOS**: XCTest target `SoloCompassTests` (default sim: iPhone 16 Pro, iOS latest). Always start the Simulator in the background — never let it occupy the foreground terminal.
+**iOS**: XCTest target `SoloCompassTests` (default sim: iPhone 17 Pro, iOS latest). Always start the Simulator in the background — never let it occupy the foreground terminal.
 
 **TS**: per-package `pnpm test` via turbo.
 

--- a/apps/ios/SoloCompass/Services/OverpassService.swift
+++ b/apps/ios/SoloCompass/Services/OverpassService.swift
@@ -416,7 +416,9 @@ public final class OverpassService {
             return wrapper.elements.compactMap { el -> POI? in
                 guard let lat = el.lat, let lon = el.lon, let tags = el.tags else { return nil }
                 let nameEn = tags["name:en"]
-                let name = tags["name"] ?? nameEn ?? ""
+                // Prefer romanized/English so the UI doesn't mix scripts; the
+                // raw `name` tag is the country's native language (e.g. Lao).
+                let name = nameEn ?? tags["int_name"] ?? tags["name:en-Latn"] ?? tags["name"] ?? ""
                 guard !name.isEmpty else { return nil }
                 return POI(osmId: el.id, name: name, nameEn: nameEn, lat: lat, lon: lon, tags: tags)
             }

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -367,7 +367,11 @@ public final class MapViewModel {
         let center = locationService.currentLocation?.coordinate ?? defaultCenterForSelectedCity
         let radiusKm = max(1.0, preferences.maxDistanceKm)
         let nearby = applyFilters(near: center, radiusKm: radiusKm)
-        visibleExperiences = nearby
+        // Animate the marker set so filter changes fade pins in/out instead
+        // of flashing the whole layer.
+        withAnimation(.easeInOut(duration: 0.25)) {
+            visibleExperiences = nearby
+        }
         nearbySoloCount = computeNearbySoloCount(in: nearby)
         updateBottomInfo()
     }
@@ -552,10 +556,14 @@ public final class MapViewModel {
     /// reacting to user pan/zoom — that would create a feedback loop where
     /// every gesture resets the zoom level.
     public func recenter(on coordinate: CLLocationCoordinate2D) {
-        cameraPosition = .region(MKCoordinateRegion(
-            center: coordinate,
-            span: MKCoordinateSpan(latitudeDelta: 0.04, longitudeDelta: 0.04)
-        ))
+        // Animate the camera so an explicit "locate me" glides into place
+        // instead of snapping, matching focusOnExperience's feel.
+        withAnimation(.smooth(duration: 0.35)) {
+            cameraPosition = .region(MKCoordinateRegion(
+                center: coordinate,
+                span: MKCoordinateSpan(latitudeDelta: 0.04, longitudeDelta: 0.04)
+            ))
+        }
         loadNearbyExperiences()
         updateBottomInfo()
     }
@@ -565,7 +573,9 @@ public final class MapViewModel {
     public func refreshForLocation(_ coordinate: CLLocationCoordinate2D) {
         let radiusKm = max(1.0, preferences.maxDistanceKm)
         let nearby = applyFilters(near: coordinate, radiusKm: radiusKm)
-        visibleExperiences = nearby
+        withAnimation(.easeInOut(duration: 0.25)) {
+            visibleExperiences = nearby
+        }
         nearbySoloCount = computeNearbySoloCount(in: nearby)
         updateBottomInfo()
     }

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -409,7 +409,8 @@ public struct CompassMapView: View {
                                     MarkerIconView(
                                         category: exp.category,
                                         state: viewModel.markerState(for: exp),
-                                        confidenceLevel: exp.confidence.level
+                                        confidenceLevel: exp.confidence.level,
+                                        isSelected: viewModel.selectedExperience?.id == exp.id
                                     )
                                     if case .footprinted = viewModel.markerState(for: exp) {
                                         Text("\(viewModel.footprintCount(for: exp))")
@@ -422,6 +423,7 @@ public struct CompassMapView: View {
                                 }
                             }
                             .buttonStyle(.plain)
+                            .transition(.scale.combined(with: .opacity))
                         }
                     }
                 }
@@ -454,7 +456,7 @@ public struct CompassMapView: View {
                         repeat {
                             try? await Task.sleep(for: .milliseconds(100))
                             if Task.isCancelled { return }
-                        } while Date().timeIntervalSince(lastPanAt) < 1.5
+                        } while Date().timeIntervalSince(lastPanAt) < 0.8
                         if !Task.isCancelled {
                             isMapPanning = false
                         }

--- a/apps/ios/SoloCompass/Views/Map/MarkerIconView.swift
+++ b/apps/ios/SoloCompass/Views/Map/MarkerIconView.swift
@@ -12,6 +12,9 @@ public struct MarkerIconView: View {
     let category: ExperienceCategory
     let state: ExperienceMarkerState
     let confidenceLevel: Int
+    /// Whether this marker is the currently selected experience. Drives a
+    /// scale-up + accent ring so the user can see which pin they tapped.
+    let isSelected: Bool
 
     @Environment(\.themeService) private var themeService
     @State private var pulse = false
@@ -19,11 +22,13 @@ public struct MarkerIconView: View {
     public init(
         category: ExperienceCategory,
         state: ExperienceMarkerState,
-        confidenceLevel: Int = 5
+        confidenceLevel: Int = 5,
+        isSelected: Bool = false
     ) {
         self.category = category
         self.state = state
         self.confidenceLevel = confidenceLevel
+        self.isSelected = isSelected
     }
 
     /// True when this marker should render in "AI-generated, low
@@ -45,6 +50,16 @@ public struct MarkerIconView: View {
     @ViewBuilder
     private var defaultMarkerBody: some View {
         ZStack {
+            // Selection ring — a white-haloed accent circle behind the pin so
+            // the tapped marker reads as "active" without changing its color.
+            if isSelected {
+                Circle()
+                    .stroke(category.color, lineWidth: 3)
+                    .background(Circle().fill(.white.opacity(0.9)))
+                    .frame(width: 50, height: 50)
+                    .shadow(color: category.color.opacity(0.5), radius: 6)
+            }
+
             // Pulse ring for "best now" (suppress on low-confidence — we
             // don't want AI-guessed entries imitating verified excitement)
             if case .bestNow = state, !isLowConfidence {
@@ -72,6 +87,8 @@ public struct MarkerIconView: View {
             adornment
         }
         .frame(width: 44, height: 44)
+        .scaleEffect(isSelected ? 1.3 : 1.0)
+        .animation(.spring(response: 0.3, dampingFraction: 0.6), value: isSelected)
         .accessibilityLabel(Text(accessibilityLabel))
         .accessibilityIdentifier(accessibilityIdentifier)
     }

--- a/packages/sources/osm/src/adapter.ts
+++ b/packages/sources/osm/src/adapter.ts
@@ -102,7 +102,11 @@ function elementCoords(el: OverpassElement): readonly [number, number] | undefin
 }
 
 function elementTitle(tags: Record<string, string>): string {
-  return tags["name"] ?? tags["name:en"] ?? tags["ref"] ?? "";
+  // Prefer romanized/English so synthesized titles don't surface native
+  // scripts (the raw `name` tag is the country's local language, e.g. Lao).
+  return (
+    tags["name:en"] ?? tags["int_name"] ?? tags["name:en-Latn"] ?? tags["name"] ?? tags["ref"] ?? ""
+  );
 }
 
 function elementDescription(tags: Record<string, string>): string {


### PR DESCRIPTION
## Summary
- **English-first POI/city naming** — OSM's `name` tag is the country's native language (Lao, Thai, …), so preferring it over `name:en` surfaced mixed scripts in one list. Both the iOS Overpass decoder and the TS OSM adapter now resolve titles via `name:en → int_name → name:en-Latn → name → ref`. (#129)
- **Selected-marker feedback** — tapping a pin now scales it up with a spring + accent ring, so users see which marker they hit. (#131)
- **Camera + transitions** — `recenter()` animates the camera instead of snapping (#132); marker-set updates fade pins in/out via `withAnimation` + scale/opacity transition instead of flashing, and pan-refresh debounce drops 1.5s → 0.8s. (#133)
- **Docs** — CLAUDE.md sim examples iPhone 16 Pro → 17 Pro (CI left untouched, see #130).

## Test plan
- [x] `@solo-compass/sources-osm` typecheck + 25 unit tests pass
- [x] iOS `xcodebuild build` succeeds (iPhone 17 Pro)
- [x] iOS unit tests pass — except 2 StoreKit tests failing with `SKInternalErrorDomain Code=3` (env-only, no `.storekit` config; unrelated to this diff — tracked in #134)
- [ ] **Manual sim verification needed**: tap a pin (selection scale/ring feel), tap "locate me" (smooth camera), switch filters + drag map (pins fade, no flash; 0.8s refresh lag acceptable)

## Notes
- Residual: a POI with no romanized tag at all still falls back to native script — full romanization needs client-side `CFStringTransform` (tracked in #134).

Closes #129, #130, #131, #132, #133