### PR TITLE
feat(ios): integrate sentry-cocoa for crash & error tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,9 @@ TELEGRAM_BOT_TOKEN=
 DEVELOPMENT_TEAM=XXXXXXXXXX
 
 # ─── Sentry (error tracking) ──────────────────────────────────────────────────
+# Get a DSN at: https://sentry.io → Settings → Projects → <project> → Client Keys
+# Empty value disables Sentry on iOS (SentryService.bootstrap becomes a no-op);
+# DSN is baked into the iOS binary at build time via scripts/generate_secrets.sh.
 SENTRY_DSN=
 # Same value as SENTRY_DSN but exposed to browser bundles via Next.js public env
 NEXT_PUBLIC_SENTRY_DSN=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ packages/
 
 | Layer        | Choice                                                       | Notes                                                                                                                                                |
 | ------------ | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Platform     | **iOS 17.0+**, Swift 5.10                                    | Single Xcode target `SoloCompass.app`, **zero third-party deps**                                                                                     |
+| Platform     | **iOS 17.0+**, Swift 5.10                                    | Single Xcode target `SoloCompass.app`. SwiftPM deps kept minimal: `supabase-swift` (sync backend), `sentry-cocoa` (crash & error tracking)           |
 | Project gen  | **xcodegen** from `apps/ios/project.yml`                     | Regenerate after editing the yml; don't hand-edit `.xcodeproj`                                                                                       |
 | UI           | SwiftUI + **MapKit**                                         | `CompassMapView` is the root — no tabs, no drawer                                                                                                    |
 | State        | `@Observable` + `@MainActor` services                        | `SWIFT_STRICT_CONCURRENCY: complete` is on                                                                                                           |
@@ -44,6 +44,7 @@ packages/
 | AI           | Anthropic Messages API direct                                | `AIService.swift`, model `claude-opus-4-7`, key from `Secrets.plist` or `ANTHROPIC_API_KEY` env. Falls back to Solo-Score ranking when key is absent |
 | Seed data    | `Resources/JSON/seed_experiences.json` (bundle)              | Falls back to `ExperienceService.hardcodedSeed` for previews/tests                                                                                   |
 | Localization | `NSLocalizedString` from day 1                               | All user strings in `Resources/en.lproj/Localizable.strings`                                                                                         |
+| Telemetry    | **sentry-cocoa** via SwiftPM                                 | `SentryService.bootstrap()` in `SoloCompassApp.init`; DSN from `Secrets.sentryDSN` (build-time inject); empty DSN → SDK never starts (no-op)         |
 
 ## Project Structure
 

--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		641D80BD116D6F255A9ED26A /* PendingSyncRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A92E0AE1868C3A165F3E95 /* PendingSyncRecord.swift */; };
 		65E57E8B02E7889BD8EE8DD4 /* ContextManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1F5F43F42E03BA5F10FA2F /* ContextManager.swift */; };
 		6AA87132BC6ACDDDC6D98735 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF007DB5F72E30021CADA555 /* NetworkMonitor.swift */; };
+		6F8492E7BB9870C7E4C99CA1 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 7F7384A5D63B5A4A7371F923 /* Sentry */; };
 		73A99E8CB82341F557681FCF /* GlassmorphismCapsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5933575E731D8AC09356AB9F /* GlassmorphismCapsule.swift */; };
 		7C14629A3FAB31975BFBB0A6 /* ExperienceRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A250916F91C8EF0BE90DF763 /* ExperienceRepository.swift */; };
 		7D2B6DE6C27E0307CA998A5F /* CityPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873ACB737A9B43254C17B238 /* CityPickerSheet.swift */; };
@@ -99,6 +100,7 @@
 		D7CC906B358ED5337880A942 /* seed_experiences.json in Resources */ = {isa = PBXBuildFile; fileRef = 61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */; };
 		D825B4D4C81AC33373DA1437 /* AgentMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DCEFC3560FED53D0CB5D19 /* AgentMessage.swift */; };
 		E0DDDA434921159DDD70F035 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4442EDB5CE3602DA3EA32725 /* Assets.xcassets */; };
+		E33DAAF27B2C41B91EC74345 /* SentryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE5D2141CB2B68B7F1C560E /* SentryService.swift */; };
 		E5F463CE3CE822F7F96CA82C /* SoloCompassApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71DE291BE5569E719413B74 /* SoloCompassApp.swift */; };
 		E611DCAFD85FC84D6BF6CADD /* FoursquareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAE302128E657E150C4B0D /* FoursquareService.swift */; };
 		E7B5B022519434F7C07818CF /* ExperienceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F087E4FA7161529378098C /* ExperienceService.swift */; };
@@ -233,6 +235,7 @@
 		EB579F3F4EBBA014AA306DD1 /* SoloScoreBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloScoreBadge.swift; sourceTree = "<group>"; };
 		EC8F9EFD56A2C839428AA92D /* ConfidenceBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfidenceBadge.swift; sourceTree = "<group>"; };
 		ED3CB5045CE59A613B5CAAF5 /* SoloCompassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassTests.swift; sourceTree = "<group>"; };
+		EDE5D2141CB2B68B7F1C560E /* SentryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryService.swift; sourceTree = "<group>"; };
 		F4814DBCEAB5975B6338558D /* AIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIService.swift; sourceTree = "<group>"; };
 		F63FDD874A8F533F0717132A /* UserPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPreferences.swift; sourceTree = "<group>"; };
 		F7FB43528F45882868CCC203 /* NavigationLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLauncherTests.swift; sourceTree = "<group>"; };
@@ -246,6 +249,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				50140E7D5FFAC2588C141A3F /* Supabase in Frameworks */,
+				6F8492E7BB9870C7E4C99CA1 /* Sentry in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -420,6 +424,7 @@
 				67173C74F1A76C3CE5C38C0A /* OverpassService.swift */,
 				64BDF8B4B7CC82F3845C5068 /* ReverseGeocodeService.swift */,
 				746139AC01A1D37CE002BFCF /* ReviewsService.swift */,
+				EDE5D2141CB2B68B7F1C560E /* SentryService.swift */,
 				33B8A80F048D74BEDB8C1132 /* SubscriptionService.swift */,
 				E406C379247653B4AA5A3E0E /* SupabaseClient.swift */,
 				6163572F4644BF852B35FDA4 /* SyncService.swift */,
@@ -596,6 +601,7 @@
 			name = SoloCompass;
 			packageProductDependencies = (
 				EE5F70FDF5F3A929496EC981 /* Supabase */,
+				7F7384A5D63B5A4A7371F923 /* Sentry */,
 			);
 			productName = SoloCompass;
 			productReference = 9945A4E03F4C75ED89674594 /* SoloCompass.app */;
@@ -649,6 +655,7 @@
 			mainGroup = 8D1441732E5DC5479DD56C18;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				D857C2B82381EF138F3812F2 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				9CED3AAE0D001036D45C96A4 /* XCRemoteSwiftPackageReference "supabase-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -787,6 +794,7 @@
 				62BB74EC16B92899A9A6A44C /* ReverseGeocodeService.swift in Sources */,
 				ADD51496532A0B763048AF5B /* ReviewsService.swift in Sources */,
 				FBE9F5951D501A611EB19EEC /* SecretsRuntime.swift in Sources */,
+				E33DAAF27B2C41B91EC74345 /* SentryService.swift in Sources */,
 				58B7C9B20945838F81081941 /* SettingsView.swift in Sources */,
 				C72A178F41BDB482E0E02C39 /* ShareCardComponents.swift in Sources */,
 				987A873E2C50C8064135E1EF /* ShareCardModel.swift in Sources */,
@@ -1091,9 +1099,22 @@
 				minimumVersion = 2.0.0;
 			};
 		};
+		D857C2B82381EF138F3812F2 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.36.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		7F7384A5D63B5A4A7371F923 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D857C2B82381EF138F3812F2 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
+		};
 		EE5F70FDF5F3A929496EC981 /* Supabase */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 9CED3AAE0D001036D45C96A4 /* XCRemoteSwiftPackageReference "supabase-swift" */;

--- a/apps/ios/SoloCompass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/ios/SoloCompass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "5f3436049b395fcbc71828c07d82e81a46af698ebe0b146cdc52345a5a60558d",
+  "originHash" : "f426721f2a0daaf973b9d1e358d60db27442a4428b8b9c0cdc3cc1d54128f42a",
   "pins" : [
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "cf44aa8cb4147f39e698c1f28be0b6b2c89f79d2",
+        "version" : "8.58.2"
+      }
+    },
     {
       "identity" : "supabase-swift",
       "kind" : "remoteSourceControl",

--- a/apps/ios/SoloCompass/App/SoloCompassApp.swift
+++ b/apps/ios/SoloCompass/App/SoloCompassApp.swift
@@ -3,6 +3,12 @@ import SwiftData
 
 @main
 struct SoloCompassApp: App {
+    init() {
+        // Start Sentry as early as possible so we catch crashes during the
+        // rest of App init / first render. No-op when DSN is empty.
+        SentryService.bootstrap()
+    }
+
     @State private var locationService = LocationService.shared
     @State private var experienceService = ExperienceService()
     @State private var aiService = AIService()

--- a/apps/ios/SoloCompass/Services/SentryService.swift
+++ b/apps/ios/SoloCompass/Services/SentryService.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Sentry
+
+/// Single entry point for Sentry SDK lifecycle and manual capture.
+///
+/// `Secrets.sentryDSN` is generated from `.env` by `scripts/generate_secrets.sh`.
+/// When the DSN is empty (local dev without a `.env`, or CI without secrets)
+/// we skip `SentrySDK.start` entirely — no-op rather than crash.
+///
+/// Automatic capture once started:
+///   - Unhandled NSExceptions / Swift fatal errors
+///   - Mach signals (SIGSEGV, SIGABRT, …)
+///   - App hangs / ANR (>2s main-thread block)
+///   - Network breadcrumbs (NSURLSession)
+///   - UIKit lifecycle breadcrumbs
+///   - Low-memory warnings
+///
+/// Manual capture: `SentryService.capture(error:)` / `capture(message:)` —
+/// safe to call even when the SDK was skipped (DSN absent).
+@MainActor
+public enum SentryService {
+    /// Idempotent. Safe to call from `SoloCompassApp` `onAppear` / `init`.
+    public static func bootstrap() {
+        guard !didStart else { return }
+        let dsn = Secrets.sentryDSN
+        guard !dsn.isEmpty else {
+            #if DEBUG
+            print("[Sentry] DSN empty — skipping SentrySDK.start (set SENTRY_DSN in .env to enable)")
+            #endif
+            return
+        }
+
+        SentrySDK.start { options in
+            options.dsn = dsn
+            options.releaseName = Self.releaseString
+            options.environment = Self.environmentString
+            // Crash, hang, and signal handlers are on by default; keep them.
+            options.enableAutoPerformanceTracing = true
+            options.enableAppHangTracking = true
+            options.enableNetworkBreadcrumbs = true
+            options.enableUIViewControllerTracing = true
+            // Sampling — tune up/down per traffic. 20% is a reasonable start
+            // that keeps the free-tier quota usable.
+            options.tracesSampleRate = 0.2
+            // Don't ship PII; location/voice/chat content stays local.
+            options.sendDefaultPii = false
+            #if DEBUG
+            options.debug = true
+            options.diagnosticLevel = .warning
+            #endif
+        }
+        didStart = true
+    }
+
+    /// Capture an error from a `catch` block or a `Result.failure` path.
+    public static func capture(error: Error, context: [String: Any] = [:]) {
+        guard didStart else { return }
+        SentrySDK.capture(error: error) { scope in
+            Self.apply(context: context, to: scope)
+        }
+    }
+
+    /// Capture a non-error event (e.g. a recoverable warning worth tracking).
+    public static func capture(
+        message: String,
+        level: SentryLevel = .warning,
+        context: [String: Any] = [:]
+    ) {
+        guard didStart else { return }
+        SentrySDK.capture(message: message) { scope in
+            scope.setLevel(level)
+            Self.apply(context: context, to: scope)
+        }
+    }
+
+    // MARK: - Private
+
+    private static var didStart = false
+
+    private static func apply(context: [String: Any], to scope: Scope) {
+        guard !context.isEmpty else { return }
+        scope.setContext(value: context, key: "extra")
+    }
+
+    private static var releaseString: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+        let bundleId = Bundle.main.bundleIdentifier ?? "com.solocompass.app"
+        return "\(bundleId)@\(version)+\(build)"
+    }
+
+    private static var environmentString: String {
+        #if DEBUG
+        return "debug"
+        #else
+        return "release"
+        #endif
+    }
+}

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -99,6 +99,8 @@ targets:
     dependencies:
       - package: Supabase
         product: Supabase
+      - package: Sentry
+        product: Sentry
 
   SoloCompassTests:
     type: bundle.unit-test
@@ -123,6 +125,9 @@ packages:
   Supabase:
     url: https://github.com/supabase/supabase-swift
     from: 2.0.0
+  Sentry:
+    url: https://github.com/getsentry/sentry-cocoa
+    from: 8.36.0
 
 schemes:
   SoloCompass:

--- a/docs/SENTRY.md
+++ b/docs/SENTRY.md
@@ -1,0 +1,144 @@
+# Sentry — error tracking & auto-issue intake
+
+## What it does
+
+- **iOS app** (`apps/ios/SoloCompass`) ships with `sentry-cocoa` via SwiftPM.
+- `SentryService.bootstrap()` runs in `SoloCompassApp.init` with DSN baked in
+  from `Secrets.sentryDSN` (generated from `.env` → `GeneratedSecrets.swift`).
+- Empty DSN → `SentrySDK.start` is skipped (no crash, no-op).
+
+### Automatic capture
+
+- Unhandled NSExceptions / Swift fatal errors
+- Mach signals (SIGSEGV / SIGABRT / …)
+- App hangs / ANR (>2s main-thread block)
+- Network breadcrumbs (NSURLSession)
+- UIKit lifecycle breadcrumbs
+- Low-memory warnings
+- 20% traces sample (perf transactions) — tune in `SentryService.swift`
+
+### Manual capture
+
+```swift
+do {
+    try riskyThing()
+} catch {
+    SentryService.capture(error: error, context: ["where": "ChatSheet.send"])
+}
+
+SentryService.capture(
+    message: "Outbox grew past 100 items",
+    level: .warning,
+    context: ["count": outbox.count]
+)
+```
+
+PII is off (`sendDefaultPii = false`); location / voice / chat content stays local.
+
+---
+
+## Setup
+
+1. Get the DSN from Sentry → **Settings → Projects → solo-compass → Client Keys (DSN)**.
+2. Paste into your local `.env` (root of repo):
+   ```
+   SENTRY_DSN=https://<public_key>@o<org>.ingest.us.sentry.io/<project_id>
+   ```
+3. Build the iOS app — `scripts/generate_secrets.sh` injects the DSN into
+   `GeneratedSecrets.swift` at build time.
+4. For CI / TestFlight builds, put `SENTRY_DSN` in the GitHub Actions secret
+   used by the build job (same name).
+
+---
+
+## Auto-issue intake (Sentry → GitHub Issues)
+
+There are two ways to land Sentry events as GitHub issues. We recommend
+**Sentry's native GitHub integration** — it's the lowest-maintenance path.
+
+### Option A — Sentry's native GitHub integration (recommended)
+
+1. **Install integration** (one-time, per org)
+   - Sentry → **Settings → Integrations → GitHub → Install**
+   - Authorize for the `getyak` org (or whichever GitHub org owns this repo)
+   - Pick the repos to enable; include `getyak/solo-compass`
+
+2. **Link the project to the repo**
+   - Sentry → **Settings → Projects → solo-compass → Integrations → GitHub**
+   - Set default repo = `getyak/solo-compass`
+
+3. **Auto-create issues via Alert Rules**
+   - Sentry → **Alerts → Create Alert → Issues**
+   - Trigger: e.g. `event.type:error AND environment:release`
+     (skip `debug` — `SentryService` sets `environment = debug` for `#if DEBUG`)
+   - Filter — pick whichever combo fits the noise floor:
+     - `level:error OR level:fatal`
+     - `is:unresolved`
+     - `times_seen:>=3` (avoid one-off flukes)
+   - Action: **Create a GitHub Issue**
+     - Repo: `getyak/solo-compass`
+     - Labels: `bug`, `from:sentry`
+     - Title template: `[Sentry] {{ issue.title }}`
+     - Body: Sentry fills in the event link, stack trace, and breadcrumbs
+
+4. **Manual one-off** — on any Sentry issue page, the right-hand
+   **Linked Issues** panel has a "Create GitHub Issue" button that bypasses
+   the alert rule.
+
+### Option B — Webhook + GitHub Actions (more control)
+
+Use this if you want custom title formatting, deduping logic, or routing to
+different repos based on tags. More moving parts; only worth it once Option A
+shows real limitations.
+
+Sketch:
+
+1. Sentry → **Settings → Projects → solo-compass → Alerts → Send a
+   notification → Webhook**
+2. Webhook URL → `https://api.github.com/repos/getyak/solo-compass/dispatches`
+   with a `repository_dispatch` event type like `sentry_event`.
+3. `.github/workflows/sentry-to-issue.yml` listens for
+   `repository_dispatch: types: [sentry_event]` and runs
+   `gh issue create --title ... --body ...` with the payload from the webhook.
+
+Skipping the YAML stub on purpose — write it when you actually need Option B.
+
+---
+
+## Deduping
+
+Sentry already groups events into **Issues** by stack-trace fingerprint, so a
+crash that fires 1000 times in a day creates **one** Sentry issue → **one**
+GitHub issue. Reopened (regression) events post a comment back to the same
+GitHub issue instead of opening a new one — provided the GitHub integration
+is the linked source.
+
+If duplicates ever appear, check that the alert rule filter is `is:unresolved`
+(not `is:new`), and that the GitHub integration is installed at the org level,
+not just the user level.
+
+---
+
+## Sample rate
+
+`SentryService.tracesSampleRate = 0.2` (20%) — change in `SentryService.swift`.
+At ≥5K MAU consider 0.05 to stay inside the free tier's transaction quota.
+Error events are not sampled; every crash is sent.
+
+---
+
+## Verifying the integration
+
+After setup:
+
+```swift
+// Temporarily add to any view's onTapGesture and tap once in a release build:
+SentryService.capture(message: "smoke test", level: .error)
+```
+
+Within ~30s you should see:
+
+1. A new event in Sentry (Issues view)
+2. A new GitHub issue in `getyak/solo-compass` with label `from:sentry`
+
+Remove the test line before merging.


### PR DESCRIPTION
## Summary
Wire `sentry-cocoa` via SwiftPM and bootstrap it in `SoloCompassApp.init`. Unhandled crashes, signals, ANRs, and manual `capture(error:)` calls flow into the Sentry project. DSN is baked in from `Secrets.sentryDSN` (generated from `.env` at build time); an empty DSN makes `SentryService.bootstrap` a silent no-op so local dev / CI without secrets still compile-and-run.

### What ships
- **`SentryService`** — idempotent bootstrap with release/env metadata, 20% trace sampling, `sendDefaultPii = false` (location/voice/chat stay local). `capture(error:)` / `capture(message:)` for manual reporting.
- **`project.yml`** — add `sentry-cocoa` SwiftPM dep (from 8.36.0) + regenerated `.xcodeproj` + `Package.resolved`.
- **`docs/SENTRY.md`** — setup + Sentry-native GitHub integration recipe so alerts auto-open GH issues (deduped by stack-trace fingerprint).
- **`.env.example`** — clarify `SENTRY_DSN` behavior on iOS.
- **`CLAUDE.md`** — update iOS stack table: "zero deps" → "minimal deps: supabase-swift, sentry-cocoa" (Supabase was already breaking the rule; this just makes it honest).

### Auto-issue intake (Sentry → GitHub Issues)
Configuration is **out of band** (lives in Sentry's UI, not this PR). Recipe in `docs/SENTRY.md`:
1. Sentry → Settings → Integrations → GitHub → install for `getyak` org
2. Project → Integrations → link `getyak/solo-compass`
3. Alerts → Create Alert → Issues → action: **Create GitHub Issue**, label `from:sentry`, filter `is:unresolved AND environment:release`
4. Done — Sentry's grouping fingerprint dedupes, so 1000-event crash storm = 1 GH issue.

## Test plan
- [x] `xcodebuild build` (iPhone 17 Pro, latest iOS) → BUILD SUCCEEDED (SPM resolved sentry-cocoa 8.x)
- [ ] With DSN unset → app launches normally, no Sentry events, no crash
- [ ] With DSN set → DEBUG log shows SentrySDK init; manual `SentryService.capture(message: "smoke test", level: .error)` lands in Sentry within ~30s
- [ ] After enabling the GitHub integration + alert rule, the smoke-test event auto-opens an issue with label `from:sentry`

## Follow-ups (not in this PR)
- Enable the GitHub integration + alert rule in Sentry UI (steps in `docs/SENTRY.md`)
- Put `SENTRY_DSN` in the CI / TestFlight build job's secrets
- Consider wiring `SentryService.capture(error:)` into existing `catch` sites (Anthropic API failures, Supabase sync errors) — separate PR