### PR TITLE
fix(ios): make Explore reach AI synthesis + honest un-enriched cards

### DIFF
--- a/apps/ios/SoloCompass/App/SoloCompassApp.swift
+++ b/apps/ios/SoloCompass/App/SoloCompassApp.swift
@@ -5,7 +5,11 @@ import SwiftData
 struct SoloCompassApp: App {
     @State private var locationService = LocationService.shared
     @State private var experienceService = ExperienceService()
-    @State private var aiService = AIService()
+    // Share the global SwiftData container so AIService's quota tracking
+    // (AIUsageRecord) and synthesis cache (AISynthesisCacheRecord) actually
+    // persist. A bare AIService() leaves modelContext nil, silently disabling
+    // both — which masks why Explore never escapes skeleton mode.
+    @State private var aiService = AIService(useSharedCache: true)
     @State private var preferences = UserPreferences()
     @State private var notificationService = NotificationService.shared
     @State private var subscriptionService = SubscriptionService()

--- a/apps/ios/SoloCompass/Models/Experience.swift
+++ b/apps/ios/SoloCompass/Models/Experience.swift
@@ -398,6 +398,19 @@ public struct Experience: Codable, Hashable, Identifiable {
 
     public var coordinate: CLLocationCoordinate2D? { location.clCoordinate }
 
+    /// True when this entry was discovered via OpenStreetMap Explore
+    /// (vs. a curated seed entry). Used to surface provenance in the UI.
+    public var isFromOpenStreetMap: Bool { id.hasPrefix("exp_osm_") }
+
+    /// True only when the entry actually went through AI synthesis. The
+    /// `skeletonExperience` fallback (network/quota failure, missing key)
+    /// produces an OSM entry with no AI enrichment — its sources omit the
+    /// "+ AI" attribution. Distinguishing the two prevents the detail view
+    /// from labelling a raw, template-filled skeleton as "AI-generated".
+    public var isAIEnriched: Bool {
+        sources.contains { ($0.attribution ?? "").localizedCaseInsensitiveContains("AI") }
+    }
+
     /// Returns a new Experience with selected fields overridden. Use this when
     /// mutating tracked stats/status/etc. without rewriting all 18 init args.
     public func copy(

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -274,6 +274,7 @@
 /* Explore here */
 "explore.button" = "Explore here";
 "explore.aiBadge" = "AI-generated · OpenStreetMap";
+"explore.osmBadge" = "OpenStreetMap · not enriched";
 "explore.error.nothingFound" = "No public places found nearby. Try moving the map.";
 "explore.skeleton.oneLiner" = "A real spot pulled from OpenStreetMap.";
 "explore.skeleton.why" = "We don't have a curated story for this place yet. Visit, then add what you found.";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -260,6 +260,7 @@
 /* Explore here */
 "explore.button" = "在这里探索";
 "explore.aiBadge" = "AI 生成 · 来自 OpenStreetMap";
+"explore.osmBadge" = "来自 OpenStreetMap · 未增强";
 "explore.error.nothingFound" = "附近没找到公共场所。试试拖动地图。";
 "explore.skeleton.oneLiner" = "一处来自 OpenStreetMap 的真实地点。";
 "explore.skeleton.why" = "我们还没有这个地方的精选故事。去看看,然后告诉我们你发现了什么。";

--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -164,10 +164,24 @@ public final class AIService {
         }
     }
 
-    public func explainRecommendation(for experienceId: String) async throws -> String {
+    public func explainRecommendation(for experience: Experience) async throws -> String {
+        // Feed the model the actual place — name, category, city, and
+        // coordinate. Passing only the opaque id (the previous behaviour)
+        // gave the model nothing to ground on, so it hallucinated
+        // unrelated landmarks (e.g. describing a SF plaza as the Alhambra).
+        let coord = experience.coordinate
+        let coordText = coord.map { String(format: "%.4f, %.4f", $0.latitude, $0.longitude) } ?? "unknown"
         let prompt = """
-        Explain in one warm, concrete sentence why a solo traveler would value the experience with id \"\(experienceId)\". \
-        Avoid superlatives. Focus on a sensory detail.
+        A real place from OpenStreetMap:
+        - Name: \(experience.title)
+        - Category: \(experience.category.rawValue)
+        - City code: \(experience.location.cityCode)
+        - Coordinate (lat, lon): \(coordText)
+
+        Explain in one warm, concrete sentence why a solo traveler would value visiting THIS specific place. \
+        Ground every detail in the name/category above — do NOT invent unrelated landmarks, history, or features. \
+        If you cannot say anything specific, describe what a solo traveler typically does at a place of this category. \
+        Avoid superlatives. Focus on a plausible sensory detail.
         """
         do {
             return try await sendMessage(prompt: prompt, kind: .explanation)
@@ -757,7 +771,12 @@ public final class AIService {
         } catch {
             // Skeleton fallback — never written to cache so a
             // transient network blip doesn't poison the cache for 30
-            // days.
+            // days. Log the cause: this catch used to swallow the error
+            // silently, which made "Explore only ever shows skeletons"
+            // impossible to diagnose from the outside.
+            #if DEBUG
+            print("[AIService] synthesis failed, falling back to skeleton: \(error)")
+            #endif
             return capped.map { Self.skeletonExperience(from: $0, cityCode: cityCode) }
         }
     }

--- a/apps/ios/SoloCompass/Services/SubscriptionService.swift
+++ b/apps/ios/SoloCompass/Services/SubscriptionService.swift
@@ -77,6 +77,19 @@ public final class SubscriptionService {
         // entitlement fetch, so we never miss a renewal that arrives
         // mid-launch.
         startTransactionListener()
+
+        #if DEBUG
+        // Debug builds default to Pro so the simulator can exercise the
+        // AI-gated surfaces (Explore, AI Insight, voice) without a StoreKit
+        // sandbox. Set FF_DEBUG_FORCE_PRO=0 to test the free/paywall path.
+        // Stripped entirely from Release builds by the #if DEBUG guard.
+        // Sets the in-memory field directly (not setEntitlement) so we don't
+        // persist a fake Pro state to Keychain.
+        let env = ProcessInfo.processInfo.environment["FF_DEBUG_FORCE_PRO"]
+        if env != "0" && env?.lowercased() != "false" {
+            self.entitlement = .pro
+        }
+        #endif
     }
 
     deinit {
@@ -108,6 +121,17 @@ public final class SubscriptionService {
     /// Walk Transaction.currentEntitlements and pick the strongest
     /// entitlement. Updates `entitlement` and writes through to Keychain.
     public func refreshEntitlement() async {
+        #if DEBUG
+        // Honour the debug Pro override (set in init from FF_DEBUG_FORCE_PRO).
+        // Without this, the StoreKit walk below resolves .free on a simulator
+        // with no sandbox subscription and overwrites the forced .pro — which
+        // silently routes Explore through the free/skeleton path.
+        let env = ProcessInfo.processInfo.environment["FF_DEBUG_FORCE_PRO"]
+        if env != "0" && env?.lowercased() != "false" {
+            if entitlement != .pro { setEntitlement(.pro) }
+            return
+        }
+        #endif
         var resolved: Entitlement = .free
         var latestTransaction: Transaction?
         for await result in Transaction.currentEntitlements {

--- a/apps/ios/SoloCompass/ViewModels/ExperienceDetailViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/ExperienceDetailViewModel.swift
@@ -111,7 +111,16 @@ public final class ExperienceDetailViewModel {
             aiExplanation = NSLocalizedString("detail.aiInsight.gated", comment: "Subscribe to unlock AI Insight")
             return
         }
-        let isOSM = experience.id.hasPrefix("exp_osm_")
+        let isOSM = experience.isFromOpenStreetMap
+        // Skip AI for OSM entries that never went through synthesis (the
+        // skeleton fallback). They carry no real description, so asking the
+        // model to "explain" them only produced hallucinated landmarks. Show
+        // nothing rather than a fabricated AI Insight; the "why it matters"
+        // section keeps the honest "visit and tell us" prompt.
+        if isOSM && !experience.isAIEnriched {
+            aiExplanation = nil
+            return
+        }
         isLoadingAIExplanation = true
         if isOSM { isLoadingWhyItMatters = true }
         defer {
@@ -119,7 +128,7 @@ public final class ExperienceDetailViewModel {
             if isOSM { isLoadingWhyItMatters = false }
         }
         do {
-            aiExplanation = try await aiService.explainRecommendation(for: experience.id)
+            aiExplanation = try await aiService.explainRecommendation(for: experience)
         } catch {
             aiExplanation = nil
             #if DEBUG

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -55,7 +55,12 @@ public struct ExperienceDetailView: View {
                 if !viewModel.experience.realInconveniences.isEmpty {
                     inconveniencesSection
                 }
-                soloScoreSection
+                // Skip the Solo Score for un-enriched OSM entries. Their score
+                // is a flat 7.0 placeholder from skeletonExperience, not a real
+                // estimate — showing it as "Solo Score (AI estimate)" misleads.
+                if !(viewModel.experience.isFromOpenStreetMap && !viewModel.experience.isAIEnriched) {
+                    soloScoreSection
+                }
                 if !viewModel.experience.sources.isEmpty {
                     sourcesSection
                 }
@@ -130,18 +135,21 @@ public struct ExperienceDetailView: View {
 
     private var heroSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            if viewModel.experience.id.hasPrefix("exp_osm_") {
+            if viewModel.experience.isFromOpenStreetMap {
+                let enriched = viewModel.experience.isAIEnriched
+                let badgeKey = enriched ? "explore.aiBadge" : "explore.osmBadge"
+                let badgeText = NSLocalizedString(badgeKey, comment: "Provenance badge")
                 HStack(spacing: 6) {
-                    Image(systemName: "sparkles")
+                    Image(systemName: enriched ? "sparkles" : "mappin.and.ellipse")
                         .font(.caption2)
-                    Text(NSLocalizedString("explore.aiBadge", comment: "AI-generated from OpenStreetMap"))
+                    Text(badgeText)
                         .font(.caption.weight(.medium))
                 }
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
                 .background(Capsule().fill(Color(.tertiarySystemFill)))
-                .accessibilityLabel(Text(NSLocalizedString("explore.aiBadge", comment: "AI-generated from OpenStreetMap")))
+                .accessibilityLabel(Text(badgeText))
             }
             HStack(spacing: 8) {
                 Image(systemName: viewModel.experience.category.symbol)

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -54,38 +54,10 @@ public struct SoloScoreBadge: View {
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
-            VStack(spacing: 6) {
-                breakdownBar(label: NSLocalizedString("solo.seating", comment: ""), value: score.breakdown.seatingFriendly)
-                breakdownBar(label: NSLocalizedString("solo.patrons", comment: ""), value: score.breakdown.soloPatronRatio)
-                breakdownBar(label: NSLocalizedString("solo.staff", comment: ""), value: score.breakdown.staffPressure)
-                breakdownBar(label: NSLocalizedString("solo.portioning", comment: ""), value: score.breakdown.soloPortioning)
-                breakdownBar(label: NSLocalizedString("solo.ambiance", comment: ""), value: score.breakdown.ambianceFit)
-                breakdownBar(label: NSLocalizedString("solo.safety", comment: ""), value: score.breakdown.safety)
-            }
-            Text(String(format: NSLocalizedString("solo.basedOn", comment: ""), score.basedOnCount))
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-        }
-    }
-
-    private func breakdownBar(label: String, value: Double) -> some View {
-        HStack(spacing: 8) {
-            Text(label)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .frame(width: 96, alignment: .leading)
-            GeometryReader { geo in
-                ZStack(alignment: .leading) {
-                    Capsule().fill(Color.gray.opacity(0.2))
-                    Capsule()
-                        .fill(score.scoreColor)
-                        .frame(width: geo.size.width * (value / 10.0))
-                }
-            }
-            .frame(height: 6)
-            Text(formatted(value))
-                .font(.caption.monospacedDigit())
-                .frame(width: 32, alignment: .trailing)
+            // Per-dimension breakdown intentionally omitted: the detail view
+            // renders SoloScoreRadarChart directly below this badge, so a
+            // second bar list would duplicate it. This badge is the score
+            // header only (overall + hint).
         }
     }
 


### PR DESCRIPTION
## Summary

Explore-here entries always rendered as flat-7.0 skeletons posing as "AI-generated". Root cause was a chain of silent gates that degraded the synthesis path before it ever called DeepSeek, plus UI that presented placeholder data as real.

### AI pipeline fixes
- **modelContext injection**: `AIService()` was constructed bare → `modelContext` nil → quota tracking (`AIUsageRecord`) and synthesis cache (`AISynthesisCacheRecord`) silently disabled. Now uses the shared SwiftData container (`useSharedCache: true`).
- **DEBUG Pro override**: `refreshEntitlement()` resolved `.free` on a sandbox-less simulator and overwrote the debug-forced `.pro`, routing auto-Explore through the free → skeleton path. Now honours `FF_DEBUG_FORCE_PRO` in both `init` and `refreshEntitlement`.
- **Observability**: the synthesis `catch` swallowed every error silently (made "only skeletons" undiagnosable). Added a DEBUG log of the failure cause.

### Honesty / UI fixes for un-enriched OSM entries
- Detail badge distinguishes real AI enrichment (**"AI-generated"**) from raw skeletons (**"OpenStreetMap · not enriched"**) via new `Experience.isFromOpenStreetMap` / `.isAIEnriched` (sources attribution contains `"AI"`).
- Hide the placeholder 7.0 Solo Score and the AI Insight section for un-enriched entries instead of showing them as real estimates.
- `explainRecommendation` now feeds the model the actual place (name / category / coordinate) instead of an opaque id — fixes hallucinated landmarks (a SF plaza was described as the Alhambra).
- Removed the duplicate Solo Score breakdown: `SoloScoreBadge(.full)` is now the score header only; the radar chart owns the per-dimension view.

## Test plan
- [x] `xcodebuild build` (iPhone 17 Pro sim) — green
- [ ] Manual: trigger Explore in a fresh region as Pro → verify entries get `+ AI` attribution (differentiated scores, real AI copy, "AI-generated" badge)
- [ ] Manual: confirm un-enriched entries show no 7.0 score / no AI Insight, and the "not enriched" badge
- [ ] Manual: confirm Solo Score section renders a single breakdown (no duplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)