### PR TITLE
auto: Polish swipe-to-unfavorite: haptic + animated removal in Favorites list

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -22,13 +22,17 @@ public struct FavoritesListView: View {
             Group {
                 if sortedFavorites.isEmpty {
                     emptyState
+                        .transition(.opacity)
                 } else {
                     List(sortedFavorites) { exp in
                         favoriteRow(exp)
                     }
                     .listStyle(.plain)
+                    .animation(.easeInOut, value: sortedFavorites.count)
+                    .transition(.opacity)
                 }
             }
+            .animation(.easeInOut, value: sortedFavorites.isEmpty)
             .navigationTitle(NSLocalizedString("favorites.title", comment: "Favorites list title"))
             .navigationBarTitleDisplayMode(.inline)
         }
@@ -88,7 +92,10 @@ public struct FavoritesListView: View {
         .buttonStyle(.plain)
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             Button(role: .destructive) {
-                preferences.toggleFavorite(exp.id)
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
+                withAnimation(.easeInOut) {
+                    preferences.toggleFavorite(exp.id)
+                }
             } label: {
                 Label(NSLocalizedString("action.unfavorite", comment: "Remove from favorites"),
                       systemImage: "heart.slash")


### PR DESCRIPTION
## Auto-Dev: Polish swipe-to-unfavorite: haptic + animated removal in Favorites list

When a user swipes to remove a favorite in FavoritesListView, the row vanishes instantly with no feedback — inconsistent with the detail view, which fires a haptic on every favorite toggle. Add a success haptic and an animated row removal so unfavoriting feels intentional and matches the rest of the app's tactile language.

### Acceptance
Build with xcodebuild for iPhone 17 Pro sim. In the Simulator, open Favorites with ≥2 favorites, swipe a row to remove it: the row should animate out (not snap) and a success haptic should fire (verify on device or via code review of the generator call). Removing the final favorite should crossfade into the heart.slash empty state. #Preview still renders.