### PR TITLE
auto: Polish favorites swipe-to-unfavorite: haptic + animated row removal + undo

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -250,6 +250,10 @@
 "favorites.title" = "Favorites";
 "favorites.empty.title" = "No favorites yet";
 "favorites.empty.hint" = "Tap the heart on any experience to save it here.";
+"favorites.undo" = "Removed — Undo";
+
+/* Generic actions */
+"action.undo" = "Undo";
 
 /* Notifications */
 "settings.notifications" = "Notify me when I'm nearby";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -7,6 +7,9 @@ public struct FavoritesListView: View {
     @Environment(UserPreferences.self) private var preferences
     let onSelectExperience: (Experience) -> Void
 
+    @State private var lastUnfavorited: (id: String, date: Date)?
+    @State private var undoDismissTask: Task<Void, Never>?
+
     private var sortedFavorites: [Experience] {
         let ids = preferences.favoritedExperiences
         let experiences = ids.compactMap { experienceService.getExperience(id: $0) }
@@ -20,7 +23,7 @@ public struct FavoritesListView: View {
     public var body: some View {
         NavigationStack {
             Group {
-                if sortedFavorites.isEmpty {
+                if sortedFavorites.isEmpty && lastUnfavorited == nil {
                     emptyState
                         .transition(.opacity)
                 } else {
@@ -38,6 +41,14 @@ public struct FavoritesListView: View {
         }
         .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)
+        .overlay(alignment: .bottom) {
+            if lastUnfavorited != nil {
+                undoBar
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .padding(.bottom, 16)
+            }
+        }
+        .animation(.easeInOut, value: lastUnfavorited != nil)
     }
 
     private var emptyState: some View {
@@ -53,6 +64,32 @@ public struct FavoritesListView: View {
                 .multilineTextAlignment(.center)
         }
         .padding(32)
+    }
+
+    private var undoBar: some View {
+        HStack {
+            Text(NSLocalizedString("favorites.undo", comment: "Removed — Undo banner"))
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+            Spacer()
+            Button {
+                guard let saved = lastUnfavorited else { return }
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                undoDismissTask?.cancel()
+                undoDismissTask = nil
+                withAnimation(.easeInOut) {
+                    preferences.toggleFavorite(saved.id, at: saved.date)
+                    lastUnfavorited = nil
+                }
+            } label: {
+                Text(NSLocalizedString("action.undo", comment: "Undo action"))
+                    .font(.subheadline.weight(.semibold))
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 16)
     }
 
     @ViewBuilder
@@ -92,9 +129,22 @@ public struct FavoritesListView: View {
         .buttonStyle(.plain)
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             Button(role: .destructive) {
-                UINotificationFeedbackGenerator().notificationOccurred(.success)
+                UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                let savedDate = preferences.favoritedAt[exp.id] ?? Date()
+                let expId = exp.id
                 withAnimation(.easeInOut) {
-                    preferences.toggleFavorite(exp.id)
+                    preferences.toggleFavorite(expId)
+                }
+                lastUnfavorited = (id: expId, date: savedDate)
+                undoDismissTask?.cancel()
+                undoDismissTask = Task {
+                    try? await Task.sleep(for: .seconds(4))
+                    guard !Task.isCancelled else { return }
+                    await MainActor.run {
+                        withAnimation(.easeInOut) {
+                            lastUnfavorited = nil
+                        }
+                    }
                 }
             } label: {
                 Label(NSLocalizedString("action.unfavorite", comment: "Remove from favorites"),


### PR DESCRIPTION
## Polish favorites swipe-to-unfavorite: haptic + animated row removal + undo

In FavoritesListView, swiping to unfavorite removes the row instantly with no haptic and no animation — inconsistent with the rest of the app where destructive/success actions fire UINotificationFeedbackGenerator and list mutations animate. Add a .warning haptic, wrap the mutation in withAnimation for a smooth row collapse, and surface a brief undo affordance so an accidental swipe is recoverable.

### Acceptance
Swiping a favorite row left and tapping unfavorite produces a .warning haptic and the row animates out instead of disappearing instantly; an undo bar appears and auto-dismisses after ~4s; tapping Undo restores the experience to the list (re-sorted by its original favoritedAt) with a .light haptic. App builds (xcodebuild build, iPhone 17 Pro sim) and existing SoloCompassTests pass. No force-unwraps; all new strings localized.