### PR TITLE
feat(ios): Location Picker with Cities/Search/Map tabs

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -118,6 +118,10 @@
 		FA8584E1511404B374B57E66 /* ExploreProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0997D8150E77F70A4B8C64 /* ExploreProgressBar.swift */; };
 		FBE9F5951D501A611EB19EEC /* SecretsRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA8C8BF234F3C74D0D8A9BD /* SecretsRuntime.swift */; };
 		FD3636FCB777A292C57B7B06 /* GuideAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187534C119545F7D61CE693B /* GuideAgent.swift */; };
+		BB11223344556677889900BB /* LocationPickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11223344556677889900AA /* LocationPickerState.swift */; };
+		DD11223344556677889900DD /* LocationSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC11223344556677889900CC /* LocationSearchService.swift */; };
+		FF11223344556677889900FF /* LocationPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE11223344556677889900EE /* LocationPickerSheet.swift */; };
+		2233445566778899001122AB /* MapPinPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1122334455667788990011AB /* MapPinPickerView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -245,6 +249,10 @@
 		F7FB43528F45882868CCC203 /* NavigationLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLauncherTests.swift; sourceTree = "<group>"; };
 		F9263FC2737FA209F3CD4B5E /* ChatSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSheet.swift; sourceTree = "<group>"; };
 		FAFFA243BC698EF20C6BC1EF /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
+		AA11223344556677889900AA /* LocationPickerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationPickerState.swift; sourceTree = "<group>"; };
+		CC11223344556677889900CC /* LocationSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchService.swift; sourceTree = "<group>"; };
+		EE11223344556677889900EE /* LocationPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationPickerSheet.swift; sourceTree = "<group>"; };
+		1122334455667788990011AB /* MapPinPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapPinPickerView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -301,7 +309,9 @@
 				BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */,
 				5AB8B58A4F608F9951CBDF3C /* ExploreConsentSheet.swift */,
 				0A0997D8150E77F70A4B8C64 /* ExploreProgressBar.swift */,
+				EE11223344556677889900EE /* LocationPickerSheet.swift */,
 				0E0157D30FF53B21FF31D519 /* MarkerIconView.swift */,
+				1122334455667788990011AB /* MapPinPickerView.swift */,
 				1C23113554E651AA08FD2430 /* POILoadingBanner.swift */,
 			);
 			path = Map;
@@ -395,6 +405,7 @@
 				0709110B381DEDA32C3292AE /* ChatUIState.swift */,
 				6DFBC1C003B8745713588A23 /* City.swift */,
 				C1C97F8159A6FA7953D28DAB /* Experience.swift */,
+				AA11223344556677889900AA /* LocationPickerState.swift */,
 				F63FDD874A8F533F0717132A /* UserPreferences.swift */,
 			);
 			path = Models;
@@ -421,6 +432,7 @@
 				6556C23BF1B228BF686C5500 /* KeychainStore.swift */,
 				87002BB6D344B384A3FDFBFD /* LanguageService.swift */,
 				2C7919EAFDE363B49C4B4C47 /* LocationService.swift */,
+				CC11223344556677889900CC /* LocationSearchService.swift */,
 				06B7D586552E9F1EA44F5657 /* MapKitPOIService.swift */,
 				54F3FDE4BC9458E490AEA67A /* MarkdownExporter.swift */,
 				D07ACA7C1A1574A244E73796 /* NavigationLauncher.swift */,
@@ -776,6 +788,10 @@
 				953C7BD48AF4AF55608145A6 /* LanguageService.swift in Sources */,
 				23B40396E9D7B59CB71FBCD9 /* LocationCard.swift in Sources */,
 				31F9538643C362D7EEF64C6B /* LocationService.swift in Sources */,
+				BB11223344556677889900BB /* LocationPickerState.swift in Sources */,
+				DD11223344556677889900DD /* LocationSearchService.swift in Sources */,
+				FF11223344556677889900FF /* LocationPickerSheet.swift in Sources */,
+				2233445566778899001122AB /* MapPinPickerView.swift in Sources */,
 				A75EEA586481D5A86B7FCFDA /* MapKitPOIService.swift in Sources */,
 				CE1A6A1D5EB25B2BEA5B29DA /* MapViewModel.swift in Sources */,
 				45A4E8EED0300F00253EC049 /* MarkdownExporter.swift in Sources */,

--- a/apps/ios/SoloCompass/Models/LocationPickerState.swift
+++ b/apps/ios/SoloCompass/Models/LocationPickerState.swift
@@ -1,0 +1,62 @@
+import Foundation
+import CoreLocation
+import MapKit
+import Observation
+
+/// Transient UI state for LocationPickerSheet.
+/// Lifetime: created when the sheet opens, discarded on dismiss.
+@MainActor
+@Observable
+final class LocationPickerState {
+    enum Tab: String, CaseIterable {
+        case cities, search, map
+        var label: String {
+            switch self {
+            case .cities: return NSLocalizedString("locationPicker.tab.cities", comment: "Cities tab")
+            case .search: return NSLocalizedString("locationPicker.tab.search", comment: "Search tab")
+            case .map:    return NSLocalizedString("locationPicker.tab.map",    comment: "Map tab")
+            }
+        }
+    }
+
+    var selectedTab: Tab = .cities
+
+    // MARK: Cities tab
+    var citySearchQuery: String = ""
+
+    // MARK: Search tab
+    var searchQuery: String = ""
+    var searchResults: [MKMapItem] = []
+    var isSearching: Bool = false
+    var searchError: String?
+
+    // MARK: Map tab
+    var pinCoordinate: CLLocationCoordinate2D
+    var manualLatText: String = ""
+    var manualLonText: String = ""
+    var resolvedCityName: String?
+    var isResolving: Bool = false
+
+    init(initialCoordinate: CLLocationCoordinate2D) {
+        self.pinCoordinate = initialCoordinate
+        self.manualLatText = String(format: "%.4f", initialCoordinate.latitude)
+        self.manualLonText = String(format: "%.4f", initialCoordinate.longitude)
+    }
+
+    /// Update the pin coordinate and sync the text fields.
+    func updatePin(to coordinate: CLLocationCoordinate2D) {
+        pinCoordinate = coordinate
+        manualLatText = String(format: "%.4f", coordinate.latitude)
+        manualLonText = String(format: "%.4f", coordinate.longitude)
+        resolvedCityName = nil
+    }
+
+    /// Parse text fields → coordinate. Returns nil if either field is invalid.
+    func parsedCoordinate() -> CLLocationCoordinate2D? {
+        guard let lat = Double(manualLatText),
+              let lon = Double(manualLonText),
+              lat >= -90, lat <= 90,
+              lon >= -180, lon <= 180 else { return nil }
+        return CLLocationCoordinate2D(latitude: lat, longitude: lon)
+    }
+}

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -458,6 +458,24 @@
 "city.distanceAway.mi" = "%.1f mi away";
 "city.distanceUnknown" = "Distance unknown";
 
+/* Location picker (LocationPickerSheet) */
+"locationPicker.title" = "Choose a location";
+"locationPicker.picker.a11y" = "Location type";
+"locationPicker.tab.cities" = "Cities";
+"locationPicker.tab.search" = "Search";
+"locationPicker.tab.map" = "Map";
+"locationPicker.cities.searchPrompt" = "Search cities…";
+"locationPicker.search.prompt" = "City, place, or address";
+"locationPicker.search.error.title" = "Search failed";
+"locationPicker.map.pin" = "Selected location";
+"locationPicker.map.lat" = "Latitude";
+"locationPicker.map.lon" = "Longitude";
+"locationPicker.map.applyCoords" = "Move pin to these coordinates";
+"locationPicker.map.resolving" = "Resolving location…";
+"locationPicker.map.resolved" = "Resolved: %@";
+"locationPicker.map.setLocation" = "Set Location";
+"locationPicker.custom.fallbackName" = "Custom location";
+
 
 /* AgentRouter fallback replies (US-034) */
 "router.fallback.find" = "I found some nearby spots — check the map!";

--- a/apps/ios/SoloCompass/Services/LocationSearchService.swift
+++ b/apps/ios/SoloCompass/Services/LocationSearchService.swift
@@ -1,0 +1,42 @@
+import Foundation
+import MapKit
+import CoreLocation
+
+/// Forward-geocoding search wrapping MKLocalSearch.
+/// All methods are `@MainActor` to keep MKLocalSearch on the main thread
+/// (required by MapKit) and eliminate any sendability friction.
+@MainActor
+final class LocationSearchService {
+
+    private var activeSearch: MKLocalSearch?
+
+    /// Search for locations by natural-language query.
+    /// Cancels any in-flight search before starting a new one.
+    /// - Throws: MKLocalSearch errors (network, no results → empty array)
+    func search(_ query: String) async throws -> [MKMapItem] {
+        activeSearch?.cancel()
+
+        let request = MKLocalSearch.Request()
+        request.naturalLanguageQuery = query
+        request.resultTypes = [.address, .pointOfInterest]
+
+        let search = MKLocalSearch(request: request)
+        activeSearch = search
+
+        do {
+            let response = try await search.start()
+            return response.mapItems
+        } catch MKError.placemarkNotFound {
+            return []
+        } catch MKError.loadingThrottled {
+            // Throttled → return empty rather than propagating; the UI will retry on next keystroke.
+            return []
+        }
+        // Other errors (network, cancelled) propagate to the caller.
+    }
+
+    func cancelAll() {
+        activeSearch?.cancel()
+        activeSearch = nil
+    }
+}

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -145,7 +145,40 @@ public final class MapViewModel {
     // MARK: - City selection
 
     /// Currently selected city code (e.g. "cmi"), nil = all cities.
+    /// Custom locations use the format `custom_{lat}_{lon}`.
     public var selectedCity: String?
+
+    /// Coordinate for a custom-pin location set via LocationPickerSheet.
+    /// Non-nil when `selectedCity` starts with "custom_".
+    public var customCoordinates: CLLocationCoordinate2D?
+
+    /// Display label for a custom location (resolved city name or raw coord string).
+    public var customLocationLabel: String?
+
+    /// True when the current selection is a custom coordinate (not a preset city).
+    public var isCustomLocation: Bool {
+        selectedCity?.hasPrefix("custom_") ?? false
+    }
+
+    /// Select a custom coordinate from the LocationPickerSheet.
+    /// Zooms the map, clears city filtering (custom pin has no cityCode),
+    /// and stores the resolved label for the city pill.
+    public func selectCustomLocation(
+        coordinate: CLLocationCoordinate2D,
+        label: String,
+        cityCode: String
+    ) {
+        customCoordinates = coordinate
+        customLocationLabel = label
+        selectedCity = cityCode
+        preferences.lastSelectedCity = nil  // don't persist custom pins across restarts
+        cameraPosition = .region(MKCoordinateRegion(
+            center: coordinate,
+            span: MKCoordinateSpan(latitudeDelta: 0.06, longitudeDelta: 0.06)
+        ))
+        loadNearbyExperiences()
+        updateBottomInfo()
+    }
 
     /// All cities the user can pick from: seed-derived ones (centroid of
     /// matching experiences) plus reverse-geocoded discoveries from
@@ -196,8 +229,11 @@ public final class MapViewModel {
         return city.center
     }
 
-    /// Selects a city, recenters the map, and reloads experiences.
+    /// Selects a preset city, recenters the map, and reloads experiences.
+    /// Clears any active custom-coordinate pin.
     public func selectCity(_ cityCode: String?) {
+        customCoordinates = nil
+        customLocationLabel = nil
         selectedCity = cityCode
         preferences.lastSelectedCity = cityCode
         let center = defaultCenterForSelectedCity
@@ -395,7 +431,9 @@ public final class MapViewModel {
     }
 
     public func loadNearbyExperiences() {
-        let center = locationService.currentLocation?.coordinate ?? defaultCenterForSelectedCity
+        let center = customCoordinates
+            ?? locationService.currentLocation?.coordinate
+            ?? defaultCenterForSelectedCity
         let radiusKm = max(1.0, preferences.maxDistanceKm)
         let nearby = applyFilters(near: center, radiusKm: radiusKm)
         withAnimation(Self.markerSetAnimation) {
@@ -407,7 +445,8 @@ public final class MapViewModel {
 
     private func applyFilters(near coordinate: CLLocationCoordinate2D, radiusKm: Double) -> [Experience] {
         var nearby = experienceService.getExperiences(near: coordinate, radiusKm: radiusKm)
-        if let cityCode = selectedCity {
+        // Custom locations have no matching cityCode — show all nearby experiences instead.
+        if let cityCode = selectedCity, !cityCode.hasPrefix("custom_") {
             nearby = nearby.filter { $0.location.cityCode == cityCode }
         }
         if let category = selectedCategory {

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -337,7 +337,7 @@ public struct CompassMapView: View {
     @ViewBuilder
     private var cityPickerSheetContent: some View {
         if let vm = viewModel {
-            CityPickerSheet(viewModel: vm) {
+            LocationPickerSheet(viewModel: vm) {
                 isShowingCityPicker = false
             }
         }
@@ -739,6 +739,10 @@ private struct MapOverlayView: View {
     @ViewBuilder
     private var cityPill: some View {
         let cityName: String = {
+            // Custom location: use the resolved label stored by LocationPickerSheet.
+            if viewModel.isCustomLocation, let label = viewModel.customLocationLabel {
+                return label
+            }
             if let code = viewModel.selectedCity,
                let city = viewModel.availableCities.first(where: { $0.code == code }) {
                 return city.name

--- a/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
@@ -1,0 +1,479 @@
+import SwiftUI
+import MapKit
+import CoreLocation
+
+/// Rich location picker that replaces `CityPickerSheet`.
+/// Three tabs: Cities (browse / search preset cities), Search (forward
+/// geocoding via MKLocalSearch), Map (drag-a-pin or type coordinates).
+struct LocationPickerSheet: View {
+    @Bindable var viewModel: MapViewModel
+    let onDismiss: () -> Void
+
+    /// `@State` holds the `@Observable` state object.
+    /// Bindings to its properties are created via `@Bindable` inside body.
+    @State private var state: LocationPickerState
+    @State private var searchService = LocationSearchService()
+    @State private var searchDebounceTask: Task<Void, Never>? = nil
+    @State private var userLocation: CLLocation?
+
+    init(viewModel: MapViewModel, onDismiss: @escaping () -> Void) {
+        self.viewModel = viewModel
+        self.onDismiss = onDismiss
+        let initial = viewModel.customCoordinates ?? viewModel.defaultCenterForSelectedCity
+        self._state = State(initialValue: LocationPickerState(initialCoordinate: initial))
+    }
+
+    var body: some View {
+        // @Bindable gives us `$bs.*` bindings into the @Observable state object.
+        @Bindable var bs = state
+        NavigationStack {
+            VStack(spacing: 0) {
+                Picker(
+                    NSLocalizedString("locationPicker.picker.a11y", comment: "Location type picker"),
+                    selection: $bs.selectedTab
+                ) {
+                    ForEach(LocationPickerState.Tab.allCases, id: \.self) { tab in
+                        Text(tab.label).tag(tab)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+
+                Divider()
+
+                switch state.selectedTab {
+                case .cities: citiesContent(bs: $bs)
+                case .search: searchContent(bs: $bs)
+                case .map:    mapContent(bs: $bs)
+                }
+            }
+            .navigationTitle(NSLocalizedString("locationPicker.title", comment: "Location picker title"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(NSLocalizedString("common.cancel", comment: "Cancel")) {
+                        onDismiss()
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        .onAppear {
+            userLocation = LocationService.shared.currentLocation
+        }
+        .onDisappear {
+            searchService.cancelAll()
+            searchDebounceTask?.cancel()
+        }
+    }
+
+    // MARK: - Cities Tab
+
+    @ViewBuilder
+    private func citiesContent(bs: Bindable<LocationPickerState>) -> some View {
+        List {
+            Button {
+                viewModel.selectCity(nil)
+                onDismiss()
+            } label: {
+                HStack {
+                    Text(NSLocalizedString("city.all", comment: "All cities option"))
+                        .font(.body)
+                        .foregroundStyle(.primary)
+                    Spacer()
+                    if viewModel.selectedCity == nil {
+                        Image(systemName: "checkmark")
+                            .foregroundStyle(.tint)
+                            .font(.body.weight(.semibold))
+                    }
+                }
+            }
+
+            ForEach(filteredCities, id: \.code) { city in
+                Button {
+                    viewModel.selectCity(city.code)
+                    onDismiss()
+                } label: {
+                    CityRow(
+                        name: city.name,
+                        experienceCount: viewModel.experienceCount(for: city.code),
+                        distanceLabel: distanceLabel(for: city.center),
+                        isSelected: viewModel.selectedCity == city.code
+                    )
+                }
+            }
+        }
+        .listStyle(.plain)
+        .searchable(
+            text: bs.citySearchQuery,
+            placement: .navigationBarDrawer(displayMode: .always),
+            prompt: NSLocalizedString("locationPicker.cities.searchPrompt", comment: "Search cities")
+        )
+    }
+
+    private var filteredCities: [(code: String, name: String, center: CLLocationCoordinate2D)] {
+        let cities = sortedCities
+        guard !state.citySearchQuery.isEmpty else { return cities }
+        let query = state.citySearchQuery.lowercased()
+        return cities.filter { $0.name.lowercased().contains(query) }
+    }
+
+    private var sortedCities: [(code: String, name: String, center: CLLocationCoordinate2D)] {
+        guard let userLoc = userLocation else {
+            return viewModel.availableCities.sorted { $0.name < $1.name }
+        }
+        return viewModel.availableCities.sorted { a, b in
+            let locA = CLLocation(latitude: a.center.latitude, longitude: a.center.longitude)
+            let locB = CLLocation(latitude: b.center.latitude, longitude: b.center.longitude)
+            let dA = userLoc.distance(from: locA)
+            let dB = userLoc.distance(from: locB)
+            if abs(dA - dB) < 1_000 { return a.name < b.name }
+            return dA < dB
+        }
+    }
+
+    // MARK: - Search Tab
+
+    @ViewBuilder
+    private func searchContent(bs: Bindable<LocationPickerState>) -> some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField(
+                    NSLocalizedString("locationPicker.search.prompt", comment: "City, place, or address"),
+                    text: bs.searchQuery
+                )
+                .textInputAutocapitalization(.words)
+                .autocorrectionDisabled()
+                .submitLabel(.search)
+                .onSubmit { triggerSearch() }
+                .onChange(of: state.searchQuery) { _, _ in scheduleSearchDebounce() }
+
+                if state.isSearching {
+                    ProgressView().scaleEffect(0.8)
+                } else if !state.searchQuery.isEmpty {
+                    Button {
+                        state.searchQuery = ""
+                        state.searchResults = []
+                        state.searchError = nil
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+
+            Divider()
+
+            if let error = state.searchError {
+                ContentUnavailableView(
+                    NSLocalizedString("locationPicker.search.error.title", comment: "Search failed"),
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(error)
+                )
+                .padding(.top, 40)
+            } else if state.searchResults.isEmpty && !state.isSearching && !state.searchQuery.isEmpty {
+                ContentUnavailableView.search(text: state.searchQuery)
+                    .padding(.top, 40)
+            } else {
+                List(state.searchResults, id: \.self) { item in
+                    Button {
+                        selectSearchResult(item)
+                    } label: {
+                        SearchResultRow(item: item)
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Map Tab
+
+    @ViewBuilder
+    private func mapContent(bs: Bindable<LocationPickerState>) -> some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                MapPinPickerView(
+                    coordinate: state.pinCoordinate,
+                    onCoordinateChanged: { coord in
+                        state.updatePin(to: coord)
+                        scheduleReverseGeocode()
+                    }
+                )
+                .frame(height: 320)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .shadow(color: .black.opacity(0.1), radius: 8, y: 4)
+                .padding(.horizontal, 16)
+
+                VStack(spacing: 12) {
+                    HStack(spacing: 12) {
+                        CoordinateField(
+                            label: NSLocalizedString("locationPicker.map.lat", comment: "Latitude field label"),
+                            text: bs.manualLatText,
+                            placeholder: "18.7877"
+                        )
+                        CoordinateField(
+                            label: NSLocalizedString("locationPicker.map.lon", comment: "Longitude field label"),
+                            text: bs.manualLonText,
+                            placeholder: "98.9938"
+                        )
+                    }
+
+                    Button {
+                        applyCoordinateFields()
+                    } label: {
+                        Text(NSLocalizedString("locationPicker.map.applyCoords", comment: "Move pin to these coordinates"))
+                            .font(.subheadline)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.regular)
+                }
+                .padding(.horizontal, 16)
+
+                Group {
+                    if state.isResolving {
+                        HStack(spacing: 6) {
+                            ProgressView().scaleEffect(0.7)
+                            Text(NSLocalizedString("locationPicker.map.resolving", comment: "Resolving location name"))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } else if let name = state.resolvedCityName {
+                        HStack(spacing: 6) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                                .font(.caption)
+                            Text(String(
+                                format: NSLocalizedString("locationPicker.map.resolved", comment: "Resolved city: %@"),
+                                name
+                            ))
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16)
+
+                Button {
+                    commitMapLocation()
+                } label: {
+                    Text(NSLocalizedString("locationPicker.map.setLocation", comment: "Set this location on the map"))
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 4)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 24)
+            }
+            .padding(.top, 12)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func selectSearchResult(_ item: MKMapItem) {
+        let coord = item.placemark.coordinate
+        let label = item.name
+            ?? item.placemark.locality
+            ?? item.placemark.administrativeArea
+            ?? NSLocalizedString("locationPicker.custom.fallbackName", comment: "Custom location")
+        viewModel.selectCustomLocation(
+            coordinate: coord,
+            label: label,
+            cityCode: customCode(for: coord)
+        )
+        onDismiss()
+    }
+
+    private func commitMapLocation() {
+        let coord = state.pinCoordinate
+        let label = state.resolvedCityName
+            ?? String(format: "%.4f, %.4f", coord.latitude, coord.longitude)
+        viewModel.selectCustomLocation(
+            coordinate: coord,
+            label: label,
+            cityCode: customCode(for: coord)
+        )
+        onDismiss()
+    }
+
+    private func applyCoordinateFields() {
+        guard let coord = state.parsedCoordinate() else { return }
+        state.updatePin(to: coord)
+        scheduleReverseGeocode()
+    }
+
+    private func scheduleSearchDebounce() {
+        searchDebounceTask?.cancel()
+        guard !state.searchQuery.trimmingCharacters(in: .whitespaces).isEmpty else {
+            state.searchResults = []
+            state.searchError = nil
+            return
+        }
+        searchDebounceTask = Task {
+            try? await Task.sleep(for: .milliseconds(400))
+            guard !Task.isCancelled else { return }
+            triggerSearch()
+        }
+    }
+
+    private func triggerSearch() {
+        let query = state.searchQuery.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty else { return }
+        state.isSearching = true
+        state.searchError = nil
+        Task {
+            do {
+                let results = try await searchService.search(query)
+                state.searchResults = results
+            } catch {
+                state.searchError = error.localizedDescription
+            }
+            state.isSearching = false
+        }
+    }
+
+    private func scheduleReverseGeocode() {
+        state.isResolving = true
+        state.resolvedCityName = nil
+        let coord = state.pinCoordinate
+        Task {
+            try? await Task.sleep(for: .milliseconds(600))
+            guard !Task.isCancelled else { return }
+            let geocoder = ReverseGeocodeService()
+            let resolved = await geocoder.resolve(coordinate: coord)
+            state.resolvedCityName = resolved?.name
+            state.isResolving = false
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func customCode(for coord: CLLocationCoordinate2D) -> String {
+        String(format: "custom_%.4f_%.4f", coord.latitude, coord.longitude)
+    }
+
+    private func distanceLabel(for coord: CLLocationCoordinate2D) -> String {
+        guard let userLoc = userLocation else {
+            return NSLocalizedString("city.distanceUnknown", comment: "Distance unknown")
+        }
+        let cityLoc = CLLocation(latitude: coord.latitude, longitude: coord.longitude)
+        let km = userLoc.distance(from: cityLoc) / 1_000
+        if Locale.current.measurementSystem == .us {
+            let mi = km * 0.621371
+            return String(format: NSLocalizedString("city.distanceAway.mi", comment: ""), mi)
+        }
+        return String(format: NSLocalizedString("city.distanceAway", comment: ""), km)
+    }
+}
+
+// MARK: - Subviews
+
+private struct CityRow: View {
+    let name: String
+    let experienceCount: Int
+    let distanceLabel: String
+    let isSelected: Bool
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(name)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Text(String(
+                    format: NSLocalizedString("city.experienceCount", comment: "Experience count in city"),
+                    experienceCount
+                ))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 2) {
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.tint)
+                        .font(.body.weight(.semibold))
+                }
+                Text(distanceLabel)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .monospacedDigit()
+            }
+        }
+    }
+}
+
+private struct SearchResultRow: View {
+    let item: MKMapItem
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(item.name ?? NSLocalizedString("locationPicker.custom.fallbackName", comment: "Custom location"))
+                .font(.headline)
+                .foregroundStyle(.primary)
+
+            let subtitle = [item.placemark.locality, item.placemark.countryCode]
+                .compactMap { $0 }
+                .joined(separator: ", ")
+            if !subtitle.isEmpty {
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            let coord = item.placemark.coordinate
+            Text(String(format: "%.4f, %.4f", coord.latitude, coord.longitude))
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .monospacedDigit()
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+private struct CoordinateField: View {
+    let label: String
+    @Binding var text: String
+    let placeholder: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            TextField(placeholder, text: $text)
+                .textFieldStyle(.roundedBorder)
+                .keyboardType(.decimalPad)
+                .monospacedDigit()
+                .autocorrectionDisabled()
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    LocationPickerSheet(
+        viewModel: MapViewModel(
+            locationService: LocationService.shared,
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: UserPreferences()
+        ),
+        onDismiss: {}
+    )
+}

--- a/apps/ios/SoloCompass/Views/Map/MapPinPickerView.swift
+++ b/apps/ios/SoloCompass/Views/Map/MapPinPickerView.swift
@@ -37,7 +37,7 @@ struct MapPinPickerView: View {
                         .shadow(radius: 4)
                 }
             }
-            .mapStyle(.standard(elevation: .flat, pointsOfInterest: .includingAll))
+            .mapStyle(.standard(elevation: .flat))
             .mapControls {
                 MapCompass()
             }
@@ -58,7 +58,7 @@ struct MapPinPickerView: View {
     /// Recenter the camera only when the pin is outside the visible region
     /// (text-field entry, search tap). Avoids fighting user's manual pan.
     private func recenterIfFarOff() {
-        guard case .region(let region) = cameraPosition else { return }
+        guard let region = cameraPosition.region else { return }
         let latDelta = abs(region.center.latitude - coordinate.latitude)
         let lonDelta = abs(region.center.longitude - coordinate.longitude)
         if latDelta > region.span.latitudeDelta * 0.4 || lonDelta > region.span.longitudeDelta * 0.4 {

--- a/apps/ios/SoloCompass/Views/Map/MapPinPickerView.swift
+++ b/apps/ios/SoloCompass/Views/Map/MapPinPickerView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+import MapKit
+
+/// A compact map with a single draggable/repositionable pin.
+/// The caller receives `onCoordinateChanged` whenever the pin moves.
+///
+/// Tap anywhere on the map to move the pin to that point.
+/// The pin itself supports drag-to-reposition via `MapAnnotation`'s
+/// built-in drag; we also handle map taps via `MapReader`.
+struct MapPinPickerView: View {
+    /// The coordinate shown by the pin.
+    var coordinate: CLLocationCoordinate2D
+    /// Callback fired (on main actor) whenever the pin moves.
+    var onCoordinateChanged: (CLLocationCoordinate2D) -> Void
+
+    @State private var cameraPosition: MapCameraPosition
+
+    init(coordinate: CLLocationCoordinate2D, onCoordinateChanged: @escaping (CLLocationCoordinate2D) -> Void) {
+        self.coordinate = coordinate
+        self.onCoordinateChanged = onCoordinateChanged
+        self._cameraPosition = State(initialValue: .region(MKCoordinateRegion(
+            center: coordinate,
+            span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+        )))
+    }
+
+    var body: some View {
+        MapReader { proxy in
+            Map(position: $cameraPosition) {
+                Annotation(
+                    NSLocalizedString("locationPicker.map.pin", comment: "Location pin"),
+                    coordinate: coordinate
+                ) {
+                    Image(systemName: "mappin.circle.fill")
+                        .font(.title)
+                        .foregroundStyle(.red, .white)
+                        .shadow(radius: 4)
+                }
+            }
+            .mapStyle(.standard(elevation: .flat, pointsOfInterest: .includingAll))
+            .mapControls {
+                MapCompass()
+            }
+            // Tap-to-reposition: convert the tap location to a map coordinate.
+            .onTapGesture { screenPoint in
+                guard let coord = proxy.convert(screenPoint, from: .local) else { return }
+                onCoordinateChanged(coord)
+            }
+        }
+        // Keep the camera centered whenever the pin moves from outside
+        // (e.g., text field entry) but don't fight user pan after that.
+        .onChange(of: coordinate.latitude) { _, _ in recenterIfFarOff() }
+        .onChange(of: coordinate.longitude) { _, _ in recenterIfFarOff() }
+    }
+
+    // MARK: - Private
+
+    /// Recenter the camera only when the pin is outside the visible region
+    /// (text-field entry, search tap). Avoids fighting user's manual pan.
+    private func recenterIfFarOff() {
+        guard case .region(let region) = cameraPosition else { return }
+        let latDelta = abs(region.center.latitude - coordinate.latitude)
+        let lonDelta = abs(region.center.longitude - coordinate.longitude)
+        if latDelta > region.span.latitudeDelta * 0.4 || lonDelta > region.span.longitudeDelta * 0.4 {
+            withAnimation(.smooth(duration: 0.35)) {
+                cameraPosition = .region(MKCoordinateRegion(
+                    center: coordinate,
+                    span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+                ))
+            }
+        }
+    }
+}
+
+#Preview {
+    MapPinPickerView(
+        coordinate: CLLocationCoordinate2D(latitude: 18.7877, longitude: 98.9938),
+        onCoordinateChanged: { _ in }
+    )
+    .frame(height: 300)
+}


### PR DESCRIPTION
## Summary

Replaces the simple CityPickerSheet with a rich **LocationPickerSheet** offering three location selection modes:

### 🏙️ Cities Tab
Browse/search preset and discovered cities, sorted by distance from user. Same experience count and distance info as before, with a search bar.

### 🔍 Search Tab
Forward geocoding via MKLocalSearch — type a city, place, or address and see Apple Maps results with name, locality, and coordinates. Debounced 400ms to avoid excessive API calls.

### 📍 Map Tab
Drag a pin on the mini map, or enter latitude/longitude manually. Reverse geocodes automatically to show the resolved city name. "Set Location" button confirms the selection.

### Technical
- Custom location code format: `custom_{lat}_{lon}`
- Custom locations don't persist across restarts (current session only)
- Shows all nearby experiences (no cityCode filter) for custom locations
- MapViewModel: customCoordinates, customLocationLabel, selectCustomLocation()
- New files registered in pbxproj for CI builds