### PR TITLE
feat(ios): deep-dive enrichment agent — fewer POIs, real cross-channel signals

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		9C8CC563D33FDBB3DF57A841 /* RecentExploreRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9748B0A808BC06F6EDED3C3B /* RecentExploreRegion.swift */; };
 		9D81327AE55FA8142F9E5B8D /* ChatUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0709110B381DEDA32C3292AE /* ChatUIState.swift */; };
 		A217FA55BD40922DB3B8DEE6 /* SoloScoreRadarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D557D1D0D224C725834A08D /* SoloScoreRadarChart.swift */; };
+		A75EEA586481D5A86B7FCFDA /* MapKitPOIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B7D586552E9F1EA44F5657 /* MapKitPOIService.swift */; };
 		A84320715E7CBDA91FC3F26F /* ExperienceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */; };
 		AA75B3147A29FDA55E61B24A /* PendingCheckInBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */; };
 		ACBA4CEE6B78AA04DBD26709 /* PendingCheckInRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA0BAEC05B72704552C0906 /* PendingCheckInRecord.swift */; };
@@ -109,6 +110,7 @@
 		EC5A75D4BC8E0C767D06C424 /* SupabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E406C379247653B4AA5A3E0E /* SupabaseClient.swift */; };
 		EDBD7B0E715165E71BC0C17D /* DiscoveredCityRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE05EF69960CBB73431A6F2F /* DiscoveredCityRecord.swift */; };
 		EF2003CC07F7787C25847BDF /* ReportIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576B08910782A58C3597E596 /* ReportIssueSheet.swift */; };
+		F11FDDDC600A1EF9C08E8193 /* EnrichmentAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FC71659A5BF9CB1A547907B /* EnrichmentAgent.swift */; };
 		F34C1A42668EF5151AFEE3C3 /* AISynthesisCacheRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E69F3EF6F0100CFA47DAFE /* AISynthesisCacheRecord.swift */; };
 		F3D0A3E30E7D7825805C2801 /* ShareCardRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85D78BE6F7E5B4B82CEAC0A3 /* ShareCardRenderer.swift */; };
 		F5677DCF081E506C7E32243F /* VoiceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120FC7465285714C5FA8F96D /* VoiceService.swift */; };
@@ -131,6 +133,7 @@
 /* Begin PBXFileReference section */
 		001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIUsageRecord.swift; sourceTree = "<group>"; };
 		06086F5F9463C18F486E5694 /* QueryAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryAgent.swift; sourceTree = "<group>"; };
+		06B7D586552E9F1EA44F5657 /* MapKitPOIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapKitPOIService.swift; sourceTree = "<group>"; };
 		0709110B381DEDA32C3292AE /* ChatUIState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatUIState.swift; sourceTree = "<group>"; };
 		086B3C207483BA0EBD27451F /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
 		0A0997D8150E77F70A4B8C64 /* ExploreProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreProgressBar.swift; sourceTree = "<group>"; };
@@ -168,6 +171,7 @@
 		5C62D0EFA5859698D9C70B7D /* OfflineBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBanner.swift; sourceTree = "<group>"; };
 		5CA0BAEC05B72704552C0906 /* PendingCheckInRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingCheckInRecord.swift; sourceTree = "<group>"; };
 		5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailViewModel.swift; sourceTree = "<group>"; };
+		5FC71659A5BF9CB1A547907B /* EnrichmentAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrichmentAgent.swift; sourceTree = "<group>"; };
 		6163572F4644BF852B35FDA4 /* SyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncService.swift; sourceTree = "<group>"; };
 		61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = seed_experiences.json; sourceTree = "<group>"; };
 		64BDF8B4B7CC82F3845C5068 /* ReverseGeocodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseGeocodeService.swift; sourceTree = "<group>"; };
@@ -417,6 +421,7 @@
 				6556C23BF1B228BF686C5500 /* KeychainStore.swift */,
 				87002BB6D344B384A3FDFBFD /* LanguageService.swift */,
 				2C7919EAFDE363B49C4B4C47 /* LocationService.swift */,
+				06B7D586552E9F1EA44F5657 /* MapKitPOIService.swift */,
 				54F3FDE4BC9458E490AEA67A /* MarkdownExporter.swift */,
 				D07ACA7C1A1574A244E73796 /* NavigationLauncher.swift */,
 				AF007DB5F72E30021CADA555 /* NetworkMonitor.swift */,
@@ -456,6 +461,7 @@
 			children = (
 				D5DCEFC3560FED53D0CB5D19 /* AgentMessage.swift */,
 				A38E5736BF6DF5644D687637 /* AgentRouter.swift */,
+				5FC71659A5BF9CB1A547907B /* EnrichmentAgent.swift */,
 				187534C119545F7D61CE693B /* GuideAgent.swift */,
 				3A7A57DAFF92B20BE0BAB1F4 /* IntentAgent.swift */,
 				06086F5F9463C18F486E5694 /* QueryAgent.swift */,
@@ -746,6 +752,7 @@
 				65E57E8B02E7889BD8EE8DD4 /* ContextManager.swift in Sources */,
 				42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */,
 				EDBD7B0E715165E71BC0C17D /* DiscoveredCityRecord.swift in Sources */,
+				F11FDDDC600A1EF9C08E8193 /* EnrichmentAgent.swift in Sources */,
 				0A830B26D4A18948D16F3A42 /* Experience.swift in Sources */,
 				56F3055416F4A5316100F9B2 /* ExperienceCardView.swift in Sources */,
 				CF8B2BDE6D707CE2537C8688 /* ExperienceDetailView.swift in Sources */,
@@ -769,6 +776,7 @@
 				953C7BD48AF4AF55608145A6 /* LanguageService.swift in Sources */,
 				23B40396E9D7B59CB71FBCD9 /* LocationCard.swift in Sources */,
 				31F9538643C362D7EEF64C6B /* LocationService.swift in Sources */,
+				A75EEA586481D5A86B7FCFDA /* MapKitPOIService.swift in Sources */,
 				CE1A6A1D5EB25B2BEA5B29DA /* MapViewModel.swift in Sources */,
 				45A4E8EED0300F00253EC049 /* MarkdownExporter.swift in Sources */,
 				C2CCD06DDA37BF2F81E735E5 /* MarkdownShareSheet.swift in Sources */,

--- a/apps/ios/SoloCompass/Models/Experience.swift
+++ b/apps/ios/SoloCompass/Models/Experience.swift
@@ -84,6 +84,13 @@ public struct ExperienceLocation: Codable, Hashable {
     public let addressHint: String?
     public let placeNameLocal: String?
     public let placeNameRomanized: String?
+    // Cross-channel hard signals enriched from Foursquare / Apple MapKit.
+    // All optional; OSM-only places leave them nil. Mirrors the TS schema.
+    public let rating: Double?         // 0–10 normalized provider rating
+    public let openingHours: String?   // raw provider hours string
+    public let priceLevel: Double?     // 1–4 (1 = cheap, 4 = expensive)
+    public let website: String?
+    public let phone: String?
 
     public var clCoordinate: CLLocationCoordinate2D? {
         guard coordinates.count >= 2 else { return nil }
@@ -95,13 +102,23 @@ public struct ExperienceLocation: Codable, Hashable {
         cityCode: String,
         addressHint: String? = nil,
         placeNameLocal: String? = nil,
-        placeNameRomanized: String? = nil
+        placeNameRomanized: String? = nil,
+        rating: Double? = nil,
+        openingHours: String? = nil,
+        priceLevel: Double? = nil,
+        website: String? = nil,
+        phone: String? = nil
     ) {
         self.coordinates = coordinates
         self.cityCode = cityCode
         self.addressHint = addressHint
         self.placeNameLocal = placeNameLocal
         self.placeNameRomanized = placeNameRomanized
+        self.rating = rating
+        self.openingHours = openingHours
+        self.priceLevel = priceLevel
+        self.website = website
+        self.phone = phone
     }
 }
 

--- a/apps/ios/SoloCompass/Persistence/ExperienceRepository.swift
+++ b/apps/ios/SoloCompass/Persistence/ExperienceRepository.swift
@@ -132,6 +132,11 @@ public final class ExperienceRepository {
         record.addressHint = fresh.addressHint
         record.placeNameLocal = fresh.placeNameLocal
         record.placeNameRomanized = fresh.placeNameRomanized
+        record.rating = fresh.rating
+        record.openingHours = fresh.openingHours
+        record.priceLevel = fresh.priceLevel
+        record.website = fresh.website
+        record.phone = fresh.phone
         record.durationMin = fresh.durationMin
         record.durationMax = fresh.durationMax
         record.status = fresh.status

--- a/apps/ios/SoloCompass/Persistence/Models/ExperienceRecord.swift
+++ b/apps/ios/SoloCompass/Persistence/Models/ExperienceRecord.swift
@@ -34,6 +34,14 @@ public final class ExperienceRecord {
     public var placeNameLocal: String?
     public var placeNameRomanized: String?
 
+    // MARK: - Cross-channel hard signals (enriched from Foursquare / MapKit)
+    // All optional so rows migrated from earlier schema versions decode as nil.
+    public var rating: Double?
+    public var openingHours: String?
+    public var priceLevel: Double?
+    public var website: String?
+    public var phone: String?
+
     public var durationMin: Int
     public var durationMax: Int
 
@@ -84,6 +92,11 @@ public final class ExperienceRecord {
         addressHint: String?,
         placeNameLocal: String?,
         placeNameRomanized: String?,
+        rating: Double? = nil,
+        openingHours: String? = nil,
+        priceLevel: Double? = nil,
+        website: String? = nil,
+        phone: String? = nil,
         durationMin: Int,
         durationMax: Int,
         status: String,
@@ -110,6 +123,11 @@ public final class ExperienceRecord {
         self.addressHint = addressHint
         self.placeNameLocal = placeNameLocal
         self.placeNameRomanized = placeNameRomanized
+        self.rating = rating
+        self.openingHours = openingHours
+        self.priceLevel = priceLevel
+        self.website = website
+        self.phone = phone
         self.durationMin = durationMin
         self.durationMax = durationMax
         self.status = status
@@ -150,6 +168,11 @@ extension ExperienceRecord {
                 addressHint: experience.location.addressHint,
                 placeNameLocal: experience.location.placeNameLocal,
                 placeNameRomanized: experience.location.placeNameRomanized,
+                rating: experience.location.rating,
+                openingHours: experience.location.openingHours,
+                priceLevel: experience.location.priceLevel,
+                website: experience.location.website,
+                phone: experience.location.phone,
                 durationMin: experience.durationMinutes.min,
                 durationMax: experience.durationMinutes.max,
                 status: experience.status.rawValue,
@@ -187,7 +210,12 @@ extension ExperienceRecord {
                     cityCode: cityCode,
                     addressHint: addressHint,
                     placeNameLocal: placeNameLocal,
-                    placeNameRomanized: placeNameRomanized
+                    placeNameRomanized: placeNameRomanized,
+                    rating: rating,
+                    openingHours: openingHours,
+                    priceLevel: priceLevel,
+                    website: website,
+                    phone: phone
                 ),
                 bestTimes: try decoder.decode([TimeWindow].self, from: bestTimesBlob),
                 durationMinutes: .init(min: durationMin, max: durationMax),

--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -1091,6 +1091,44 @@ public final class AIService {
 
     // MARK: - Synthesize helpers
 
+    /// Pull the cross-channel hard signals a POI carries (from Foursquare /
+    /// MapKit enrichment) out of its tag bag and into the typed location
+    /// fields. OSM-only POIs simply have none of these keys, so everything
+    /// stays nil. `placeNameLocal`/`placeNameRomanized` keep the raw name pair.
+    static func enrichedLocation(
+        from poi: OverpassService.POI,
+        cityCode: String
+    ) -> ExperienceLocation {
+        // Foursquare rating is already 0–10. Clamp defensively.
+        let rating = poi.tags["fsq_rating"].flatMap(Double.init).map { max(0, min(10, $0)) }
+        let openingHours = poi.tags["opening_hours"]
+        let priceLevel = poi.tags["fsq_price"].flatMap(Double.init).map { max(1, min(4, $0)) }
+        let website = poi.tags["website"]
+        let phone = poi.tags["phone"]
+        let addr = poi.tags["addr"]
+        return ExperienceLocation(
+            coordinates: [poi.lon, poi.lat],
+            cityCode: cityCode,
+            addressHint: addr,
+            placeNameLocal: poi.name,
+            placeNameRomanized: poi.nameEn,
+            rating: rating,
+            openingHours: openingHours,
+            priceLevel: priceLevel,
+            website: website,
+            phone: phone
+        )
+    }
+
+    /// True when a POI carries at least one provider hard signal (rating /
+    /// hours / price). Used to decide whether the AI may cite real data for
+    /// this place rather than staying generic.
+    static func hasHardSignals(_ poi: OverpassService.POI) -> Bool {
+        poi.tags["fsq_rating"] != nil
+            || poi.tags["opening_hours"] != nil
+            || poi.tags["fsq_price"] != nil
+    }
+
     private static func synthesisPrompt(pois: [OverpassService.POI], cityCode: String, locale: Locale) -> String {
         let langTag = locale.language.languageCode?.identifier ?? "en"
         let lines = pois.map { poi -> String in
@@ -1100,18 +1138,27 @@ public final class AIService {
                 .map { "\($0.key)=\($0.value)" }
                 .sorted()
                 .joined(separator: ", ")
-            return "- osmId=\(poi.osmId) name=\"\(poi.name)\" nameEn=\"\(displayName)\" lat=\(poi.lat) lon=\(poi.lon) tags=[\(tagSummary)]"
+            // Real provider signals (Foursquare / MapKit) the model is ALLOWED
+            // to cite verbatim. Absent for OSM-only POIs.
+            var signals: [String] = []
+            if let r = poi.tags["fsq_rating"] { signals.append("rating=\(r)/10") }
+            if let p = poi.tags["fsq_price"] { signals.append("priceLevel=\(p)/4") }
+            if let pop = poi.tags["fsq_popularity"] { signals.append("popularity=\(pop)") }
+            if let addr = poi.tags["addr"] { signals.append("address=\"\(addr)\"") }
+            let signalSummary = signals.isEmpty ? "" : " realSignals=[\(signals.joined(separator: ", "))]"
+            return "- osmId=\(poi.osmId) name=\"\(poi.name)\" nameEn=\"\(displayName)\" lat=\(poi.lat) lon=\(poi.lon) tags=[\(tagSummary)]\(signalSummary)"
         }.joined(separator: "\n")
 
         return """
         You are writing solo-traveler-focused entries for real places sourced from OpenStreetMap.
 
         CRITICAL CONSTRAINTS — your output is read by users on the ground:
-        - Use ONLY the provided OSM tags. Do NOT invent menu items, interior details, hours, prices, owner backstories, dish names, or specific seating positions.
-        - If a field is not derivable from tags, write a generic safe value. Example: when no opening_hours tag is present, set bestStartHour to 9 and bestEndHour to 21 (a generic daytime window) rather than guessing a specific schedule.
-        - howTo must contain navigation/orientation steps only. Do NOT write "order the X", "try the X", "ask for X", "sit at the bar/window/back".
-        - Avoid the phrases: "menu", "specialty", "best seat", "the owner", "opens at", "closes at", "price", "order the", "try the".
-        - Solo Score should be a conservative 7.0–8.5 unless tags clearly indicate something exceptional (e.g. tourism=viewpoint with a name → up to 9.0).
+        - You have TWO kinds of input per POI: OSM `tags` (categorical, reliable) and an optional `realSignals` bag (rating/priceLevel/popularity/address sourced from Foursquare or Apple Maps — REAL provider data you MAY cite).
+        - You MAY reference anything in `realSignals` as fact: cite the rating, reflect the price level in your framing, use the address in orientation. These are real.
+        - You may NOT invent specifics NOT present in either bag: no menu items, dish names, owner backstories, or interior/seating details. If `realSignals` has no opening hours, do not state hours.
+        - When a POI has NO `realSignals`, fall back to generic-safe framing exactly as before: bestStartHour 9 / bestEndHour 21 when category gives no better hint.
+        - howTo must contain navigation/orientation steps only. Do NOT write "order the X", "try the X", "ask for X", "sit at the bar/window/back" — those are interior specifics you cannot verify.
+        - Solo Score: anchor on REAL signals when present. A high rating (>= 8/10) or strong popularity supports up to 9.0–9.5; a low/absent rating or sparse data should stay 6.5–8.0. With NO realSignals, keep it conservative 7.0–8.0. Make the six breakdown dimensions genuinely DIFFERENT from each other based on the place type (e.g. a library scores high on seatingFriendly + low staffPressure; a bar scores lower on soloPatronRatio) — do NOT output the same number across all six.
 
         DISTANCE AWARENESS: The POI list may span 0–12 km from the user (a Pro radial Explore covers 4 rings: 1.5/3/6/12 km). Infer approximate distance from each POI's lat/lon relative to the others; closer POIs should lean toward in-the-moment framings (walk-up, sidewalk), farther POIs toward half-day-out framings (worth a transit ride). Do NOT mention distances or rings explicitly in the output — just let the framing reflect the proximity.
 
@@ -1139,7 +1186,15 @@ public final class AIService {
           "durationMaxMinutes": <int>,
           "howTo": ["navigation step 1", "navigation step 2", "navigation step 3"],
           "soloHint": "<one short hint for solo visitors>",
-          "soloOverall": <number 6.0-9.5>
+          "soloOverall": <number 6.0-9.5>,
+          "soloBreakdown": {
+            "seatingFriendly": <0-10>,
+            "soloPatronRatio": <0-10>,
+            "staffPressure": <0-10>,
+            "soloPortioning": <0-10>,
+            "ambianceFit": <0-10>,
+            "safety": <0-10>
+          }
         }
 
         Output a JSON array containing one object per POI, in input order. No prose. No markdown fences.
@@ -1179,6 +1234,16 @@ public final class AIService {
             let howTo: [String]?
             let soloHint: String?
             let soloOverall: Double?
+            let soloBreakdown: Breakdown?
+
+            struct Breakdown: Decodable {
+                let seatingFriendly: Double?
+                let soloPatronRatio: Double?
+                let staffPressure: Double?
+                let soloPortioning: Double?
+                let ambianceFit: Double?
+                let safety: Double?
+            }
         }
         let items = try JSONDecoder().decode([Item].self, from: data)
         let poiById = Dictionary(uniqueKeysWithValues: pois.map { ($0.osmId, $0) })
@@ -1191,42 +1256,55 @@ public final class AIService {
             let endHour = item.bestEndHour.map { max(0, min(23, $0)) } ?? 21
             let dMin = item.durationMinMinutes ?? 30
             let dMax = max(dMin, item.durationMaxMinutes ?? 90)
-            let overall = max(6.0, min(9.5, item.soloOverall ?? 7.0))
+            // Wider clamp now that real signals can justify higher/lower scores;
+            // still bounded to a sane 5.0–9.8 to reject obvious model garbage.
+            let overall = max(5.0, min(9.8, item.soloOverall ?? 7.0))
+            // Prefer the model's per-dimension breakdown when it returned one;
+            // fall back to `overall` per dimension only when absent. Each dim
+            // independently clamped 0–10.
+            func dim(_ value: Double?) -> Double { max(0, min(10, value ?? overall)) }
             let breakdown = SoloScore.Breakdown(
-                seatingFriendly: overall, soloPatronRatio: overall, staffPressure: overall,
-                soloPortioning: overall, ambianceFit: overall, safety: overall
+                seatingFriendly: dim(item.soloBreakdown?.seatingFriendly),
+                soloPatronRatio: dim(item.soloBreakdown?.soloPatronRatio),
+                staffPressure: dim(item.soloBreakdown?.staffPressure),
+                soloPortioning: dim(item.soloBreakdown?.soloPortioning),
+                ambianceFit: dim(item.soloBreakdown?.ambianceFit),
+                safety: dim(item.soloBreakdown?.safety)
             )
             let howTo = (item.howTo ?? []).enumerated().map { HowToStep(order: $0.offset + 1, text: $0.element) }
+            // basedOnCount reflects whether this score is anchored on real
+            // provider signals (>0) or pure category inference (0).
+            let basedOnCount = hasHardSignals(poi) ? 1 : 0
             return Experience(
                 id: "exp_osm_\(poi.osmId)",
                 title: item.title,
                 oneLiner: item.oneLiner,
                 whyItMatters: item.whyItMatters,
                 category: category,
-                location: ExperienceLocation(
-                    coordinates: [poi.lon, poi.lat],
-                    cityCode: cityCode,
-                    addressHint: nil,
-                    placeNameLocal: poi.name,
-                    placeNameRomanized: poi.nameEn
-                ),
+                location: enrichedLocation(from: poi, cityCode: cityCode),
                 bestTimes: [TimeWindow(startHour: startHour, endHour: endHour)],
                 durationMinutes: .init(min: dMin, max: dMax),
                 howTo: howTo,
                 realInconveniences: [],
-                soloScore: SoloScore(overall: overall, breakdown: breakdown, hint: item.soloHint, basedOnCount: 0),
+                soloScore: SoloScore(overall: overall, breakdown: breakdown, hint: item.soloHint, basedOnCount: basedOnCount),
                 sources: [
                     InformationSource(
                         type: .user,
                         url: URL(string: "https://www.openstreetmap.org/node/\(poi.osmId)"),
-                        attribution: "© OpenStreetMap contributors + AI",
+                        attribution: basedOnCount > 0
+                            ? "© OpenStreetMap contributors + Foursquare/Apple Maps + AI"
+                            : "© OpenStreetMap contributors + AI",
                         verifiedAt: now
                     )
                 ],
                 confidence: Confidence(
-                    level: 1,
+                    // Real provider signals bump confidence one notch above the
+                    // pure-OSM baseline so the UI's confidence chip reflects it.
+                    level: basedOnCount > 0 ? 2 : 1,
                     lastVerifiedAt: now,
-                    reason: "AI-synthesized from OpenStreetMap, unverified",
+                    reason: basedOnCount > 0
+                        ? "AI-synthesized from OpenStreetMap + Foursquare/Apple Maps signals"
+                        : "AI-synthesized from OpenStreetMap, unverified",
                     signals: .init(aiScrapeAgeDays: 0, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)
                 ),
                 nearbyExperienceIds: [],
@@ -1254,13 +1332,7 @@ public final class AIService {
             oneLiner: NSLocalizedString("explore.skeleton.oneLiner", comment: "Generic OSM POI tagline"),
             whyItMatters: NSLocalizedString("explore.skeleton.why", comment: "Generic OSM POI rationale"),
             category: category,
-            location: ExperienceLocation(
-                coordinates: [poi.lon, poi.lat],
-                cityCode: cityCode,
-                addressHint: nil,
-                placeNameLocal: poi.name,
-                placeNameRomanized: poi.nameEn
-            ),
+            location: enrichedLocation(from: poi, cityCode: cityCode),
             bestTimes: [TimeWindow(startHour: 9, endHour: 21)],
             durationMinutes: .init(min: 30, max: 90),
             howTo: [],

--- a/apps/ios/SoloCompass/Services/Agents/EnrichmentAgent.swift
+++ b/apps/ios/SoloCompass/Services/Agents/EnrichmentAgent.swift
@@ -1,0 +1,173 @@
+import Foundation
+import CoreLocation
+
+/// Deep-dive enrichment orchestrator. Where the legacy `exploreNearby` pipeline
+/// fetched a wide ring of shallow POIs and synthesized them in one pass, this
+/// agent does the opposite: a SMALL radius, a SHORT list of high-signal places,
+/// each cross-referenced across every available channel before synthesis.
+///
+/// Pipeline:
+///   1. Collect POIs in a small radius from Overpass (OSM) + Apple MapKit,
+///      concurrently. Merge by coordinate cell.
+///   2. Fold Foursquare hard signals (rating/hours/price) INTO the matching
+///      POIs via `FoursquareService.enrichMerge` — not a winner-takes-all merge.
+///   3. Rank by signal richness and keep the top N. Fewer, deeper entries beat
+///      a long list of skeletons.
+///   4. Backfill a street-level address on any survivor that still lacks one,
+///      using reverse geocoding, so howTo orientation steps can be concrete.
+///   5. Hand the enriched, ranked POIs to `AIService.synthesizeExperiences`,
+///      which now cites the real signals instead of writing generic filler.
+///
+/// Not an `Agent` (that protocol returns text/metadata for the voice pipeline);
+/// this returns strongly-typed `[Experience]`, so it stands alone.
+@MainActor
+public final class EnrichmentAgent {
+    /// Default search radius. Deliberately small — the whole point is depth
+    /// over breadth. Callers can widen it for a sparse area.
+    public static let defaultRadiusMeters = 800
+
+    /// How many enriched POIs survive ranking and reach synthesis. Keeps the
+    /// AI call cheap and the result set curated rather than overwhelming.
+    public static let defaultTopN = 6
+
+    private let overpassService: OverpassService
+    private let mapKitService: MapKitPOIService
+    private let foursquareService: FoursquareService
+    private let geocodeService: any ReverseGeocoding
+    private let aiService: AIService
+
+    public init(
+        overpassService: OverpassService,
+        mapKitService: MapKitPOIService,
+        foursquareService: FoursquareService,
+        geocodeService: any ReverseGeocoding,
+        aiService: AIService
+    ) {
+        self.overpassService = overpassService
+        self.mapKitService = mapKitService
+        self.foursquareService = foursquareService
+        self.geocodeService = geocodeService
+        self.aiService = aiService
+    }
+
+    /// Run the deep-dive enrichment for a coordinate. Returns synthesized
+    /// Experiences (already enriched with real signals where available).
+    /// Throws only on a hard Overpass failure; MapKit / Foursquare / geocoding
+    /// are best-effort and degrade silently to whatever signal we did get.
+    public func enrich(
+        at coordinate: CLLocationCoordinate2D,
+        radiusMeters: Int = EnrichmentAgent.defaultRadiusMeters,
+        category: ExperienceCategory? = nil,
+        cityCode: String,
+        locale: Locale = .current,
+        topN: Int = EnrichmentAgent.defaultTopN
+    ) async throws -> [Experience] {
+        // 1. Concurrent base collection. Overpass is the authoritative source
+        //    and may throw; MapKit is best-effort (empty array on failure).
+        async let overpassTask = overpassService.fetchPOIs(
+            near: coordinate, radiusMeters: radiusMeters, category: category
+        )
+        async let mapKitTask = mapKitPOIsBestEffort(
+            near: coordinate, radiusMeters: radiusMeters, category: category
+        )
+
+        let overpassPois = try await overpassTask
+        let mapKitPois = await mapKitTask
+
+        // Merge base sources by cell; Overpass wins identity on overlap.
+        var pois = FoursquareService.enrichMerge(base: overpassPois, enrichment: mapKitPois)
+        guard !pois.isEmpty else { return [] }
+
+        // 2. Fold Foursquare hard signals into the matching base POIs. One
+        //    region call (with fields) covers the whole small radius. Skipped
+        //    when no key is configured.
+        if !Secrets.resolvedFoursquareKey.isEmpty {
+            do {
+                let fsq = try await foursquareService.fetchPOIs(
+                    near: coordinate, radiusMeters: radiusMeters, category: category
+                )
+                pois = FoursquareService.enrichMerge(base: pois, enrichment: fsq)
+            } catch {
+                #if DEBUG
+                print("[EnrichmentAgent] Foursquare enrichment failed: \(error)")
+                #endif
+            }
+        }
+
+        // 3. Rank by signal richness, keep the deepest N.
+        let ranked = Array(
+            pois.sorted { Self.signalScore($0) > Self.signalScore($1) }.prefix(topN)
+        )
+
+        // 4. Backfill a street-level address on survivors missing one.
+        let enriched = await backfillAddresses(ranked)
+
+        // 5. Synthesize. The (already-relaxed) prompt cites the real signals.
+        return try await aiService.synthesizeExperiences(
+            from: enriched, cityCode: cityCode, locale: locale
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func mapKitPOIsBestEffort(
+        near coordinate: CLLocationCoordinate2D,
+        radiusMeters: Int,
+        category: ExperienceCategory?
+    ) async -> [OverpassService.POI] {
+        do {
+            return try await mapKitService.fetchPOIs(
+                near: coordinate, radiusMeters: radiusMeters, category: category
+            )
+        } catch {
+            #if DEBUG
+            print("[EnrichmentAgent] MapKit fetch failed: \(error)")
+            #endif
+            return []
+        }
+    }
+
+    /// Reverse-geocode each POI that still lacks an `addr` tag. Best-effort and
+    /// rate-limited by the OS; failures leave the POI without an address rather
+    /// than blocking the whole run.
+    private func backfillAddresses(_ pois: [OverpassService.POI]) async -> [OverpassService.POI] {
+        var result: [OverpassService.POI] = []
+        for poi in pois {
+            guard poi.tags["addr"] == nil else {
+                result.append(poi)
+                continue
+            }
+            let coord = CLLocationCoordinate2D(latitude: poi.lat, longitude: poi.lon)
+            if let resolved = await geocodeService.resolve(coordinate: coord) {
+                var tags = poi.tags
+                tags["addr"] = resolved.name
+                result.append(OverpassService.POI(
+                    osmId: poi.osmId, name: poi.name, nameEn: poi.nameEn,
+                    lat: poi.lat, lon: poi.lon, tags: tags
+                ))
+            } else {
+                result.append(poi)
+            }
+        }
+        return result
+    }
+
+    /// Heuristic richness score: each real hard signal is worth more than a
+    /// raw OSM tag, so signal-bearing POIs float to the top of the ranking.
+    static func signalScore(_ poi: OverpassService.POI) -> Int {
+        var score = 0
+        if poi.tags["fsq_rating"] != nil { score += 4 }
+        if poi.tags["opening_hours"] != nil { score += 3 }
+        if poi.tags["fsq_price"] != nil { score += 2 }
+        if poi.tags["fsq_popularity"] != nil { score += 2 }
+        if poi.tags["website"] != nil { score += 1 }
+        if poi.tags["phone"] != nil { score += 1 }
+        if poi.tags["addr"] != nil { score += 1 }
+        // A named place with a real category is inherently more useful than a
+        // bare node, so reward those too (smaller weight than hard signals).
+        if poi.tags["amenity"] != nil || poi.tags["tourism"] != nil || poi.tags["leisure"] != nil {
+            score += 1
+        }
+        return score
+    }
+}

--- a/apps/ios/SoloCompass/Services/FeatureFlags.swift
+++ b/apps/ios/SoloCompass/Services/FeatureFlags.swift
@@ -61,6 +61,19 @@ public enum FeatureFlags {
         readBool("FF_PRO_MULTI_RING_EXPLORE", default: false)
     }
 
+    /// When true, `MapViewModel.exploreNearby` routes through `EnrichmentAgent`:
+    /// a small-radius, deep-dive pass that cross-references each place across
+    /// Overpass + Apple MapKit + Foursquare (real rating/hours/price) and
+    /// reverse-geocoded addresses before AI synthesis. Fewer, richer entries
+    /// instead of a wide ring of skeletons. When false, the legacy wide-ring
+    /// pipeline runs unchanged so we can fall back instantly.
+    ///
+    /// Default on — the deep-dive output is strictly richer; the flag exists
+    /// purely as a kill switch.
+    public static var deepDiveEnrichment: Bool {
+        readBool("FF_DEEP_DIVE_ENRICHMENT", default: true)
+    }
+
     // MARK: - Internals
 
     static func readBool(_ key: String, default fallback: Bool) -> Bool {

--- a/apps/ios/SoloCompass/Services/FoursquareService.swift
+++ b/apps/ios/SoloCompass/Services/FoursquareService.swift
@@ -84,7 +84,11 @@ public final class FoursquareService {
             URLQueryItem(name: "ll", value: "\(coordinate.latitude),\(coordinate.longitude)"),
             URLQueryItem(name: "radius", value: String(radiusMeters)),
             URLQueryItem(name: "limit", value: String(maxResults)),
-            URLQueryItem(name: "sort", value: "DISTANCE")
+            URLQueryItem(name: "sort", value: "DISTANCE"),
+            // Request the enrichment fields the deep-dive pipeline cares about.
+            // Foursquare returns whatever the key's tier permits; missing fields
+            // simply decode as nil and the POI keeps its OSM-only signal set.
+            URLQueryItem(name: "fields", value: Self.requestedFields)
         ]
         if let category, let fsqCategories = Self.categoryToFoursquareIds[category] {
             items.append(URLQueryItem(name: "categories", value: fsqCategories))
@@ -108,6 +112,13 @@ public final class FoursquareService {
         }
         return try Self.decodePOIs(from: data)
     }
+
+    /// Comma-separated `fields` requested from `/places/search`. `fsq_id`,
+    /// `name`, `geocodes`, `categories` are the baseline; the rest are the
+    /// "hard signals" the deep-dive enrichment pipeline surfaces to the AI.
+    /// A free-tier key may silently omit `rating`/`hours`/`price` — those just
+    /// decode as nil, so requesting them is always safe.
+    static let requestedFields = "fsq_id,name,geocodes,categories,rating,hours,price,website,tel,popularity"
 
     // MARK: - Category mapping
 
@@ -139,6 +150,13 @@ public final class FoursquareService {
             let name: String?
             let geocodes: Geocodes?
             let categories: [Category]?
+            // Enrichment fields — all optional; a free-tier key omits them.
+            let rating: Double?       // 0–10
+            let hours: Hours?
+            let price: Int?           // 1–4
+            let website: String?
+            let tel: String?
+            let popularity: Double?   // 0–1
         }
         struct Geocodes: Decodable {
             let main: LatLon?
@@ -150,6 +168,10 @@ public final class FoursquareService {
         struct Category: Decodable {
             let id: Int?
             let name: String?
+        }
+        struct Hours: Decodable {
+            let display: String?      // human-readable, e.g. "Mon-Fri 8:00 AM-6:00 PM"
+            let open_now: Bool?
         }
 
         do {
@@ -163,6 +185,15 @@ public final class FoursquareService {
                 if let firstCat = row.categories?.first?.name {
                     tags["amenity"] = mapFoursquareCategoryToAmenity(firstCat)
                 }
+                // Hard signals — namespaced under fsq_ so downstream code (the
+                // enrichment merge + AI prompt builder) can distinguish them
+                // from raw OSM tags and cite them as real provider data.
+                if let rating = row.rating { tags["fsq_rating"] = String(rating) }
+                if let hours = row.hours?.display, !hours.isEmpty { tags["opening_hours"] = hours }
+                if let price = row.price { tags["fsq_price"] = String(price) }
+                if let website = row.website, !website.isEmpty { tags["website"] = website }
+                if let tel = row.tel, !tel.isEmpty { tags["phone"] = tel }
+                if let popularity = row.popularity { tags["fsq_popularity"] = String(popularity) }
                 let stableId = stableInt64Id(forFsqId: row.fsq_id)
                 return OverpassService.POI(
                     osmId: stableId,
@@ -239,5 +270,57 @@ public final class FoursquareService {
         let rLat = (lat * 10_000).rounded() / 10_000
         let rLon = (lon * 10_000).rounded() / 10_000
         return String(format: "%.4f_%.4f", rLat, rLon)
+    }
+
+    /// Enrichment merge used by the deep-dive pipeline. Unlike `merge` — which
+    /// keeps one POI per cell and discards the other — this folds the *signal*
+    /// tags from `enrichment` POIs INTO the matching `base` POI in the same
+    /// cell, so an OSM/MapKit place gains Foursquare's rating/hours/price
+    /// without losing its identity. Enrichment-only cells (no base match) are
+    /// appended as standalone POIs.
+    ///
+    /// Only the hard-signal keys are folded; `base`'s own tags win on any
+    /// key collision so we never overwrite a more authoritative source name.
+    static func enrichMerge(
+        base: [OverpassService.POI],
+        enrichment: [OverpassService.POI]
+    ) -> [OverpassService.POI] {
+        let signalKeys = ["fsq_rating", "opening_hours", "fsq_price", "website", "phone", "fsq_popularity", "addr"]
+        // Index enrichment POIs by cell for O(1) lookup.
+        var enrichmentByCell: [String: OverpassService.POI] = [:]
+        for poi in enrichment {
+            enrichmentByCell[cellKey(lat: poi.lat, lon: poi.lon), default: poi] = poi
+        }
+
+        var usedCells = Set<String>()
+        var result: [OverpassService.POI] = []
+        for poi in base {
+            let key = cellKey(lat: poi.lat, lon: poi.lon)
+            usedCells.insert(key)
+            guard let match = enrichmentByCell[key] else {
+                result.append(poi)
+                continue
+            }
+            var tags = poi.tags
+            for sk in signalKeys where tags[sk] == nil {
+                if let value = match.tags[sk] { tags[sk] = value }
+            }
+            result.append(OverpassService.POI(
+                osmId: poi.osmId,
+                name: poi.name,
+                nameEn: poi.nameEn,
+                lat: poi.lat,
+                lon: poi.lon,
+                tags: tags
+            ))
+        }
+        // Enrichment-only cells become standalone POIs.
+        for poi in enrichment {
+            let key = cellKey(lat: poi.lat, lon: poi.lon)
+            if usedCells.insert(key).inserted {
+                result.append(poi)
+            }
+        }
+        return result
     }
 }

--- a/apps/ios/SoloCompass/Services/MapKitPOIService.swift
+++ b/apps/ios/SoloCompass/Services/MapKitPOIService.swift
@@ -1,0 +1,184 @@
+import Foundation
+import CoreLocation
+import MapKit
+import Observation
+
+/// Tertiary POI data source backed by Apple's `MKLocalSearch`. Free, native,
+/// key-less — used by the deep-dive enrichment pipeline to thicken the signal
+/// set for each place beyond what OSM/Overpass exposes.
+///
+/// Returns `OverpassService.POI` instances (the canonical POI shape across the
+/// app) so results merge through the same dedupe path as Overpass + Foursquare.
+/// Apple's `MKMapItem` exposes `pointOfInterestCategory`, `phoneNumber`, and
+/// `url`; we map the category to an OSM-style `amenity`/`tourism`/`leisure`
+/// tag so `OverpassService.category(for:)` keeps working unchanged. Hours and
+/// rating are not part of the public MapItem surface, so those stay nil here
+/// (Foursquare is the rating/hours source).
+///
+/// `@MainActor` because `MKLocalSearch` completion is dispatched on the main
+/// queue and the rest of the explore pipeline is main-actor-bound.
+@MainActor
+@Observable
+public final class MapKitPOIService {
+    public enum MapKitPOIError: Error, LocalizedError {
+        case searchFailed(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .searchFailed(let msg):
+                return msg
+            }
+        }
+    }
+
+    public private(set) var isFetching: Bool = false
+
+    public init() {}
+
+    /// Search Apple Maps POIs within `radiusMeters` of `coordinate`. `category`
+    /// narrows the `MKPointOfInterestCategory` filter when provided; otherwise
+    /// the search returns the full POI set in the region. Best-effort — returns
+    /// an empty array rather than throwing on an empty result so callers can
+    /// treat it as a soft enrichment source.
+    public func fetchPOIs(
+        near coordinate: CLLocationCoordinate2D,
+        radiusMeters: Int = 1000,
+        category: ExperienceCategory? = nil
+    ) async throws -> [OverpassService.POI] {
+        isFetching = true
+        defer { isFetching = false }
+
+        let request = MKLocalPointsOfInterestRequest(
+            center: coordinate,
+            radius: CLLocationDistance(radiusMeters)
+        )
+        if let category, let filter = Self.poiFilter(for: category) {
+            request.pointOfInterestFilter = filter
+        }
+
+        let search = MKLocalSearch(request: request)
+        let response: MKLocalSearch.Response
+        do {
+            response = try await search.start()
+        } catch {
+            // An empty-result search surfaces as an error on some OS versions;
+            // treat that as "no POIs" rather than a hard failure.
+            let ns = error as NSError
+            if ns.domain == MKError.errorDomain {
+                return []
+            }
+            throw MapKitPOIError.searchFailed(String(describing: error))
+        }
+
+        return response.mapItems.compactMap { Self.poi(from: $0) }
+    }
+
+    // MARK: - Mapping
+
+    /// Convert an `MKMapItem` into an `OverpassService.POI`. Returns nil when
+    /// the item has no name or usable coordinate.
+    static func poi(from item: MKMapItem) -> OverpassService.POI? {
+        let placemark = item.placemark
+        let name = item.name ?? placemark.name
+        guard let name, !name.isEmpty else { return nil }
+        let coord = placemark.coordinate
+        guard CLLocationCoordinate2DIsValid(coord) else { return nil }
+
+        var tags: [String: String] = ["name": name, "source": "mapkit"]
+        if let osmTag = item.pointOfInterestCategory.flatMap(osmTag(for:)) {
+            tags[osmTag.key] = osmTag.value
+        }
+        if let phone = item.phoneNumber, !phone.isEmpty {
+            tags["phone"] = phone
+        }
+        if let url = item.url?.absoluteString, !url.isEmpty {
+            tags["website"] = url
+        }
+        // A street-level address hint when the placemark carries one — helps
+        // the AI write accurate howTo orientation steps.
+        if let thoroughfare = placemark.thoroughfare {
+            let withNumber = [placemark.subThoroughfare, thoroughfare]
+                .compactMap { $0 }
+                .joined(separator: " ")
+            tags["addr"] = withNumber.isEmpty ? thoroughfare : withNumber
+        }
+
+        let stableId = stableInt64Id(forMapItem: item, name: name, coordinate: coord)
+        return OverpassService.POI(
+            osmId: stableId,
+            name: name,
+            nameEn: nil,
+            lat: coord.latitude,
+            lon: coord.longitude,
+            tags: tags
+        )
+    }
+
+    /// Map an `MKPointOfInterestCategory` to an OSM-style tag (key, value) so
+    /// `OverpassService.category(for:)` resolves it to the right bucket.
+    static func osmTag(for category: MKPointOfInterestCategory) -> (key: String, value: String)? {
+        switch category {
+        case .cafe, .bakery:
+            return ("amenity", "cafe")
+        case .restaurant, .foodMarket:
+            return ("amenity", "restaurant")
+        case .nightlife, .brewery, .winery:
+            return ("amenity", "bar")
+        case .library:
+            return ("amenity", "library")
+        case .museum:
+            return ("tourism", "museum")
+        case .nationalPark, .park:
+            return ("leisure", "park")
+        case .beach:
+            return ("natural", "beach")
+        case .fitnessCenter:
+            return ("leisure", "fitness_centre")
+        case .aquarium, .zoo:
+            return ("tourism", "zoo")
+        default:
+            return nil
+        }
+    }
+
+    /// Build an `MKPointOfInterestFilter` that narrows the search to the
+    /// categories matching one of our `ExperienceCategory` buckets. Returns nil
+    /// for buckets with no clean MapKit equivalent (caller then searches all).
+    static func poiFilter(for category: ExperienceCategory) -> MKPointOfInterestFilter? {
+        let categories: [MKPointOfInterestCategory]
+        switch category {
+        case .coffee:    categories = [.cafe, .bakery]
+        case .food:      categories = [.restaurant, .foodMarket]
+        case .nightlife: categories = [.nightlife, .brewery, .winery]
+        case .work:      categories = [.library]
+        case .culture:   categories = [.museum]
+        case .nature:    categories = [.nationalPark, .park, .beach, .aquarium, .zoo]
+        case .wellness:  categories = [.fitnessCenter]
+        case .hidden:    return nil
+        }
+        return MKPointOfInterestFilter(including: categories)
+    }
+
+    /// Hash an Apple Maps item into a stable `Int64`. Apple has no public stable
+    /// identifier, so we hash name + rounded coordinate. The high marker bit
+    /// (0x2000…) is distinct from the OSM range and Foursquare's 0x4000… bit,
+    /// so MapKit ids never collide with the other two sources.
+    static func stableInt64Id(
+        forMapItem item: MKMapItem,
+        name: String,
+        coordinate: CLLocationCoordinate2D
+    ) -> Int64 {
+        // 4-decimal coordinate (~11 m) keeps the id stable across runs even if
+        // Apple jitters the coordinate slightly.
+        let rLat = (coordinate.latitude * 10_000).rounded() / 10_000
+        let rLon = (coordinate.longitude * 10_000).rounded() / 10_000
+        let seed = "\(name)|\(rLat)|\(rLon)"
+        var hash: UInt64 = 1469598103934665603 // FNV offset basis
+        for byte in seed.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1099511628211 // FNV prime
+        }
+        let positive = hash & 0x7FFF_FFFF_FFFF_FFFF
+        return Int64(bitPattern: positive | 0x2000_0000_0000_0000)
+    }
+}

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -2448,6 +2448,11 @@ final class SoloCompassTests: XCTestCase {
     /// DiscoveredCityRecord row exists with name "Hanoi".
     @MainActor
     func testExploreNearbyUsesReverseGeocodedCityCode() async throws {
+        // This test drives the legacy wide-ring pipeline via a stubbed Overpass
+        // session. Disable the deep-dive agent (which uses its own live channel
+        // services and bypasses the stub) so the assertions stay valid.
+        setenv("FF_DEEP_DIVE_ENRICHMENT", "0", 1)
+        defer { unsetenv("FF_DEEP_DIVE_ENRICHMENT") }
         // --- Overpass stub: returns one cafe near Hanoi ---
         let overpassJSON = #"""
         {"elements":[{"type":"node","id":7001,"lat":21.0280,"lon":105.8540,"tags":{"amenity":"cafe","name":"Hanoi Cafe"}}]}
@@ -2526,6 +2531,10 @@ final class SoloCompassTests: XCTestCase {
     /// and lastExploreToast contains "Hanoi".
     @MainActor
     func testExploreNearbyAutoSwitchesSelectedCityAndSetsToast() async throws {
+        // Legacy wide-ring pipeline test — disable the deep-dive agent so the
+        // stubbed Overpass session drives the assertions.
+        setenv("FF_DEEP_DIVE_ENRICHMENT", "0", 1)
+        defer { unsetenv("FF_DEEP_DIVE_ENRICHMENT") }
         let overpassJSON = #"""
         {"elements":[{"type":"node","id":8001,"lat":21.0280,"lon":105.8540,"tags":{"amenity":"cafe","name":"Pho Spot"}}]}
         """#
@@ -2780,6 +2789,10 @@ final class SoloCompassTests: XCTestCase {
     /// Successful exploreNearby → lastExploreToast is set (named variant).
     @MainActor
     func testExploreNearbySuccessSetToast() async throws {
+        // Legacy wide-ring pipeline test — disable the deep-dive agent so the
+        // stubbed Overpass session drives the assertions.
+        setenv("FF_DEEP_DIVE_ENRICHMENT", "0", 1)
+        defer { unsetenv("FF_DEEP_DIVE_ENRICHMENT") }
         let overpassJSON = #"""
         {"elements":[{"type":"node","id":9001,"lat":21.028,"lon":105.854,"tags":{"amenity":"cafe","name":"Test Cafe"}}]}
         """#
@@ -4651,6 +4664,10 @@ final class VoiceAgentOrchestratorUnconfiguredTests: XCTestCase {
     /// setting lastExploreError.
     @MainActor
     func testExploreNearbyUsesCacheWhenFetchReturnsEmpty() async throws {
+        // Legacy wide-ring pipeline test — disable the deep-dive agent so the
+        // stubbed empty Overpass session triggers the cache fallback path.
+        setenv("FF_DEEP_DIVE_ENRICHMENT", "0", 1)
+        defer { unsetenv("FF_DEEP_DIVE_ENRICHMENT") }
         // 1. Stub Overpass to return an empty elements array — no network error,
         //    just zero POIs found. exploreNearby reaches the `guard !pois.isEmpty`
         //    branch and should query the repo before setting lastExploreError.
@@ -4725,6 +4742,10 @@ final class VoiceAgentOrchestratorUnconfiguredTests: XCTestCase {
     /// should lastExploreError be set.
     @MainActor
     func testExploreNearbySetErrorWhenBothFetchAndCacheEmpty() async throws {
+        // Legacy wide-ring pipeline test — disable the deep-dive agent so the
+        // stubbed empty Overpass session reaches the error path.
+        setenv("FF_DEEP_DIVE_ENRICHMENT", "0", 1)
+        defer { unsetenv("FF_DEEP_DIVE_ENRICHMENT") }
         StubURLProtocol.requestCount = 0
         StubURLProtocol.handler = { request in
             let empty = #"{"elements":[]}"#
@@ -5620,5 +5641,104 @@ final class FoursquareServiceTests: XCTestCase {
 
         prefs.incrementFoursquareCallsToday(now: today, calendar: cal)
         XCTAssertEqual(prefs.foursquareCallsToday, 2, "subsequent same-day calls must increment")
+    }
+}
+
+// MARK: - Deep-dive enrichment (cross-channel signal folding)
+
+@MainActor
+final class EnrichmentPipelineTests: XCTestCase {
+
+    private func poi(
+        id: Int64, lat: Double, lon: Double, tags: [String: String]
+    ) -> OverpassService.POI {
+        OverpassService.POI(osmId: id, name: tags["name"] ?? "Place", nameEn: nil, lat: lat, lon: lon, tags: tags)
+    }
+
+    /// enrichMerge folds Foursquare hard signals INTO the matching base POI
+    /// (same coordinate cell) instead of discarding one source.
+    func testEnrichMergeFoldsSignalsIntoBasePOI() {
+        let base = poi(id: 7001, lat: 21.0280, lon: 105.8540, tags: ["amenity": "cafe", "name": "Hanoi Cafe"])
+        let enrichment = poi(id: 0x4000_0000_0000_0001, lat: 21.0280, lon: 105.8540,
+                             tags: ["name": "Hanoi Cafe", "fsq_rating": "8.6", "opening_hours": "Mon-Fri 8:00-18:00", "fsq_price": "2"])
+
+        let merged = FoursquareService.enrichMerge(base: [base], enrichment: [enrichment])
+
+        XCTAssertEqual(merged.count, 1, "same-cell POIs collapse to one entry")
+        let result = merged[0]
+        XCTAssertEqual(result.osmId, 7001, "base identity wins")
+        XCTAssertEqual(result.tags["fsq_rating"], "8.6", "rating folded in from enrichment")
+        XCTAssertEqual(result.tags["opening_hours"], "Mon-Fri 8:00-18:00")
+        XCTAssertEqual(result.tags["fsq_price"], "2")
+        XCTAssertEqual(result.tags["amenity"], "cafe", "base tags preserved")
+    }
+
+    /// enrichMerge keeps a base tag when both sources set the same key.
+    func testEnrichMergeBaseTagWinsOnCollision() {
+        let base = poi(id: 7002, lat: 1.0, lon: 1.0, tags: ["name": "A", "website": "https://base.example"])
+        let enrichment = poi(id: 0x4000_0000_0000_0002, lat: 1.0, lon: 1.0,
+                             tags: ["name": "A", "website": "https://fsq.example"])
+        let merged = FoursquareService.enrichMerge(base: [base], enrichment: [enrichment])
+        XCTAssertEqual(merged[0].tags["website"], "https://base.example", "base wins on key collision")
+    }
+
+    /// Enrichment-only cells (no base match) survive as standalone POIs.
+    func testEnrichMergeAppendsEnrichmentOnlyCells() {
+        let base = poi(id: 7003, lat: 10.0, lon: 10.0, tags: ["name": "Base"])
+        let enrichment = poi(id: 0x4000_0000_0000_0003, lat: 20.0, lon: 20.0, tags: ["name": "FsqOnly", "fsq_rating": "9.1"])
+        let merged = FoursquareService.enrichMerge(base: [base], enrichment: [enrichment])
+        XCTAssertEqual(merged.count, 2, "non-overlapping enrichment POI is appended")
+    }
+
+    /// signalScore ranks hard-signal POIs above bare ones.
+    func testSignalScoreRanksRichPOIsHigher() {
+        let rich = poi(id: 1, lat: 0, lon: 0,
+                       tags: ["amenity": "cafe", "fsq_rating": "8", "opening_hours": "x", "fsq_price": "2"])
+        let bare = poi(id: 2, lat: 0, lon: 0, tags: ["amenity": "cafe"])
+        XCTAssertGreaterThan(EnrichmentAgent.signalScore(rich), EnrichmentAgent.signalScore(bare))
+    }
+
+    /// enrichedLocation lifts tag-bag hard signals into typed location fields.
+    func testEnrichedLocationExtractsHardSignals() {
+        let p = poi(id: 1, lat: 21.03, lon: 105.85,
+                    tags: ["name": "Place", "fsq_rating": "8.4", "opening_hours": "Mon-Sun 9-21",
+                           "fsq_price": "3", "website": "https://x.example", "phone": "+84 1", "addr": "12 Pho St"])
+        let loc = AIService.enrichedLocation(from: p, cityCode: "vn-hanoi")
+        XCTAssertEqual(loc.rating, 8.4)
+        XCTAssertEqual(loc.openingHours, "Mon-Sun 9-21")
+        XCTAssertEqual(loc.priceLevel, 3)
+        XCTAssertEqual(loc.website, "https://x.example")
+        XCTAssertEqual(loc.phone, "+84 1")
+        XCTAssertEqual(loc.addressHint, "12 Pho St")
+        XCTAssertEqual(loc.cityCode, "vn-hanoi")
+    }
+
+    /// An OSM-only POI yields a location with all hard-signal fields nil.
+    func testEnrichedLocationNilWhenNoSignals() {
+        let p = poi(id: 1, lat: 0, lon: 0, tags: ["amenity": "cafe", "name": "Bare"])
+        let loc = AIService.enrichedLocation(from: p, cityCode: "cmi")
+        XCTAssertNil(loc.rating)
+        XCTAssertNil(loc.openingHours)
+        XCTAssertNil(loc.priceLevel)
+        XCTAssertFalse(AIService.hasHardSignals(p))
+    }
+
+    /// MapKit POI mapping produces an OSM-compatible tag the category resolver
+    /// understands, and a MapKit-range id distinct from OSM/Foursquare.
+    func testMapKitOSMTagMappingAndIdRange() {
+        guard let tag = MapKitPOIService.osmTag(for: .cafe) else {
+            return XCTFail("cafe should map to an OSM tag")
+        }
+        XCTAssertEqual(tag.key, "amenity")
+        XCTAssertEqual(tag.value, "cafe")
+
+        let id = MapKitPOIService.stableInt64Id(
+            forMapItem: MKMapItem(),
+            name: "Test Cafe",
+            coordinate: CLLocationCoordinate2D(latitude: 21.0, longitude: 105.0)
+        )
+        // MapKit marker bit is 0x2000…; must not collide with Foursquare's 0x4000…
+        XCTAssertEqual(id & 0x4000_0000_0000_0000, 0, "MapKit id must not carry the Foursquare marker bit")
+        XCTAssertNotEqual(id & 0x2000_0000_0000_0000, 0, "MapKit id must carry its own marker bit")
     }
 }

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -26,6 +26,19 @@ public final class MapViewModel {
     private let foursquareService: FoursquareService
     private let geocodeService: any ReverseGeocoding
     private let preferences: UserPreferences
+
+    /// Lazily built deep-dive orchestrator. Reuses the existing channel
+    /// services and adds an Apple MapKit source. `@ObservationIgnored` so the
+    /// `@Observable` macro leaves it as a plain stored property (and permits
+    /// `lazy`); non-explore code paths and tests never pay for it.
+    @ObservationIgnored
+    private lazy var enrichmentAgent = EnrichmentAgent(
+        overpassService: overpassService,
+        mapKitService: MapKitPOIService(),
+        foursquareService: foursquareService,
+        geocodeService: geocodeService,
+        aiService: aiService
+    )
     /// Optional so existing tests / previews can construct without a
     /// real StoreKit-aware service. Production wires this from the
     /// environment in `CompassMapView` (Epic D US-024).
@@ -892,56 +905,8 @@ public final class MapViewModel {
         aiService.isProTier = isProUser
 
         do {
-            // US-MR-01: Pro multi-ring schedule (4 rings, dedup'd, single
-            // synthesis). Falls back to a 1-ring fetch when the flag is off
-            // or the user isn't on Pro. Returns the radius we should record
-            // for offline fallback (PRD §7: outermost ring only).
-            let (overpassPois, effectiveRadius) = try await fetchExplorePOIs(
-                near: coordinate,
-                singleRingRadius: radiusMeters,
-                category: category
-            )
-
-            // US-013: Foursquare fallback. Thin Overpass results (< 5) AND a
-            // configured key trigger ONE Foursquare call at the same radius +
-            // category. Merged via 4-decimal-cell dedupe; Overpass wins on
-            // collision. Counter increments for visibility — never enforced.
-            var pois = overpassPois
-            let fsqKey = Secrets.resolvedFoursquareKey
-            if overpassPois.count < Self.foursquareFallbackThreshold, !fsqKey.isEmpty {
-                do {
-                    let fsq = try await foursquareService.fetchPOIs(
-                        near: coordinate,
-                        radiusMeters: radiusMeters,
-                        category: category
-                    )
-                    preferences.incrementFoursquareCallsToday()
-                    pois = FoursquareService.merge(overpass: overpassPois, foursquare: fsq)
-                } catch {
-                    // Best-effort. A Foursquare miss still leaves Overpass
-                    // pois in place — never blocks the Explore flow.
-                    #if DEBUG
-                    print("[MapViewModel] Foursquare fallback failed: \(error)")
-                    #endif
-                }
-            }
-            guard !pois.isEmpty else {
-                if let region = experienceService.repo.closestRecentRegion(to: coordinate) {
-                    let cached = experienceService.repo.experiences(in: region)
-                    if !cached.isEmpty {
-                        visibleExperiences = cached
-                        nearbySoloCount = 0
-                        updateBottomInfo()
-                        lastExploreToast = NSLocalizedString("explore.toast.cachedFallback", comment: "Showing cached results")
-                        return
-                    }
-                }
-                lastExploreError = NSLocalizedString("explore.error.nothingFound", comment: "No POIs found nearby")
-                return
-            }
-
-            // US-016: try a real city name first; fall back to the
-            // synthetic osm_<lat>_<lon> only when the geocoder fails.
+            // US-016: resolve a real city name up front (both pipelines need
+            // it). Fall back to the synthetic osm_<lat>_<lon> on geocoder miss.
             let resolved = await geocodeService.resolve(coordinate: coordinate)
             let cityCode = resolved?.cityCode ?? Self.cityCode(for: coordinate)
 
@@ -956,18 +921,93 @@ public final class MapViewModel {
                 )
             }
 
-            // US-MR-04: switch the progress capsule to "synthesizing" once
-            // Overpass is done. In single-ring legacy mode this never
-            // triggers because exploreProgress stays `.idle` (no scanning
-            // phase was set).
-            if exploreProgress != .idle {
-                exploreProgress = .synthesizing(poiCount: pois.count)
+            let generated: [Experience]
+            let effectiveRadius: Int
+
+            if FeatureFlags.deepDiveEnrichment {
+                // Deep-dive: small radius, cross-channel enrichment, curated
+                // top-N, then synthesis. Returns synthesized Experiences
+                // directly. Empty result → cached/error fallback below.
+                if exploreProgress != .idle {
+                    exploreProgress = .synthesizing(poiCount: 0)
+                }
+                let enriched = try await enrichmentAgent.enrich(
+                    at: coordinate,
+                    radiusMeters: min(radiusMeters, EnrichmentAgent.defaultRadiusMeters),
+                    category: category,
+                    cityCode: cityCode,
+                    locale: LanguageService.shared.effectiveLocale
+                )
+                guard !enriched.isEmpty else {
+                    if let region = experienceService.repo.closestRecentRegion(to: coordinate),
+                       case let cached = experienceService.repo.experiences(in: region),
+                       !cached.isEmpty {
+                        visibleExperiences = cached
+                        nearbySoloCount = 0
+                        updateBottomInfo()
+                        lastExploreToast = NSLocalizedString("explore.toast.cachedFallback", comment: "Showing cached results")
+                        return
+                    }
+                    lastExploreError = NSLocalizedString("explore.error.nothingFound", comment: "No POIs found nearby")
+                    return
+                }
+                generated = enriched
+                effectiveRadius = min(radiusMeters, EnrichmentAgent.defaultRadiusMeters)
+            } else {
+                // Legacy wide-ring pipeline (kill-switch path).
+                // US-MR-01: Pro multi-ring schedule (4 rings, dedup'd, single
+                // synthesis). Falls back to a 1-ring fetch when the flag is off
+                // or the user isn't on Pro.
+                let (overpassPois, ringRadius) = try await fetchExplorePOIs(
+                    near: coordinate,
+                    singleRingRadius: radiusMeters,
+                    category: category
+                )
+
+                // US-013: Foursquare fallback when Overpass is thin.
+                var pois = overpassPois
+                let fsqKey = Secrets.resolvedFoursquareKey
+                if overpassPois.count < Self.foursquareFallbackThreshold, !fsqKey.isEmpty {
+                    do {
+                        let fsq = try await foursquareService.fetchPOIs(
+                            near: coordinate,
+                            radiusMeters: radiusMeters,
+                            category: category
+                        )
+                        preferences.incrementFoursquareCallsToday()
+                        pois = FoursquareService.merge(overpass: overpassPois, foursquare: fsq)
+                    } catch {
+                        #if DEBUG
+                        print("[MapViewModel] Foursquare fallback failed: \(error)")
+                        #endif
+                    }
+                }
+                guard !pois.isEmpty else {
+                    if let region = experienceService.repo.closestRecentRegion(to: coordinate) {
+                        let cached = experienceService.repo.experiences(in: region)
+                        if !cached.isEmpty {
+                            visibleExperiences = cached
+                            nearbySoloCount = 0
+                            updateBottomInfo()
+                            lastExploreToast = NSLocalizedString("explore.toast.cachedFallback", comment: "Showing cached results")
+                            return
+                        }
+                    }
+                    lastExploreError = NSLocalizedString("explore.error.nothingFound", comment: "No POIs found nearby")
+                    return
+                }
+
+                if exploreProgress != .idle {
+                    exploreProgress = .synthesizing(poiCount: pois.count)
+                }
+                generated = try await aiService.synthesizeExperiences(
+                    from: pois,
+                    cityCode: cityCode,
+                    locale: LanguageService.shared.effectiveLocale
+                )
+                effectiveRadius = ringRadius
             }
-            let generated = try await aiService.synthesizeExperiences(
-                from: pois,
-                cityCode: cityCode,
-                locale: LanguageService.shared.effectiveLocale
-            )
+
             let added = experienceService.appendGenerated(generated)
             lastExploreAddedCount = added
 

--- a/packages/core/src/experience.ts
+++ b/packages/core/src/experience.ts
@@ -73,6 +73,15 @@ export interface ExperienceLocation {
   readonly addressHint?: string; // human-readable, NOT the source of truth
   readonly placeNameLocal?: string; // "วัดสวนดอก" — local language
   readonly placeNameRomanized?: string; // "Wat Suan Dok"
+  // Cross-channel "hard" signals enriched from Foursquare / Apple MapKit when
+  // available. All optional: OSM-only places leave them undefined. Surfaced to
+  // the AI synthesis prompt so generated copy can cite real data instead of
+  // generic placeholders, and shown in the detail view when present.
+  readonly rating?: number; // 0–10 normalized provider rating (Foursquare uses 0–10)
+  readonly openingHours?: string; // raw provider hours string, e.g. "Mon-Fri 8:00-18:00"
+  readonly priceLevel?: number; // 1–4 (1 = cheap, 4 = expensive)
+  readonly website?: string;
+  readonly phone?: string;
 }
 
 /**


### PR DESCRIPTION
## 背景

用户反馈"数据太少"。排查后确认**不是编译/打包问题**(bundle 一直正常),而是数据来源单一 + AI 被刻意限制:

- Explore 走的是 wide-ring 管道(3–12km 摊大饼,几十个浅 POI,一次批量 synthesis)。
- 只喂 OSM tag 给 AI,且 prompt 禁止补全 → 输出全是 7.0 分 + 通用占位文案。
- Foursquare 明明能返回 rating/hours/price,代码却只取了 name/坐标/category。

按"**逐点深挖 agent:范围更小、每点更深**"的方向重做数据获取。

## Summary

- **EnrichmentAgent**(新):~800m 小半径 → Overpass + Apple MapKit 并发采集 → 折叠 Foursquare 真信号 → 按信号丰富度排序取 top-6 → 反查地址 → synthesis。少而深。
- **FoursquareService**:真正解析 rating / hours / price / popularity / website / tel(以前丢弃);新增 `enrichMerge` 把信号**折叠进**匹配的基础 POI(而非二选一丢弃)。
- **MapKitPOIService**(新):免费、原生、无 key 的第三渠道,`MKLocalSearch`。
- **AIService**:放宽 prompt 允许引用真实信号;去掉 7.0–8.5 死 clamp 与全等 breakdown;把 rating/hours/price 提升为 `ExperienceLocation` 强类型字段。
- **Schema**:`ExperienceLocation` 加可选 rating/openingHours/priceLevel/website/phone(TS + Swift + SwiftData 三处 parity 同步)。
- **`FF_DEEP_DIVE_ENRICHMENT`**(默认开):kill switch,可瞬间回退旧管道。

## Test plan

- [x] `pnpm parity:check` 全绿(TS↔Swift / TS↔DB / SQL↔Swift / TS↔SwiftData)
- [x] `xcodebuild build` 成功
- [x] 全套 285 测试通过 0 失败(含 7 个新增 EnrichmentPipelineTests)
- [ ] **真机带 Foursquare key + AI key 实跑 Explore**,确认深挖出的真实 rating/hours/价格真的出现在卡片上(模拟器无 key 会走 skeleton,我无法端到端验证真实数据观感)

## 已知取舍

- 深挖路径里 Foursquare 调用未调 `incrementFoursquareCallsToday()`(该计数器仅用于可见性、never enforced)。为它把 prefs 穿透进 agent 属过度设计,故保持现状。