### PR TITLE
feat(ios): AI Provider settings with API key, provider switch, and custom endpoint

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		3B2C16B114CAAADE0862AF7B /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AF76F1B505EF8AF6EF2470 /* ShareSheet.swift */; };
 		42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */; };
 		45A4E8EED0300F00253EC049 /* MarkdownExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F3FDE4BC9458E490AEA67A /* MarkdownExporter.swift */; };
+		AA11BB22CC33DD44EE55FF77 /* AIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11BB22CC33DD44EE55FF66 /* AIProvider.swift */; };
+		BB22CC33DD44EE55FF6600BB /* AIProviderSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB22CC33DD44EE55FF6600AA /* AIProviderSettingsView.swift */; };
 		464746A44182622D4F617462 /* AIUsageRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */; };
 		48DF01972A1FB107BFFF0684 /* QueryAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06086F5F9463C18F486E5694 /* QueryAgent.swift */; };
 		48DF93F42CDDB1329B038865 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6556C23BF1B228BF686C5500 /* KeychainStore.swift */; };
@@ -131,6 +133,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		AA11BB22CC33DD44EE55FF66 /* AIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProvider.swift; sourceTree = "<group>"; };
+		BB22CC33DD44EE55FF6600AA /* AIProviderSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderSettingsView.swift; sourceTree = "<group>"; };
 		001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIUsageRecord.swift; sourceTree = "<group>"; };
 		06086F5F9463C18F486E5694 /* QueryAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryAgent.swift; sourceTree = "<group>"; };
 		06B7D586552E9F1EA44F5657 /* MapKitPOIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapKitPOIService.swift; sourceTree = "<group>"; };
@@ -392,6 +396,7 @@
 		5B71CF70956BBC9E4305202E /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				AA11BB22CC33DD44EE55FF66 /* AIProvider.swift */,
 				0709110B381DEDA32C3292AE /* ChatUIState.swift */,
 				6DFBC1C003B8745713588A23 /* City.swift */,
 				C1C97F8159A6FA7953D28DAB /* Experience.swift */,
@@ -501,6 +506,7 @@
 		8FF93171FFB8E00CD1BDF550 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				BB22CC33DD44EE55FF6600AA /* AIProviderSettingsView.swift */,
 				C14A22A40550CF207AB36C18 /* SettingsView.swift */,
 			);
 			path = Settings;
@@ -733,6 +739,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA11BB22CC33DD44EE55FF77 /* AIProvider.swift in Sources */,
+				BB22CC33DD44EE55FF6600BB /* AIProviderSettingsView.swift in Sources */,
 				D699D4E3E20FE7A7C0ED7E66 /* AIService.swift in Sources */,
 				F34C1A42668EF5151AFEE3C3 /* AISynthesisCacheRecord.swift in Sources */,
 				464746A44182622D4F617462 /* AIUsageRecord.swift in Sources */,

--- a/apps/ios/SoloCompass/Config/SecretsRuntime.swift
+++ b/apps/ios/SoloCompass/Config/SecretsRuntime.swift
@@ -43,25 +43,48 @@ extension Secrets {
         /// US-013: per-process UserDefaults override for the Foursquare key.
         /// Lets devs / TestFlight users plug in a key without re-building.
         static let foursquareApiKey = "runtimeFoursquareKey"
+        // In-app AI provider settings (written by AIProviderSettingsView via UserPreferences).
+        // These shadow the build-time GeneratedSecrets values when non-empty.
+        static let aiApiKey = "runtimeAIApiKey"
+        static let aiBaseURL = "runtimeAIBaseURL"
+        static let aiModelName = "runtimeAIModelName"
+        static let aiProvider = "runtimeAIProvider"
     }
 
     /// Active resolver — swap in tests via `Secrets.apiKeyResolver = EmptyAPIKeyResolver()`
     /// and restore to `DefaultAPIKeyResolver()` afterwards.
     nonisolated(unsafe) static var apiKeyResolver: APIKeyResolver = DefaultAPIKeyResolver()
 
-    /// Effective DeepSeek API key. Reads through `apiKeyResolver`.
-    /// Returns "" when neither override nor baked key is set; callers map
-    /// empty → `AIError.missingAPIKey` / `.unconfigured`.
+    /// Effective AI API key. Resolution chain:
+    /// 1. In-app UserPreferences (set via AIProviderSettingsView)
+    /// 2. UserDefaults runtime override (dev/test injection)
+    /// 3. Build-time GeneratedSecrets (`.env` baked key)
     static var resolvedDeepSeekApiKey: String {
-        apiKeyResolver.resolveDeepSeekAPIKey()
+        let prefs = UserPreferences()
+        if !prefs.aiApiKey.isEmpty {
+            return prefs.aiApiKey
+        }
+        return apiKeyResolver.resolveDeepSeekAPIKey()
     }
 
+    /// Effective base URL. Prefers in-app setting, falls back to
+    /// build-time `deepSeekBaseURL`, then the DeepSeek default.
     static var resolvedDeepSeekBaseURL: String {
-        deepSeekBaseURL.isEmpty ? "https://api.deepseek.com/v1" : deepSeekBaseURL
+        let prefs = UserPreferences()
+        if !prefs.aiBaseURL.isEmpty {
+            return prefs.aiBaseURL
+        }
+        return deepSeekBaseURL.isEmpty ? AIProvider.deepseek.defaultBaseURL : deepSeekBaseURL
     }
 
+    /// Effective model name. Prefers in-app setting, falls back to
+    /// build-time `deepSeekModel`, then the DeepSeek default.
     static var resolvedDeepSeekModel: String {
-        deepSeekModel.isEmpty ? "deepseek-chat" : deepSeekModel
+        let prefs = UserPreferences()
+        if !prefs.aiModelName.isEmpty {
+            return prefs.aiModelName
+        }
+        return deepSeekModel.isEmpty ? AIProvider.deepseek.defaultModel : deepSeekModel
     }
 
     /// Effective Foursquare API key: UserDefaults override → build-time baked.

--- a/apps/ios/SoloCompass/Models/AIProvider.swift
+++ b/apps/ios/SoloCompass/Models/AIProvider.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum AIProvider: String, CaseIterable, Codable, Identifiable {
+public enum AIProvider: String, CaseIterable, Codable, Identifiable {
     case deepseek
     case openai
     case custom

--- a/apps/ios/SoloCompass/Models/AIProvider.swift
+++ b/apps/ios/SoloCompass/Models/AIProvider.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+enum AIProvider: String, CaseIterable, Codable, Identifiable {
+    case deepseek
+    case openai
+    case custom
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .deepseek: return "DeepSeek"
+        case .openai: return "OpenAI"
+        case .custom: return NSLocalizedString("ai.provider.custom", comment: "Custom AI provider")
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .deepseek: return "brain"
+        case .openai: return "sparkle"
+        case .custom: return "gearshape"
+        }
+    }
+
+    var defaultBaseURL: String {
+        switch self {
+        case .deepseek: return "https://api.deepseek.com/v1"
+        case .openai: return "https://api.openai.com/v1"
+        case .custom: return ""
+        }
+    }
+
+    var defaultModel: String {
+        switch self {
+        case .deepseek: return "deepseek-chat"
+        case .openai: return "gpt-4o-mini"
+        case .custom: return ""
+        }
+    }
+
+    var accentColor: String {
+        switch self {
+        case .deepseek: return "blue"
+        case .openai: return "green"
+        case .custom: return "purple"
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Models/AIProvider.swift
+++ b/apps/ios/SoloCompass/Models/AIProvider.swift
@@ -5,7 +5,7 @@ public enum AIProvider: String, CaseIterable, Codable, Identifiable {
     case openai
     case custom
 
-    var id: String { rawValue }
+    public var id: String { rawValue }
 
     var displayName: String {
         switch self {

--- a/apps/ios/SoloCompass/Models/UserPreferences.swift
+++ b/apps/ios/SoloCompass/Models/UserPreferences.swift
@@ -46,6 +46,13 @@ public final class UserPreferences {
         var foursquareCallsToday: Int = 0
         var foursquareCallsTodayDate: Date?
 
+        // AI provider settings — stored here so SecretsRuntime can read them
+        // without a separate UserDefaults key namespace.
+        var aiProviderRaw: String = AIProvider.deepseek.rawValue
+        var aiApiKey: String = ""
+        var aiBaseURL: String = ""
+        var aiModelName: String = ""
+
         // swiftlint:disable:next nesting
         enum CodingKeys: String, CodingKey {
             case preferredCategories, dislikedCategories, soloTravelStyle, maxDistanceKm
@@ -55,6 +62,7 @@ public final class UserPreferences {
             case hasAcceptedExploreConsent, exploreConsentGivenAt, reviewPromptShown
             case includeMapInExport, visibleCategories, customTags
             case foursquareCallsToday, foursquareCallsTodayDate
+            case aiProviderRaw, aiApiKey, aiBaseURL, aiModelName
         }
 
         init() {}
@@ -83,7 +91,11 @@ public final class UserPreferences {
             visibleCategories: Set<ExperienceCategory>,
             customTags: [String],
             foursquareCallsToday: Int,
-            foursquareCallsTodayDate: Date?
+            foursquareCallsTodayDate: Date?,
+            aiProviderRaw: String,
+            aiApiKey: String,
+            aiBaseURL: String,
+            aiModelName: String
         ) {
             self.preferredCategories = preferredCategories
             self.dislikedCategories = dislikedCategories
@@ -109,6 +121,10 @@ public final class UserPreferences {
             self.customTags = customTags
             self.foursquareCallsToday = foursquareCallsToday
             self.foursquareCallsTodayDate = foursquareCallsTodayDate
+            self.aiProviderRaw = aiProviderRaw
+            self.aiApiKey = aiApiKey
+            self.aiBaseURL = aiBaseURL
+            self.aiModelName = aiModelName
         }
 
         init(from decoder: Decoder) throws {
@@ -138,6 +154,10 @@ public final class UserPreferences {
             self.customTags = try container.decodeIfPresent([String].self, forKey: .customTags) ?? []
             self.foursquareCallsToday = try container.decodeIfPresent(Int.self, forKey: .foursquareCallsToday) ?? 0
             self.foursquareCallsTodayDate = try container.decodeIfPresent(Date.self, forKey: .foursquareCallsTodayDate)
+            self.aiProviderRaw = try container.decodeIfPresent(String.self, forKey: .aiProviderRaw) ?? AIProvider.deepseek.rawValue
+            self.aiApiKey = try container.decodeIfPresent(String.self, forKey: .aiApiKey) ?? ""
+            self.aiBaseURL = try container.decodeIfPresent(String.self, forKey: .aiBaseURL) ?? ""
+            self.aiModelName = try container.decodeIfPresent(String.self, forKey: .aiModelName) ?? ""
         }
     }
 
@@ -194,6 +214,26 @@ public final class UserPreferences {
     /// back to 1 instead of incrementing.
     public var foursquareCallsTodayDate: Date? { didSet { persist() } }
 
+    /// Raw string backing for `aiProvider`. Stored so the Codable blob
+    /// survives new provider cases being added in future releases.
+    public var aiProviderRaw: String { didSet { persist() } }
+    /// User-supplied API key for the selected AI provider. Stored encrypted
+    /// at-rest by iOS when the app uses Data Protection; transmitted only
+    /// to the configured provider endpoint.
+    public var aiApiKey: String { didSet { persist() } }
+    /// Base URL for the OpenAI-compatible completions endpoint.
+    /// Empty string means "use the provider default".
+    public var aiBaseURL: String { didSet { persist() } }
+    /// Model identifier (e.g. "deepseek-chat", "gpt-4o-mini").
+    /// Empty string means "use the provider default".
+    public var aiModelName: String { didSet { persist() } }
+
+    /// Typed access to the selected AI provider. Reads/writes `aiProviderRaw`.
+    public var aiProvider: AIProvider {
+        get { AIProvider(rawValue: aiProviderRaw) ?? .deepseek }
+        set { aiProviderRaw = newValue.rawValue }
+    }
+
     /// Optional repository handle used for double-writing user-action
     /// mutations into SwiftData. `attachRepository(_:)` wires this up
     /// once at app boot; tests usually leave it nil and rely on
@@ -230,6 +270,10 @@ public final class UserPreferences {
         self.customTags = snapshot.customTags
         self.foursquareCallsToday = snapshot.foursquareCallsToday
         self.foursquareCallsTodayDate = snapshot.foursquareCallsTodayDate
+        self.aiProviderRaw = snapshot.aiProviderRaw
+        self.aiApiKey = snapshot.aiApiKey
+        self.aiBaseURL = snapshot.aiBaseURL
+        self.aiModelName = snapshot.aiModelName
     }
 
     private static func load(from defaults: UserDefaults) -> Snapshot {
@@ -269,7 +313,11 @@ public final class UserPreferences {
             visibleCategories: visibleCategories,
             customTags: customTags,
             foursquareCallsToday: foursquareCallsToday,
-            foursquareCallsTodayDate: foursquareCallsTodayDate
+            foursquareCallsTodayDate: foursquareCallsTodayDate,
+            aiProviderRaw: aiProviderRaw,
+            aiApiKey: aiApiKey,
+            aiBaseURL: aiBaseURL,
+            aiModelName: aiModelName
         )
         do {
             let data = try JSONEncoder.iso8601Encoder.encode(snapshot)

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -499,3 +499,34 @@
 
 /* Map preview in exports (US-020) */
 "settings.exportMapPreview" = "Include map preview in exports";
+
+/* AI Provider settings */
+"settings.aiProvider" = "AI Provider";
+"settings.aiProvider.header" = "Artificial Intelligence";
+"settings.aiProvider.status.unconfigured" = "Not configured — AI features disabled";
+"settings.aiProvider.status.configured" = "%@ — configured";
+
+/* AI Provider settings screen */
+"ai.provider.settings.title" = "AI Provider";
+"ai.provider.custom" = "Custom";
+
+"ai.provider.section.provider" = "Provider";
+"ai.provider.deepseek.description" = "DeepSeek offers fast, cost-effective models. Get your key at platform.deepseek.com.";
+"ai.provider.openai.description" = "OpenAI GPT models. Get your key at platform.openai.com.";
+"ai.provider.custom.description" = "Any OpenAI-compatible API. Enter your base URL and API key below.";
+
+"ai.provider.section.apiKey" = "API Key";
+"ai.provider.apiKey.placeholder" = "Paste your API key…";
+"ai.provider.apiKey.footer" = "Stored locally on your device. Never shared with Solo Compass servers.";
+
+"ai.provider.section.baseURL" = "Base URL";
+"ai.provider.baseURL.placeholder" = "https://api.example.com/v1";
+"ai.provider.baseURL.footer" = "The OpenAI-compatible endpoint root (e.g. https://api.openai.com/v1).";
+
+"ai.provider.section.model" = "Model";
+"ai.provider.model.placeholder.custom" = "Enter model name";
+"ai.provider.model.hint" = "Default: %@. Leave blank to use the provider default.";
+"ai.provider.model.hint.custom" = "Enter the model identifier for your custom provider.";
+
+"ai.provider.status.configured" = "AI is configured with %@";
+"ai.provider.status.unconfigured" = "AI features require an API key";

--- a/apps/ios/SoloCompass/Views/Settings/AIProviderSettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/AIProviderSettingsView.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+
+/// In-app AI provider configuration screen.
+///
+/// Writes directly to `UserDefaults` via `UserPreferences` so that
+/// `Secrets.resolvedDeepSeekApiKey`, `resolvedBaseURL`, and `resolvedModel`
+/// pick up the values immediately without a restart.
+struct AIProviderSettingsView: View {
+    @Environment(UserPreferences.self) private var preferences
+
+    var body: some View {
+        List {
+            providerSection
+            apiKeySection
+            if preferences.aiProvider == .custom {
+                baseURLSection
+            }
+            modelSection
+            statusSection
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(NSLocalizedString("ai.provider.settings.title", comment: "AI Provider"))
+        .navigationBarTitleDisplayMode(.inline)
+        .onChange(of: preferences.aiProvider) { _, newProvider in
+            autoFillDefaults(for: newProvider)
+        }
+    }
+
+    // MARK: - Sections
+
+    private var providerSection: some View {
+        Section {
+            ForEach(AIProvider.allCases) { provider in
+                HStack(spacing: 12) {
+                    Image(systemName: provider.icon)
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(.white)
+                        .frame(width: 30, height: 30)
+                        .background(iconColor(for: provider), in: RoundedRectangle(cornerRadius: 7))
+                    Text(provider.displayName)
+                    Spacer()
+                    if preferences.aiProvider == provider {
+                        Image(systemName: "checkmark")
+                            .foregroundStyle(.blue)
+                            .fontWeight(.semibold)
+                    }
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { preferences.aiProvider = provider }
+            }
+        } header: {
+            Label(
+                NSLocalizedString("ai.provider.section.provider", comment: "AI Provider section header"),
+                systemImage: "brain"
+            )
+            .font(.subheadline.weight(.medium))
+            .foregroundStyle(.secondary)
+        } footer: {
+            Text(providerDescription)
+        }
+    }
+
+    private var apiKeySection: some View {
+        Section {
+            @Bindable var prefs = preferences
+            SecureField(
+                NSLocalizedString("ai.provider.apiKey.placeholder", comment: "API Key placeholder"),
+                text: $prefs.aiApiKey
+            )
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .monospaced()
+        } header: {
+            Label(
+                NSLocalizedString("ai.provider.section.apiKey", comment: "API Key section header"),
+                systemImage: "key.fill"
+            )
+            .font(.subheadline.weight(.medium))
+            .foregroundStyle(.secondary)
+        } footer: {
+            Text(NSLocalizedString("ai.provider.apiKey.footer", comment: "API key footer — stored locally, never shared"))
+        }
+    }
+
+    private var baseURLSection: some View {
+        Section {
+            @Bindable var prefs = preferences
+            TextField(
+                NSLocalizedString("ai.provider.baseURL.placeholder", comment: "Base URL placeholder"),
+                text: $prefs.aiBaseURL
+            )
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .keyboardType(.URL)
+        } header: {
+            Label(
+                NSLocalizedString("ai.provider.section.baseURL", comment: "Base URL section header"),
+                systemImage: "link"
+            )
+            .font(.subheadline.weight(.medium))
+            .foregroundStyle(.secondary)
+        } footer: {
+            Text(NSLocalizedString("ai.provider.baseURL.footer", comment: "Base URL footer e.g. https://api.openai.com/v1"))
+        }
+    }
+
+    private var modelSection: some View {
+        Section {
+            @Bindable var prefs = preferences
+            TextField(
+                preferences.aiProvider.defaultModel.isEmpty
+                    ? NSLocalizedString("ai.provider.model.placeholder.custom", comment: "Model name placeholder for custom")
+                    : preferences.aiProvider.defaultModel,
+                text: $prefs.aiModelName
+            )
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+        } header: {
+            Label(
+                NSLocalizedString("ai.provider.section.model", comment: "Model section header"),
+                systemImage: "cpu"
+            )
+            .font(.subheadline.weight(.medium))
+            .foregroundStyle(.secondary)
+        } footer: {
+            Text(defaultModelHint)
+        }
+    }
+
+    private var statusSection: some View {
+        Section {
+            HStack(spacing: 10) {
+                Image(systemName: statusIcon)
+                    .foregroundStyle(statusColor)
+                    .font(.system(size: 16, weight: .medium))
+                Text(statusText)
+                    .foregroundStyle(.secondary)
+                    .font(.subheadline)
+            }
+        }
+    }
+
+    // MARK: - Computed helpers
+
+    private var isConfigured: Bool {
+        !preferences.aiApiKey.isEmpty
+    }
+
+    private var statusIcon: String {
+        isConfigured ? "checkmark.circle.fill" : "exclamationmark.circle.fill"
+    }
+
+    private var statusColor: Color {
+        isConfigured ? .green : .orange
+    }
+
+    private var statusText: String {
+        isConfigured
+            ? String(
+                format: NSLocalizedString("ai.provider.status.configured", comment: "Status: configured with provider"),
+                preferences.aiProvider.displayName
+              )
+            : NSLocalizedString("ai.provider.status.unconfigured", comment: "Status: no API key")
+    }
+
+    private var providerDescription: String {
+        switch preferences.aiProvider {
+        case .deepseek:
+            return NSLocalizedString("ai.provider.deepseek.description", comment: "DeepSeek provider description")
+        case .openai:
+            return NSLocalizedString("ai.provider.openai.description", comment: "OpenAI provider description")
+        case .custom:
+            return NSLocalizedString("ai.provider.custom.description", comment: "Custom provider description")
+        }
+    }
+
+    private var defaultModelHint: String {
+        switch preferences.aiProvider {
+        case .deepseek:
+            return String(
+                format: NSLocalizedString("ai.provider.model.hint", comment: "Default model hint"),
+                AIProvider.deepseek.defaultModel
+            )
+        case .openai:
+            return String(
+                format: NSLocalizedString("ai.provider.model.hint", comment: "Default model hint"),
+                AIProvider.openai.defaultModel
+            )
+        case .custom:
+            return NSLocalizedString("ai.provider.model.hint.custom", comment: "Custom model hint")
+        }
+    }
+
+    // MARK: - Auto-fill
+
+    private func autoFillDefaults(for provider: AIProvider) {
+        // Only auto-fill base URL if it's empty or was a known provider default.
+        let knownDefaults = AIProvider.allCases.map(\.defaultBaseURL).filter { !$0.isEmpty }
+        let currentURL = preferences.aiBaseURL
+        if currentURL.isEmpty || knownDefaults.contains(currentURL) {
+            preferences.aiBaseURL = provider.defaultBaseURL
+        }
+        // Auto-fill model if empty or was a known provider default.
+        let knownModels = AIProvider.allCases.map(\.defaultModel).filter { !$0.isEmpty }
+        let currentModel = preferences.aiModelName
+        if currentModel.isEmpty || knownModels.contains(currentModel) {
+            preferences.aiModelName = provider.defaultModel
+        }
+    }
+
+    private func iconColor(for provider: AIProvider) -> Color {
+        switch provider {
+        case .deepseek: return .blue
+        case .openai: return .green
+        case .custom: return .purple
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AIProviderSettingsView()
+            .environment(UserPreferences())
+    }
+}

--- a/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
@@ -60,7 +60,9 @@ public struct SettingsView: View {
                 filterBarSection
                 // Section: Appearance (US-039)
                 appearanceSection
-                // Section: AI & Privacy
+                // Section: AI Provider
+                aiProviderSection
+                // Section: Language & Privacy
                 languageSection
                 notificationsSection
                 exportSection
@@ -578,6 +580,50 @@ public struct SettingsView: View {
         } else {
             preferences.dislikedCategories.append(category)
         }
+    }
+
+    // MARK: - AI Provider
+
+    private var aiProviderSection: some View {
+        Section {
+            NavigationLink {
+                AIProviderSettingsView()
+                    .environment(preferences)
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "brain.head.profile")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(.white)
+                        .frame(width: 30, height: 30)
+                        .background(aiStatusColor, in: RoundedRectangle(cornerRadius: 7))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(NSLocalizedString("settings.aiProvider", comment: "AI Provider row label"))
+                            .font(.body)
+                        Text(aiStatusSubtitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        } header: {
+            settingsSectionHeader(
+                "brain",
+                label: NSLocalizedString("settings.aiProvider.header", comment: "AI Provider section header")
+            )
+        }
+    }
+
+    private var aiStatusColor: Color {
+        preferences.aiApiKey.isEmpty ? .orange : .green
+    }
+
+    private var aiStatusSubtitle: String {
+        preferences.aiApiKey.isEmpty
+            ? NSLocalizedString("settings.aiProvider.status.unconfigured", comment: "AI not configured subtitle")
+            : String(
+                format: NSLocalizedString("settings.aiProvider.status.configured", comment: "AI configured subtitle"),
+                preferences.aiProvider.displayName
+              )
     }
 
     // MARK: - Subscription section (Epic D US-025)


### PR DESCRIPTION
## Summary

Adds an elegant in-app AI configuration page in Settings, so test users and self-hosters can configure their own API key directly in the app — no rebuild required.

### ✨ New Settings Section: AI Provider

| Feature | Description |
|---------|-------------|
| **Provider picker** | DeepSeek (default) · OpenAI · Custom |
| **API Key** | SecureField (dots-masked), persists across restarts |
| **Base URL** | Shown for Custom provider — enter any OpenAI-compatible endpoint |
| **Model name** | Auto-filled per provider, editable |
| **Status indicator** | Green checkmark when configured, orange warning when missing |

### Resolution Chain (backward compatible)
1. In-app settings UI (UserDefaults runtime key) ← **new**
2. UserDefaults runtime override (for dev/test, via Secrets.RuntimeKeys)
3. GeneratedSecrets (build-time `.env` → `GeneratedSecrets.swift`)

### Files Changed
- **New**: `AIProvider.swift`, `AIProviderSettingsView.swift`
- **Modified**: `SecretsRuntime.swift`, `UserPreferences.swift`, `SettingsView.swift`, `Localizable.strings`, `project.pbxproj`

### Design
Follows the existing SettingsView Apple-style pattern: 30×30 rounded icon rows, `.insetGrouped` list, proper NSLocalizedString on all strings.