### PR TITLE
auto: One-tap favorite heart on the map's floating Experience card

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		397C20402788F9B63F06A01A /* City.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFBC1C003B8745713588A23 /* City.swift */; };
 		3AA7B0463C3B8084D954C3AA /* ChatStateModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E9EE8B07B66490112B696A /* ChatStateModifier.swift */; };
 		3B2C16B114CAAADE0862AF7B /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AF76F1B505EF8AF6EF2470 /* ShareSheet.swift */; };
+		CC00AA11BB22CC33DD44EE66 /* CompletionCelebrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00AA11BB22CC33DD44EE55 /* CompletionCelebrationView.swift */; };
 		42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */; };
 		45A4E8EED0300F00253EC049 /* MarkdownExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F3FDE4BC9458E490AEA67A /* MarkdownExporter.swift */; };
 		AA11BB22CC33DD44EE55FF77 /* AIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11BB22CC33DD44EE55FF66 /* AIProvider.swift */; };
@@ -229,6 +230,8 @@
 		C215AE07BA32182A887226F9 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		C28A851F789C7482CD44DCAE /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		C5C3BA25EFA9F149FB4FAAB3 /* FavoritesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesListView.swift; sourceTree = "<group>"; };
+				CC00AA11BB22CC33DD44EE55 /* CompletionCelebrationView.swift */,
+		CC00AA11BB22CC33DD44EE55 /* CompletionCelebrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionCelebrationView.swift; sourceTree = "<group>"; };
 		C660F7996B1E4387C37720B3 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		CA1F5F43F42E03BA5F10FA2F /* ContextManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextManager.swift; sourceTree = "<group>"; };
 		CE05EF69960CBB73431A6F2F /* DiscoveredCityRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveredCityRecord.swift; sourceTree = "<group>"; };
@@ -280,6 +283,7 @@
 				30E9EE8B07B66490112B696A /* ChatStateModifier.swift */,
 				EC8F9EFD56A2C839428AA92D /* ConfidenceBadge.swift */,
 				C5C3BA25EFA9F149FB4FAAB3 /* FavoritesListView.swift */,
+				CC00AA11BB22CC33DD44EE55 /* CompletionCelebrationView.swift */,
 				5933575E731D8AC09356AB9F /* GlassmorphismCapsule.swift */,
 				5C62D0EFA5859698D9C70B7D /* OfflineBanner.swift */,
 				130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */,
@@ -768,6 +772,7 @@
 				397C20402788F9B63F06A01A /* City.swift in Sources */,
 				7D2B6DE6C27E0307CA998A5F /* CityPickerSheet.swift in Sources */,
 				C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */,
+				CC00AA11BB22CC33DD44EE66 /* CompletionCelebrationView.swift in Sources */,
 				240FFFC4A2B2B8F941129783 /* ConfidenceBadge.swift in Sources */,
 				65E57E8B02E7889BD8EE8DD4 /* ContextManager.swift in Sources */,
 				42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */,

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -62,11 +62,11 @@ public struct ExperienceCardView: View {
                 }
                 Spacer()
                 Button {
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                    preferences.toggleFavorite(experience.id)
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
-                        preferences.toggleFavorite(experience.id)
                         heartScale = 1.3
                     }
-                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.5).delay(0.1)) {
                         heartScale = 1.0
                     }

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -12,6 +12,8 @@ public struct ExperienceCardView: View {
 
     // Pre-allocated so prepare() can be called when the drag starts.
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
+    @Environment(UserPreferences.self) private var preferences
+    @State private var heartScale: CGFloat = 1.0
 
     public init(
         experience: Experience,
@@ -37,6 +39,10 @@ public struct ExperienceCardView: View {
         1 - min(0.4, abs(dragTranslation) / 300)
     }
 
+    private var isFavorited: Bool {
+        preferences.favoritedExperiences.contains(experience.id)
+    }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 10) {
@@ -55,6 +61,27 @@ public struct ExperienceCardView: View {
                         .lineLimit(1)
                 }
                 Spacer()
+                Button {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
+                        preferences.toggleFavorite(experience.id)
+                        heartScale = 1.3
+                    }
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.5).delay(0.1)) {
+                        heartScale = 1.0
+                    }
+                } label: {
+                    Image(systemName: isFavorited ? "heart.fill" : "heart")
+                        .foregroundStyle(isFavorited ? .red : .secondary)
+                        .symbolEffect(.bounce, value: isFavorited)
+                        .scaleEffect(heartScale)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Text(isFavorited
+                    ? NSLocalizedString("action.unfavorite", comment: "Remove favorite")
+                    : NSLocalizedString("action.favorite", comment: "Add favorite")))
                 ConfidenceBadge(confidence: experience.confidence, compact: true)
             }
 
@@ -145,6 +172,7 @@ public struct ExperienceCardView: View {
             )
         }
         .background(Color(red: 0xF5/255, green: 0xF0/255, blue: 0xE8/255))
+        .environment(UserPreferences())
     } else {
         Text("No seed data")
     }

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -158,6 +158,13 @@ public struct ExperienceCardView: View {
                    String(format: "%.1f", experience.soloScore.overall))
         ))
         .accessibilityHint(Text(NSLocalizedString("experience.card.hint", comment: "Double tap to view details")))
+        .accessibilityAction(
+            named: Text(isFavorited
+                ? NSLocalizedString("action.unfavorite", comment: "Remove favorite")
+                : NSLocalizedString("action.favorite", comment: "Add favorite"))
+        ) {
+            preferences.toggleFavorite(experience.id)
+        }
     }
 }
 
@@ -172,7 +179,7 @@ public struct ExperienceCardView: View {
             )
         }
         .background(Color(red: 0xF5/255, green: 0xF0/255, blue: 0xE8/255))
-        .environment(UserPreferences())
+        .environment(UserPreferences(defaults: UserDefaults(suiteName: "preview")!))
     } else {
         Text("No seed data")
     }


### PR DESCRIPTION
## One-tap favorite heart on the map's floating Experience card

The floating card that slides up when a map pin is tapped has no way to favorite an experience — users must open the full detail sheet to tap the heart. This adds a quick-favorite heart button to the card header with a spring scale animation and haptic feedback, matching the existing favorite UX while removing two taps from the most common surface.

### Acceptance
Tapping a map pin shows the floating card with a heart in the top-right of the header. Tapping the heart toggles favorite state with a spring bounce and medium haptic, does NOT expand the card or open detail, and persists (the same experience shows filled in FavoritesListView and the detail sheet). VoiceOver announces 'Add favorite'/'Remove favorite'. The card's existing tap-to-expand and swipe gestures still work.  and the SoloCompassTests suite pass.