### PR TITLE
auto: Heart 'pop' animation + success haptic on favoriting in Experience detail

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -17,6 +17,7 @@ public struct ExperienceDetailView: View {
     @State private var isShowingReport: Bool = false
     @State private var showingRadarTooltip: Bool = false
     @State private var exportMarkdown: String? = nil
+    @State private var heartPop = false
 
     public init(
         viewModel: ExperienceDetailViewModel,
@@ -491,12 +492,23 @@ public struct ExperienceDetailView: View {
     private var actionBar: some View {
         HStack(spacing: 12) {
             Button {
-                viewModel.toggleFavorite()
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                let willFavorite = !viewModel.isFavorited
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.45)) {
+                    viewModel.toggleFavorite()
+                    heartPop.toggle()
+                }
+                if willFavorite {
+                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                } else {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                }
             } label: {
                 Image(systemName: viewModel.isFavorited ? "heart.fill" : "heart")
                     .font(.title3)
                     .foregroundStyle(viewModel.isFavorited ? .red : .primary)
+                    .symbolEffect(.bounce, value: viewModel.isFavorited)
+                    .scaleEffect(viewModel.isFavorited ? 1.12 : 1.0)
+                    .animation(.spring(response: 0.3, dampingFraction: 0.45), value: viewModel.isFavorited)
                     .frame(width: 50, height: 50)
                     .background(Circle().fill(.regularMaterial))
             }


### PR DESCRIPTION
## Heart 'pop' animation + success haptic on favoriting in Experience detail

The favorite heart button in the Experience detail action bar instantly swaps icons with only a flat light-impact haptic, missing the most rewarding micro-moment in the app. Add a spring-based scale 'pop' (overshoot then settle) plus a SF Symbol bounce when favoriting, and upgrade the add-favorite cue to a satisfying success haptic while keeping a light tap for un-favoriting — giving the single most-tapped affordance tactile and visual delight.

### Acceptance
Tapping the heart in the Experience detail action bar animates a spring scale 'pop' with an SF Symbol bounce and fills red; favoriting plays a success haptic while un-favoriting plays a light-impact haptic; the icon swap is no longer instantaneous.  succeeds, existing SoloCompassTests pass, and the change is verified visually in the Simulator (#Preview alone is insufficient).