### PR TITLE
auto: Interactive finger-tracking drag on ExperienceCardView

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -10,6 +10,9 @@ public struct ExperienceCardView: View {
     @GestureState private var dragTranslation: CGFloat = 0
     @State private var dragOffset: CGFloat = 0
 
+    // Pre-allocated so prepare() can be called when the drag starts.
+    private let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
+
     public init(
         experience: Experience,
         onExpand: @escaping () -> Void,
@@ -29,8 +32,9 @@ public struct ExperienceCardView: View {
         rubberBanded(dragTranslation) + dragOffset
     }
 
+    /// Fades in both directions: downward (dismiss) and upward (expand).
     private var dragOpacity: Double {
-        1 - min(0.4, max(0, dragTranslation) / 300)
+        1 - min(0.4, abs(dragTranslation) / 300)
     }
 
     public var body: some View {
@@ -92,13 +96,21 @@ public struct ExperienceCardView: View {
                 .updating($dragTranslation) { value, state, _ in
                     state = value.translation.height
                 }
+                .onChanged { _ in
+                    feedbackGenerator.prepare()
+                }
                 .onEnded { value in
                     let t = value.translation.height
+                    // Commit the live visual position into dragOffset before
+                    // @GestureState resets dragTranslation to 0, so the card
+                    // stays at its dragged position rather than snapping back
+                    // before the exit transition runs.
+                    dragOffset = rubberBanded(t)
                     if t > 60 {
-                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                        feedbackGenerator.impactOccurred()
                         onDismiss()
                     } else if t < -60 {
-                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                        feedbackGenerator.impactOccurred()
                         onExpand()
                     } else {
                         withAnimation(.interactiveSpring()) {

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -7,6 +7,9 @@ public struct ExperienceCardView: View {
     var onExpand: () -> Void
     var onDismiss: () -> Void
 
+    @GestureState private var dragTranslation: CGFloat = 0
+    @State private var dragOffset: CGFloat = 0
+
     public init(
         experience: Experience,
         onExpand: @escaping () -> Void,
@@ -15,6 +18,19 @@ public struct ExperienceCardView: View {
         self.experience = experience
         self.onExpand = onExpand
         self.onDismiss = onDismiss
+    }
+
+    /// Rubber-bands upward drags to 40% travel; downward dismissal drags follow 1:1.
+    private func rubberBanded(_ t: CGFloat) -> CGFloat {
+        t < 0 ? t * 0.4 : t
+    }
+
+    private var totalOffset: CGFloat {
+        rubberBanded(dragTranslation) + dragOffset
+    }
+
+    private var dragOpacity: Double {
+        1 - min(0.4, max(0, dragTranslation) / 300)
     }
 
     public var body: some View {
@@ -69,13 +85,25 @@ public struct ExperienceCardView: View {
                 .shadow(color: .black.opacity(0.1), radius: 12, y: -2)
         )
         .padding(.horizontal, 12)
+        .offset(y: totalOffset)
+        .opacity(dragOpacity)
         .gesture(
             DragGesture(minimumDistance: 20)
+                .updating($dragTranslation) { value, state, _ in
+                    state = value.translation.height
+                }
                 .onEnded { value in
-                    if value.translation.height > 60 {
+                    let t = value.translation.height
+                    if t > 60 {
+                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                         onDismiss()
-                    } else if value.translation.height < -60 {
+                    } else if t < -60 {
+                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                         onExpand()
+                    } else {
+                        withAnimation(.interactiveSpring()) {
+                            dragOffset = 0
+                        }
                     }
                 }
         )


### PR DESCRIPTION
## Interactive finger-tracking drag on ExperienceCardView

The experience card's drag gesture currently does nothing visually until release, then snaps to dismiss or expand — making it feel unresponsive and giving no hint about the swipe-up/swipe-down affordance. Replace the discrete onEnded-only gesture with a live finger-tracking drag that translates the card with rubber-banding, fades it as it's pulled toward dismissal, and adds a directional haptic on commit so the card feels physically attached to the finger.

### Acceptance
Dragging the card down moves it 1:1 with the finger and fades it; releasing past the 60pt threshold dismisses with a medium haptic, otherwise it springs back to rest. Dragging up shows damped resistance and expands to the detail sheet past -60pt. No regression to tap-to-expand, the appear haptic, or VoiceOver labels.  succeeds and the card renders correctly in .