### PR TITLE
auto: Animated, breathing empty state for the Favorites list

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -24,8 +24,8 @@ public struct FavoritesListView: View {
         NavigationStack {
             Group {
                 if sortedFavorites.isEmpty && lastUnfavorited == nil {
-                    emptyState
-                        .transition(.opacity)
+                    EmptyFavoritesView()
+                        .transition(.scale(scale: 0.85).combined(with: .opacity))
                 } else {
                     List(sortedFavorites) { exp in
                         favoriteRow(exp)
@@ -51,11 +51,24 @@ public struct FavoritesListView: View {
         .animation(.easeInOut, value: lastUnfavorited != nil)
     }
 
-    private var emptyState: some View {
+}
+
+private struct EmptyFavoritesView: View {
+    @State private var isBreathing = false
+
+    var body: some View {
         VStack(spacing: 12) {
-            Image(systemName: "heart.slash")
+            Image(systemName: "heart")
                 .font(.system(size: 48))
-                .foregroundStyle(.secondary)
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(.tint)
+                .scaleEffect(isBreathing ? 1.08 : 0.94)
+                .opacity(isBreathing ? 1.0 : 0.7)
+                .onAppear {
+                    withAnimation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true)) {
+                        isBreathing = true
+                    }
+                }
             Text(NSLocalizedString("favorites.empty.title", comment: "No favorites yet"))
                 .font(.headline)
             Text(NSLocalizedString("favorites.empty.hint", comment: "Tap the heart on any experience"))
@@ -64,9 +77,18 @@ public struct FavoritesListView: View {
                 .multilineTextAlignment(.center)
         }
         .padding(32)
+        .transition(.scale(scale: 0.85).combined(with: .opacity))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            NSLocalizedString("favorites.empty.title", comment: "No favorites yet") + ". " +
+            NSLocalizedString("favorites.empty.hint", comment: "Tap the heart on any experience")
+        )
     }
+}
 
-    private var undoBar: some View {
+private extension FavoritesListView {
+
+    var undoBar: some View {
         HStack {
             Text(NSLocalizedString("favorites.undo", comment: "Removed — Undo banner"))
                 .font(.subheadline)
@@ -93,7 +115,7 @@ public struct FavoritesListView: View {
     }
 
     @ViewBuilder
-    private func favoriteRow(_ exp: Experience) -> some View {
+    func favoriteRow(_ exp: Experience) -> some View {
         Button {
             onSelectExperience(exp)
         } label: {


### PR DESCRIPTION
## Animated, breathing empty state for the Favorites list

The Favorites list empty state is currently a static  icon with two text lines — flat and lifeless compared to the app's heart-pop and finger-drag animations shipped in recent commits. Add a gentle continuous breathing/pulse animation to the icon plus a soft entrance transition so the empty state feels intentional and on-brand with Solo Compass's polished, tactile feel.

### Acceptance
Building the SoloCompass scheme succeeds. When the Favorites sheet is opened with zero favorites, the heart icon visibly and smoothly pulses (scale + opacity) on a continuous ~1.6s loop, and the empty state fades/scales in rather than appearing abruptly. Existing localization keys are reused (no Localizable.strings change). VoiceOver announces the empty state as a single combined element. No SwiftData/@Model files touched; change confined to FavoritesListView.swift and under 100 lines.