### PR TITLE
auto: Confetti burst + checkmark draw-on when marking an Experience done

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -18,6 +18,7 @@ public struct ExperienceDetailView: View {
     @State private var showingRadarTooltip: Bool = false
     @State private var exportMarkdown: String? = nil
     @State private var heartPop = false
+    @State private var celebrationTrigger = 0
 
     public init(
         viewModel: ExperienceDetailViewModel,
@@ -490,6 +491,7 @@ public struct ExperienceDetailView: View {
     // MARK: - Action bar
 
     private var actionBar: some View {
+        ZStack(alignment: .center) {
         HStack(spacing: 12) {
             Button {
                 let willFavorite = !viewModel.isFavorited
@@ -520,13 +522,14 @@ public struct ExperienceDetailView: View {
                 let wasCompleted = viewModel.isCompleted
                 viewModel.toggleComplete()
                 UINotificationFeedbackGenerator().notificationOccurred(.success)
-                // Show micro-survey only when marking done (not when un-marking).
                 if !wasCompleted {
+                    celebrationTrigger += 1
                     onMarkDone?(viewModel.experience)
                 }
             } label: {
                 HStack {
                     Image(systemName: viewModel.isCompleted ? "checkmark.circle.fill" : "checkmark.circle")
+                        .symbolEffect(.bounce, value: viewModel.isCompleted)
                     Text(viewModel.isCompleted
                         ? NSLocalizedString("action.completed", comment: "")
                         : NSLocalizedString("action.markDone", comment: ""))
@@ -554,6 +557,11 @@ public struct ExperienceDetailView: View {
                 .ignoresSafeArea(edges: .bottom)
                 .opacity(0.6)
         )
+
+        CompletionCelebrationView(trigger: celebrationTrigger)
+            .frame(maxWidth: .infinity)
+            .offset(y: -28)
+        }
     }
 
     // MARK: - Helpers

--- a/apps/ios/SoloCompass/Views/Shared/CompletionCelebrationView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/CompletionCelebrationView.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+/// One-shot confetti burst + checkmark pop overlay fired when an experience is
+/// marked complete. Driven by `trigger`: each increment spawns a new burst.
+/// Respects Reduce Motion: skips particles, only shows the checkmark pop.
+public struct CompletionCelebrationView: View {
+    let trigger: Int
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private struct Particle: Identifiable {
+        let id = UUID()
+        let color: Color
+        let angle: Double   // radians
+        let distance: CGFloat
+        let size: CGFloat
+        let isCircle: Bool
+    }
+
+    @State private var particles: [Particle] = []
+    @State private var animated = false
+    @State private var checkmarkPop = false
+
+    private static let palette: [Color] = ExperienceCategory.allCases.map(\.color)
+
+    public var body: some View {
+        ZStack {
+            if !reduceMotion {
+                ForEach(particles) { p in
+                    Group {
+                        if p.isCircle {
+                            Circle().fill(p.color)
+                        } else {
+                            Capsule().fill(p.color)
+                        }
+                    }
+                    .frame(
+                        width: p.isCircle ? p.size : p.size * 0.45,
+                        height: p.isCircle ? p.size : p.size * 1.4
+                    )
+                    .offset(
+                        x: animated ? cos(p.angle) * p.distance : 0,
+                        y: animated ? sin(p.angle) * p.distance + (animated ? 18 : 0) : 0
+                    )
+                    .opacity(animated ? 0 : 0.9)
+                    .scaleEffect(animated ? 0.3 : 1.0)
+                }
+            }
+
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(.white)
+                .scaleEffect(checkmarkPop ? 1.0 : 0.01)
+                .opacity(checkmarkPop ? 1.0 : 0.0)
+                .symbolEffect(.bounce, value: checkmarkPop)
+        }
+        .allowsHitTesting(false)
+        .onChange(of: trigger) { _, _ in
+            guard trigger > 0 else { return }
+            fire()
+        }
+    }
+
+    private func fire() {
+        let count = 14
+        particles = (0..<count).map { i in
+            Particle(
+                color: Self.palette[i % Self.palette.count],
+                angle: Double(i) / Double(count) * .pi * 2 + Double.random(in: -0.3...0.3),
+                distance: CGFloat.random(in: 52...92),
+                size: CGFloat.random(in: 6...11),
+                isCircle: Bool.random()
+            )
+        }
+        animated = false
+        checkmarkPop = false
+
+        withAnimation(.spring(response: 0.15, dampingFraction: 0.6)) {
+            checkmarkPop = true
+        }
+
+        if !reduceMotion {
+            withAnimation(.easeOut(duration: 0.8)) {
+                animated = true
+            }
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            particles = []
+            animated = false
+            checkmarkPop = false
+        }
+    }
+}
+
+#Preview("Burst") {
+    struct Demo: View {
+        @State private var trigger = 0
+        var body: some View {
+            ZStack {
+                Color(.systemBackground).ignoresSafeArea()
+                VStack(spacing: 32) {
+                    Button("Fire celebration") { trigger += 1 }
+                        .buttonStyle(.borderedProminent)
+                    CompletionCelebrationView(trigger: trigger)
+                }
+            }
+        }
+    }
+    return Demo()
+}
+
+#Preview("Reduce Motion") {
+    struct Demo: View {
+        @State private var trigger = 0
+        var body: some View {
+            ZStack {
+                Color(.systemBackground).ignoresSafeArea()
+                VStack(spacing: 32) {
+                    Button("Fire (no particles)") { trigger += 1 }
+                        .buttonStyle(.borderedProminent)
+                    CompletionCelebrationView(trigger: trigger)
+                        .environment(\.accessibilityReduceMotion, true)
+                }
+            }
+        }
+    }
+    return Demo()
+}


### PR DESCRIPTION
## Confetti burst + checkmark draw-on when marking an Experience done

Marking an Experience 'done' is the core emotional payoff of an experience-as-unit product, yet today it only swaps the button to green with a success haptic — far less rewarding than the favorite heart's recent 'pop' animation (#155). Add a lightweight one-shot confetti/spark burst overlay plus a draw-on checkmark scale-pop that fires when (and only when) the user marks an experience complete, celebrating the moment without adding any persistent UI or engagement loop.

### Acceptance
Tapping 'Mark done' on an Experience that is not yet completed plays a brief confetti/spark burst over the action bar and a checkmark pop, alongside the existing success haptic; tapping again to un-complete (or the already-completed state) plays NO burst. With Reduce Motion enabled, no particles animate but the checkmark still pops. The new view has a #Preview, builds cleanly via , and no @Model/schema files are touched.