### PR TITLE
auto: Animated result-count badge for active map filters

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -11,6 +11,8 @@
 /* Filters */
 "filter.now" = "Now";
 "filter.all" = "All";
+"filter.matches.one" = "%d match";
+"filter.matches.other" = "%d matches";
 
 /* Health */
 "health.healthy" = "Fresh — multiply verified";

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -580,6 +580,10 @@ private struct MapOverlayView: View {
     @Binding var dismissedQuotaInfo: String?
     @Binding var isMapPanning: Bool
 
+    private var isFilterActive: Bool {
+        viewModel.selectedCategory != nil || viewModel.selectedCustomTag != nil || viewModel.isNowFilter
+    }
+
     var body: some View {
         VStack {
             HStack {
@@ -600,6 +604,14 @@ private struct MapOverlayView: View {
                 isMapPanning: $isMapPanning
             )
             .padding(.top, 4)
+
+            if isFilterActive && !viewModel.visibleExperiences.isEmpty {
+                filterResultBadge
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                    .opacity(isMapPanning ? 0.4 : 1.0)
+                    .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isMapPanning)
+                    .animation(.spring(response: 0.3, dampingFraction: 0.8), value: viewModel.visibleExperiences.count)
+            }
 
             if let errorText = viewModel.lastAIError, errorText != dismissedAIError {
                 DismissibleBanner(
@@ -734,6 +746,39 @@ private struct MapOverlayView: View {
                 .animation(.spring(response: 0.4), value: viewModel.pendingCheckIn != nil)
             }
         }
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isFilterActive)
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: viewModel.visibleExperiences.count)
+    }
+
+    @ViewBuilder
+    private var filterResultBadge: some View {
+        let count = viewModel.visibleExperiences.count
+        let dotColor: Color = {
+            if let cat = viewModel.selectedCategory { return cat.color }
+            if viewModel.isNowFilter { return Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255) }
+            return Color.accentColor
+        }()
+        let countText = count == 1
+            ? String(format: NSLocalizedString("filter.matches.one", comment: "1 match"), count)
+            : String(format: NSLocalizedString("filter.matches.other", comment: "%d matches"), count)
+
+        GlassmorphismCapsule(
+            horizontalPadding: 12,
+            verticalPadding: 6,
+            shadowRadius: 6,
+            shadowY: 3
+        ) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(dotColor)
+                    .frame(width: 8, height: 8)
+                Text(countText)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.primary)
+            }
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: count)
+        .accessibilityLabel(Text(countText))
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Animated result-count badge for active map filters

When the user taps a category, custom-tag, or 'Now' filter on the map, dots appear/disappear silently — there's no confirmation of how many experiences match. Add a small glassmorphism count badge below the FilterBarView that fades/slides in only when a filter is active, showing e.g. '7 matches' and updating with a spring animation. This closes the feedback loop on filtering, the app's most-used interaction, without violating the map-first 'no chrome' principle since it auto-hides when 'All' is selected.

### Acceptance
Tapping any category/Now/custom-tag pill shows a count badge under the filter bar within one animation frame, reading the exact number of visible experiences (verified against map dot count); selecting 'All' hides the badge with a fade; switching filters animates the number change with a spring; when a filter yields zero results the badge is absent and only the existing EmptyStateOverlay shows; badge dims during map pan like the filter bar; xcodebuild build + existing SoloCompassTests pass and the view renders correctly in Simulator (not just #Preview).