### PR TITLE
auto: Animated draw-on for the SoloScore radar chart & fallback bars

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
@@ -5,6 +5,9 @@ import SwiftUI
 public struct SoloScoreRadarChart: View {
     let score: SoloScore
 
+    @State private var drawProgress: Double = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private static let axes: [(label: String, symbol: String, keyPath: KeyPath<SoloScore.Breakdown, Double>)] = [
         (NSLocalizedString("solo.seating",    comment: ""), "chair",              \.seatingFriendly),
         (NSLocalizedString("solo.staff",      comment: ""), "person.crop.circle", \.staffPressure),
@@ -30,10 +33,21 @@ public struct SoloScoreRadarChart: View {
     }
 
     public var body: some View {
-        if variance >= 0.5 {
-            radarChart
-        } else {
-            fallbackBars
+        Group {
+            if variance >= 0.5 {
+                radarChart
+            } else {
+                fallbackBars
+            }
+        }
+        .onAppear {
+            if reduceMotion {
+                drawProgress = 1
+            } else {
+                withAnimation(.spring(response: 0.7, dampingFraction: 0.75)) {
+                    drawProgress = 1
+                }
+            }
         }
     }
 
@@ -69,11 +83,11 @@ public struct SoloScoreRadarChart: View {
                     .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
                 }
 
-                // Data polygon
-                radarPolygon(center: center, radius: radius, count: axisCount, values: values.map { $0 / 10.0 })
+                // Data polygon (scaled by drawProgress for entrance animation)
+                radarPolygon(center: center, radius: radius, count: axisCount, values: values.map { $0 / 10.0 * drawProgress })
                     .fill(score.scoreColor.opacity(0.15))
 
-                radarPolygon(center: center, radius: radius, count: axisCount, values: values.map { $0 / 10.0 })
+                radarPolygon(center: center, radius: radius, count: axisCount, values: values.map { $0 / 10.0 * drawProgress })
                     .stroke(score.scoreColor, lineWidth: 2)
 
                 // Axis labels with SF Symbol icons
@@ -151,7 +165,7 @@ public struct SoloScoreRadarChart: View {
                             Capsule().fill(Color.gray.opacity(0.15))
                             Capsule()
                                 .fill(score.scoreColor)
-                                .frame(width: geo.size.width * (val / 10.0))
+                                .frame(width: geo.size.width * (val / 10.0) * drawProgress)
                         }
                     }
                     .frame(height: 6)


### PR DESCRIPTION
## Animated draw-on for the SoloScore radar chart & fallback bars

The SoloScore radar chart — the product's signature differentiator — currently snaps into existence fully drawn when the Experience detail sheet opens. Add a spring-driven 'grow from center' entrance: the data polygon scales its values from 0→actual on appear, and the fallback bars fill left-to-right, so the score feels measured rather than pre-printed. This is the one place where the app's honest-curation thesis becomes a visual, and it deserves a moment.

### Acceptance
Opening an Experience detail sheet shows the radar polygon springing outward from center to its true shape (~0.7s), and the low-variance fallback bars filling left-to-right; final rendered state is pixel-identical to today. Grid/spokes/labels/numbers do not move or fade. With Reduce Motion enabled, the chart appears fully drawn with no animation. Both #Preview variants still render. `xcodebuild build` and the existing SoloCompassTests pass.