### PR TITLE
auto: Count-up animation on the detail sheet's full Solo Score number

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -7,6 +7,9 @@ public struct SoloScoreBadge: View {
 
     public enum Style { case compact, full }
 
+    @State private var animatedScore: Double = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     public init(score: SoloScore, style: Style = .compact) {
         self.score = score
         self.style = style
@@ -45,9 +48,15 @@ public struct SoloScoreBadge: View {
                 Text(NSLocalizedString("solo.scoreTitle", comment: "Solo Score"))
                     .font(.headline)
                 Spacer()
-                Text(formatted(score.overall))
+                Text(formatted(animatedScore))
                     .font(.system(.largeTitle, design: .rounded, weight: .bold))
                     .foregroundStyle(score.scoreColor)
+                    .monospacedDigit()
+                    .contentTransition(.numericText(value: animatedScore))
+                    .accessibilityLabel(Text(String(
+                        format: NSLocalizedString("solo.a11y", comment: "Solo Score %@ of 10"),
+                        formatted(score.overall)
+                    )))
             }
             if let hint = score.hint {
                 Text(hint)
@@ -58,6 +67,15 @@ public struct SoloScoreBadge: View {
             // renders SoloScoreRadarChart directly below this badge, so a
             // second bar list would duplicate it. This badge is the score
             // header only (overall + hint).
+        }
+        .onAppear {
+            if reduceMotion {
+                animatedScore = score.overall
+            } else {
+                withAnimation(.easeOut(duration: 0.7)) {
+                    animatedScore = score.overall
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Count-up animation on the detail sheet's full Solo Score number

The detail sheet's headline Solo Score (e.g. "8.7") renders as a static largeTitle while the radar chart directly below it already draws on (commit 616ef38), making the two feel out of sync. Add a count-up animation that rolls the overall score from 0.0 to its final value on appear, matching the established micro-interaction vocabulary (animated badges, draw-on radar) and making the detail sheet's score block feel cohesive. Compact style stays untouched since it appears in scrolling lists/cards where a roll-up would be noisy.

### Acceptance
Opening an experience detail sheet rolls the headline Solo Score from 0.0 up to its real value (~0.7s) in time with the radar chart draw-on; the number stays right-aligned without horizontal jitter thanks to monospaced digits. With Reduce Motion enabled the number appears immediately at its final value. Compact badges on cards/lists are visually unchanged. xcodebuild build and existing SoloCompassTests pass; #Preview renders the full-style badge animating on appear.