### PR TITLE
auto: Tappable starter-prompt chips in the chat empty state

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -405,6 +405,11 @@
 "chat.title" = "Solo Compass";
 "chat.empty.title" = "Ask me anything about places near you";
 "chat.empty.subtitle" = "Try 'what's good around me?' or hold the mic to talk.";
+
+/* Chat starter prompts */
+"chat.empty.prompt.nearby" = "What's good around me?";
+"chat.empty.prompt.coffee" = "Find me a quiet café";
+"chat.empty.prompt.evening" = "Plan my evening";
 "chat.input.placeholder" = "Type a message…";
 "chat.input.send.a11y" = "Send";
 "chat.input.mic.a11y" = "Voice";

--- a/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
@@ -37,6 +37,13 @@ public struct ChatSheet: View {
     /// state). Set on appear when `startInVoiceMode`; user can opt into the
     /// classic chat list with a single tap.
     @State private var showVoiceSurface: Bool = false
+    @State private var starterPromptsAppeared: Bool = false
+
+    private static let starterPrompts: [String] = [
+        NSLocalizedString("chat.empty.prompt.nearby",  comment: "Starter chip — what's good around me"),
+        NSLocalizedString("chat.empty.prompt.coffee",  comment: "Starter chip — find a quiet café"),
+        NSLocalizedString("chat.empty.prompt.evening", comment: "Starter chip — plan my evening"),
+    ]
 
     public init(
         orchestrator: VoiceAgentOrchestrator,
@@ -391,14 +398,49 @@ public struct ChatSheet: View {
                 .font(.subheadline.weight(.medium))
                 .foregroundStyle(.primary)
                 .multilineTextAlignment(.center)
-            Text(NSLocalizedString("chat.empty.subtitle", comment: "Try ‘what's good around me?’ or hold the mic to talk."))
+            Text(NSLocalizedString("chat.empty.subtitle", comment: "Try ‘what’s good around me?’ or hold the mic to talk."))
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 24)
+            starterPromptChips
             Spacer()
         }
         .frame(maxWidth: .infinity)
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.4).delay(0.15)) {
+                starterPromptsAppeared = true
+            }
+        }
+    }
+
+    private var starterPromptChips: some View {
+        VStack(spacing: 8) {
+            ForEach(Array(Self.starterPrompts.enumerated()), id: \.offset) { index, prompt in
+                Button {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    handleSend(prompt)
+                } label: {
+                    Text(prompt)
+                        .font(.body)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .frame(maxWidth: .infinity)
+                        .background(Color(.secondarySystemBackground))
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(prompt)
+                .opacity(starterPromptsAppeared ? 1 : 0)
+                .offset(y: starterPromptsAppeared ? 0 : 8)
+                .animation(
+                    .easeOut(duration: 0.35).delay(Double(index) * 0.08),
+                    value: starterPromptsAppeared
+                )
+            }
+        }
+        .padding(.horizontal, 32)
+        .padding(.top, 4)
     }
 
     // MARK: - Derived state


### PR DESCRIPTION
## Tappable starter-prompt chips in the chat empty state

The chat sheet's empty state currently only describes what the user could ask ('Try what's good around me?') but offers nothing to tap, leaving a cold-start dead end for the app's core 'ask me anything about places' loop. Add three tappable suggestion chips that fire the existing handleSend(_:) path on tap, with a light haptic and a staggered fade-in so the empty state feels alive and immediately actionable.

### Acceptance
Opening the chat sheet with no history shows the icon/title/subtitle plus 3 tappable starter-prompt pills that fade/slide in with a slight stagger. Tapping a pill sends that prompt (visible as a user bubble) and triggers a light haptic, after which the empty state is replaced by the conversation. Pills are VoiceOver-labeled with their prompt text. Build succeeds via xcodebuild for the SoloCompass scheme and the existing #Preview('Empty') renders the chips. No SwiftData/@Model files touched; change is under 100 lines across 2 files.