### PR TITLE
auto: Tappable source attribution links in Experience detail

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -234,6 +234,7 @@
 /* Experience detail overflow */
 "detail.report" = "Report an issue";
 "detail.more" = "More options";
+"detail.source.openHint" = "Opens the original source";
 
 /* US-004: Ask Solo about this experience (Pro chat) */
 "experience.askSolo.cta" = "Ask Solo about this";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -440,19 +440,61 @@ public struct ExperienceDetailView: View {
         sectionContainer(title: NSLocalizedString("section.sources", comment: "")) {
             VStack(alignment: .leading, spacing: 6) {
                 ForEach(viewModel.experience.sources) { source in
-                    HStack {
-                        Image(systemName: "link")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Text(source.attribution ?? source.type.rawValue)
-                            .font(.caption)
-                        Spacer()
-                        Text(source.verifiedAt, style: .date)
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
-                    }
+                    sourceRow(source)
                 }
             }
+        }
+    }
+
+    @ViewBuilder
+    private func sourceRow(_ source: InformationSource) -> some View {
+        let label = source.attribution ?? source.type.rawValue
+        let iconName = symbol(for: source.type)
+        if let url = source.url {
+            Link(destination: url) {
+                HStack {
+                    Image(systemName: iconName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(label)
+                        .font(.caption)
+                    Spacer()
+                    Text(source.verifiedAt, style: .date)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                    Image(systemName: "arrow.up.right")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .simultaneousGesture(TapGesture().onEnded {
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            })
+            .accessibilityAddTraits(.isLink)
+            .accessibilityHint(Text(NSLocalizedString("detail.source.openHint", comment: "Opens the original source")))
+        } else {
+            HStack {
+                Image(systemName: iconName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(label)
+                    .font(.caption)
+                Spacer()
+                Text(source.verifiedAt, style: .date)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    private func symbol(for type: InformationSource.SourceType) -> String {
+        switch type {
+        case .wikivoyage, .wikipedia: return "book"
+        case .reddit:                 return "bubble.left.and.bubble.right"
+        case .blog:                   return "doc.text"
+        case .youtube:                return "play.rectangle"
+        case .user:                   return "person.crop.circle"
+        case .fieldVisit:             return "figure.walk"
         }
     }
 


### PR DESCRIPTION
## Tappable source attribution links in Experience detail

The Sources section in ExperienceDetailView renders every source as static text, even though InformationSource carries a real `url: URL?` (e.g. the Wikivoyage page, Reddit thread, or blog it was synthesized from). This makes the app's transparency-first brand un-verifiable. Wrap each source row that has a URL in a tappable Link that opens the original page, with a type-appropriate icon, an `arrow.up.right` affordance, and a light haptic — falling back to the existing plain-text row when no URL exists.

### Acceptance
Open an Experience whose Sources include a URL (e.g. Chiang Mai Wikivoyage seed): the row shows a type-specific icon, an up-right arrow, and is tappable — tapping opens the URL in the browser/Safari with a light haptic. Sources without a URL (e.g. the EatingThaiFood blog seed) render as before with no arrow and are not tappable. VoiceOver announces tappable rows as links with the 'Opens the original source' hint. `xcodebuild build` and the SoloCompassTests suite pass.