### PR TITLE
auto: Animated 'thinking' indicator bubble in the text chat while the agent works

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -420,6 +420,7 @@
 "chat.error.retry" = "Retry";
 "chat.bubble.user.a11y" = "You said: %@";
 "chat.bubble.assistant.a11y" = "Solo said: %@";
+"chat.typing.a11y" = "Solo Compass is thinking…";
 "chat.tool.exploreNearby" = "Searched nearby";
 "chat.tool.filter" = "Filtered the map";
 "chat.tool.showDetails" = "Opened a place";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -409,6 +409,7 @@
 "chat.error.retry" = "重试";
 "chat.bubble.user.a11y" = "你说:%@";
 "chat.bubble.assistant.a11y" = "Solo 说:%@";
+"chat.typing.a11y" = "Solo Compass 正在思考…";
 "chat.tool.exploreNearby" = "搜索附近";
 "chat.tool.filter" = "筛选地图";
 "chat.tool.showDetails" = "打开地点";

--- a/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
@@ -256,6 +256,15 @@ public struct ChatSheet: View {
                             .opacity(0.6)
                         }
 
+                        if isAgentWorking {
+                            TypingIndicatorBubble(
+                                label: orchestrator.thinkingStep.isEmpty ? nil : orchestrator.thinkingStep
+                            )
+                            .id(Self.typingIndicatorID)
+                            .transition(.opacity)
+                            .animation(.easeInOut(duration: 0.2), value: isAgentWorking)
+                        }
+
                         Color.clear
                             .frame(height: 1)
                             .id(Self.bottomAnchorID)
@@ -271,6 +280,9 @@ public struct ChatSheet: View {
                     scrollToBottom(proxy: proxy)
                 }
                 .onChange(of: liveTranscript) { _, _ in
+                    scrollToBottom(proxy: proxy)
+                }
+                .onChange(of: orchestrator.session.state) { _, _ in
                     scrollToBottom(proxy: proxy)
                 }
                 .onAppear { scrollToBottom(proxy: proxy, animated: false) }
@@ -449,6 +461,22 @@ public struct ChatSheet: View {
     /// can see "Searched nearby" indicators inline with the conversation.
     private var visibleMessages: [VoiceAgentSession.Message] {
         orchestrator.session.messages.filter { $0.role != .system }
+    }
+
+    /// True while the agent is thinking or executing a tool but no streamed
+    /// text or live voice transcript has arrived yet.
+    private var isAgentWorking: Bool {
+        let state = orchestrator.session.state
+        let agentBusy: Bool
+        switch state {
+        case .thinking, .toolExecuting:
+            agentBusy = true
+        default:
+            agentBusy = orchestrator.isExecutingTool
+        }
+        return agentBusy
+            && orchestrator.streamingContent.isEmpty
+            && liveTranscript.isEmpty
     }
 
     private var micState: ChatInputBar.MicState {
@@ -645,6 +673,7 @@ public struct ChatSheet: View {
     private static let bottomAnchorID = "chat.bottom"
     private static let streamingBubbleID = "chat.streaming"
     private static let liveTranscriptID = "chat.liveTranscript"
+    private static let typingIndicatorID = "chat.typing"
 
     private func scrollToBottom(proxy: ScrollViewProxy, animated: Bool = true) {
         let anchor = Self.bottomAnchorID

--- a/apps/ios/SoloCompass/Views/Chat/MessageBubble.swift
+++ b/apps/ios/SoloCompass/Views/Chat/MessageBubble.swift
@@ -163,6 +163,81 @@ public struct MessageBubble: View {
     }
 }
 
+/// Animated three-dot 'typing' bubble shown while the agent is thinking or
+/// executing a tool and no streamed text has arrived yet.
+public struct TypingIndicatorBubble: View {
+    /// Optional localized step label (e.g. "🔍 Searching nearby…").
+    public let label: String?
+
+    public init(label: String? = nil) {
+        self.label = label
+    }
+
+    public var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            assistantAvatar
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 5) {
+                    ForEach(0..<3, id: \.self) { index in
+                        BouncingDot(delay: Double(index) * 0.18)
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 11)
+                .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+
+                if let label, !label.isEmpty {
+                    Text(label)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.leading, 4)
+                        .transition(.opacity)
+                }
+            }
+            Spacer(minLength: 48)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(NSLocalizedString(
+            "chat.typing.a11y",
+            comment: "VoiceOver label for the typing indicator — Solo Compass is thinking…"
+        )))
+    }
+
+    private var assistantAvatar: some View {
+        Circle()
+            .fill(Color.accentColor.opacity(0.15))
+            .frame(width: 28, height: 28)
+            .overlay {
+                Image(systemName: "location.north.line.fill")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color.accentColor)
+            }
+            .accessibilityHidden(true)
+    }
+}
+
+/// Single dot in the typing indicator, bouncing with a staggered delay.
+private struct BouncingDot: View {
+    let delay: Double
+    @State private var bouncing = false
+
+    var body: some View {
+        Circle()
+            .fill(Color.secondary.opacity(0.6))
+            .frame(width: 7, height: 7)
+            .offset(y: bouncing ? -4 : 0)
+            .opacity(bouncing ? 1.0 : 0.5)
+            .animation(
+                .easeInOut(duration: 0.5)
+                    .repeatForever(autoreverses: true)
+                    .delay(delay),
+                value: bouncing
+            )
+            .onAppear { bouncing = true }
+            .accessibilityHidden(true)
+    }
+}
+
 /// Soft pulsing dot rendered on the trailing edge of a streaming bubble.
 /// Pure visual — has no semantic meaning for VoiceOver.
 private struct StreamingCursor: View {
@@ -180,6 +255,15 @@ private struct StreamingCursor: View {
             .onAppear { pulse = true }
             .accessibilityHidden(true)
     }
+}
+
+#Preview("Typing Indicator") {
+    VStack(alignment: .leading, spacing: 12) {
+        TypingIndicatorBubble()
+        TypingIndicatorBubble(label: "🔍 Searching nearby…")
+    }
+    .padding()
+    .frame(maxWidth: .infinity, alignment: .leading)
 }
 
 #Preview("Conversation") {


### PR DESCRIPTION
## Animated 'thinking' indicator bubble in the text chat while the agent works

In text-chat mode, the conversation appears frozen between sending a message and the first streamed token — an LLM round-trip plus any tool calls, often several seconds of silence. This adds an animated three-dot 'typing' bubble (with the assistant avatar and the orchestrator's localized thinkingStep label, e.g. 'Searching nearby…') that appears at the bottom of the message list whenever the agent is thinking or running a tool and no streamed text has arrived yet, then disappears the instant tokens begin streaming.

### Acceptance
Sending a text message shows an animated three-dot bubble with the assistant avatar at the bottom of the chat within one frame; the bubble reflects the current thinkingStep label (e.g. 'Searching nearby…') during tool calls; it disappears as soon as streamed assistant text begins and is replaced by the streaming bubble; VoiceOver announces 'Solo Compass is thinking…' rather than the raw dots; #Preview compiles and `xcodebuild build -scheme SoloCompass` succeeds with no new warnings.