### PR TITLE
auto: Trust-signal redesign for the ConfidenceBadge detail popover

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -26,6 +26,7 @@
 "confidence.gps" = "GPS hits (30d)";
 "confidence.reports" = "User reports (30d)";
 "confidence.trusted" = "Trusted verifications";
+"confidence.lastVerified" = "Verified %@";
 
 /* Solo Score */
 "solo.label" = "Solo";

--- a/apps/ios/SoloCompass/Views/Shared/ConfidenceBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/ConfidenceBadge.swift
@@ -36,30 +36,109 @@ public struct ConfidenceBadge: View {
         }
         .buttonStyle(.plain)
         .popover(isPresented: $showSignals) {
-            VStack(alignment: .leading, spacing: 8) {
-                Text(confidence.health.localizedDescription)
-                    .font(.headline)
-                Text(confidence.reason)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                Divider()
-                Group {
-                    signalLine(label: NSLocalizedString("confidence.aiScrape", comment: ""), value: "\(confidence.signals.aiScrapeAgeDays)d")
-                    signalLine(label: NSLocalizedString("confidence.gps", comment: ""), value: "\(confidence.signals.passiveGpsHits30d)")
-                    signalLine(label: NSLocalizedString("confidence.reports", comment: ""), value: "\(confidence.signals.activeReports30d)")
-                    signalLine(label: NSLocalizedString("confidence.trusted", comment: ""), value: "\(confidence.signals.trustedVerifications)")
-                }
-                .font(.caption)
-            }
-            .padding()
-            .frame(minWidth: 240)
-            .presentationCompactAdaptation(.popover)
+            PopoverContent(confidence: confidence)
         }
         .accessibilityLabel(Text(confidence.health.localizedDescription))
     }
+}
 
-    private func signalLine(label: String, value: String) -> some View {
-        HStack {
+private struct PopoverContent: View {
+    let confidence: Confidence
+    @State private var appeared = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // Header: dot + health description + level capsule
+            HStack(spacing: 8) {
+                ZStack {
+                    Circle()
+                        .fill(confidence.health.color)
+                        .frame(width: 10, height: 10)
+                    if let symbol = confidence.health.accessibilitySymbol {
+                        Image(systemName: symbol)
+                            .font(.system(size: 5, weight: .bold))
+                            .foregroundColor(.white)
+                    }
+                }
+                Text(confidence.health.localizedDescription)
+                    .font(.headline)
+                Spacer()
+                Text("L\(confidence.level)")
+                    .font(.caption.weight(.semibold))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(confidence.health.color.opacity(0.15))
+                    .clipShape(Capsule())
+            }
+
+            // Reason subhead
+            Text(confidence.reason)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            // Last verified line
+            if let relativeDate = relativeVerifiedString {
+                HStack(spacing: 4) {
+                    Image(systemName: "clock")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(relativeDate)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Divider()
+
+            // Signal rows
+            Group {
+                signalRow(
+                    symbol: "sparkles",
+                    label: NSLocalizedString("confidence.aiScrape", comment: ""),
+                    value: "\(confidence.signals.aiScrapeAgeDays)d"
+                )
+                signalRow(
+                    symbol: "location.fill",
+                    label: NSLocalizedString("confidence.gps", comment: ""),
+                    value: "\(confidence.signals.passiveGpsHits30d)"
+                )
+                signalRow(
+                    symbol: "flag.fill",
+                    label: NSLocalizedString("confidence.reports", comment: ""),
+                    value: "\(confidence.signals.activeReports30d)"
+                )
+                signalRow(
+                    symbol: "checkmark.seal.fill",
+                    label: NSLocalizedString("confidence.trusted", comment: ""),
+                    value: "\(confidence.signals.trustedVerifications)"
+                )
+            }
+            .font(.caption)
+        }
+        .padding()
+        .frame(minWidth: 240)
+        .presentationCompactAdaptation(.popover)
+        .opacity(appeared ? 1 : 0)
+        .onAppear {
+            withAnimation(.easeIn(duration: 0.2)) {
+                appeared = true
+            }
+        }
+    }
+
+    private var relativeVerifiedString: String? {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        let relative = formatter.localizedString(for: confidence.lastVerifiedAt, relativeTo: Date())
+        let format = NSLocalizedString("confidence.lastVerified", comment: "")
+        return String(format: format, relative)
+    }
+
+    private func signalRow(symbol: String, label: String, value: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: symbol)
+                .frame(width: 20)
+                .foregroundStyle(.secondary)
             Text(label).foregroundStyle(.secondary)
             Spacer()
             Text(value).fontWeight(.medium)


### PR DESCRIPTION
## Trust-signal redesign for the ConfidenceBadge detail popover

The ConfidenceBadge is described in code as 'the trust signal across the app' and trust is the product's explicit brand, yet its detail popover lists four bare number rows (e.g. '7d', '24', '8', '1') with no icons, no visual hierarchy, and no sense of which signals are strong. Redesign the popover so each signal gets a leading SF Symbol, a human-readable relative 'last verified' line, and a prominent colored level header — making the trust breakdown legible at a glance for a component reused on every card, marker, and detail view.

### Acceptance
Tapping any ConfidenceBadge opens a popover showing: a colored level header with the health description and an L{n} chip; the reason text; a relative 'Verified {time} ago' line when a verification date exists; and four signal rows each prefixed by a distinct SF Symbol. Existing accessibility label (health.localizedDescription) is preserved, compact badge layout on cards is unchanged, the #Preview renders both L4 and L1 states correctly, and `xcodebuild build -scheme SoloCompass` succeeds with no new warnings.