### PR TITLE
auto: Result-count badge on the selected filter pill

### DIFF
--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -15,6 +15,9 @@ public struct FilterBarView: View {
     let onSelectCustomTag: (String) -> Void
     /// Driven by the parent when the map camera is moving; triggers fade+shrink.
     @Binding var isMapPanning: Bool
+    /// Number of experiences currently visible on the map. Used to render the
+    /// count badge on the selected pill. Defaults to 0 for previews/back-compat.
+    let resultCount: Int
 
     /// Namespace for the shared gliding selection highlight.
     @Namespace private var pillHighlight
@@ -32,7 +35,8 @@ public struct FilterBarView: View {
         onSelectAll: @escaping () -> Void,
         onSelectCategory: @escaping (ExperienceCategory) -> Void,
         onSelectCustomTag: @escaping (String) -> Void = { _ in },
-        isMapPanning: Binding<Bool> = .constant(false)
+        isMapPanning: Binding<Bool> = .constant(false),
+        resultCount: Int = 0
     ) {
         self.selectedCategory = selectedCategory
         self.isNowSelected = isNowSelected
@@ -42,6 +46,7 @@ public struct FilterBarView: View {
         self.onSelectCategory = onSelectCategory
         self.onSelectCustomTag = onSelectCustomTag
         self._isMapPanning = isMapPanning
+        self.resultCount = resultCount
     }
 
     /// Stable string ID for the currently selected pill — drives matchedGeometryEffect.
@@ -127,9 +132,18 @@ public struct FilterBarView: View {
                 .overlay(
                     Capsule().stroke(isSelected ? Color.clear : Color.primary.opacity(0.2), lineWidth: 1)
                 )
+                .overlay(alignment: .topTrailing) {
+                    if isSelected && resultCount > 0 {
+                        countBadge(count: resultCount, tint: color)
+                            .offset(x: 6, y: -6)
+                            .transition(.scale.combined(with: .opacity))
+                    }
+                }
+                .animation(.spring(response: 0.3, dampingFraction: 0.65), value: resultCount)
         }
         .buttonStyle(PressableButtonStyle())
         .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityValue(isSelected && resultCount > 0 ? Text("\(resultCount) results") : Text(""))
     }
 
     private func iconPill(category: ExperienceCategory, isSelected: Bool, action: @escaping () -> Void) -> some View {
@@ -151,10 +165,19 @@ public struct FilterBarView: View {
                 .overlay(
                     Circle().stroke(isSelected ? Color.clear : category.color.opacity(0.4), lineWidth: 1)
                 )
+                .overlay(alignment: .topTrailing) {
+                    if isSelected && resultCount > 0 {
+                        countBadge(count: resultCount, tint: category.color)
+                            .offset(x: 6, y: -6)
+                            .transition(.scale.combined(with: .opacity))
+                    }
+                }
+                .animation(.spring(response: 0.3, dampingFraction: 0.65), value: resultCount)
         }
         .buttonStyle(PressableButtonStyle())
         .accessibilityLabel(Text(category.localizedTitle))
         .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityValue(isSelected && resultCount > 0 ? Text("\(resultCount) results") : Text(""))
     }
 
     /// Pill rendered for each entry in `UserPreferences.customTags`. Same
@@ -179,10 +202,29 @@ public struct FilterBarView: View {
                 .overlay(
                     Circle().stroke(isSelected ? Color.clear : Color.accentColor.opacity(0.4), lineWidth: 1)
                 )
+                .overlay(alignment: .topTrailing) {
+                    if isSelected && resultCount > 0 {
+                        countBadge(count: resultCount, tint: .accentColor)
+                            .offset(x: 6, y: -6)
+                            .transition(.scale.combined(with: .opacity))
+                    }
+                }
+                .animation(.spring(response: 0.3, dampingFraction: 0.65), value: resultCount)
         }
         .buttonStyle(PressableButtonStyle())
         .accessibilityLabel(Text(tag))
         .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityValue(isSelected && resultCount > 0 ? Text("\(resultCount) results") : Text(""))
+    }
+
+    @ViewBuilder
+    private func countBadge(count: Int, tint: Color) -> some View {
+        Text("\(count)")
+            .font(.caption2.weight(.semibold).monospacedDigit())
+            .foregroundStyle(.white)
+            .padding(.horizontal, 5)
+            .frame(minWidth: 16, minHeight: 16)
+            .background(Capsule().fill(tint))
     }
 }
 

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -601,7 +601,8 @@ private struct MapOverlayView: View {
                 onSelectAll: { viewModel.clearFilters() },
                 onSelectCategory: { viewModel.selectCategory($0) },
                 onSelectCustomTag: { viewModel.selectCustomTag($0) },
-                isMapPanning: $isMapPanning
+                isMapPanning: $isMapPanning,
+                resultCount: viewModel.visibleExperiences.count
             )
             .padding(.top, 4)
 


### PR DESCRIPTION
## Result-count badge on the selected filter pill

When a category, custom tag, or 'Now' filter is active, show a small count badge on the selected FilterBarView pill reflecting how many experiences are currently on the map (e.g. '3'). This gives instant confirmation of how many options a filter yielded right where the user tapped, reinforcing the 'AI filters to a few, you choose' product pillar and softening the surprise of landing on a near-empty map.

### Acceptance
xcodebuild build succeeds for the SoloCompass scheme. Selecting a category pill shows a count badge matching the number of visible markers; deselecting (back to All) hides per-category badges. Badge animates in with a spring, uses monospaced digits, and is hidden when count is 0. VoiceOver reads the selected pill's count via its accessibility value. Existing FilterBarView #Preview and FilterBarView unit tests still compile (resultCount defaulted).