### PR TITLE
auto: Animated 'Copied!' confirmation on the LocationCard copy-coordinates button

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -447,6 +447,8 @@
 /* Location card + navigation picker */
 "location.navigate" = "Navigate";
 "location.copyCoords" = "Copy coordinates";
+"location.copied" = "Copied!";
+"location.copied.a11y" = "Coordinates copied";
 "location.openIn.apple" = "Apple Maps";
 "location.openIn.google" = "Google Maps";
 "location.openIn.amap" = "Amap";

--- a/apps/ios/SoloCompass/Views/Experience/LocationCard.swift
+++ b/apps/ios/SoloCompass/Views/Experience/LocationCard.swift
@@ -10,6 +10,7 @@ struct LocationCard: View {
     let addressHint: String?
 
     @State private var isShowingPicker = false
+    @State private var didCopy = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -63,12 +64,30 @@ struct LocationCard: View {
                 Button {
                     UIPasteboard.general.string = "\(coordinate.latitude), \(coordinate.longitude)"
                     UINotificationFeedbackGenerator().notificationOccurred(.success)
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                        didCopy = true
+                    }
+                    Task {
+                        try? await Task.sleep(for: .seconds(1.5))
+                        withAnimation { didCopy = false }
+                    }
                 } label: {
-                    Image(systemName: "doc.on.doc")
-                        .frame(width: 44, height: 44)
-                        .foregroundStyle(.secondary)
+                    VStack(spacing: 2) {
+                        Image(systemName: didCopy ? "checkmark.circle.fill" : "doc.on.doc")
+                            .contentTransition(.symbolEffect(.replace))
+                            .foregroundStyle(didCopy ? Color.green : Color.secondary)
+                        if didCopy {
+                            Text(NSLocalizedString("location.copied", comment: "Coordinates copied confirmation"))
+                                .font(.caption2)
+                                .foregroundStyle(Color.green)
+                        }
+                    }
+                    .frame(width: 44, height: 44)
                 }
-                .accessibilityLabel(Text(NSLocalizedString("location.copyCoords", comment: "Copy coordinates to clipboard")))
+                .accessibilityLabel(Text(didCopy
+                    ? NSLocalizedString("location.copied.a11y", comment: "VoiceOver: coordinates were copied")
+                    : NSLocalizedString("location.copyCoords", comment: "Copy coordinates to clipboard")
+                ))
             }
         }
         .padding(12)


### PR DESCRIPTION
## Animated 'Copied!' confirmation on the LocationCard copy-coordinates button

The copy-coordinates button in LocationCard fires a success haptic but gives no visual feedback, so users can't tell the copy succeeded (especially with VoiceOver or Reduce Motion users who miss the haptic). This adds a brief animated state swap where the doc.on.doc icon morphs into a green checkmark with a 'Copied!' label that auto-reverts after ~1.5s, matching the app's existing micro-interaction polish pattern.

### Acceptance
Tapping the copy button on a LocationCard copies the coordinates to the clipboard (unchanged), fires the success haptic (unchanged), and now visibly swaps the icon to a green checkmark with a 'Copied!' confirmation that springs in and auto-reverts to the doc.on.doc icon after ~1.5 seconds; the button frame stays 44x44 with no layout shift; VoiceOver announces the copied state; the new string is localized; the iOS target builds clean via xcodebuild.