### PR TITLE
auto: Fix broken empty-state heart animation in FavoritesListView (unresolved symbol)

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -66,9 +66,9 @@ private struct EmptyFavoritesView: View {
                 Image(systemName: "heart.fill")
                     .font(.system(size: 48))
                     .foregroundStyle(Color.pink.opacity(0.7))
-                    .scaleEffect(animatePulse ? 1.08 : 0.94)
-                    .opacity(animatePulse ? 1.0 : 0.7)
-                    .animation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true), value: animatePulse)
+                    .scaleEffect(isBreathing ? 1.08 : 0.94)
+                    .opacity(isBreathing ? 1.0 : 0.7)
+                    .animation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true), value: isBreathing)
             }
             Text(NSLocalizedString("favorites.empty.title", comment: "No favorites yet"))
                 .font(.headline)
@@ -79,8 +79,8 @@ private struct EmptyFavoritesView: View {
         }
         .padding(32)
         .onAppear {
-            guard !animatePulse else { return }
-            animatePulse = true
+            guard !isBreathing else { return }
+            isBreathing = true
         }
     }
 }


### PR DESCRIPTION
## Fix broken empty-state heart animation in FavoritesListView (unresolved symbol)

EmptyFavoritesView declares an unused @State `isBreathing` but its body references `animatePulse`, an identifier that only exists on the parent FavoritesListView and is therefore out of scope — the file does not compile. Wire the struct's body and onAppear to its own `isBreathing` state so the empty favorites screen shows its intended gentle pulsing heart.

### Acceptance
`xcodebuild build -project apps/ios/SoloCompass.xcodeproj -scheme SoloCompass -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest'` succeeds (was failing with a 'cannot find animatePulse in scope' error). Launching the app and opening Favorites with zero favorites shows the heart icon gently pulsing/breathing in a loop; no unused-variable warning for isBreathing remains.