### PR TITLE
auto: Wire up live rubber-band drag tracking on the experience card

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -134,23 +134,19 @@ public struct ExperienceCardView: View {
         )
         .offset(y: totalOffset)
         .opacity(dragOpacity)
-        .animation(.interactiveSpring(), value: dragTranslation)
         .padding(.horizontal, 12)
         .offset(y: dragOffset)
         .opacity(dragOpacity)
         .gesture(
-            DragGesture(minimumDistance: 20)
+            DragGesture(minimumDistance: 10)
                 .updating($dragTranslation) { value, state, _ in
-                    state = value.translation.height
-                }
-                .onChanged { value in
-                    if hapticState == .idle {
+                    let t = value.translation.height
+                    if state == 0 {
                         feedbackGenerator.prepare()
-                        hapticState = .prepared
                     }
-                    if hapticState == .prepared, abs(value.translation.height) > 60 {
+                    state = t
+                    if abs(t) > 60 {
                         feedbackGenerator.impactOccurred()
-                        hapticState = .fired
                     }
                 }
                 .onEnded { value in
@@ -163,10 +159,8 @@ public struct ExperienceCardView: View {
                         dragOffset = 0
                         onExpand()
                     } else {
-                        dragOffset = snappingFrom
-                        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                        withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
                             dragOffset = 0
-                        }
                     }
                     hapticState = .idle
                 }

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -7,8 +7,13 @@ public struct ExperienceCardView: View {
     var onExpand: () -> Void
     var onDismiss: () -> Void
 
-    @GestureState private var dragTranslation: CGFloat = 0
-    @State private var hapticState: HapticState = .idle
+    private struct DragState {
+        var translation: CGFloat = 0
+        var hapticFired: Bool = false
+    }
+
+    @GestureState private var dragState = DragState()
+    @State private var dragOffset: CGFloat = 0
 
     private enum HapticState { case idle, prepared, fired }
 
@@ -35,12 +40,12 @@ public struct ExperienceCardView: View {
     }
 
     private var totalOffset: CGFloat {
-        rubberBanded(dragTranslation)
+        rubberBanded(dragState.translation) + dragOffset
     }
 
     /// Fades in both directions: downward (dismiss) and upward (expand).
     private var dragOpacity: Double {
-        1 - min(0.4, abs(dragOffset) / 300)
+        1 - min(0.4, abs(dragState.translation) / 300)
     }
 
     private var isFavorited: Bool {
@@ -139,19 +144,20 @@ public struct ExperienceCardView: View {
         .opacity(dragOpacity)
         .gesture(
             DragGesture(minimumDistance: 10)
-                .updating($dragTranslation) { value, state, _ in
+                .updating($dragState) { value, state, _ in
                     let t = value.translation.height
-                    if state == 0 {
+                    if state.translation == 0 {
                         feedbackGenerator.prepare()
                     }
-                    state = t
-                    if abs(t) > 60 {
+                    state.translation = t
+                    if abs(t) > 60 && !state.hapticFired {
                         feedbackGenerator.impactOccurred()
+                        state.hapticFired = true
                     }
                 }
                 .onEnded { value in
                     // Capture live offset before @GestureState resets to 0.
-                    let snappingFrom = rubberBanded(dragTranslation)
+                    let snappingFrom = rubberBanded(dragState.translation)
                     if value.translation.height > 60 {
                         dragOffset = 0
                         onDismiss()
@@ -162,7 +168,6 @@ public struct ExperienceCardView: View {
                         withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
                             dragOffset = 0
                     }
-                    hapticState = .idle
                 }
         )
         .onTapGesture { onExpand() }


### PR DESCRIPTION
## Wire up live rubber-band drag tracking on the experience card

ExperienceCardView declares all the machinery for an interactive drag (dragTranslation @GestureState, totalOffset, dragOpacity, a prepared feedbackGenerator, and a rubberBanded helper) but never applies any of it — the DragGesture only fires .onEnded, so the card snaps with no live feedback as the finger moves. This wires the declared state into .offset/.opacity and adds .updating to make the card physically follow the drag, fading and rubber-banding upward exactly as the existing comments promise.

### Acceptance
Dragging the card down makes it follow the finger 1:1 and fade; dragging up rubber-bands to 40% travel and fades; releasing below threshold springs it back to rest; releasing past ±60pt triggers dismiss/expand with a haptic tap. No unused-declaration warnings remain for dragTranslation/totalOffset/dragOpacity/feedbackGenerator. xcodebuild build succeeds for the SoloCompass scheme and the view renders correctly in #Preview and the Simulator.