### PR TITLE
auto: Name the removed experience + show a draining countdown in the Favorites undo bar

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 "favorites.empty.title" = "No favorites yet";
 "favorites.empty.hint" = "Tap the heart on any experience to save it here.";
 "favorites.undo" = "Removed — Undo";
+"favorites.undo.named" = "Removed \"%@\"";
 
 /* Generic actions */
 "action.undo" = "Undo";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -242,6 +242,7 @@
 "favorites.title" = "收藏";
 "favorites.empty.title" = "还没有收藏";
 "favorites.empty.hint" = "点击任意体验上的爱心即可保存到这里。";
+"favorites.undo.named" = "已移除\"%@\"";
 
 /* Notifications */
 "settings.notifications" = "靠近时提醒我";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -7,9 +7,10 @@ public struct FavoritesListView: View {
     @Environment(UserPreferences.self) private var preferences
     let onSelectExperience: (Experience) -> Void
 
-    @State private var lastUnfavorited: (id: String, date: Date)?
+    @State private var lastUnfavorited: (id: String, title: String, date: Date)?
     @State private var undoDismissTask: Task<Void, Never>?
     @State private var animatePulse = false
+    @State private var undoProgress: CGFloat = 1
 
     private var sortedFavorites: [Experience] {
         let ids = preferences.favoritedExperiences
@@ -88,29 +89,50 @@ private struct EmptyFavoritesView: View {
 private extension FavoritesListView {
 
     var undoBar: some View {
-        HStack {
-            Text(NSLocalizedString("favorites.undo", comment: "Removed — Undo banner"))
-                .font(.subheadline)
-                .foregroundStyle(.primary)
-            Spacer()
-            Button {
-                guard let saved = lastUnfavorited else { return }
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                undoDismissTask?.cancel()
-                undoDismissTask = nil
-                withAnimation(.easeInOut) {
-                    preferences.toggleFavorite(saved.id, at: saved.date)
-                    lastUnfavorited = nil
+        ZStack(alignment: .bottom) {
+            HStack {
+                Text(String(format: NSLocalizedString("favorites.undo.named", comment: "Removed named experience undo banner"), lastUnfavorited?.title ?? ""))
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer()
+                Button {
+                    guard let saved = lastUnfavorited else { return }
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    undoDismissTask?.cancel()
+                    undoDismissTask = nil
+                    undoProgress = 1
+                    withAnimation(.easeInOut) {
+                        preferences.toggleFavorite(saved.id, at: saved.date)
+                        lastUnfavorited = nil
+                    }
+                } label: {
+                    Text(NSLocalizedString("action.undo", comment: "Undo action"))
+                        .font(.subheadline.weight(.semibold))
                 }
-            } label: {
-                Text(NSLocalizedString("action.undo", comment: "Undo action"))
-                    .font(.subheadline.weight(.semibold))
             }
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            .padding(.bottom, 14)
+
+            GeometryReader { geo in
+                Capsule()
+                    .fill(Color.accentColor)
+                    .frame(width: geo.size.width * undoProgress, height: 2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(height: 2)
+            .padding(.horizontal, 2)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
         .padding(.horizontal, 16)
+        .onAppear {
+            undoProgress = 1
+            withAnimation(.linear(duration: 4)) {
+                undoProgress = 0
+            }
+        }
     }
 
     @ViewBuilder
@@ -153,10 +175,12 @@ private extension FavoritesListView {
                 UINotificationFeedbackGenerator().notificationOccurred(.warning)
                 let savedDate = preferences.favoritedAt[exp.id] ?? Date()
                 let expId = exp.id
+                let expTitle = exp.title
+                undoProgress = 1
                 withAnimation(.easeInOut) {
                     preferences.toggleFavorite(expId)
                 }
-                lastUnfavorited = (id: expId, date: savedDate)
+                lastUnfavorited = (id: expId, title: expTitle, date: savedDate)
                 undoDismissTask?.cancel()
                 undoDismissTask = Task {
                     try? await Task.sleep(for: .seconds(4))


### PR DESCRIPTION
## Name the removed experience + show a draining countdown in the Favorites undo bar

The Favorites undo bar currently shows a generic 'Removed — Undo' with no indication of which experience was unfavorited or how long the undo window lasts before the 4-second timer silently expires. This adds the experience title to the message and a thin draining progress bar across the bottom of the undo banner so the user can see the remaining time, matching the iMessage/Mail-style undo affordance.

### Acceptance
Swiping to unfavorite an experience shows an undo banner naming that experience's title; a thin progress bar visibly drains left-to-right over ~4 seconds and the banner auto-dismisses when it empties; tapping Undo within the window restores the favorite, cancels the timer, and resets the bar; both English and zh-Hans display the localized named message; xcodebuild build and the SoloCompassTests suite pass.