### PR TITLE
auto: Make ExperienceCardView actually follow the finger while dragging

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -9,11 +9,7 @@ public struct ExperienceCardView: View {
 
     @GestureState private var dragTranslation: CGFloat = 0
     @State private var dragOffset: CGFloat = 0
-    @State private var didCrossThreshold = false
-    @State private var didPrepareHaptic = false
-    @State private var isPulsing = false
-    @State private var heartBounce = 0
-    @State private var heartBurst = false
+    @State private var didFireThresholdHaptic = false
 
     // Pre-allocated so prepare() can be called once when the drag starts.
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
@@ -131,6 +127,9 @@ public struct ExperienceCardView: View {
                 .fill(.regularMaterial)
                 .shadow(color: .black.opacity(0.1), radius: 12, y: -2)
         )
+        .offset(y: totalOffset)
+        .opacity(dragOpacity)
+        .animation(.interactiveSpring(), value: dragTranslation)
         .padding(.horizontal, 12)
         .offset(y: dragOffset)
         .opacity(dragOpacity)
@@ -140,21 +139,20 @@ public struct ExperienceCardView: View {
                     state = value.translation.height
                 }
                 .onChanged { value in
-                    let t = value.translation.height
-                    if !didPrepareHaptic {
+                    if state == 0 {
                         feedbackGenerator.prepare()
-                        didPrepareHaptic = true
                     }
-                    if !didCrossThreshold && abs(t) > 60 {
-                        didCrossThreshold = true
+                    state = value.translation.height
+                }
+                .onChanged { value in
+                    if !didFireThresholdHaptic, abs(value.translation.height) > 60 {
                         feedbackGenerator.impactOccurred()
+                        didFireThresholdHaptic = true
                     }
                 }
                 .onEnded { value in
                     // Capture live offset before @GestureState resets to 0.
                     let snappingFrom = rubberBanded(dragTranslation)
-                    didCrossThreshold = false
-                    didPrepareHaptic = false
                     if value.translation.height > 60 {
                         dragOffset = 0
                         onDismiss()
@@ -166,6 +164,10 @@ public struct ExperienceCardView: View {
                         withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                             dragOffset = 0
                         }
+                    }
+                    withAnimation(.spring(response: 0.3)) {
+                        dragOffset = 0
+                        didFireThresholdHaptic = false
                     }
                 }
         )

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -8,8 +8,9 @@ public struct ExperienceCardView: View {
     var onDismiss: () -> Void
 
     @GestureState private var dragTranslation: CGFloat = 0
-    @State private var dragOffset: CGFloat = 0
-    @State private var didFireThresholdHaptic = false
+    @State private var hapticState: HapticState = .idle
+
+    private enum HapticState { case idle, prepared, fired }
 
     // Pre-allocated so prepare() can be called once when the drag starts.
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
@@ -31,6 +32,10 @@ public struct ExperienceCardView: View {
     /// Rubber-bands upward drags to 40% travel; downward dismissal drags follow 1:1.
     private func rubberBanded(_ t: CGFloat) -> CGFloat {
         t < 0 ? t * 0.4 : t
+    }
+
+    private var totalOffset: CGFloat {
+        rubberBanded(dragTranslation)
     }
 
     /// Fades in both directions: downward (dismiss) and upward (expand).
@@ -139,15 +144,13 @@ public struct ExperienceCardView: View {
                     state = value.translation.height
                 }
                 .onChanged { value in
-                    if state == 0 {
+                    if hapticState == .idle {
                         feedbackGenerator.prepare()
+                        hapticState = .prepared
                     }
-                    state = value.translation.height
-                }
-                .onChanged { value in
-                    if !didFireThresholdHaptic, abs(value.translation.height) > 60 {
+                    if hapticState == .prepared, abs(value.translation.height) > 60 {
                         feedbackGenerator.impactOccurred()
-                        didFireThresholdHaptic = true
+                        hapticState = .fired
                     }
                 }
                 .onEnded { value in
@@ -165,10 +168,7 @@ public struct ExperienceCardView: View {
                             dragOffset = 0
                         }
                     }
-                    withAnimation(.spring(response: 0.3)) {
-                        dragOffset = 0
-                        didFireThresholdHaptic = false
-                    }
+                    hapticState = .idle
                 }
         )
         .onTapGesture { onExpand() }


### PR DESCRIPTION
## Make ExperienceCardView actually follow the finger while dragging

The floating Experience card declares all the scaffolding for an interactive drag (dragTranslation GestureState, dragOffset, rubber-banded totalOffset, dragOpacity, a pre-allocated medium-impact feedbackGenerator) but none of it is wired to the view — the DragGesture only runs discrete onEnded threshold checks, so the card stays frozen until you release and never gives the prepared haptic. Wire the existing computed offsets/opacity into the card and add .updating + prepare()/impact so the card tracks the finger with rubber-banding, fades toward dismiss/expand, and fires a single haptic when a threshold is crossed.

### Acceptance
Dragging the floating card down moves it 1:1 with the finger and fades it slightly; dragging up rubber-bands to 40% travel; a single medium haptic fires the moment the 60pt dismiss/expand threshold is crossed; releasing past threshold dismisses/expands as before, releasing short springs the card back to rest; no unused-variable warnings remain (totalOffset, dragOpacity, feedbackGenerator all referenced); xcodebuild build succeeds for the SoloCompass scheme and the existing #Preview renders an interactive card.