### PR TITLE
auto: Wire up live interactive drag on ExperienceCardView (currently dead state)

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -10,8 +10,9 @@ public struct ExperienceCardView: View {
     @GestureState private var dragTranslation: CGFloat = 0
     @State private var dragOffset: CGFloat = 0
     @State private var didCrossThreshold = false
+    @State private var hasPreparedFeedback = false
 
-    // Pre-allocated so prepare() can be called when the drag starts.
+    // Pre-allocated so prepare() can be called once when the drag starts.
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
     @Environment(UserPreferences.self) private var preferences
 
@@ -30,13 +31,9 @@ public struct ExperienceCardView: View {
         t < 0 ? t * 0.4 : t
     }
 
-    private var totalOffset: CGFloat {
-        rubberBanded(dragTranslation) + dragOffset
-    }
-
     /// Fades in both directions: downward (dismiss) and upward (expand).
     private var dragOpacity: Double {
-        1 - min(0.4, abs(dragTranslation) / 300)
+        1 - min(0.4, abs(dragOffset) / 300)
     }
 
     private var isFavorited: Bool {
@@ -111,19 +108,22 @@ public struct ExperienceCardView: View {
                 .fill(.regularMaterial)
                 .shadow(color: .black.opacity(0.1), radius: 12, y: -2)
         )
-        .offset(y: totalOffset)
-        .opacity(dragOpacity)
         .padding(.horizontal, 12)
+        .offset(y: dragOffset)
+        .opacity(dragOpacity)
         .gesture(
             DragGesture(minimumDistance: 20)
                 .updating($dragTranslation) { value, state, _ in
                     state = value.translation.height
-                    if !didCrossThreshold {
-                        feedbackGenerator.prepare()
-                    }
                 }
                 .onChanged { value in
                     let translation = value.translation.height
+                    // Commit live position to dragOffset so snap-back can animate from here.
+                    dragOffset = rubberBanded(translation)
+                    if !hasPreparedFeedback {
+                        hasPreparedFeedback = true
+                        feedbackGenerator.prepare()
+                    }
                     if !didCrossThreshold && abs(translation) > 60 {
                         didCrossThreshold = true
                         feedbackGenerator.impactOccurred()
@@ -131,9 +131,12 @@ public struct ExperienceCardView: View {
                 }
                 .onEnded { value in
                     didCrossThreshold = false
+                    hasPreparedFeedback = false
                     if value.translation.height > 60 {
+                        dragOffset = 0
                         onDismiss()
                     } else if value.translation.height < -60 {
+                        dragOffset = 0
                         onExpand()
                     } else {
                         withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -9,6 +9,7 @@ public struct ExperienceCardView: View {
 
     @GestureState private var dragTranslation: CGFloat = 0
     @State private var dragOffset: CGFloat = 0
+    @State private var didCrossThreshold = false
 
     // Pre-allocated so prepare() can be called when the drag starts.
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
@@ -110,14 +111,34 @@ public struct ExperienceCardView: View {
                 .fill(.regularMaterial)
                 .shadow(color: .black.opacity(0.1), radius: 12, y: -2)
         )
+        .offset(y: totalOffset)
+        .opacity(dragOpacity)
         .padding(.horizontal, 12)
         .gesture(
             DragGesture(minimumDistance: 20)
+                .updating($dragTranslation) { value, state, _ in
+                    state = value.translation.height
+                    if !didCrossThreshold {
+                        feedbackGenerator.prepare()
+                    }
+                }
+                .onChanged { value in
+                    let translation = value.translation.height
+                    if !didCrossThreshold && abs(translation) > 60 {
+                        didCrossThreshold = true
+                        feedbackGenerator.impactOccurred()
+                    }
+                }
                 .onEnded { value in
+                    didCrossThreshold = false
                     if value.translation.height > 60 {
                         onDismiss()
                     } else if value.translation.height < -60 {
                         onExpand()
+                    } else {
+                        withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                            dragOffset = 0
+                        }
                     }
                 }
         )


### PR DESCRIPTION
## Wire up live interactive drag on ExperienceCardView (currently dead state)

ExperienceCardView already declares all the machinery for an interactive drag — `@GestureState dragTranslation`, `dragOffset`, `totalOffset`, `dragOpacity`, and a `rubberBanded(_:)` helper — but the actual `DragGesture` only uses `.onEnded`, so none of it is ever applied. The card snaps abruptly on release with zero finger-tracking feedback. Connect the existing state to the gesture and view so the card follows the finger (rubber-banded upward, 1:1 downward) and fades toward the threshold, with a haptic tick when the dismiss/expand threshold is crossed.

### Acceptance
Dragging the card up or down moves it under the finger in real time (rubber-banded ~40% upward, 1:1 downward) and the card fades as it travels; releasing below threshold springs it back to rest, releasing past 60pt up expands and past 60pt down dismisses; a single medium haptic fires the moment the threshold is crossed; tap-to-expand and accessibility actions still work; `xcodebuild build`/`test` for the SoloCompass scheme pass and the `#Preview` renders.