### PR TITLE
auto: Animate the 'Best Now' badge on ExperienceCardView to match the pulsing Now signal elsewhere

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -11,10 +11,14 @@ public struct ExperienceCardView: View {
     @State private var dragOffset: CGFloat = 0
     @State private var didCrossThreshold = false
     @State private var hasPreparedFeedback = false
+    @State private var isPulsing = false
 
     // Pre-allocated so prepare() can be called once when the drag starts.
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
     @Environment(UserPreferences.self) private var preferences
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private static let accentGold = Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)
 
     public init(
         experience: Experience,
@@ -86,14 +90,7 @@ public struct ExperienceCardView: View {
             HStack {
                 SoloScoreBadge(score: experience.soloScore, style: .compact)
                 if experience.isBestNow() {
-                    Label(NSLocalizedString("experience.bestNow", comment: ""), systemImage: "sparkle")
-                        .font(.caption)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(
-                            Capsule().fill(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255).opacity(0.2))
-                        )
-                        .foregroundStyle(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255))
+                    bestNowBadge
                 }
                 Spacer()
                 Button(action: onExpand) {
@@ -164,6 +161,43 @@ public struct ExperienceCardView: View {
         ) {
             preferences.toggleFavorite(experience.id)
         }
+    }
+
+    @ViewBuilder
+    private var bestNowBadge: some View {
+        Label(NSLocalizedString("experience.bestNow", comment: ""), systemImage: "sparkle")
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .foregroundStyle(Self.accentGold)
+            .background(
+                ZStack {
+                    Capsule()
+                        .fill(Self.accentGold.opacity(0.25))
+                        .scaleEffect(isPulsing ? 1.12 : 1.0)
+                        .opacity(isPulsing ? 0.0 : 0.5)
+                        .blur(radius: 4)
+                    Capsule()
+                        .fill(Self.accentGold.opacity(0.2))
+                }
+            )
+            .opacity(isPulsing ? 0.75 : 1.0)
+            .scaleEffect(isPulsing ? 0.97 : 1.0)
+            .onAppear {
+                guard !reduceMotion else { return }
+                withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
+                    isPulsing = true
+                }
+            }
+            .onChange(of: reduceMotion) { _, reduced in
+                if reduced {
+                    withAnimation(.default) { isPulsing = false }
+                } else {
+                    withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
+                        isPulsing = true
+                    }
+                }
+            }
     }
 }
 


### PR DESCRIPTION
## Animate the 'Best Now' badge on ExperienceCardView to match the pulsing Now signal elsewhere

The map marker (MarkerIconView) and the Now filter pill (FilterBarView, #178) both render the 'best time now' signal with a live pulsing animation, but the same signal on the experience card is a flat, static Label — a visible inconsistency for what should read as the app's most time-sensitive cue. This adds a gentle pulsing glow + sparkle shimmer to the card's Best Now badge, reusing the existing accent-gold color and the reduce-motion guard pattern already established in FilterBarView's nowPill.

### Acceptance
Build succeeds via xcodebuild for the SoloCompass scheme. When an experience with isBestNow()==true is shown, the Best Now badge has a visible gentle pulsing glow/shimmer (verified in Simulator). With Reduce Motion enabled (Settings > Accessibility), the badge renders fully static with no animation. The accent-gold color exactly matches the existing badge and the Now pill. No change to layout, copy, or the accessibility label string; #Preview still renders.