### PR TITLE
auto: Add haptic feedback to location selection in LocationPickerSheet

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
@@ -75,6 +75,7 @@ struct LocationPickerSheet: View {
     private func citiesContent(bs: Bindable<LocationPickerState>) -> some View {
         List {
             Button {
+                commitHaptic()
                 viewModel.selectCity(nil)
                 onDismiss()
             } label: {
@@ -93,6 +94,7 @@ struct LocationPickerSheet: View {
 
             ForEach(filteredCities, id: \.code) { city in
                 Button {
+                    commitHaptic()
                     viewModel.selectCity(city.code)
                     onDismiss()
                 } label: {
@@ -284,7 +286,10 @@ struct LocationPickerSheet: View {
 
     // MARK: - Actions
 
+    private func commitHaptic() { UIImpactFeedbackGenerator(style: .light).impactOccurred() }
+
     private func selectSearchResult(_ item: MKMapItem) {
+        commitHaptic()
         let coord = item.placemark.coordinate
         let label = item.name
             ?? item.placemark.locality
@@ -299,6 +304,7 @@ struct LocationPickerSheet: View {
     }
 
     private func commitMapLocation() {
+        commitHaptic()
         let coord = state.pinCoordinate
         let label = state.resolvedCityName
             ?? String(format: "%.4f, %.4f", coord.latitude, coord.longitude)


### PR DESCRIPTION
## Add haptic feedback to location selection in LocationPickerSheet

The LocationPickerSheet is the core location-switching flow for this map-first app, yet it's the only major interactive sheet with no haptic feedback — selecting a city, tapping a search result, or committing a map pin all happen silently, while FavoritesListView, FilterBarView, ExperienceCardView and others already use UIImpactFeedbackGenerator. This adds light selection-confirmation haptics at the four commit points so changing your location feels as tactile as the rest of the app.

### Acceptance
xcodebuild build succeeds for the SoloCompass scheme on iPhone 17 Pro simulator. Existing SoloCompassTests still pass. Manually in the Simulator (or on device): opening the location picker and (a) tapping a city row, (b) tapping 'All cities', (c) selecting a Search-tab result, and (d) tapping 'Set this location' on the Map tab each fire a light impact haptic before the sheet dismisses. No regression to selection behavior, #Preview still renders, and no new SwiftUI warnings.