### PR TITLE
auto: Add vertex dots + tap-to-replay with completion haptic to SoloScoreRadarChart

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -42,6 +42,7 @@
 "solo.noise" = "Noise";
 "solo.basedOn" = "Based on %d solo travelers";
 "solo.radar.a11y" = "Solo Score radar";
+"solo.radar.replayHint" = "Tap to replay the draw-in animation";
 "solo.basedOn.early" = "Based on %d early reports";
 "solo.estimate.pill" = "AI estimate";
 "solo.section.estimate" = "Solo Score (AI estimate)";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -422,6 +422,7 @@
 
 /* Solo score */
 "solo.radar.a11y" = "独行评分雷达图";
+"solo.radar.replayHint" = "轻点以重播绘制动画";
 "solo.wifi" = "WiFi";
 "solo.noise" = "噪音";
 

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
@@ -2,11 +2,16 @@ import SwiftUI
 
 /// Radar chart visualising the six SoloScore dimensions.
 /// Falls back to highlighted progress bars when dimension variance < 0.5.
+/// Tap the chart to replay the draw-in animation (Reduce Motion: no replay, no haptic).
 public struct SoloScoreRadarChart: View {
     let score: SoloScore
 
     @State private var drawProgress: Double = 0
+    @State private var isReplaying: Bool = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private let haptic = UIImpactFeedbackGenerator(style: .soft)
+    private static let springDuration: Double = 0.7
 
     private static let axes: [(label: String, symbol: String, keyPath: KeyPath<SoloScore.Breakdown, Double>)] = [
         (NSLocalizedString("solo.seating",    comment: ""), "chair",              \.seatingFriendly),
@@ -44,8 +49,12 @@ public struct SoloScoreRadarChart: View {
             if reduceMotion {
                 drawProgress = 1
             } else {
-                withAnimation(.spring(response: 0.7, dampingFraction: 0.75)) {
+                withAnimation(.spring(response: Self.springDuration, dampingFraction: 0.75)) {
                     drawProgress = 1
+                }
+                haptic.prepare()
+                DispatchQueue.main.asyncAfter(deadline: .now() + Self.springDuration) {
+                    haptic.impactOccurred()
                 }
             }
         }
@@ -92,6 +101,24 @@ public struct SoloScoreRadarChart: View {
                 radarPolygon(center: center, radius: radius, count: axisCount, values: animatedValues)
                     .stroke(score.scoreColor, lineWidth: 2)
 
+                // Vertex dots — one per dimension, grow in sync with drawProgress
+                ForEach(0..<axisCount, id: \.self) { i in
+                    let angle = axisAngle(index: i, count: axisCount)
+                    let dotRadius = size * 0.018
+                    let dotPos = point(
+                        center: center,
+                        radius: radius * CGFloat(values[i] / 10.0) * CGFloat(drawProgress),
+                        angle: angle
+                    )
+                    Circle()
+                        .fill(score.scoreColor)
+                        .overlay(Circle().strokeBorder(.white, lineWidth: 1.5))
+                        .frame(width: dotRadius * 2, height: dotRadius * 2)
+                        .scaleEffect(drawProgress)
+                        .position(dotPos)
+                        .accessibilityHidden(true)
+                }
+
                 // Axis labels with SF Symbol icons — stagger-fade per axis
                 ForEach(0..<axisCount, id: \.self) { i in
                     let angle = axisAngle(index: i, count: axisCount)
@@ -118,6 +145,20 @@ public struct SoloScoreRadarChart: View {
         }
         .aspectRatio(1, contentMode: .fit)
         .accessibilityLabel(radarAccessibilityLabel)
+        .accessibilityHint(reduceMotion ? Text("") : Text(NSLocalizedString("solo.radar.replayHint", comment: "Tap to replay the draw-in animation")))
+        .onTapGesture {
+            guard !reduceMotion, !isReplaying else { return }
+            isReplaying = true
+            drawProgress = 0
+            withAnimation(.spring(response: Self.springDuration, dampingFraction: 0.75)) {
+                drawProgress = 1
+            }
+            haptic.prepare()
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.springDuration) {
+                haptic.impactOccurred()
+                isReplaying = false
+            }
+        }
     }
 
     private func radarPolygon(center: CGPoint, radius: CGFloat, count: Int, values: [Double]) -> Path {
@@ -201,8 +242,9 @@ public struct SoloScoreRadarChart: View {
         basedOnCount: 22
     )
     return VStack(spacing: 24) {
-        Text("Radar Chart (high variance)")
+        Text("Radar Chart (high variance) — tap to replay, dots at vertices")
             .font(.headline)
+            .multilineTextAlignment(.center)
         SoloScoreRadarChart(score: highVariance)
             .frame(width: 280, height: 280)
             .padding()


### PR DESCRIPTION
## Add vertex dots + tap-to-replay with completion haptic to SoloScoreRadarChart

The SoloScore radar chart — the product's signature solo-friendliness visualization — draws its data polygon as a filled/stroked shape but renders no markers at the six data vertices, making it hard to read exactly where each dimension lands. This adds small circular dots at each polygon vertex (color-matched to scoreColor, animating outward with drawProgress) and makes the chart tappable to replay its draw-in animation, firing a soft completion haptic when the polygon finishes growing. All changes respect Reduce Motion and are confined to one file.

### Acceptance
Build succeeds via xcodebuild for SoloCompass scheme on iPhone 17 Pro sim. In the high-variance preview, six color-matched dots appear at each data vertex and grow in sync with the polygon. Tapping the chart replays the draw-in animation. A soft haptic fires when the draw completes (device only). With Reduce Motion on, dots appear immediately at full position, no replay animation runs, and no haptic fires. radarAccessibilityLabel still reports all six final dimension values; dots are excluded from accessibility. Low-variance fallback bars are unchanged.