### PR TITLE
auto: Satisfying heart-favorite confirmation on the floating map card

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -12,6 +12,8 @@ public struct ExperienceCardView: View {
     @State private var didCrossThreshold = false
     @State private var hasPreparedFeedback = false
     @State private var isPulsing = false
+    @State private var heartBounce = 0
+    @State private var heartBurst = false
 
     // Pre-allocated so prepare() can be called once when the drag starts.
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
@@ -63,17 +65,37 @@ public struct ExperienceCardView: View {
                 }
                 Spacer()
                 Button {
+                    let wasFavorited = preferences.isFavorited(experience.id)
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                     withAnimation(.spring(response: 0.3)) {
                         preferences.toggleFavorite(experience.id)
                     }
+                    if !wasFavorited {
+                        heartBounce += 1
+                        if !reduceMotion {
+                            heartBurst = true
+                            Task {
+                                try? await Task.sleep(nanoseconds: 450_000_000)
+                                heartBurst = false
+                            }
+                        }
+                    }
                 } label: {
                     let favorited = preferences.isFavorited(experience.id)
-                    Image(systemName: favorited ? "heart.fill" : "heart")
-                        .foregroundStyle(favorited ? Color.red : Color.secondary)
-                        .frame(width: 32, height: 32)
-                        .scaleEffect(favorited ? 1.15 : 1.0)
-                        .contentShape(Rectangle())
+                    ZStack {
+                        Circle()
+                            .stroke(Color.red.opacity(0.5), lineWidth: 2)
+                            .scaleEffect(heartBurst ? 1.8 : 0.4)
+                            .opacity(heartBurst ? 0 : 0.8)
+                            .animation(.easeOut(duration: 0.45), value: heartBurst)
+                            .allowsHitTesting(false)
+                        Image(systemName: favorited ? "heart.fill" : "heart")
+                            .foregroundStyle(favorited ? Color.red : Color.secondary)
+                            .scaleEffect(favorited ? 1.15 : 1.0)
+                            .symbolEffect(.bounce, value: heartBounce)
+                    }
+                    .frame(width: 32, height: 32)
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(preferences.isFavorited(experience.id)


### PR DESCRIPTION
## Satisfying heart-favorite confirmation on the floating map card

The favorite heart on ExperienceCardView is the single most-tapped positive action, yet it only does a static scaleEffect — no symbol bounce or burst — unlike the confetti/checkmark polish used when completing an experience. Add a SF Symbol .bounce effect plus a one-shot radiating ring burst that fires only when newly favoriting (not when un-favoriting), respecting Reduce Motion, so the gesture lands with a clear, delightful confirmation matching the app's existing animation family.

### Acceptance
Tapping the heart to favorite triggers a symbol bounce + a single outward ring pulse and light haptic; tapping again to un-favorite does NOT fire the burst. With Reduce Motion enabled, the ring burst is suppressed (symbol bounce/state change still applies). The button's accessibility label still flips between 'Add to favorites' and 'Remove from favorites'. xcodebuild build succeeds for the SoloCompass scheme and the #Preview renders the card with a working heart.