### PR TITLE
auto: Add a guided empty state to CityPickerSheet when no cities are discovered yet

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -134,6 +134,8 @@
 "city.all" = "All Cities";
 "city.picker.title" = "Choose a city";
 "city.experienceCount" = "%d experiences";
+"city.empty.title" = "No cities yet";
+"city.empty.hint" = "Cities appear here as you explore the map.";
 
 /* Action bar */
 "action.favorite" = "Add to favorites";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -121,6 +121,8 @@
 "city.all" = "全部城市";
 "city.picker.title" = "选择城市";
 "city.experienceCount" = "%d 处体验";
+"city.empty.title" = "暂无城市";
+"city.empty.hint" = "探索地图时，城市会陆续出现在这里。";
 
 /* Action bar */
 "action.favorite" = "添加到收藏";

--- a/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
@@ -24,61 +24,69 @@ public struct CityPickerSheet: View {
 
     public var body: some View {
         NavigationStack {
-            List {
-                // "All Cities" option
-                Button {
-                    selectCity(nil)
-                } label: {
-                    HStack {
-                        Text(NSLocalizedString("city.all", comment: "All cities option"))
-                            .font(.body)
-                            .foregroundStyle(.primary)
-                        Spacer()
-                        if viewModel.selectedCity == nil {
-                            Image(systemName: "checkmark")
-                                .foregroundStyle(.tint)
-                                .font(.body.weight(.semibold))
-                                .scaleEffect(justSelectedCode == "all" ? 1.3 : 1.0)
-                                .symbolEffect(.bounce, value: justSelectedCode)
-                        }
-                    }
-                }
-
-                // US-019: Sort by distance ascending, then alphabetical
-                ForEach(sortedCities, id: \.code) { city in
-                    Button {
-                        selectCity(city.code)
-                    } label: {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(city.name)
-                                    .font(.headline)
+            Group {
+                if viewModel.availableCities.isEmpty {
+                    CityEmptyStateView()
+                        .transition(.scale(scale: 0.85).combined(with: .opacity))
+                } else {
+                    List {
+                        // "All Cities" option
+                        Button {
+                            selectCity(nil)
+                        } label: {
+                            HStack {
+                                Text(NSLocalizedString("city.all", comment: "All cities option"))
+                                    .font(.body)
                                     .foregroundStyle(.primary)
-                                Text(String(
-                                    format: NSLocalizedString("city.experienceCount", comment: "Experience count in city"),
-                                    viewModel.experienceCount(for: city.code)
-                                ))
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            VStack(alignment: .trailing, spacing: 2) {
-                                if viewModel.selectedCity == city.code {
+                                Spacer()
+                                if viewModel.selectedCity == nil {
                                     Image(systemName: "checkmark")
                                         .foregroundStyle(.tint)
                                         .font(.body.weight(.semibold))
-                                        .scaleEffect(justSelectedCode == city.code ? 1.3 : 1.0)
+                                        .scaleEffect(justSelectedCode == "all" ? 1.3 : 1.0)
                                         .symbolEffect(.bounce, value: justSelectedCode)
                                 }
-                                Text(distanceLabel(for: city.center))
-                                    .font(.caption)
-                                    .foregroundStyle(.tertiary)
-                                    .monospacedDigit()
+                            }
+                        }
+
+                        // US-019: Sort by distance ascending, then alphabetical
+                        ForEach(sortedCities, id: \.code) { city in
+                            Button {
+                                selectCity(city.code)
+                            } label: {
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(city.name)
+                                            .font(.headline)
+                                            .foregroundStyle(.primary)
+                                        Text(String(
+                                            format: NSLocalizedString("city.experienceCount", comment: "Experience count in city"),
+                                            viewModel.experienceCount(for: city.code)
+                                        ))
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                    }
+                                    Spacer()
+                                    VStack(alignment: .trailing, spacing: 2) {
+                                        if viewModel.selectedCity == city.code {
+                                            Image(systemName: "checkmark")
+                                                .foregroundStyle(.tint)
+                                                .font(.body.weight(.semibold))
+                                                .scaleEffect(justSelectedCode == city.code ? 1.3 : 1.0)
+                                                .symbolEffect(.bounce, value: justSelectedCode)
+                                        }
+                                        Text(distanceLabel(for: city.center))
+                                            .font(.caption)
+                                            .foregroundStyle(.tertiary)
+                                            .monospacedDigit()
+                                    }
+                                }
                             }
                         }
                     }
                 }
             }
+            .animation(.easeInOut, value: viewModel.availableCities.isEmpty)
             .navigationTitle(NSLocalizedString("city.picker.title", comment: "City picker sheet title"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -125,7 +133,51 @@ public struct CityPickerSheet: View {
     }
 }
 
-#Preview {
+private struct CityEmptyStateView: View {
+    @State private var isBreathing = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(Color.accentColor.opacity(0.12))
+                    .frame(width: 80, height: 80)
+                Image(systemName: "map.circle")
+                    .font(.system(size: 48))
+                    .foregroundStyle(Color.accentColor.opacity(0.7))
+                    .scaleEffect(isBreathing ? 1.08 : 0.94)
+                    .opacity(isBreathing ? 1.0 : 0.7)
+                    .animation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true), value: isBreathing)
+            }
+            Text(NSLocalizedString("city.empty.title", comment: "No cities yet"))
+                .font(.headline)
+            Text(NSLocalizedString("city.empty.hint", comment: "Cities appear as you explore the map"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(32)
+        .onAppear {
+            guard !isBreathing, !reduceMotion else { return }
+            isBreathing = true
+        }
+    }
+}
+
+#Preview("With cities") {
+    CityPickerSheet(
+        viewModel: MapViewModel(
+            locationService: LocationService.shared,
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: UserPreferences()
+        ),
+        onDismiss: {}
+    )
+}
+
+#Preview("Empty state") {
     CityPickerSheet(
         viewModel: MapViewModel(
             locationService: LocationService.shared,


### PR DESCRIPTION
## Add a guided empty state to CityPickerSheet when no cities are discovered yet

When the user opens the city picker before any experiences/cities have loaded (fresh install, offline first-run, or all data filtered out), CityPickerSheet renders a bare List with only the 'All Cities' row and no explanation — a confusing dead-end. This adds a polished ContentUnavailableView empty state (matching the existing idiom in LocationPickerSheet) that tells the user cities appear as they explore, with a subtly breathing map icon like EmptyFavoritesView, so the sheet always communicates intent.

### Acceptance
Building with `xcodebuild build` succeeds and `#Preview` renders. With availableCities empty, the picker shows the breathing map icon + 'No cities yet' title and hint instead of a near-empty list; with cities present, the existing list and selection bounce behavior are unchanged. New strings exist in both en and zh-Hans Localizable.strings (no NSLocalizedString fallback to raw keys). With Reduce Motion enabled, the icon is static. A new #Preview demonstrating the empty state is added.