### PR TITLE
auto: Animate the MicroSurveySheet star ratings with a spring bounce and cross-fading labels

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/MicroSurveySheet.swift
+++ b/apps/ios/SoloCompass/Views/Experience/MicroSurveySheet.swift
@@ -96,6 +96,8 @@ public struct MicroSurveySheet: View {
             Text(comfortLabel(comfort))
                 .font(.caption)
                 .foregroundStyle(.secondary)
+                .id(comfort)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
         }
     }
 
@@ -108,6 +110,8 @@ public struct MicroSurveySheet: View {
             Text(pressureLabel(staffPressure))
                 .font(.caption)
                 .foregroundStyle(.secondary)
+                .id(staffPressure)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
         }
     }
 
@@ -196,16 +200,26 @@ private struct StarRatingRow: View {
     @Binding var value: Int
     let max: Int
 
+    @State private var poppedStar: Int?
+
     var body: some View {
         HStack(spacing: 8) {
             ForEach(1...max, id: \.self) { star in
                 Button {
-                    value = star
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.6)) {
+                        value = star
+                    }
                     UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
+                    poppedStar = star
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                        poppedStar = nil
+                    }
                 } label: {
                     Image(systemName: star <= value ? "star.fill" : "star")
                         .font(.title3)
                         .foregroundStyle(starColor(star))
+                        .scaleEffect(poppedStar == star ? 1.3 : 1.0)
+                        .animation(.spring(response: 0.3, dampingFraction: 0.6), value: poppedStar)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(Text("\(star) " + NSLocalizedString("survey.stars", comment: "stars")))


### PR DESCRIPTION
## Animate the MicroSurveySheet star ratings with a spring bounce and cross-fading labels

The post-visit micro-survey is a core feedback moment that feeds soloScore recomputation, but its StarRatingRow fills instantly with no tactile animation and its comfort/pressure labels swap abruptly — out of step with the app's spring-animated UX elsewhere (radar chart, heart-favorite, filter pills). Add a per-star pop-scale spring on selection and a cross-fade transition on the descriptive label so the feedback feels as satisfying as the rest of the app.

### Acceptance
Tapping a star in the comfort or staff-pressure question produces a spring pop on the tapped star and animates the fill; the descriptive caption label cross-fades rather than snapping when the value changes; existing haptics still fire; the sheet builds with `xcodebuild build` and renders correctly in the Simulator with no layout shift.