### PR TITLE
auto: Add tactile feedback to the PendingCheckInBanner swipe-to-dismiss gesture

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
@@ -9,7 +9,10 @@ public struct PendingCheckInBanner: View {
     var onDismiss: () -> Void
 
     @State private var dragOffset: CGFloat = 0
+    @State private var crossedThreshold = false
     private let dismissThreshold: CGFloat = 80
+    private let selectionFeedback = UISelectionFeedbackGenerator()
+    private let impactFeedback = UIImpactFeedbackGenerator(style: .soft)
 
     public init(
         experienceTitle: String,
@@ -19,6 +22,8 @@ public struct PendingCheckInBanner: View {
         self.experienceTitle = experienceTitle
         self.onConfirm = onConfirm
         self.onDismiss = onDismiss
+        selectionFeedback.prepare()
+        impactFeedback.prepare()
     }
 
     public var body: some View {
@@ -74,13 +79,23 @@ public struct PendingCheckInBanner: View {
         .gesture(
             DragGesture()
                 .onChanged { gesture in
-                    dragOffset = min(0, gesture.translation.height)
+                    dragOffset = min(0, gesture.translation.height * 0.85)
+                    let overThreshold = -gesture.translation.height > dismissThreshold
+                    if overThreshold && !crossedThreshold {
+                        crossedThreshold = true
+                        selectionFeedback.selectionChanged()
+                    } else if !overThreshold && crossedThreshold {
+                        crossedThreshold = false
+                    }
                 }
                 .onEnded { gesture in
                     if gesture.translation.height < -dismissThreshold {
+                        impactFeedback.impactOccurred()
+                        crossedThreshold = false
                         withAnimation(.easeOut(duration: 0.2)) { dragOffset = -200 }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { onDismiss() }
                     } else {
+                        crossedThreshold = false
                         withAnimation(.spring(response: 0.3)) { dragOffset = 0 }
                     }
                 }


### PR DESCRIPTION
## Add tactile feedback to the PendingCheckInBanner swipe-to-dismiss gesture

The floating check-in banner lets users swipe up to dismiss, but unlike every other interaction in the app (favorite, confirm, location-pick) the gesture is completely silent — there's no haptic when the dismiss threshold is crossed or when the swipe completes. This adds a light selection haptic the moment the user drags past the dismiss threshold and a soft impact on release, plus a subtle rubber-band resistance so the gesture feels physical and consistent with the app's tactile design language.

### Acceptance
Dragging the banner upward past the dismiss threshold produces a single crisp selection tick exactly once (not repeatedly), dragging back down and up again re-arms it; releasing past the threshold plays a soft impact and dismisses; releasing below springs back with no impact. The drag now has gentle resistance. xcodebuild build succeeds, the #Preview renders, and the existing confirm/dismiss button haptics and VoiceOver labels are unchanged.