### PR TITLE
auto: Surface the next best time-of-day window on the floating experience card

### DIFF
--- a/apps/ios/SoloCompass/Models/Experience.swift
+++ b/apps/ios/SoloCompass/Models/Experience.swift
@@ -462,6 +462,81 @@ public struct Experience: Codable, Hashable, Identifiable {
     }
 }
 
+// MARK: - Best Time Hint
+
+extension Experience {
+    /// Returns a localized short time range (e.g. "7–9am", "6pm") for the soonest
+    /// applicable bestTimes window when the experience is NOT currently at its best.
+    /// Returns nil when isBestNow() is true or when bestTimes is empty.
+    public func bestTimeHint(at date: Date = Date()) -> String? {
+        guard !isBestNow(at: date) else { return nil }
+        guard !bestTimes.isEmpty else { return nil }
+
+        let cal = Calendar.current
+        let weekday = cal.component(.weekday, from: date) - 1 // Sun=0
+        let month = cal.component(.month, from: date)
+        let currentHour = cal.component(.hour, from: date)
+
+        let applicable = bestTimes.filter { window in
+            if let days = window.dayOfWeek, !days.isEmpty, !days.contains(weekday) { return false }
+            if let seasons = window.season, !seasons.isEmpty, !seasons.contains(month) { return false }
+            return true
+        }
+
+        let pool = applicable.isEmpty ? bestTimes : applicable
+
+        // Prefer windows whose start is still ahead today; fall back to earliest overall.
+        let upcoming = pool.filter { $0.startHour > currentHour }
+        let chosen = upcoming.min(by: { $0.startHour < $1.startHour }) ?? pool.min(by: { $0.startHour < $1.startHour })
+
+        guard let window = chosen else { return nil }
+        return Self.formatTimeRange(startHour: window.startHour, endHour: window.endHour)
+    }
+
+    private static func formatTimeRange(startHour: Int, endHour: Int) -> String {
+        let cal = Calendar.current
+        var start = cal.startOfDay(for: Date())
+        start = cal.date(byAdding: .hour, value: startHour, to: start) ?? start
+        var end = cal.startOfDay(for: Date())
+        end = cal.date(byAdding: .hour, value: endHour, to: end) ?? end
+
+        let fmt = DateFormatter()
+        fmt.locale = Locale.current
+        fmt.dateFormat = Locale.current.uses24HourClock ? "H" : "ha"
+        fmt.amSymbol = "am"
+        fmt.pmSymbol = "pm"
+
+        let startStr = fmt.string(from: start)
+        let endStr = fmt.string(from: end)
+
+        // Collapse suffix when both share the same am/pm period (12h only)
+        if !Locale.current.uses24HourClock {
+            let startPeriod = startHour < 12 ? "am" : "pm"
+            let endPeriod = endHour < 12 ? "am" : "pm"
+            if startPeriod == endPeriod {
+                // e.g. "7–9am"
+                let shortFmt = DateFormatter()
+                shortFmt.locale = Locale.current
+                shortFmt.dateFormat = "h"
+                let shortStart = shortFmt.string(from: start)
+                return "\(shortStart)–\(endStr)"
+            }
+        }
+        return "\(startStr)–\(endStr)"
+    }
+}
+
+private extension Locale {
+    var uses24HourClock: Bool {
+        let fmt = DateFormatter()
+        fmt.locale = self
+        fmt.dateStyle = .none
+        fmt.timeStyle = .short
+        let sample = fmt.string(from: Date())
+        return !sample.contains(fmt.amSymbol) && !sample.contains(fmt.pmSymbol)
+    }
+}
+
 // MARK: - Marker State
 
 public enum ExperienceMarkerState: Hashable {

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -65,6 +65,8 @@
 /* Experience */
 "experience.bestNow" = "Best now";
 "experience.viewDetails" = "View details →";
+"experience.bestTime.hint" = "Best %@";
+"experience.bestTime.hint.a11y" = "Best %@";
 
 /* Bottom info */
 "info.morning" = "Good morning. %d coffee spots nearby are at their best right now.";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -113,6 +113,8 @@ public struct ExperienceCardView: View {
                 SoloScoreBadge(score: experience.soloScore, style: .compact)
                 if experience.isBestNow() {
                     bestNowBadge
+                } else if let hint = experience.bestTimeHint() {
+                    bestTimeHintPill(hint)
                 }
                 Spacer()
                 Button(action: onExpand) {
@@ -173,7 +175,13 @@ public struct ExperienceCardView: View {
         .accessibilityLabel(Text(
             "\(experience.title). \(experience.oneLiner). " +
             String(format: NSLocalizedString("solo.a11y", comment: "Solo Score %@ of 10"),
-                   String(format: "%.1f", experience.soloScore.overall))
+                   String(format: "%.1f", experience.soloScore.overall)) +
+            {
+                if let hint = experience.bestTimeHint() {
+                    return ". " + String(format: NSLocalizedString("experience.bestTime.hint.a11y", comment: "Best time accessibility"), hint)
+                }
+                return ""
+            }()
         ))
         .accessibilityHint(Text(NSLocalizedString("experience.card.hint", comment: "Double tap to view details")))
         .accessibilityAction(
@@ -183,6 +191,19 @@ public struct ExperienceCardView: View {
         ) {
             preferences.toggleFavorite(experience.id)
         }
+    }
+
+    @ViewBuilder
+    private func bestTimeHintPill(_ hint: String) -> some View {
+        Label(
+            String(format: NSLocalizedString("experience.bestTime.hint", comment: "Best time hint"), hint),
+            systemImage: "clock"
+        )
+        .font(.caption)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .foregroundStyle(Color.secondary)
+        .background(Capsule().fill(Color.secondary.opacity(0.12)))
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Surface the next best time-of-day window on the floating experience card

When a marker is tapped but the experience is NOT currently at its best time, the floating ExperienceCardView shows no hint about when to go — the rich bestTimes data only appears if the user opens the full detail sheet. Add a subtle 'Best 7–9am' clock pill that renders in the badge row whenever isBestNow() is false and a representative time window exists, giving solo travelers an at-a-glance reason to plan around the right hours. When the experience IS best now, the existing pulsing 'Best Now' badge continues to take that slot unchanged.

### Acceptance
Tapping a marker whose current local hour is outside all bestTimes windows shows a static 'Best <range>' clock pill in the card's badge row; tapping one that is currently best still shows only the pulsing 'Best Now' badge (no clock pill). The pill text respects 12/24-hour locale. bestTimeHint() returns nil when isBestNow() is true and a non-nil formatted range otherwise. No SwiftData/@Model or Codable schema changes; `pnpm parity:check` still passes; iOS target builds and existing SoloCompassTests pass; VoiceOver label includes the best-time hint.