### PR TITLE
auto: Signal the 200-char limit on ReportIssueSheet detail field instead of silently truncating

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ReportIssueSheet.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ReportIssueSheet.swift
@@ -35,6 +35,8 @@ public struct ReportIssueSheet: View {
     @State private var selectedReason: ReportReason?
     @State private var detail: String = ""
     @FocusState private var detailFocused: Bool
+    @State private var didHitLimit = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let detailLimit = 200
 
@@ -72,6 +74,15 @@ public struct ReportIssueSheet: View {
             }
         }
         .presentationDetents([.medium, .large])
+    }
+
+    // MARK: - Helpers
+
+    private var counterColor: Color {
+        let ratio = Double(detail.count) / Double(detailLimit)
+        if detail.count >= detailLimit { return .red }
+        if ratio >= 0.8 { return .orange }
+        return .secondary
     }
 
     // MARK: - Sections
@@ -118,16 +129,28 @@ public struct ReportIssueSheet: View {
                     .frame(minHeight: 80)
                     .onChange(of: detail) { _, new in
                         if new.count > detailLimit {
-                            detail = String(new.prefix(detailLimit))
+                            withAnimation {
+                                detail = String(new.prefix(detailLimit))
+                            }
+                            if !didHitLimit {
+                                didHitLimit = true
+                                UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                            }
+                        } else {
+                            didHitLimit = false
                         }
                     }
             }
             HStack {
                 Spacer()
+                let atLimit = detail.count >= detailLimit
                 Text("\(detail.count)/\(detailLimit)")
                     .font(.caption2)
-                    .foregroundStyle(detail.count >= detailLimit ? .red : .secondary)
+                    .foregroundStyle(counterColor)
                     .monospacedDigit()
+                    .scaleEffect(atLimit && !reduceMotion ? 1.12 : 1.0)
+                    .animation(.spring(response: 0.3, dampingFraction: 0.5), value: atLimit)
+                    .animation(.default, value: detail.count)
             }
         } header: {
             Text(NSLocalizedString("report.detail.header", comment: "Additional details (optional)"))


### PR DESCRIPTION
## Signal the 200-char limit on ReportIssueSheet detail field instead of silently truncating

When a user types past the 200-character cap in the report detail TextEditor, input silently stops and excess characters vanish with zero feedback — the counter just sits at 200/200. Add a one-time warning haptic plus an animated color/scale emphasis on the counter the moment the cap is reached, and give the counter a smooth color transition as it approaches the limit so the constraint feels intentional rather than broken.

### Acceptance
Typing toward the cap fades the counter from secondary to orange (>=160 chars) to red (200); hitting 200 triggers a single warning haptic and a brief spring pop of the counter, and no further characters are accepted; deleting back below 200 re-arms the haptic and returns the color. Respects Reduce Motion (no scale animation). xcodebuild build succeeds and the existing #Preview still compiles.