### PR TITLE
auto: Give OfflineBanner a breathing wifi-slash pulse to match its sibling banners

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/OfflineBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/OfflineBanner.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 /// Amber pill banner shown in CompassMapView when the app is offline and showing cached data (US-041).
 struct OfflineBanner: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isPulsing = false
+
     var body: some View {
         GlassmorphismCapsule(
             verticalPadding: 8,
@@ -9,6 +12,8 @@ struct OfflineBanner: View {
                 Image(systemName: "wifi.slash")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(Color.orange)
+                    .scaleEffect(isPulsing ? 1.12 : 0.96)
+                    .opacity(isPulsing ? 1.0 : 0.65)
             },
             content: {
                 Text(NSLocalizedString("offline.banner", comment: "Offline mode banner"))
@@ -17,6 +22,23 @@ struct OfflineBanner: View {
             }
         )
         .transition(.move(edge: .top).combined(with: .opacity))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(NSLocalizedString("offline.banner", comment: "Offline mode banner")))
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true)) {
+                isPulsing = true
+            }
+        }
+        .onChange(of: reduceMotion) { _, reduced in
+            if reduced {
+                withAnimation(.default) { isPulsing = false }
+            } else {
+                withAnimation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true)) {
+                    isPulsing = true
+                }
+            }
+        }
     }
 }
 
@@ -26,4 +48,13 @@ struct OfflineBanner: View {
         OfflineBanner()
             .padding(.top, 60)
     }
+}
+
+#Preview("Reduce Motion") {
+    ZStack {
+        Color(.systemBackground).ignoresSafeArea()
+        OfflineBanner()
+            .padding(.top, 60)
+    }
+    .environment(\.accessibilityReduceMotion, true)
 }


### PR DESCRIPTION
## Give OfflineBanner a breathing wifi-slash pulse to match its sibling banners

OfflineBanner is the only top-of-map banner without an animated leading glyph or an explicit accessibility label — its static wifi.slash reads as a flat error next to the animated POILoadingBanner spinner, the pulsing Now-pill dot, and the breathing empty-favorites heart. Add a subtle slow pulse (scale + opacity) to the wifi.slash icon that gently signals 'still offline, still live' without alarming, gated on Reduce Motion, plus an explicit combined accessibility label so VoiceOver announces the offline state as one element like POILoadingBanner already does.

### Acceptance
Build succeeds (xcodebuild build, iPhone 17 Pro sim). With Reduce Motion off, the wifi.slash icon slowly breathes (scale 0.96↔1.12, opacity 0.65↔1.0) on a ~1.4s autoreversing loop; with Reduce Motion on it is fully static. Toggling Reduce Motion at runtime starts/stops the pulse without leaving it frozen mid-animation. VoiceOver reads the banner as a single element announcing the offline message. Both #Previews render. No other banner behavior changes.