### PR TITLE
auto: Respect Reduce Motion in SkeletonView shimmer

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/SkeletonView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SkeletonView.swift
@@ -33,6 +33,7 @@ public struct SkeletonView: View {
 private struct SkeletonLine: View {
     let widthFraction: CGFloat
     @State private var shimmerPhase: CGFloat = -1.0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         GeometryReader { geo in
@@ -42,9 +43,20 @@ private struct SkeletonLine: View {
         }
         .frame(height: 14)
         .onAppear {
-            withAnimation(.linear(duration: 1.4).repeatForever(autoreverses: false)) {
-                shimmerPhase = 1.0
-            }
+            startShimmer()
+        }
+        .onChange(of: reduceMotion) { _, _ in
+            startShimmer()
+        }
+    }
+
+    private func startShimmer() {
+        guard !reduceMotion else {
+            shimmerPhase = 0
+            return
+        }
+        withAnimation(.linear(duration: 1.4).repeatForever(autoreverses: false)) {
+            shimmerPhase = 1.0
         }
     }
 
@@ -79,6 +91,26 @@ extension View {
         )
         .opacity(isLoading ? 0 : 1)
     }
+}
+
+#Preview("Reduce Motion") {
+    VStack(alignment: .leading, spacing: 24) {
+        Text("Reduce Motion — static placeholders")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+        SkeletonView(lineCount: 3)
+
+        Divider()
+
+        Text("Custom widths — no sweep")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+        SkeletonView(lineCount: 4, widthFractions: [1.0, 0.85, 0.9, 0.5])
+    }
+    .padding()
+    .environment(\.accessibilityReduceMotion, true)
 }
 
 #Preview("3-line text skeleton") {


### PR DESCRIPTION
## Respect Reduce Motion in SkeletonView shimmer

The shimmer loading placeholder (SkeletonView) animates a perpetual gradient sweep with `.repeatForever`, ignoring the system Reduce Motion accessibility setting — a WCAG/HIG violation for the app's most frequently shown loading component. This adds an `@Environment(\.accessibilityReduceMotion)` guard so each line renders as a calm static placeholder (no animation) when Reduce Motion is on, matching the pattern already used in CompletionCelebrationView and ExperienceCardView.

### Acceptance
With Reduce Motion ON, SkeletonView shows static gray placeholder bars with no sweeping shimmer; with it OFF, the shimmer animates as before. Toggling the setting while a skeleton is on screen starts/stops the animation accordingly. Existing call sites (skeletonRedacted, standalone SkeletonView) compile unchanged; `xcodebuild build` succeeds and the new Reduce Motion #Preview renders without animation.