### PR TITLE
auto: Add a favorites count subtitle and a first-run swipe-to-remove hint to FavoritesListView

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -299,6 +299,7 @@
 "favorites.empty.hint" = "Tap the heart on any experience to save it here.";
 "favorites.undo" = "Removed — Undo";
 "favorites.undo.named" = "Removed \"%@\"";
+/* Plural forms handled by Localizable.stringsdict */
 "favorites.count" = "%d saved";
 "favorites.distance.km" = "%.1f km";
 "favorites.distance.m" = "%d m";

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -299,14 +299,16 @@
 "favorites.empty.hint" = "Tap the heart on any experience to save it here.";
 "favorites.undo" = "Removed — Undo";
 "favorites.undo.named" = "Removed \"%@\"";
-"favorites.search.prompt" = "Search favorites";
-"favorites.search.noResults" = "No matches for \"%@\"";
-"favorites.sort.label" = "Sort";
-"favorites.sort.recent" = "Recent";
-"favorites.sort.nearest" = "Nearest";
-"favorites.distance.m" = "%d m";
+"favorites.count" = "%d saved";
 "favorites.distance.km" = "%.1f km";
+"favorites.distance.m" = "%d m";
 "favorites.distance.mi" = "%.1f mi";
+"favorites.search.noResults" = "No matches for \"%@\"";
+"favorites.search.prompt" = "Search favorites";
+"favorites.sort.label" = "Sort";
+"favorites.sort.nearest" = "Nearest";
+"favorites.sort.recent" = "Recent";
+"favorites.swipe.hint" = "Swipe left to remove";
 
 /* Generic actions */
 "action.undo" = "Undo";

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.stringsdict
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.stringsdict
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>favorites.count</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@count@</string>
+        <key>count</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>d</string>
+            <key>one</key>
+            <string>%d saved</string>
+            <key>other</key>
+            <string>%d saved</string>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -17,9 +17,12 @@ public struct FavoritesListView: View {
     @State private var animatePulse = false
     @State private var undoProgress: CGFloat = 1
     @State private var undoDragOffset: CGFloat = 0
+    @State private var undoDragOffset: CGFloat = 0
     @State private var undoDragCrossedThreshold = false
     @State private var searchText = ""
     @State private var sortMode: FavSort = .recent
+    @State private var showSwipeHint = false
+    @AppStorage("favorites.swipeHintSeen") private var swipeHintSeen = false
     private let undoSelectionFeedback = UISelectionFeedbackGenerator()
     private let undoImpactFeedback = UIImpactFeedbackGenerator(style: .soft)
 
@@ -28,7 +31,6 @@ public struct FavoritesListView: View {
         let d = locationService.distance(to: coord)
         return d < .greatestFiniteMagnitude ? d : nil
     }
-
     private var sortedFavorites: [Experience] {
         let ids = preferences.favoritedExperiences
         let experiences = ids.compactMap { experienceService.getExperience(id: $0) }
@@ -70,28 +72,58 @@ public struct FavoritesListView: View {
                     NoSearchResultsView(query: searchText)
                         .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
                 } else {
-                    List {
-                        if locationService.currentLocation != nil {
-                            Section {
-                                Picker(NSLocalizedString("favorites.sort.label", comment: "Sort favorites"),
-                                       selection: $sortMode.animation(reduceMotion ? nil : .easeInOut)) {
-                                    Text(NSLocalizedString("favorites.sort.recent", comment: "Sort by recency"))
-                                        .tag(FavSort.recent)
-                                    Text(NSLocalizedString("favorites.sort.nearest", comment: "Sort by distance"))
-                                        .tag(FavSort.nearest)
+                    VStack(spacing: 0) {
+                        Text(String(
+                            format: NSLocalizedString("favorites.count", comment: "N saved"),
+                            sortedFavorites.count
+                        ))
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 6)
+
+                        List {
+                            if locationService.currentLocation != nil {
+                                Section {
+                                    Picker(NSLocalizedString("favorites.sort.label", comment: "Sort favorites"),
+                                           selection: $sortMode.animation(reduceMotion ? nil : .easeInOut)) {
+                                        Text(NSLocalizedString("favorites.sort.recent", comment: "Sort by recency"))
+                                            .tag(FavSort.recent)
+                                        Text(NSLocalizedString("favorites.sort.nearest", comment: "Sort by distance"))
+                                            .tag(FavSort.nearest)
+                                    }
+                                    .pickerStyle(.segmented)
+                                    .listRowBackground(Color.clear)
+                                    .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
                                 }
-                                .pickerStyle(.segmented)
-                                .listRowBackground(Color.clear)
-                                .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+                            }
+                            ForEach(filteredFavorites) { exp in
+                                favoriteRow(exp)
                             }
                         }
-                        ForEach(filteredFavorites) { exp in
-                            favoriteRow(exp)
+                        .listStyle(.plain)
+                        .animation(.easeInOut, value: filteredFavorites.count)
+                        .animation(reduceMotion ? nil : .easeInOut, value: sortMode)
+                        .overlay(alignment: .top) {
+                            if showSwipeHint {
+                                swipeHintCapsule
+                                    .transition(.move(edge: .top).combined(with: .opacity))
+                                    .padding(.top, 8)
+                            }
+                        }
+                        .onAppear {
+                            guard !swipeHintSeen, !sortedFavorites.isEmpty else { return }
+                            withAnimation(.easeOut) { showSwipeHint = true }
+                            swipeHintSeen = true
+                            Task {
+                                try? await Task.sleep(for: .seconds(2.5))
+                                await MainActor.run {
+                                    withAnimation(.easeIn) { showSwipeHint = false }
+                                }
+                            }
                         }
                     }
-                    .listStyle(.plain)
-                    .animation(.easeInOut, value: filteredFavorites.count)
-                    .animation(reduceMotion ? nil : .easeInOut, value: sortMode)
                     .transition(.opacity)
                 }
             }
@@ -122,7 +154,6 @@ public struct FavoritesListView: View {
 
 }
 
-private struct EmptyFavoritesView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isBreathing = false
 
@@ -170,9 +201,26 @@ private struct NoSearchResultsView: View {
     }
 }
 
+private struct SwipeHintCapsuleView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        Label(
+            NSLocalizedString("favorites.swipe.hint", comment: "Swipe left to remove"),
+            systemImage: "hand.draw"
+        )
+        .font(.footnote.weight(.medium))
+        .foregroundStyle(.secondary)
+        .symbolEffect(.bounce, options: reduceMotion ? .default.speed(0) : .repeating.speed(0.6))
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(.regularMaterial, in: Capsule())
+        .shadow(color: .black.opacity(0.08), radius: 4, y: 2)
+    }
+}
+
 private extension FavoritesListView {
 
-    func distanceBadgeText(_ meters: CLLocationDistance) -> String {
         if Locale.current.measurementSystem == .us {
             let miles = meters / 1_609.344
             return String(format: NSLocalizedString("favorites.distance.mi", comment: "Distance in miles"), miles)
@@ -184,6 +232,10 @@ private extension FavoritesListView {
         return String(format: NSLocalizedString("favorites.distance.km", comment: "Distance in kilometres"), km)
     }
 
+    @ViewBuilder
+    var swipeHintCapsule: some View {
+        SwipeHintCapsuleView()
+    }
     var undoBar: some View {
         ZStack(alignment: .bottom) {
             HStack {
@@ -348,6 +400,7 @@ private extension FavoritesListView {
             }
         }
     }
+}
 }
 
 #Preview {

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -22,6 +22,7 @@ public struct FavoritesListView: View {
     @State private var searchText = ""
     @State private var sortMode: FavSort = .recent
     @State private var showSwipeHint = false
+    @State private var hintDismissTask: Task<Void, Never>?
     @AppStorage("favorites.swipeHintSeen") private var swipeHintSeen = false
     private let undoSelectionFeedback = UISelectionFeedbackGenerator()
     private let undoImpactFeedback = UIImpactFeedbackGenerator(style: .soft)
@@ -73,15 +74,17 @@ public struct FavoritesListView: View {
                         .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
                 } else {
                     VStack(spacing: 0) {
-                        Text(String(
-                            format: NSLocalizedString("favorites.count", comment: "N saved"),
-                            sortedFavorites.count
-                        ))
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 6)
+                        if sortedFavorites.count > 0 {
+                            Text(String(
+                                format: NSLocalizedString("favorites.count", comment: "N saved"),
+                                sortedFavorites.count
+                            ))
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 6)
+                        }
 
                         List {
                             if locationService.currentLocation != nil {
@@ -107,7 +110,7 @@ public struct FavoritesListView: View {
                         .animation(reduceMotion ? nil : .easeInOut, value: sortMode)
                         .overlay(alignment: .top) {
                             if showSwipeHint {
-                                swipeHintCapsule
+                                SwipeHintCapsuleView()
                                     .transition(.move(edge: .top).combined(with: .opacity))
                                     .padding(.top, 8)
                             }
@@ -116,12 +119,16 @@ public struct FavoritesListView: View {
                             guard !swipeHintSeen, !sortedFavorites.isEmpty else { return }
                             withAnimation(.easeOut) { showSwipeHint = true }
                             swipeHintSeen = true
-                            Task {
+                            hintDismissTask = Task {
                                 try? await Task.sleep(for: .seconds(2.5))
+                                guard !Task.isCancelled else { return }
                                 await MainActor.run {
                                     withAnimation(.easeIn) { showSwipeHint = false }
                                 }
                             }
+                        }
+                        .onDisappear {
+                            hintDismissTask?.cancel()
                         }
                     }
                     .transition(.opacity)
@@ -205,37 +212,31 @@ private struct SwipeHintCapsuleView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        Label(
+        label
+            .font(.footnote.weight(.medium))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .background(.regularMaterial, in: Capsule())
+            .shadow(color: .black.opacity(0.08), radius: 4, y: 2)
+    }
+
+    @ViewBuilder
+    private var label: some View {
+        let base = Label(
             NSLocalizedString("favorites.swipe.hint", comment: "Swipe left to remove"),
             systemImage: "hand.draw"
         )
-        .font(.footnote.weight(.medium))
-        .foregroundStyle(.secondary)
-        .symbolEffect(.bounce, options: reduceMotion ? .default.speed(0) : .repeating.speed(0.6))
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
-        .background(.regularMaterial, in: Capsule())
-        .shadow(color: .black.opacity(0.08), radius: 4, y: 2)
+        if reduceMotion {
+            base
+        } else {
+            base.symbolEffect(.bounce, options: .repeating.speed(0.6))
+        }
     }
 }
 
 private extension FavoritesListView {
 
-        if Locale.current.measurementSystem == .us {
-            let miles = meters / 1_609.344
-            return String(format: NSLocalizedString("favorites.distance.mi", comment: "Distance in miles"), miles)
-        }
-        if meters < 1_000 {
-            return String(format: NSLocalizedString("favorites.distance.m", comment: "Distance in metres"), Int(meters.rounded()))
-        }
-        let km = meters / 1_000
-        return String(format: NSLocalizedString("favorites.distance.km", comment: "Distance in kilometres"), km)
-    }
-
-    @ViewBuilder
-    var swipeHintCapsule: some View {
-        SwipeHintCapsuleView()
-    }
     var undoBar: some View {
         ZStack(alignment: .bottom) {
             HStack {


### PR DESCRIPTION
## Add a favorites count subtitle and a first-run swipe-to-remove hint to FavoritesListView

The populated favorites list currently jumps straight into rows with no sense of scale and no discovery cue for the destructive swipe action, while the empty state already has a polished breathing-heart treatment. Add a count subtitle under the nav title ("3 saved") and a one-time, auto-fading swipe-to-remove hint overlay on first appearance with favorites present, so users learn the gesture without trial-and-error. This matches the team's recent cadence of small, visible UX-polish commits (PendingCheckInBanner haptics, OfflineBanner pulse).

### Acceptance
Opening Favorites with ≥1 saved item shows a '\u003cN\u003e saved' subtitle that updates live as items are removed/undone; on the very first open with favorites present a swipe-to-remove hint capsule fades in at the top and auto-dismisses after ~2.5s, never reappearing on subsequent opens (persisted via AppStorage); the hint and its motion are suppressed under Reduce Motion; empty state is unchanged; xcodebuild build succeeds and the view's #Preview renders both the subtitle and hint.