### PR TITLE
auto: Add a glanceable 'go now?' status pill to the Best Times section

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -52,6 +52,8 @@
 "timeline.now.good" = "Right now is a great time.";
 "timeline.now.off" = "Right now is not the ideal time.";
 "timeline.a11y" = "Best between %@. %@";
+"bestTimes.now.pill" = "Good time now";
+"bestTimes.next.pill" = "Better at %@";
 
 /* Sections */
 "section.whyItMatters" = "Why it matters";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -275,9 +275,49 @@ public struct ExperienceDetailView: View {
         }
     }
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var bestTimeStatusPill: some View {
+        let isNow = viewModel.experience.isBestNow()
+        let hint = viewModel.experience.bestTimeHint()
+        let label: String
+        let symbol: String
+        let background: Color
+        if isNow {
+            label = NSLocalizedString("bestTimes.now.pill", comment: "Good time now pill")
+            symbol = "clock.badge.checkmark"
+            background = Color.green.opacity(0.15)
+        } else if let hint {
+            label = String(format: NSLocalizedString("bestTimes.next.pill", comment: "Better at time pill"), hint)
+            symbol = "clock"
+            background = Color(.tertiarySystemFill)
+        } else {
+            return AnyView(EmptyView())
+        }
+        let a11yLabel = isNow
+            ? NSLocalizedString("timeline.now.good", comment: "")
+            : NSLocalizedString("timeline.now.off", comment: "")
+        return AnyView(
+            HStack(spacing: 4) {
+                Image(systemName: symbol)
+                    .font(.caption2.weight(.semibold))
+                    .symbolEffect(.pulse, isActive: isNow && !reduceMotion)
+                Text(label)
+                    .font(.caption.weight(.semibold))
+            }
+            .foregroundStyle(isNow ? Color.green : Color.secondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Capsule().fill(background))
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(Text(a11yLabel))
+        )
+    }
+
     private var bestTimesSection: some View {
         sectionContainer(title: NSLocalizedString("section.bestTimes", comment: "")) {
             VStack(alignment: .leading, spacing: 6) {
+                HStack { Spacer(); bestTimeStatusPill }
                 BestTimesTimeline(experience: viewModel.experience)
                     .padding(.bottom, 4)
                 ForEach(viewModel.experience.bestTimes, id: \.self) { window in


### PR DESCRIPTION
## Add a glanceable 'go now?' status pill to the Best Times section

The experience detail's Best Times section has a rich 24-hour timeline, but the only signal of whether *now* is a good time is the color of a thin marker (yellow vs accent) — easy to miss. This adds a status pill beside the section title: a green 'Good time now' pill when the experience is currently at its best, or a muted 'Better at {time}' pill that surfaces the next window, reusing the existing tested model helpers isBestNow() and bestTimeHint().

### Acceptance
Building with `xcodebuild build -scheme SoloCompass` succeeds. In the Simulator, opening any experience whose bestTimes window includes the current hour shows a green 'Good time now' pill in the Best Times section header; for an experience outside its window, a muted 'Better at <time>' pill appears matching the timeline marker state. The pill respects Reduce Motion (no pulse), and VoiceOver reads a status consistent with the existing timeline.now.good/off labels. No changes to @Model/SwiftData files; diff is under 100 lines across the two files.