### PR TITLE
auto: Add haptic feedback and Reduce-Motion guard to VoiceButton

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
+++ b/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
@@ -5,6 +5,8 @@ public struct VoiceButton: View {
     let voiceService: VoiceService
     let onTranscript: (String) -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @State private var isRecording = false
     @State private var liveTranscript: String = ""
     @State private var showPermissionAlert = false
@@ -23,9 +25,12 @@ public struct VoiceButton: View {
                 Circle()
                     .stroke(Color.red.opacity(0.5), lineWidth: 4)
                     .frame(width: 72, height: 72)
-                    .scaleEffect(pulse ? 1.2 : 0.95)
-                    .opacity(pulse ? 0.0 : 0.8)
-                    .animation(.easeOut(duration: 1.0).repeatForever(autoreverses: false), value: pulse)
+                    .scaleEffect(reduceMotion ? 1.0 : (pulse ? 1.2 : 0.95))
+                    .opacity(reduceMotion ? 0.7 : (pulse ? 0.0 : 0.8))
+                    .animation(
+                        reduceMotion ? nil : .easeOut(duration: 1.0).repeatForever(autoreverses: false),
+                        value: pulse
+                    )
             }
 
             Circle()
@@ -84,7 +89,8 @@ public struct VoiceButton: View {
             }
             do {
                 isRecording = true
-                pulse = true
+                if !reduceMotion { pulse = true }
+                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                 liveTranscript = ""
                 let stream = try voiceService.startListening()
                 streamTask = Task {
@@ -116,6 +122,7 @@ public struct VoiceButton: View {
         let final = liveTranscript
         streamTask?.cancel()
         streamTask = nil
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
         if !final.isEmpty {
             onTranscript(final)
         }


### PR DESCRIPTION
## Add haptic feedback and Reduce-Motion guard to VoiceButton

VoiceButton is the app's primary voice input control but, unlike nearly every other interactive view, it gives no tactile confirmation when recording starts or stops, and its pulse ring animates unconditionally despite Reduce Motion being respected everywhere else (ExperienceCardView, FavoritesListView, OfflineBanner, etc.). This adds a medium impact haptic on record-start and a light impact on record-stop (matching the existing UIImpactFeedbackGenerator pattern in FilterBarView), and gates the repeating pulse animation behind accessibilityReduceMotion so motion-sensitive users get a static recording indicator instead.

### Acceptance
Long-pressing the voice button triggers a medium haptic and the recording ring appears; releasing triggers a light haptic and fires onTranscript with the final text. With Reduce Motion enabled, the pulse ring no longer animates continuously (static indicator shown) while haptics and transcript behavior are unchanged. `xcodebuild build -project apps/ios/SoloCompass.xcodeproj -scheme SoloCompass -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest'` succeeds and existing tests pass.