### PR TITLE
auto: Turn the Settings 'Your Journey' section into a milestone progress card

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -168,6 +168,15 @@
 "voice.error.permission" = "Microphone or speech recognition permission was denied. Please allow access in Settings.";
 "voice.error.unavailable" = "Speech recognition is unavailable on this device.";
 
+/* Journey progress card */
+"journey.progress.title" = "Experiences completed";
+"journey.progress.count" = "%d / %d";
+"journey.caption.start" = "Every journey starts with a single step.";
+"journey.caption.rolling" = "You're on a roll — keep exploring!";
+"journey.caption.seasoned" = "A seasoned solo traveler. Impressive.";
+"journey.milestone.reached" = "Milestone reached!";
+"journey.progress.a11y" = "Completed %d of %d experiences";
+
 /* Settings */
 "settings.title" = "Preferences";
 "settings.done" = "Done";

--- a/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
@@ -403,8 +403,28 @@ public struct SettingsView: View {
 
     // MARK: - Stats
 
+    private static let milestones = [3, 10, 25, 50, 100]
+
+    private var nextMilestone: Int {
+        let count = preferences.completedExperiences.count
+        return Self.milestones.first { $0 > count } ?? 100
+    }
+
+    private var journeyCaption: String {
+        let count = preferences.completedExperiences.count
+        if count < 3 {
+            return NSLocalizedString("journey.caption.start", comment: "Journey caption just started")
+        } else if count < 25 {
+            return NSLocalizedString("journey.caption.rolling", comment: "Journey caption on a roll")
+        } else {
+            return NSLocalizedString("journey.caption.seasoned", comment: "Journey caption seasoned")
+        }
+    }
+
     private var statsSection: some View {
         Section {
+            journeyProgressCard
+
             Button {
                 onShowFavorites?()
                 onClose()
@@ -414,13 +434,17 @@ public struct SettingsView: View {
                                 value: "\(preferences.favoritedExperiences.count)")
             }
             .foregroundStyle(.primary)
-
-            settingsIconRow(icon: "checkmark.circle", color: .green,
-                            label: NSLocalizedString("settings.completed", comment: "Completed"),
-                            value: "\(preferences.completedExperiences.count)")
         } header: {
             settingsSectionHeader("trophy", label: NSLocalizedString("settings.stats", comment: "Your Journey"))
         }
+    }
+
+    private var journeyProgressCard: some View {
+        JourneyProgressCard(
+            completed: preferences.completedExperiences.count,
+            milestone: nextMilestone,
+            caption: journeyCaption
+        )
     }
 
     // MARK: - Data
@@ -750,6 +774,92 @@ extension UserPreferences.SoloTravelStyle {
     var localizedDescription: String {
         NSLocalizedString("style.\(rawValue).description", comment: "Travel style description")
     }
+}
+
+// MARK: - Journey Progress Card
+
+private struct JourneyProgressCard: View {
+    let completed: Int
+    let milestone: Int
+    let caption: String
+
+    @State private var animateProgress = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var progress: Double {
+        guard milestone > 0 else { return 1 }
+        return min(Double(completed) / Double(milestone), 1)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Text(NSLocalizedString("journey.progress.title", comment: "Journey progress title"))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(
+                    String(
+                        format: NSLocalizedString("journey.progress.count", comment: "Journey progress count format"),
+                        completed,
+                        milestone
+                    )
+                )
+                .font(.title2.bold().monospacedDigit())
+                .foregroundStyle(.primary)
+            }
+
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Color(uiColor: .secondarySystemFill))
+                        .frame(height: 8)
+                    Capsule()
+                        .fill(Color.green)
+                        .frame(
+                            width: geo.size.width * (animateProgress ? progress : 0),
+                            height: 8
+                        )
+                        .animation(
+                            reduceMotion ? nil : .spring(response: 0.6, dampingFraction: 0.8),
+                            value: animateProgress
+                        )
+                }
+            }
+            .frame(height: 8)
+
+            Text(caption)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 6)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            String(
+                format: NSLocalizedString("journey.progress.a11y", comment: "Journey progress accessibility label"),
+                completed,
+                milestone
+            )
+        )
+        .onAppear {
+            if reduceMotion {
+                animateProgress = true
+            } else {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    animateProgress = true
+                }
+            }
+        }
+    }
+}
+
+#Preview("Journey Progress Card") {
+    List {
+        JourneyProgressCard(completed: 5, milestone: 10, caption: "You're on a roll!")
+        JourneyProgressCard(completed: 0, milestone: 3, caption: "Every journey starts here.")
+        JourneyProgressCard(completed: 25, milestone: 50, caption: "A seasoned solo traveler.")
+    }
+    .listStyle(.insetGrouped)
 }
 
 #Preview {


### PR DESCRIPTION
## Turn the Settings 'Your Journey' section into a milestone progress card

The stats section in SettingsView currently shows Favorites and Completed as two flat number rows — an emotionally inert dead-end for the app's core achievement surface, even though completing an experience fires confetti elsewhere. Replace it with a compact progress card that shows the completed count prominently against the next milestone (e.g. '5 / 10 experiences'), a slim animated progress bar, and a contextual encouragement caption, so a solo traveler sees momentum toward their next badge every time they open Settings.

### Acceptance
Build succeeds (xcodebuild build, iPhone 17 Pro). Opening Settings shows the Journey section with a progress card: large completed count over the next milestone denominator, a green progress bar that animates to its proportional width on appear (and is static under Reduce Motion), and a tier-appropriate encouragement caption. Favorites row still navigates to FavoritesListView and dismisses Settings. VoiceOver reads the card as a single combined element stating completed count and milestone. All new strings resolve via NSLocalizedString (no raw keys visible). No SwiftData/@Model files touched; existing tests still pass.