### PR TITLE
auto: Add tactile feedback to VoiceButton press-and-hold recording

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
+++ b/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
@@ -12,6 +12,9 @@ public struct VoiceButton: View {
     @State private var pulse = false
     @State private var streamTask: Task<Void, Never>?
 
+    private let startFeedback = UIImpactFeedbackGenerator(style: .medium)
+    private let endFeedback = UIImpactFeedbackGenerator(style: .soft)
+
     public init(voiceService: VoiceService, onTranscript: @escaping (String) -> Void) {
         self.voiceService = voiceService
         self.onTranscript = onTranscript
@@ -86,6 +89,9 @@ public struct VoiceButton: View {
                 isRecording = true
                 pulse = true
                 liveTranscript = ""
+                startFeedback.prepare()
+                startFeedback.impactOccurred()
+                endFeedback.prepare()
                 let stream = try voiceService.startListening()
                 streamTask = Task {
                     do {
@@ -117,6 +123,7 @@ public struct VoiceButton: View {
         streamTask?.cancel()
         streamTask = nil
         if !final.isEmpty {
+            endFeedback.impactOccurred()
             onTranscript(final)
         }
         liveTranscript = ""


### PR DESCRIPTION
## Add tactile feedback to VoiceButton press-and-hold recording

VoiceButton is the press-and-hold voice input control, but it fires zero haptics — yet it's the one control users operate while looking away from the screen (they're talking, not watching). Add a medium impact when recording starts (confirming capture began) and a soft impact on release when a transcript is sent, matching the established UIImpactFeedbackGenerator idiom already used in PendingCheckInBanner and MicroSurveySheet.

### Acceptance
xcodebuild build succeeds for the SoloCompass scheme. Manually in Simulator/device: pressing and holding the mic produces a medium haptic the instant recording starts (red state appears together with the tap); releasing after speaking produces a soft haptic when the transcript is sent; releasing with no transcript produces no end haptic. Existing VoiceButton behavior (permission alert, live transcript overlay, error alert, onTranscript callback) is unchanged, and the #Preview still compiles.