### PR TITLE
auto: Add search + a distinct no-results state to the Favorites list

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -271,6 +271,8 @@
 "favorites.empty.hint" = "Tap the heart on any experience to save it here.";
 "favorites.undo" = "Removed — Undo";
 "favorites.undo.named" = "Removed \"%@\"";
+"favorites.search.prompt" = "Search favorites";
+"favorites.search.noResults" = "No matches for \"%@\"";
 
 /* Generic actions */
 "action.undo" = "Undo";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -14,6 +14,7 @@ public struct FavoritesListView: View {
     @State private var undoProgress: CGFloat = 1
     @State private var undoDragOffset: CGFloat = 0
     @State private var undoDragCrossedThreshold = false
+    @State private var searchText = ""
     private let undoSelectionFeedback = UISelectionFeedbackGenerator()
     private let undoImpactFeedback = UIImpactFeedbackGenerator(style: .soft)
 
@@ -27,24 +28,42 @@ public struct FavoritesListView: View {
         }
     }
 
+    private var filteredFavorites: [Experience] {
+        let query = searchText.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty else { return sortedFavorites }
+        return sortedFavorites.filter {
+            $0.title.localizedCaseInsensitiveContains(query) ||
+            $0.oneLiner.localizedCaseInsensitiveContains(query)
+        }
+    }
+
     public var body: some View {
         NavigationStack {
             Group {
                 if sortedFavorites.isEmpty && lastUnfavorited == nil {
                     EmptyFavoritesView()
                         .transition(.scale(scale: 0.85).combined(with: .opacity))
+                } else if filteredFavorites.isEmpty {
+                    NoSearchResultsView(query: searchText)
+                        .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
                 } else {
-                    List(sortedFavorites) { exp in
+                    List(filteredFavorites) { exp in
                         favoriteRow(exp)
                     }
                     .listStyle(.plain)
-                    .animation(.easeInOut, value: sortedFavorites.count)
+                    .animation(.easeInOut, value: filteredFavorites.count)
                     .transition(.opacity)
                 }
             }
             .animation(.easeInOut, value: sortedFavorites.isEmpty)
+            .animation(.easeInOut, value: filteredFavorites.isEmpty)
             .navigationTitle(NSLocalizedString("favorites.title", comment: "Favorites list title"))
             .navigationBarTitleDisplayMode(.inline)
+            .searchable(
+                text: $searchText,
+                placement: .navigationBarDrawer(displayMode: .always),
+                prompt: Text(NSLocalizedString("favorites.search.prompt", comment: "Search favorites"))
+            )
         }
         .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)
@@ -92,6 +111,22 @@ private struct EmptyFavoritesView: View {
             guard !isBreathing, !reduceMotion else { return }
             isBreathing = true
         }
+    }
+}
+
+private struct NoSearchResultsView: View {
+    let query: String
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+            Text(String(format: NSLocalizedString("favorites.search.noResults", comment: "No matches for search query"), query))
+                .font(.headline)
+                .multilineTextAlignment(.center)
+        }
+        .padding(32)
     }
 }
 


### PR DESCRIPTION
## Add search + a distinct no-results state to the Favorites list

The FavoritesListView renders a flat, unfiltered list, so a solo traveler with favorites spanning several cities can only scroll to find one. Add a `.searchable` field that filters favorites by title and one-liner in real time, plus a dedicated 'no matches' empty state (distinct from the existing 'no favorites yet' state) so an empty filter result doesn't look like a bug.

### Acceptance
Opening Favorites with multiple saved experiences shows a search bar; typing filters the list live by title/one-liner; clearing restores the full sorted list; a query with no matches shows the 'No matches for …' state (not the 'No favorites yet' state); with zero favorites the original empty state shows and no search bar appears; Reduce Motion suppresses the no-results animation; `xcodebuild build` and the SoloCompassTests target both pass.