### PR TITLE
auto: Distinguish filter-empty from location-empty: a 'no matches, clear filter' pill

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -14,6 +14,8 @@
 "filter.now.a11y" = "Now, %d experiences at their best";
 "filter.matches.one" = "%d match";
 "filter.matches.other" = "%d matches";
+"filter.matches.none" = "No matches";
+"filter.clear" = "Clear filter";
 
 /* Health */
 "health.healthy" = "Fresh — multiply verified";

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -33,6 +33,10 @@ public struct CompassMapView: View {
 
     private let networkMonitor = NetworkMonitor.shared
 
+    private var isFilterActive: Bool {
+        (viewModel?.selectedCategory != nil) || (viewModel?.selectedCustomTag != nil) || (viewModel?.isNowFilter == true)
+    }
+
     /// Idle window after the last pan before POIs refresh. Lowered from 1.5s
     /// to cut the "dragged the map, nothing happened" lag (#133).
     private static let panRefreshDebounce: TimeInterval = 0.8
@@ -170,7 +174,7 @@ public struct CompassMapView: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                 }
 
-                if viewModel.visibleExperiences.isEmpty {
+                if viewModel.visibleExperiences.isEmpty && !isFilterActive {
                     EmptyStateOverlay(
                         viewModel: viewModel,
                         preferences: preferences,
@@ -607,7 +611,7 @@ private struct MapOverlayView: View {
             )
             .padding(.top, 4)
 
-            if isFilterActive && !viewModel.visibleExperiences.isEmpty {
+            if isFilterActive {
                 filterResultBadge
                     .transition(.opacity.combined(with: .move(edge: .top)))
                     .opacity(isMapPanning ? 0.4 : 1.0)
@@ -760,27 +764,72 @@ private struct MapOverlayView: View {
             if viewModel.isNowFilter { return Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255) }
             return Color.accentColor
         }()
-        let countText = count == 1
-            ? String(format: NSLocalizedString("filter.matches.one", comment: "1 match"), count)
-            : String(format: NSLocalizedString("filter.matches.other", comment: "%d matches"), count)
 
-        GlassmorphismCapsule(
-            horizontalPadding: 12,
-            verticalPadding: 6,
-            shadowRadius: 6,
-            shadowY: 3
-        ) {
-            HStack(spacing: 6) {
-                Circle()
-                    .fill(dotColor)
-                    .frame(width: 8, height: 8)
-                Text(countText)
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.primary)
+        if count == 0 {
+            let noMatchText = NSLocalizedString("filter.matches.none", comment: "No matches")
+            let clearText = NSLocalizedString("filter.clear", comment: "Clear filter")
+            let a11yLabel = "\(noMatchText) · \(clearText)"
+
+            GlassmorphismCapsule(
+                horizontalPadding: 12,
+                verticalPadding: 6,
+                shadowRadius: 6,
+                shadowY: 3
+            ) {
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(dotColor)
+                        .frame(width: 8, height: 8)
+                    Text(noMatchText)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.primary)
+                    Text("·")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Button {
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        viewModel.clearFilters()
+                    } label: {
+                        Text(clearText)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(dotColor)
+                    }
+                    .buttonStyle(.plain)
+                }
             }
+            .contentTransition(.opacity)
+            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: count)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(Text(a11yLabel))
+            .accessibilityAddTraits(.isButton)
+            .accessibilityAction {
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                viewModel.clearFilters()
+            }
+        } else {
+            let countText = count == 1
+                ? String(format: NSLocalizedString("filter.matches.one", comment: "1 match"), count)
+                : String(format: NSLocalizedString("filter.matches.other", comment: "%d matches"), count)
+
+            GlassmorphismCapsule(
+                horizontalPadding: 12,
+                verticalPadding: 6,
+                shadowRadius: 6,
+                shadowY: 3
+            ) {
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(dotColor)
+                        .frame(width: 8, height: 8)
+                    Text(countText)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.primary)
+                }
+            }
+            .contentTransition(.numericText())
+            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: count)
+            .accessibilityLabel(Text(countText))
         }
-        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: count)
-        .accessibilityLabel(Text(countText))
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Distinguish filter-empty from location-empty: a 'no matches, clear filter' pill

When a category/tag/Now filter is active but matches zero visible experiences, the map currently suppresses the result-count pill and instead shows the generic 'no experiences nearby — expand your radius' overlay, which misattributes the cause: the spots exist, the filter just excluded them all. This adds a distinct zero-match filter pill (matching filterResultBadge's glassmorphism style, tinted by the active filter color) with a one-tap 'Clear filter' action, and suppresses the misleading location-based EmptyStateOverlay while a filter is the actual cause of emptiness.

### Acceptance
Selecting a category (or Now/custom tag) that has zero visible experiences shows a filter-tinted 'No matches · Clear filter' pill instead of the generic 'expand your radius' overlay; tapping 'Clear filter' resets to All and restores markers. When the same filter has ≥1 match the existing count pill is unchanged. With a filter inactive and genuinely no nearby experiences, the original EmptyStateOverlay still appears. VoiceOver reads the no-match state and clear action; Reduce Motion suppresses any added looping animation. `xcodebuild build` and the SoloCompassTests suite pass.