### PR TITLE
auto: Group inconvenience rows as single VoiceOver elements with semantic warning labels

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -56,6 +56,17 @@
 "bestTimes.now.pill" = "Good time now";
 "bestTimes.next.pill" = "Better at %@";
 
+/* Inconvenience categories */
+"inconvenience.category.scam" = "Scam risk";
+"inconvenience.category.crowds" = "Crowds";
+"inconvenience.category.logistics" = "Logistics";
+"inconvenience.category.weather" = "Weather";
+"inconvenience.category.etiquette" = "Etiquette";
+"inconvenience.category.safety" = "Safety";
+"inconvenience.category.other" = "Heads up";
+/* Accessibility label for each inconvenience row: "Heads up: <category> — <text>" */
+"inconvenience.a11y.prefix" = "Heads up: %@ — %@";
+
 /* Sections */
 "section.whyItMatters" = "Why it matters";
 "section.bestTimes" = "Best times";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -360,6 +360,11 @@ public struct ExperienceDetailView: View {
         }
     }
 
+    private func inconvenienceCategoryName(_ category: RealInconvenience.Category) -> String {
+        let key = "inconvenience.category.\(category.rawValue)"
+        return NSLocalizedString(key, comment: "Inconvenience category display name")
+    }
+
     private var inconveniencesSection: some View {
         sectionContainer(title: NSLocalizedString("section.inconveniences", comment: "")) {
             VStack(alignment: .leading, spacing: 10) {
@@ -368,6 +373,7 @@ public struct ExperienceDetailView: View {
                         Image(systemName: item.category.symbol)
                             .foregroundStyle(.orange)
                             .frame(width: 20)
+                            .accessibilityHidden(true)
                         Text(item.text)
                             .font(.subheadline)
                             .fixedSize(horizontal: false, vertical: true)
@@ -378,6 +384,12 @@ public struct ExperienceDetailView: View {
                         RoundedRectangle(cornerRadius: 10)
                             .fill(Color.orange.opacity(0.08))
                     )
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(Text(String(
+                        format: NSLocalizedString("inconvenience.a11y.prefix", comment: "Heads up: <category> — <text>"),
+                        inconvenienceCategoryName(item.category),
+                        item.text
+                    )))
                 }
             }
         }


### PR DESCRIPTION
## Group inconvenience rows as single VoiceOver elements with semantic warning labels

The brand-defining 'Real Inconveniences' section renders each item as a separate icon + text pair, so VoiceOver reads them as two disconnected elements and the orange warning glyph (which carries the 'heads-up' meaning) is announced as an unlabeled image. This combines each row into one accessibility element and prefixes it with a localized 'Heads up' label plus the inconvenience category, so blind users get the same prominent warning sighted users do.

### Acceptance
Build succeeds (xcodebuild build, iPhone 17 Pro sim). With VoiceOver on, each inconvenience row is announced as one element beginning with 'Heads up' followed by the category and the inconvenience text; the warning icon is no longer announced separately. Sighted layout is visually unchanged. New strings exist in Localizable.strings and no parity:check or test regressions occur.