### PR TITLE
auto: Animate the VoiceButton live-transcript overlay with a Listening… placeholder for the silent gap

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
+++ b/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
@@ -80,7 +80,7 @@ public struct VoiceButton: View {
                     .padding(.vertical, 6)
                     .background(.thinMaterial, in: Capsule())
                     .offset(y: -50)
-                    .transition(.opacity)
+                    .transition(reduceMotion ? .identity : .opacity)
                     .id(liveTranscript.isEmpty)
                     .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: liveTranscript.isEmpty)
             }
@@ -99,19 +99,18 @@ public struct VoiceButton: View {
             do {
                 isRecording = true
                 if !reduceMotion { pulse = true }
-                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                 liveTranscript = ""
-                startFeedback.prepare()
                 startFeedback.impactOccurred()
                 endFeedback.prepare()
                 let stream = try voiceService.startListening()
-                let noMotion = reduceMotion
                 streamTask = Task {
                     do {
                         for try await text in stream {
-                            await MainActor.run { withAnimation(noMotion ? nil : .easeOut(duration: 0.18)) { liveTranscript = text } }
+                            let animate = !reduceMotion
+                            await MainActor.run { withAnimation(animate ? .easeOut(duration: 0.18) : nil) { liveTranscript = text } }
                         }
                     } catch {
+                        guard !(error is CancellationError) else { return }
                         // Surface recognition errors to the user via alert.
                         await MainActor.run {
                             isRecording = false
@@ -183,13 +182,14 @@ private struct _ListeningPlaceholderPreview: View {
                 .padding(.vertical, 6)
                 .background(.thinMaterial, in: Capsule())
                 .offset(y: -50)
-                .transition(.opacity)
+                .transition(reduceMotion ? .identity : .opacity)
                 .id(liveTranscript.isEmpty)
                 .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: liveTranscript.isEmpty)
         }
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                withAnimation(.easeOut(duration: 0.18)) { liveTranscript = "quiet café nearby" }
+                let animate = !reduceMotion
+                withAnimation(animate ? .easeOut(duration: 0.18) : nil) { liveTranscript = "quiet café nearby" }
             }
         }
     }

--- a/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
+++ b/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
@@ -69,14 +69,20 @@ public struct VoiceButton: View {
             Text(recognitionError ?? "")
         }
         .overlay(alignment: .top) {
-            if isRecording, !liveTranscript.isEmpty {
-                Text(liveTranscript)
+            if isRecording {
+                let displayText = liveTranscript.isEmpty
+                    ? NSLocalizedString("chat.voice.listening", comment: "Listening placeholder")
+                    : liveTranscript
+                Text(displayText)
                     .font(.caption)
+                    .foregroundStyle(liveTranscript.isEmpty ? .secondary : .primary)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 6)
                     .background(.thinMaterial, in: Capsule())
                     .offset(y: -50)
                     .transition(.opacity)
+                    .id(liveTranscript.isEmpty)
+                    .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: liveTranscript.isEmpty)
             }
         }
     }
@@ -99,10 +105,11 @@ public struct VoiceButton: View {
                 startFeedback.impactOccurred()
                 endFeedback.prepare()
                 let stream = try voiceService.startListening()
+                let noMotion = reduceMotion
                 streamTask = Task {
                     do {
                         for try await text in stream {
-                            await MainActor.run { liveTranscript = text }
+                            await MainActor.run { withAnimation(noMotion ? nil : .easeOut(duration: 0.18)) { liveTranscript = text } }
                         }
                     } catch {
                         // Surface recognition errors to the user via alert.
@@ -137,9 +144,53 @@ public struct VoiceButton: View {
     }
 }
 
-#Preview {
+#Preview("Default") {
     VoiceButton(voiceService: VoiceService()) { transcript in
         print("Got: \(transcript)")
     }
     .padding()
+}
+
+#Preview("Listening placeholder") {
+    // Simulates the recording state before any speech is recognized.
+    _ListeningPlaceholderPreview()
+        .padding()
+}
+
+private struct _ListeningPlaceholderPreview: View {
+    @State private var isRecording = true
+    @State private var liveTranscript = ""
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(Color.red)
+                .frame(width: 56, height: 56)
+                .shadow(radius: 10)
+            Image(systemName: "waveform")
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(.white)
+        }
+        .overlay(alignment: .top) {
+            let displayText = liveTranscript.isEmpty
+                ? NSLocalizedString("chat.voice.listening", comment: "Listening placeholder")
+                : liveTranscript
+            Text(displayText)
+                .font(.caption)
+                .foregroundStyle(liveTranscript.isEmpty ? .secondary : .primary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(.thinMaterial, in: Capsule())
+                .offset(y: -50)
+                .transition(.opacity)
+                .id(liveTranscript.isEmpty)
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: liveTranscript.isEmpty)
+        }
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                withAnimation(.easeOut(duration: 0.18)) { liveTranscript = "quiet café nearby" }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Animate the VoiceButton live-transcript overlay with a "Listening…" placeholder for the silent gap

While recording, VoiceButton's transcript bubble only appears once the first word is recognized (`if isRecording, !liveTranscript.isEmpty`), so there's a silent dead zone right after press where the user gets no on-screen confirmation that recognition started — and when words do arrive they snap in with no animation. This adds an animated "Listening…" placeholder bubble that shows immediately on record-start and crossfades into the live words as they stream in, giving continuous visual feedback during long-press dictation.

### Acceptance
Long-pressing the mic immediately shows a "I'm listening…" bubble above the button before any speech is recognized; as words stream in, the bubble crossfades from the placeholder to the live transcript and subsequent updates animate smoothly rather than snapping; with Reduce Motion enabled the placeholder and text still appear but without animation. `xcodebuild build -project apps/ios/SoloCompass.xcodeproj -scheme SoloCompass -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest'` succeeds and the two #Previews render.