### PR TITLE
auto: Add a glanceable distance / walking-time pill to the floating experience card

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -184,6 +184,10 @@
 "card.favorite.add" = "Add to favorites";
 "card.favorite.remove" = "Remove from favorites";
 
+/* Experience card distance pill */
+"card.distance.walk" = "%d min walk";
+"card.distance.walkSub1" = "<1 min walk";
+
 /* Voice recognition error alert */
 "voice.error.title" = "Voice recognition error";
 "voice.error.permission" = "Microphone or speech recognition permission was denied. Please allow access in Settings.";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -29,8 +29,18 @@ public struct ExperienceCardView: View {
     private var distanceMeters: Double? {
         guard let coord = experience.coordinate else { return nil }
         let d = locationService.distance(to: coord)
-        return d.isFinite ? d : nil
+        // greatestFiniteMagnitude is the sentinel returned when no fix is available;
+        // isFinite alone cannot distinguish it from a real reading.
+        return (d.isFinite && d < .greatestFiniteMagnitude) ? d : nil
     }
+
+    private static let distanceFormatter: MeasurementFormatter = {
+        let f = MeasurementFormatter()
+        f.unitOptions = .naturalScale
+        f.unitStyle = .abbreviated
+        f.numberFormatter.maximumFractionDigits = 1
+        return f
+    }()
 
     /// Formats a distance in meters into a human-readable walk-time or distance string.
     private static func formatDistance(_ meters: Double) -> String {
@@ -43,10 +53,7 @@ public struct ExperienceCardView: View {
             return String(format: NSLocalizedString("card.distance.walk", comment: "Distance in walk minutes"), minutes)
         }
         let measurement = Measurement(value: meters, unit: UnitLength.meters)
-        let formatter = MeasurementFormatter()
-        formatter.unitOptions = .naturalScale
-        formatter.numberFormatter.maximumFractionDigits = 1
-        return formatter.string(from: measurement)
+        return distanceFormatter.string(from: measurement)
     }
 
     public init(

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import CoreLocation
 
 /// Floating card that slides up when a marker is tapped. Tap → expand. Swipe
 /// down → dismiss. Swipe up → full detail sheet.
@@ -20,8 +21,33 @@ public struct ExperienceCardView: View {
     // Pre-allocated so prepare() can be called once when the drag starts.
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
     @Environment(UserPreferences.self) private var preferences
+    @Environment(LocationService.self) private var locationService
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+
+    /// Finite distance in meters, or nil when location is unknown.
+    private var distanceMeters: Double? {
+        guard let coord = experience.coordinate else { return nil }
+        let d = locationService.distance(to: coord)
+        return d.isFinite ? d : nil
+    }
+
+    /// Formats a distance in meters into a human-readable walk-time or distance string.
+    private static func formatDistance(_ meters: Double) -> String {
+        let walkMetersPerMin = 80.0
+        if meters < 1000 {
+            let minutes = Int((meters / walkMetersPerMin).rounded(.up))
+            if minutes < 1 {
+                return NSLocalizedString("card.distance.walkSub1", comment: "Distance less than 1 min walk")
+            }
+            return String(format: NSLocalizedString("card.distance.walk", comment: "Distance in walk minutes"), minutes)
+        }
+        let measurement = Measurement(value: meters, unit: UnitLength.meters)
+        let formatter = MeasurementFormatter()
+        formatter.unitOptions = .naturalScale
+        formatter.numberFormatter.maximumFractionDigits = 1
+        return formatter.string(from: measurement)
+    }
 
     public init(
         experience: Experience,
@@ -116,8 +142,15 @@ public struct ExperienceCardView: View {
 
             HStack {
                 SoloScoreBadge(score: experience.soloScore, style: .compact)
-                if experience.isBestNow() {
-                    BestNowBadge()
+                if let meters = distanceMeters {
+                    distancePill(Self.formatDistance(meters))
+                }
+                if !experience.realInconveniences.isEmpty {
+                    inconveniencePill
+                } else if experience.isBestNow() {
+                    bestNowBadge
+                } else if let hint = experience.bestTimeHint() {
+                    bestTimeHintPill(hint)
                 }
                 Spacer()
                 Button(action: onExpand) {
@@ -176,17 +209,17 @@ public struct ExperienceCardView: View {
             String(format: NSLocalizedString("solo.a11y", comment: "Solo Score %@ of 10"),
                    String(format: "%.1f", experience.soloScore.overall)) +
             {
-                if let hint = experience.bestTimeHint() {
-                    return ". " + String(format: NSLocalizedString("experience.bestTime.hint.a11y", comment: "Best time accessibility"), hint)
+                var parts = ""
+                if let meters = distanceMeters {
+                    parts += ". " + Self.formatDistance(meters)
                 }
-                return ""
-            }() +
-            {
                 let count = experience.realInconveniences.count
                 if count > 0 {
-                    return ". " + String(format: NSLocalizedString("inconvenience.card.a11y", comment: "Heads up: N things to know"), count)
+                    parts += ". " + String(format: NSLocalizedString("inconvenience.card.a11y", comment: "Heads up: N things to know"), count)
+                } else if let hint = experience.bestTimeHint() {
+                    parts += ". " + String(format: NSLocalizedString("experience.bestTime.hint.a11y", comment: "Best time accessibility"), hint)
                 }
-                return ""
+                return parts
             }()
         ))
         .accessibilityHint(Text(NSLocalizedString("experience.card.hint", comment: "Double tap to view details")))
@@ -197,6 +230,16 @@ public struct ExperienceCardView: View {
         ) {
             preferences.toggleFavorite(experience.id)
         }
+    }
+
+    @ViewBuilder
+    private func distancePill(_ label: String) -> some View {
+        Label(label, systemImage: "figure.walk")
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .foregroundStyle(Color.secondary)
+            .background(Capsule().fill(Color.secondary.opacity(0.12)))
     }
 
     @ViewBuilder
@@ -270,7 +313,13 @@ private struct BestNowBadge: View {
 
 #Preview {
     if let exp = ExperienceService.hardcodedSeed.first {
-        VStack {
+        let locationService = LocationService()
+        // Simulate a location ~450 m from the seed experience so the pill is visible in preview.
+        if let coord = exp.coordinate {
+            let offset = CLLocation(latitude: coord.latitude + 0.004, longitude: coord.longitude)
+            locationService.simulate(location: offset)
+        }
+        return AnyView(VStack {
             Spacer()
             ExperienceCardView(
                 experience: exp,
@@ -280,7 +329,8 @@ private struct BestNowBadge: View {
         }
         .background(Color(red: 0xF5/255, green: 0xF0/255, blue: 0xE8/255))
         .environment(UserPreferences(defaults: UserDefaults(suiteName: "preview")!))
+        .environment(locationService))
     } else {
-        Text("No seed data")
+        return AnyView(Text("No seed data"))
     }
 }


### PR DESCRIPTION
## Add a glanceable distance / walking-time pill to the floating experience card

When a marker is tapped on the map-first home screen, the floating ExperienceCardView shows title, place, solo score, and best-time — but never how far the experience is from the user, which is the single most relevant piece of glanceable info for a solo traveler standing on a map. This adds a distance pill (e.g. "6 min walk" / "450 m" / "2.3 km") to the card's bottom badge row, reusing the existing LocationService.distance(to:) helper and respecting locale units.

### Acceptance
Tapping a marker shows the floating card with a distance pill between the SoloScore and best-time badges; near experiences read e.g. "6 min walk", far ones read e.g. "2.3 km" (or miles in imperial locales). When the device has no location fix the pill is hidden and the rest of the card is unchanged. VoiceOver reads the distance as part of the card label. Reduce Motion is unaffected. `xcodebuild build -scheme SoloCompass` succeeds and existing SoloCompassTests pass; verified visually in the iPhone 17 Pro simulator with a simulated location.