### PR TITLE
auto: Severity-tinted inconvenience rows with a visible category chip

### DIFF
--- a/apps/ios/SoloCompass/Models/Experience.swift
+++ b/apps/ios/SoloCompass/Models/Experience.swift
@@ -141,14 +141,6 @@ public struct RealInconvenience: Codable, Hashable, Identifiable {
     public enum Severity {
         case high, medium, low
 
-        public var tintColor: Color {
-            switch self {
-            case .high:   return Color(.systemRed)
-            case .medium: return Color(.systemOrange)
-            case .low:    return Color(.systemGray)
-            }
-        }
-
         public var backgroundOpacity: Double {
             switch self {
             case .high:   return 0.10

--- a/apps/ios/SoloCompass/Models/Experience.swift
+++ b/apps/ios/SoloCompass/Models/Experience.swift
@@ -138,6 +138,26 @@ public struct HowToStep: Codable, Hashable, Identifiable {
 // MARK: - Real inconvenience
 
 public struct RealInconvenience: Codable, Hashable, Identifiable {
+    public enum Severity {
+        case high, medium, low
+
+        public var tintColor: Color {
+            switch self {
+            case .high:   return Color(.systemRed)
+            case .medium: return Color(.systemOrange)
+            case .low:    return Color(.systemGray)
+            }
+        }
+
+        public var backgroundOpacity: Double {
+            switch self {
+            case .high:   return 0.10
+            case .medium: return 0.08
+            case .low:    return 0.06
+            }
+        }
+    }
+
     public enum Category: String, Codable, Hashable {
         case scam, crowds, logistics, weather, etiquette, safety, other
 
@@ -150,6 +170,14 @@ public struct RealInconvenience: Codable, Hashable, Identifiable {
             case .etiquette: return "hand.raised"
             case .safety:    return "shield.lefthalf.filled"
             case .other:     return "info.circle"
+            }
+        }
+
+        public var severity: Severity {
+            switch self {
+            case .scam, .safety:                       return .high
+            case .crowds, .weather, .logistics, .etiquette: return .medium
+            case .other:                               return .low
             }
         }
     }

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -403,33 +403,31 @@ public struct ExperienceDetailView: View {
         sectionContainer(title: NSLocalizedString("section.inconveniences", comment: "")) {
             VStack(alignment: .leading, spacing: 10) {
                 ForEach(viewModel.experience.realInconveniences) { item in
-                    HStack(alignment: .top, spacing: 10) {
-                        Image(systemName: item.category.symbol)
-                            .foregroundStyle(.orange)
-                            .frame(width: 20)
-                            .accessibilityHidden(true)
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(inconvenienceCategoryName(item.category).uppercased())
-                                .font(.caption2.weight(.semibold))
-                                .foregroundStyle(.orange)
-                                .tracking(0.5)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
-                                .background(
-                                    Capsule()
-                                        .fill(Color.orange.opacity(0.15))
-                                )
+                    let severity = item.category.severity
+                    let tint = severity.tintColor
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack(spacing: 6) {
+                            Image(systemName: item.category.symbol)
+                                .foregroundStyle(tint)
+                                .frame(width: 20)
                                 .accessibilityHidden(true)
-                            Text(item.text)
-                                .font(.subheadline)
-                                .fixedSize(horizontal: false, vertical: true)
+                            Text(inconvenienceCategoryName(item.category))
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(tint)
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 3)
+                                .background(Capsule().fill(tint.opacity(0.15)))
+                                .accessibilityHidden(true)
                         }
+                        Text(item.text)
+                            .font(.subheadline)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                     .padding(10)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(
                         RoundedRectangle(cornerRadius: 10)
-                            .fill(Color.orange.opacity(0.08))
+                            .fill(tint.opacity(severity.backgroundOpacity))
                     )
                     .accessibilityElement(children: .ignore)
                     .accessibilityLabel(Text(String(

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -416,7 +416,7 @@ public struct ExperienceDetailView: View {
                                 .foregroundStyle(tint)
                                 .padding(.horizontal, 7)
                                 .padding(.vertical, 3)
-                                .background(Capsule().fill(tint.opacity(0.15)))
+                                .background(Capsule().fill(tint.opacity(severity.backgroundOpacity)))
                                 .accessibilityHidden(true)
                         }
                         Text(item.text)
@@ -905,5 +905,15 @@ private struct BestTimesTimeline: View {
         .environment(\.dynamicTypeSize, .accessibility3)
     } else {
         Text("No seed data")
+    }
+}
+
+private extension RealInconvenience.Severity {
+    var tintColor: Color {
+        switch self {
+        case .high:   return Color(.systemRed)
+        case .medium: return Color(.systemOrange)
+        case .low:    return Color(.systemGray)
+        }
     }
 }


### PR DESCRIPTION
## Severity-tinted inconvenience rows with a visible category chip

The 'Real inconveniences' section — a core honest-curation pillar — currently renders every item identically in orange and only exposes the category to VoiceOver, so a scam/safety warning looks the same as a 'might be crowded' note. Give each row a severity-derived tint (red for safety/scam, amber for crowds/weather/logistics/etiquette, neutral for other) and surface the category name as a small visible chip beside the icon, so the seriousness of each heads-up reads at a glance for sighted users too.

### Acceptance
A safety/scam inconvenience row renders with a red tint and a visible 'Safety'/'Scam risk' chip; a crowds/weather row renders amber; an 'other' row renders neutral. The category name is now visible to sighted users, not just VoiceOver. VoiceOver still reads each row as one element via the existing 'Heads up: <category> — <text>' label. No changes to RealInconvenience's stored properties, init, or Codable encoding (parity:check unaffected). iOS target builds clean and ExperienceDetailView #Preview renders.