### PR TITLE
auto: Filter pills: selection haptics that only fire on an actual filter change

### DIFF
--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -30,6 +30,12 @@ public struct FilterBarView: View {
     @Environment(UserPreferences.self) private var preferences
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isPulsing: Bool = false
+    @State private var selectionFeedback = UISelectionFeedbackGenerator()
+
+    private func fireSelectionHaptic(alreadySelected: Bool) {
+        guard !alreadySelected else { return }
+        selectionFeedback.selectionChanged()
+    }
 
     public init(
         selectedCategory: ExperienceCategory?,
@@ -123,7 +129,7 @@ public struct FilterBarView: View {
             : label
 
         return Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            fireSelectionHaptic(alreadySelected: isSelected)
             action()
         } label: {
             HStack(spacing: 5) {
@@ -160,6 +166,7 @@ public struct FilterBarView: View {
         .accessibilityLabel(Text(a11yLabel))
         .accessibilityAddTraits(isSelected ? .isSelected : [])
         .onAppear {
+            selectionFeedback.prepare()
             guard !reduceMotion else { return }
             withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
                 isPulsing = true
@@ -178,7 +185,7 @@ public struct FilterBarView: View {
 
     private func pill(id: String, label: String, isSelected: Bool, color: Color, action: @escaping () -> Void) -> some View {
         Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            fireSelectionHaptic(alreadySelected: isSelected)
             action()
         } label: {
             Text(label)
@@ -212,7 +219,7 @@ public struct FilterBarView: View {
 
     private func iconPill(category: ExperienceCategory, isSelected: Bool, action: @escaping () -> Void) -> some View {
         Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            fireSelectionHaptic(alreadySelected: isSelected)
             action()
         } label: {
             Image(systemName: category.symbol)
@@ -249,7 +256,7 @@ public struct FilterBarView: View {
     /// it visually reads as part of the same filter row. US-008.
     private func customTagPill(tag: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
         Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            fireSelectionHaptic(alreadySelected: isSelected)
             action()
         } label: {
             Image(systemName: "tag.fill")


### PR DESCRIPTION
## Filter pills: selection haptics that only fire on an actual filter change

Every pill in FilterBarView currently fires a generic UIImpactFeedbackGenerator(style:.light) on every tap, including re-tapping the already-active pill — so a no-op tap feels identical to a real filter change, and the time-sensitive 'Now' pill feels the same as a passive category. Switch to the idiomatic UISelectionFeedbackGenerator (prepared in advance for low latency), and suppress the haptic when the tapped pill is already selected so the tactile signal maps exactly to 'the map filter just changed.'

### Acceptance
Tapping an unselected pill produces a crisp selection-change haptic; re-tapping the already-selected pill produces no haptic but still runs its action; first tap after the bar appears has no perceptible delay (generator was prepared). `xcodebuild build -scheme SoloCompass -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest'` succeeds, all four pill types compile, existing FilterBarView previews still render, and Reduce Motion behavior is unchanged.