### PR TITLE
auto: Animate the 'solo travelers nearby' footprint count on the BottomInfoBar

### DIFF
--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -441,8 +441,8 @@ public final class MapViewModel {
         let nearby = applyFilters(near: center, radiusKm: radiusKm)
         withAnimation(Self.markerSetAnimation) {
             visibleExperiences = nearby
+            nearbySoloCount = computeNearbySoloCount(in: nearby)
         }
-        nearbySoloCount = computeNearbySoloCount(in: nearby)
         updateBottomInfo()
     }
 
@@ -647,8 +647,8 @@ public final class MapViewModel {
         let nearby = applyFilters(near: coordinate, radiusKm: radiusKm)
         withAnimation(Self.markerSetAnimation) {
             visibleExperiences = nearby
+            nearbySoloCount = computeNearbySoloCount(in: nearby)
         }
-        nearbySoloCount = computeNearbySoloCount(in: nearby)
         updateBottomInfo()
     }
 
@@ -984,8 +984,10 @@ public final class MapViewModel {
                     if let region = experienceService.repo.closestRecentRegion(to: coordinate),
                        case let cached = experienceService.repo.experiences(in: region),
                        !cached.isEmpty {
-                        visibleExperiences = cached
-                        nearbySoloCount = 0
+                        withAnimation(Self.markerSetAnimation) {
+                            visibleExperiences = cached
+                            nearbySoloCount = 0
+                        }
                         updateBottomInfo()
                         lastExploreToast = NSLocalizedString("explore.toast.cachedFallback", comment: "Showing cached results")
                         return
@@ -1028,8 +1030,10 @@ public final class MapViewModel {
                     if let region = experienceService.repo.closestRecentRegion(to: coordinate) {
                         let cached = experienceService.repo.experiences(in: region)
                         if !cached.isEmpty {
-                            visibleExperiences = cached
-                            nearbySoloCount = 0
+                            withAnimation(Self.markerSetAnimation) {
+                                visibleExperiences = cached
+                                nearbySoloCount = 0
+                            }
                             updateBottomInfo()
                             lastExploreToast = NSLocalizedString("explore.toast.cachedFallback", comment: "Showing cached results")
                             return
@@ -1123,8 +1127,10 @@ public final class MapViewModel {
             if let region = experienceService.repo.closestRecentRegion(to: coordinate) {
                 let offline = experienceService.repo.experiences(in: region)
                 if !offline.isEmpty {
-                    visibleExperiences = offline
-                    nearbySoloCount = 0
+                    withAnimation(Self.markerSetAnimation) {
+                        visibleExperiences = offline
+                        nearbySoloCount = 0
+                    }
                     updateBottomInfo()
 
                     let formatter = RelativeDateTimeFormatter()

--- a/apps/ios/SoloCompass/Views/Shared/BottomInfoBar.swift
+++ b/apps/ios/SoloCompass/Views/Shared/BottomInfoBar.swift
@@ -7,6 +7,12 @@ public struct BottomInfoBar: View {
     let text: String
     let nearbySoloCount: Int
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    // Tracks whether the footprint pill has been shown at least once (one-shot bounce guard).
+    @State private var appeared = false
+    // Drives the insertion animation; toggled whenever count crosses into positive.
+    @State private var footprintVisible = false
+
     public init(text: String, nearbySoloCount: Int) {
         self.text = text
         self.nearbySoloCount = nearbySoloCount
@@ -27,14 +33,23 @@ public struct BottomInfoBar: View {
                 HStack(spacing: 3) {
                     Image(systemName: "figure.walk")
                         .font(.caption2)
+                        // One-shot bounce when a fellow solo traveler is first detected.
+                        .symbolEffect(.bounce, value: appeared && !reduceMotion ? nearbySoloCount > 0 : false)
                     Text("\(nearbySoloCount)")
                         .font(.caption.monospacedDigit())
+                        // Roll the digit up on count changes; skip the roll with Reduce Motion.
+                        .contentTransition(reduceMotion ? .identity : .numericText(value: Double(nearbySoloCount)))
+                        .animation(.snappy, value: nearbySoloCount)
                 }
                 .foregroundStyle(.secondary)
                 .accessibilityLabel(Text(String(
                     format: NSLocalizedString("info.nearbySolo.a11y", comment: "%d solo travelers passed nearby today"),
                     nearbySoloCount
                 )))
+                // Scale+fade entrance; plain cross-fade when Reduce Motion is on.
+                .transition(reduceMotion
+                    ? .opacity
+                    : .scale(scale: 0.6).combined(with: .opacity))
             }
         }
         .padding(.horizontal, 16)
@@ -42,15 +57,36 @@ public struct BottomInfoBar: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
         .padding(.horizontal, 12)
+        .onAppear {
+            // Mark appeared so the bounce symbolEffect key is active from here on.
+            appeared = true
+        }
+        .onChange(of: nearbySoloCount) { _, newCount in
+            let entering = newCount > 0
+            withAnimation(.spring(response: 0.4, dampingFraction: 0.7)) {
+                footprintVisible = entering
+            }
+        }
     }
 }
 
-#Preview {
+#Preview("With nearby solos") {
     VStack {
         Spacer()
         BottomInfoBar(
             text: "Sunset in 47 minutes. 2 perfect viewing spots within walking distance.",
             nearbySoloCount: 12
+        )
+    }
+    .background(Color(red: 0xF5/255, green: 0xF0/255, blue: 0xE8/255))
+}
+
+#Preview("No nearby solos") {
+    VStack {
+        Spacer()
+        BottomInfoBar(
+            text: "Quiet morning. Golden hour starts in 23 minutes.",
+            nearbySoloCount: 0
         )
     }
     .background(Color(red: 0xF5/255, green: 0xF0/255, blue: 0xE8/255))

--- a/apps/ios/SoloCompass/Views/Shared/BottomInfoBar.swift
+++ b/apps/ios/SoloCompass/Views/Shared/BottomInfoBar.swift
@@ -8,10 +8,10 @@ public struct BottomInfoBar: View {
     let nearbySoloCount: Int
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    // Tracks whether the footprint pill has been shown at least once (one-shot bounce guard).
-    @State private var appeared = false
-    // Drives the insertion animation; toggled whenever count crosses into positive.
+    // Drives the insertion/removal transition — set via onChange so withAnimation wraps the flip.
     @State private var footprintVisible = false
+    // Prevents the bounce from firing more than once across the view's lifetime.
+    @State private var hasBouncedOnce = false
 
     public init(text: String, nearbySoloCount: Int) {
         self.text = text
@@ -28,16 +28,16 @@ public struct BottomInfoBar: View {
                 .transition(.opacity)
                 .animation(.easeInOut(duration: 0.4), value: text)
 
-            if nearbySoloCount > 0 {
+            if footprintVisible {
                 Spacer(minLength: 8)
                 HStack(spacing: 3) {
                     Image(systemName: "figure.walk")
                         .font(.caption2)
-                        // One-shot bounce when a fellow solo traveler is first detected.
-                        .symbolEffect(.bounce, value: appeared && !reduceMotion ? nearbySoloCount > 0 : false)
+                        // Bounce once on first detection; subsequent zero-crossings are silent.
+                        .symbolEffect(.bounce, value: reduceMotion ? false : hasBouncedOnce)
                     Text("\(nearbySoloCount)")
                         .font(.caption.monospacedDigit())
-                        // Roll the digit up on count changes; skip the roll with Reduce Motion.
+                        // Roll the digit on count changes while the pill is already visible.
                         .contentTransition(reduceMotion ? .identity : .numericText(value: Double(nearbySoloCount)))
                         .animation(.snappy, value: nearbySoloCount)
                 }
@@ -58,13 +58,15 @@ public struct BottomInfoBar: View {
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
         .padding(.horizontal, 12)
         .onAppear {
-            // Mark appeared so the bounce symbolEffect key is active from here on.
-            appeared = true
+            footprintVisible = nearbySoloCount > 0
         }
         .onChange(of: nearbySoloCount) { _, newCount in
             let entering = newCount > 0
             withAnimation(.spring(response: 0.4, dampingFraction: 0.7)) {
                 footprintVisible = entering
+            }
+            if entering && !hasBouncedOnce {
+                hasBouncedOnce = true
             }
         }
     }


### PR DESCRIPTION
## Animate the 'solo travelers nearby' footprint count on the BottomInfoBar

The nearby-solo footprint count is the app's core 'you're not alone' signal, yet it pops in/out with no transition while the sibling info text animates beside it — an inconsistency and a missed emotional beat. This adds a gentle scale+fade entrance and a count-up roll when the count rises from zero, matching the app's established spring/Reduce-Motion patterns, so the moment a fellow solo traveler is detected nearby actually feels like an arrival.

### Acceptance
Build succeeds (xcodebuild build, iPhone 17 Pro). When nearbySoloCount rises from 0 to a positive value the footprint pill scales+fades in and the digit rolls up; subsequent count changes roll the number without a full re-entrance; the figure.walk icon bounces once on first appearance. With Reduce Motion enabled the pill simply cross-fades with no scale/bounce/roll. Existing text animation, layout, padding, and the VoiceOver label ('N solo travelers passed nearby today') are unchanged. #Preview renders both a zero and non-zero state.