### PR TITLE
auto: Surface the raw provider opening-hours string in the Best Times section

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -485,6 +485,8 @@
 "common.settings" = "Settings";
 
 /* Location card + navigation picker */
+"location.openingHours" = "Posted hours";
+"location.openingHours.a11y" = "Posted hours: %@";
 "location.navigate" = "Navigate";
 "location.copyCoords" = "Copy coordinates";
 "location.copied" = "Copied!";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "glassmorphism.preview.customPadding" = "自定义内边距和阴影";
 
 /* Location card + navigation picker */
+"location.openingHours" = "营业时间";
+"location.openingHours.a11y" = "营业时间:%@";
 "location.navigate" = "导航";
 "location.copyCoords" = "复制坐标";
 "location.openIn.apple" = "苹果地图";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -48,7 +48,9 @@ public struct ExperienceDetailView: View {
                 }
                 whyItMattersSection
                 aiInsightSection
-                if !viewModel.experience.bestTimes.isEmpty {
+                let hasOpeningHours = viewModel.experience.location.openingHours
+                    .map { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty } ?? false
+                if !viewModel.experience.bestTimes.isEmpty || hasOpeningHours {
                     bestTimesSection
                 }
                 if !viewModel.experience.howTo.isEmpty {
@@ -314,29 +316,60 @@ public struct ExperienceDetailView: View {
         )
     }
 
+    @ViewBuilder
+    private var openingHoursRow: some View {
+        if let raw = viewModel.experience.location.openingHours {
+            let hours = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !hours.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "building.2")
+                            .foregroundStyle(.secondary)
+                            .accessibilityHidden(true)
+                        Text(NSLocalizedString("location.openingHours", comment: "Posted hours label"))
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                        Text(hours)
+                            .font(.subheadline)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(Text(String(
+                        format: NSLocalizedString("location.openingHours.a11y", comment: "Posted hours accessibility label"),
+                        hours
+                    )))
+                    Divider()
+                }
+            }
+        }
+    }
+
     private var bestTimesSection: some View {
         sectionContainer(title: NSLocalizedString("section.bestTimes", comment: "")) {
             VStack(alignment: .leading, spacing: 6) {
-                HStack { Spacer(); bestTimeStatusPill }
-                BestTimesTimeline(experience: viewModel.experience)
-                    .padding(.bottom, 4)
-                ForEach(viewModel.experience.bestTimes, id: \.self) { window in
-                    HStack(spacing: 8) {
-                        Image(systemName: "clock")
-                            .foregroundStyle(.secondary)
-                        Text(format(window: window))
-                            .font(.subheadline)
-                        if let note = window.note {
-                            Text(note)
-                                .font(.caption)
-                                .foregroundStyle(.tertiary)
+                openingHoursRow
+                if !viewModel.experience.bestTimes.isEmpty {
+                    HStack { Spacer(); bestTimeStatusPill }
+                    BestTimesTimeline(experience: viewModel.experience)
+                        .padding(.bottom, 4)
+                    ForEach(viewModel.experience.bestTimes, id: \.self) { window in
+                        HStack(spacing: 8) {
+                            Image(systemName: "clock")
+                                .foregroundStyle(.secondary)
+                            Text(format(window: window))
+                                .font(.subheadline)
+                            if let note = window.note {
+                                Text(note)
+                                    .font(.caption)
+                                    .foregroundStyle(.tertiary)
+                            }
                         }
                     }
+                    let range = viewModel.experience.durationMinutes
+                    Text(String(format: NSLocalizedString("section.duration", comment: ""), range.min, range.max))
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
                 }
-                let range = viewModel.experience.durationMinutes
-                Text(String(format: NSLocalizedString("section.duration", comment: ""), range.min, range.max))
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
             }
         }
     }


### PR DESCRIPTION
## Surface the raw provider opening-hours string in the Best Times section

Experience.location.openingHours (the real provider hours string from Foursquare/Apple MapKit) is stored on the model but never rendered in any view — leaving the app's curated bestTimes windows as the only timing signal, with no ground-truth 'when is the door actually open' answer. This directly serves the product pillar 'is this open right now in the rain on a Tuesday afternoon.' Add a compact, clearly-labeled hours row at the top of the Best Times section that only appears when the field is present, visually distinct from the AI-curated bestTimes so users can tell the hard signal apart from the soft recommendation.

### Acceptance
1) Opening an experience whose location.openingHours is non-nil shows a 'Posted hours' row with the raw string at the top of the Best Times section, visually distinct from the curated bestTimes windows. 2) Experiences with nil/empty openingHours show no change (no empty row, no stray divider). 3) An OSM-only entry that has openingHours but no bestTimes now renders the section (previously hidden). 4) VoiceOver reads the row as a single combined element 'Posted hours: <value>'. 5) Strings resolve in both en and zh-Hans. 6) `xcodebuild build` succeeds and the existing SoloCompassTests pass; #Preview still renders.