### PR TITLE
auto: Show the inconvenience category as a visible tag, not just a VoiceOver label

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -407,9 +407,22 @@ public struct ExperienceDetailView: View {
                             .foregroundStyle(.orange)
                             .frame(width: 20)
                             .accessibilityHidden(true)
-                        Text(item.text)
-                            .font(.subheadline)
-                            .fixedSize(horizontal: false, vertical: true)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(inconvenienceCategoryName(item.category).uppercased())
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(.orange)
+                                .tracking(0.5)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(
+                                    Capsule()
+                                        .fill(Color.orange.opacity(0.15))
+                                )
+                                .accessibilityHidden(true)
+                            Text(item.text)
+                                .font(.subheadline)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
                     }
                     .padding(10)
                     .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Show the inconvenience category as a visible tag, not just a VoiceOver label

Each row in the experience detail's 'Real Inconveniences' section renders an orange icon plus raw text, but the semantic category name (Scam risk, Crowds, Logistics, Weather, Etiquette, Safety, Heads up) is only spoken to VoiceOver and never shown to sighted users. This surfaces that category as a small uppercase tag above the inconvenience text, giving everyone the honest at-a-glance framing that is a core product pillar, and reuses the existing localized `inconvenience.category.*` strings so no new copy or schema change is required.

### Acceptance
Open an experience whose detail sheet has a 'Real Inconveniences' section (e.g. a seed experience with realInconveniences). Each inconvenience row now shows a small orange uppercase category tag (e.g. 'CROWDS', 'LOGISTICS') directly above its description text, while the icon and tinted card background are unchanged. VoiceOver still reads exactly one combined 'Heads up: <category> — <text>' label per row (the tag is accessibilityHidden, no double-read). zh-Hans locale shows the translated category names. `xcodebuild build -project SoloCompass.xcodeproj -scheme SoloCompass` succeeds and existing SoloCompassTests pass.