### PR TITLE
auto: Surface an honest-inconvenience indicator on the floating map card

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -68,6 +68,10 @@
 "inconvenience.category.other" = "Heads up";
 /* Accessibility label for each inconvenience row: "Heads up: <category> — <text>" */
 "inconvenience.a11y.prefix" = "Heads up: %@ — %@";
+/* Inconvenience pill on floating card: visible count label */
+"inconvenience.card.count" = "%d";
+/* VoiceOver suffix appended to the card's accessibilityLabel when inconveniences exist */
+"inconvenience.card.a11y" = "Heads up: %d things to know";
 
 /* Sections */
 "section.whyItMatters" = "Why it matters";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -111,7 +111,9 @@ public struct ExperienceCardView: View {
 
             HStack {
                 SoloScoreBadge(score: experience.soloScore, style: .compact)
-                if experience.isBestNow() {
+                if !experience.realInconveniences.isEmpty {
+                    inconveniencePill
+                } else if experience.isBestNow() {
                     bestNowBadge
                 } else if let hint = experience.bestTimeHint() {
                     bestTimeHintPill(hint)
@@ -181,6 +183,13 @@ public struct ExperienceCardView: View {
                     return ". " + String(format: NSLocalizedString("experience.bestTime.hint.a11y", comment: "Best time accessibility"), hint)
                 }
                 return ""
+            }() +
+            {
+                let count = experience.realInconveniences.count
+                if count > 0 {
+                    return ". " + String(format: NSLocalizedString("inconvenience.card.a11y", comment: "Heads up: N things to know"), count)
+                }
+                return ""
             }()
         ))
         .accessibilityHint(Text(NSLocalizedString("experience.card.hint", comment: "Double tap to view details")))
@@ -204,6 +213,34 @@ public struct ExperienceCardView: View {
         .padding(.vertical, 4)
         .foregroundStyle(Color.secondary)
         .background(Capsule().fill(Color.secondary.opacity(0.12)))
+    }
+
+    // Severity order: safety > scam > weather > crowds > logistics > etiquette > other
+    private static let inconvenienceSeverity: [RealInconvenience.Category] = [
+        .safety, .scam, .weather, .crowds, .logistics, .etiquette, .other
+    ]
+
+    private var mostSevereInconvenience: RealInconvenience.Category? {
+        let categories = Set(experience.realInconveniences.map(\.category))
+        return Self.inconvenienceSeverity.first { categories.contains($0) }
+    }
+
+    @ViewBuilder
+    private var inconveniencePill: some View {
+        if let category = mostSevereInconvenience {
+            let isHighSeverity = category == .safety || category == .scam
+            let tint = isHighSeverity ? Color.red : Color(red: 0xF5/255, green: 0x9E/255, blue: 0x0B/255)
+            let count = experience.realInconveniences.count
+            Label(
+                String(format: NSLocalizedString("inconvenience.card.count", comment: "Inconvenience count on card"), count),
+                systemImage: category.symbol
+            )
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .foregroundStyle(tint)
+            .background(Capsule().fill(tint.opacity(0.12)))
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Surface an honest-inconvenience indicator on the floating map card

The product's core pillar is 'honest inconvenience,' yet the floating ExperienceCardView (the first decision surface on the map-first home screen) shows SoloScore, confidence, and best-time hints but no caveat signal — a solo traveler only learns an experience carries scam/crowd/safety warnings after expanding to full detail. Add a compact, glanceable inconvenience pill to the card (e.g. a warning icon + count, colored by the most severe category) that reuses the existing RealInconvenience category symbols, so honest tradeoffs are visible before the user commits to expanding.

### Acceptance
Building an experience with one or more realInconveniences shows a colored warning pill (icon + count) on the floating card; the pill's icon and tint reflect the most severe category (red for safety/scam, amber otherwise). An experience with no inconveniences shows no pill and is visually unchanged. The pill's content is announced in the card's VoiceOver label. Visible strings are localized via NSLocalizedString. `xcodebuild build` and the SoloCompassTests target pass on iPhone 17 Pro (iOS latest), and the change is verified visually in the Simulator.