### PR TITLE
auto: Surface inconvenience category labels as visible severity-colored tags in the detail view

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -399,6 +399,13 @@ public struct ExperienceDetailView: View {
         return NSLocalizedString(key, comment: "Inconvenience category display name")
     }
 
+    private func inconvenienceTint(_ category: RealInconvenience.Category) -> Color {
+        switch category {
+        case .safety, .scam: return .red
+        default:             return .orange
+        }
+    }
+
     private var inconveniencesSection: some View {
         sectionContainer(title: NSLocalizedString("section.inconveniences", comment: "")) {
             VStack(alignment: .leading, spacing: 10) {
@@ -428,6 +435,11 @@ public struct ExperienceDetailView: View {
                     .background(
                         RoundedRectangle(cornerRadius: 10)
                             .fill(tint.opacity(severity.backgroundOpacity))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .strokeBorder(tint.opacity(0.25), lineWidth: 1)
+>>>>>>> c27bf69 (auto: Surface inconvenience category labels as visible severity-colored tags in the detail view)
                     )
                     .accessibilityElement(children: .ignore)
                     .accessibilityLabel(Text(String(

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -401,8 +401,9 @@ public struct ExperienceDetailView: View {
 
     private func inconvenienceTint(_ category: RealInconvenience.Category) -> Color {
         switch category {
-        case .safety, .scam: return .red
-        default:             return .orange
+        case .safety, .scam:                            return .red
+        case .crowds, .logistics, .weather,
+             .etiquette, .other:                        return .orange
         }
     }
 
@@ -439,7 +440,6 @@ public struct ExperienceDetailView: View {
                     .overlay(
                         RoundedRectangle(cornerRadius: 10)
                             .strokeBorder(tint.opacity(0.25), lineWidth: 1)
->>>>>>> c27bf69 (auto: Surface inconvenience category labels as visible severity-colored tags in the detail view)
                     )
                     .accessibilityElement(children: .ignore)
                     .accessibilityLabel(Text(String(
@@ -927,5 +927,46 @@ private extension RealInconvenience.Severity {
         case .medium: return Color(.systemOrange)
         case .low:    return Color(.systemGray)
         }
+    }
+}
+
+#Preview("Severity tints") {
+    if let base = ExperienceService.hardcodedSeed.first {
+        let now = Date()
+        let exp = Experience(
+            id: "preview_severity",
+            title: base.title,
+            oneLiner: base.oneLiner,
+            whyItMatters: base.whyItMatters,
+            category: base.category,
+            location: base.location,
+            bestTimes: base.bestTimes,
+            durationMinutes: base.durationMinutes,
+            howTo: base.howTo,
+            realInconveniences: [
+                RealInconvenience(category: .safety, text: "Pre-dawn route is unlit. Use a torch."),
+                RealInconvenience(category: .scam, text: "Tuk-tuks near the gate charge 3× the metered rate."),
+                RealInconvenience(category: .logistics, text: "Cash only at the entrance booth."),
+            ],
+            soloScore: base.soloScore,
+            sources: base.sources,
+            confidence: base.confidence,
+            nearbyExperienceIds: base.nearbyExperienceIds,
+            stats: base.stats,
+            status: base.status,
+            createdAt: now,
+            updatedAt: now
+        )
+        let vm = ExperienceDetailViewModel(
+            experience: exp,
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: UserPreferences()
+        )
+        NavigationStack {
+            ExperienceDetailView(viewModel: vm) {}
+        }
+    } else {
+        Text("No seed data")
     }
 }


### PR DESCRIPTION
## Surface inconvenience category labels as visible severity-colored tags in the detail view

The Real Inconveniences section — a core brand surface the codebase explicitly calls 'the product's brand' — shows only an orange SF Symbol per item, so a 'cash only' logistics note and a 'safety' warning look identical at a glance to sighted users. The category name is already localized and already announced to VoiceOver (#213), but never shown visually. This adds a small uppercase category tag above each item's text and colors safety/scam items red (vs. amber for the rest) so genuine risks read as more urgent than mere inconveniences.

### Acceptance
Each inconvenience row shows an uppercase localized category label (e.g. 'LOGISTICS', 'SAFETY') above its description text; safety and scam rows render in red while all others stay amber. VoiceOver still announces each row as a single grouped element using the existing 'Heads up: <category> — <text>' label (unchanged from #213). `xcodebuild build` and the existing SoloCompassTests pass; the section renders correctly in both light and dark mode in the Simulator.