### PR TITLE
auto: Add a one-tap Directions action to the experience detail action bar

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -163,6 +163,7 @@
 /* Action bar */
 "action.favorite" = "Add to favorites";
 "action.unfavorite" = "Remove from favorites";
+"action.directions" = "Directions";
 "action.close" = "Close";
 
 /* Dismiss */

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -127,6 +127,7 @@
 /* Action bar */
 "action.favorite" = "添加到收藏";
 "action.unfavorite" = "取消收藏";
+"action.directions" = "导航";
 "action.close" = "关闭";
 
 /* Dismiss */

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -19,6 +19,7 @@ public struct ExperienceDetailView: View {
     @State private var exportMarkdown: String? = nil
     @State private var heartPop = false
     @State private var celebrationTrigger = 0
+    @State private var isShowingNavPicker = false
 
     public init(
         viewModel: ExperienceDetailViewModel,
@@ -660,6 +661,20 @@ public struct ExperienceDetailView: View {
                 ? NSLocalizedString("action.unfavorite", comment: "Remove favorite")
                 : NSLocalizedString("action.favorite", comment: "Add favorite")))
 
+            if viewModel.experience.location.clCoordinate != nil {
+                Button {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    isShowingNavPicker = true
+                } label: {
+                    Image(systemName: "arrow.triangle.turn.up.right.diagonal")
+                        .font(.title3)
+                        .foregroundStyle(.primary)
+                        .frame(width: 50, height: 50)
+                        .background(Circle().fill(.regularMaterial))
+                }
+                .accessibilityLabel(Text(NSLocalizedString("action.directions", comment: "Open directions picker")))
+            }
+
             Button {
                 let wasCompleted = viewModel.isCompleted
                 viewModel.toggleComplete()
@@ -699,6 +714,23 @@ public struct ExperienceDetailView: View {
                 .ignoresSafeArea(edges: .bottom)
                 .opacity(0.6)
         )
+        .confirmationDialog(
+            NSLocalizedString("location.navigate", comment: ""),
+            isPresented: $isShowingNavPicker,
+            titleVisibility: .visible
+        ) {
+            if let coord = viewModel.experience.location.clCoordinate {
+                let name = viewModel.experience.location.placeNameLocal
+                    ?? viewModel.experience.location.placeNameRomanized
+                    ?? viewModel.experience.title
+                ForEach(NavigationLauncher.availableApps()) { app in
+                    Button(app.displayName) {
+                        NavigationLauncher.open(app: app, coordinate: coord, name: name)
+                    }
+                }
+            }
+            Button(NSLocalizedString("action.cancel", comment: "Cancel picker"), role: .cancel) { }
+        }
 
         CompletionCelebrationView(trigger: celebrationTrigger)
             .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Add a one-tap Directions action to the experience detail action bar

The persistent bottom action bar in ExperienceDetailView only offers Favorite and Mark Done — there is no way to launch turn-by-turn navigation without scrolling back up to the embedded LocationCard. For a map-first 'go do this thing' product, getting directions is the single most goal-aligned action, so it belongs in the always-visible action bar. This adds a circular Directions button (mirroring the Favorite button) that opens the existing nav-app confirmation dialog via NavigationLauncher.

### Acceptance
Opening any experience with a coordinate shows a Directions button in the bottom action bar; tapping it presents the nav-app picker and selecting an app launches walking directions to the experience. The button is hidden (or absent) for experiences with no coordinate. VoiceOver reads a 'Directions' label. Mark Done remains the primary full-width button. `xcodebuild build` and the existing SoloCompassTests pass; `pnpm parity:check` is unaffected (no schema change).