### PR TITLE
feat: upgrade LocationPickerSheet with custom city persistence and save flow

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */; };
 		45A4E8EED0300F00253EC049 /* MarkdownExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F3FDE4BC9458E490AEA67A /* MarkdownExporter.swift */; };
 		AA11BB22CC33DD44EE55FF77 /* AIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11BB22CC33DD44EE55FF66 /* AIProvider.swift */; };
+		DD55EE66FF77AA8807 /* SavedCity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD55EE66FF77AA8806 /* SavedCity.swift */; };
 		BB22CC33DD44EE55FF6600BB /* AIProviderSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB22CC33DD44EE55FF6600AA /* AIProviderSettingsView.swift */; };
 		464746A44182622D4F617462 /* AIUsageRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */; };
 		48DF01972A1FB107BFFF0684 /* QueryAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06086F5F9463C18F486E5694 /* QueryAgent.swift */; };
@@ -130,6 +131,7 @@
 
 /* Begin PBXContainerItemProxy section */
 		2C6D32C9538461241D786D7D /* PBXContainerItemProxy */ = {
+		DD55EE66FF77AA8809 /* CustomCityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD55EE66FF77AA8808 /* CustomCityStore.swift */; };
 			isa = PBXContainerItemProxy;
 			containerPortal = 75685F3A029520F918427CD0 /* Project object */;
 			proxyType = 1;
@@ -264,6 +266,8 @@
 		3CBB5430693D4A01BFC85AF2 /* CompletionCelebrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionCelebrationView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+			DD55EE66FF77AA8806 /* SavedCity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedCity.swift; sourceTree = "<group>"; };
+			DD55EE66FF77AA8808 /* CustomCityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCityStore.swift; sourceTree = "<group>"; };
 /* Begin PBXFrameworksBuildPhase section */
 		760FFA2394573B6BC3FB8434 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -420,6 +424,7 @@
 				DD55EE66FF77AA8800 /* LocationPickerState.swift */,
 				F63FDD874A8F533F0717132A /* UserPreferences.swift */,
 			);
+				DD55EE66FF77AA8806 /* SavedCity.swift */,
 			path = Models;
 			sourceTree = "<group>";
 		};
@@ -463,6 +468,7 @@
 				20208D92E4F564C474E8AEED /* VoiceAgentToolRouter.swift */,
 				120FC7465285714C5FA8F96D /* VoiceService.swift */,
 				7A49D3BA616DE54B8E6F4B7C /* Agents */,
+				DD55EE66FF77AA8808 /* CustomCityStore.swift */,
 				CD349A8744520E6EB084B41A /* Cache */,
 				4889864C3C5478D1001C73B3 /* Context */,
 				7E78DD425BF25E90036C6E0B /* Themes */,
@@ -774,6 +780,7 @@
 				3AA7B0463C3B8084D954C3AA /* ChatStateModifier.swift in Sources */,
 				9D81327AE55FA8142F9E5B8D /* ChatUIState.swift in Sources */,
 				397C20402788F9B63F06A01A /* City.swift in Sources */,
+				DD55EE66FF77AA8807 /* SavedCity.swift in Sources */,
 				7D2B6DE6C27E0307CA998A5F /* CityPickerSheet.swift in Sources */,
 				C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */,
 				CC00AA11BB22CC33DD44EE66 /* CompletionCelebrationView.swift in Sources */,
@@ -807,6 +814,7 @@
 				CC33DD44EE55FF6600AA11DD /* LocationPickerSheet.swift in Sources */,
 				DD55EE66FF77AA8801 /* LocationPickerState.swift in Sources */,
 				DD55EE66FF77AA8803 /* LocationSearchService.swift in Sources */,
+				DD55EE66FF77AA8809 /* CustomCityStore.swift in Sources */,
 				31F9538643C362D7EEF64C6B /* LocationService.swift in Sources */,
 				A75EEA586481D5A86B7FCFDA /* MapKitPOIService.swift in Sources */,
 				CE1A6A1D5EB25B2BEA5B29DA /* MapViewModel.swift in Sources */,

--- a/apps/ios/SoloCompass/Models/LocationPickerState.swift
+++ b/apps/ios/SoloCompass/Models/LocationPickerState.swift
@@ -30,12 +30,28 @@ final class LocationPickerState {
     var isSearching: Bool = false
     var searchError: String?
 
+    /// Item pending the "save as city?" confirmation.
+    var pendingSaveItem: MKMapItem?
+    /// True while the save-name alert for a search result is shown.
+    var isShowingSaveSearchAlert: Bool = false
+    /// Editable name field inside the save alert.
+    var saveNameText: String = ""
+    /// Ephemeral success confirmation (checkmark animation).
+    var searchSaveConfirmed: Bool = false
+
     // MARK: Map tab
     var pinCoordinate: CLLocationCoordinate2D
     var manualLatText: String = ""
     var manualLonText: String = ""
     var resolvedCityName: String?
     var isResolving: Bool = false
+
+    /// True while the save-name alert for the map pin is shown.
+    var isShowingSaveMapAlert: Bool = false
+    /// Editable name for saving the map location.
+    var mapSaveNameText: String = ""
+    /// Ephemeral success confirmation after saving from map tab.
+    var mapSaveConfirmed: Bool = false
 
     init(initialCoordinate: CLLocationCoordinate2D) {
         self.pinCoordinate = initialCoordinate
@@ -49,6 +65,7 @@ final class LocationPickerState {
         manualLatText = String(format: "%.4f", coordinate.latitude)
         manualLonText = String(format: "%.4f", coordinate.longitude)
         resolvedCityName = nil
+        mapSaveConfirmed = false
     }
 
     /// Parse text fields → coordinate. Returns nil if either field is invalid.

--- a/apps/ios/SoloCompass/Models/SavedCity.swift
+++ b/apps/ios/SoloCompass/Models/SavedCity.swift
@@ -1,0 +1,16 @@
+import Foundation
+import CoreLocation
+
+/// A user-created city persisted across launches via CustomCityStore.
+struct SavedCity: Codable, Identifiable, Hashable {
+    let id: String          // "custom_{uuid}"
+    var name: String
+    var latitude: Double
+    var longitude: Double
+    var countryCode: String?
+    var dateAdded: Date
+
+    var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+}

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -605,3 +605,42 @@
 
 "ai.provider.status.configured" = "AI is configured with %@";
 "ai.provider.status.unconfigured" = "AI features require an API key";
+
+/* Location picker — custom cities */
+"locationPicker.cities.addCity" = "Add custom city";
+"locationPicker.cities.section.places" = "Places with Experiences";
+"locationPicker.cities.section.saved" = "Saved Locations";
+"locationPicker.cities.saved.subtitle" = "Saved location";
+
+/* Location picker — search tab save flow */
+"locationPicker.search.saveCity.title" = "Save as Custom City";
+"locationPicker.search.saveCity.message" = "This city will appear in your Saved Locations list.";
+"locationPicker.search.saveCity.namePlaceholder" = "City name";
+"locationPicker.search.saveCity.save" = "Save";
+"locationPicker.search.saveCity.swipe" = "Save City";
+"locationPicker.search.saveCity.confirmed" = "City saved!";
+
+/* Location picker — map tab save flow */
+"locationPicker.map.saveCity.title" = "Name This Location";
+"locationPicker.map.saveCity.message" = "Saved locations appear in your Cities list for quick access.";
+"locationPicker.map.saveCity.namePlaceholder" = "Location name";
+"locationPicker.map.saveCity.save" = "Save & Set";
+"locationPicker.map.saveAndSet" = "Save & Set Location";
+"locationPicker.map.saveCity.confirmed" = "Location saved!";
+
+/* Location picker — general UI */
+"locationPicker.picker.a11y" = "Location type";
+"locationPicker.title" = "Choose Location";
+"locationPicker.tab.cities" = "Cities";
+"locationPicker.tab.search" = "Search";
+"locationPicker.tab.map" = "Map";
+"locationPicker.cities.searchPrompt" = "Search cities";
+"locationPicker.search.prompt" = "City, place, or address";
+"locationPicker.search.error.title" = "Search failed";
+"locationPicker.map.lat" = "Latitude";
+"locationPicker.map.lon" = "Longitude";
+"locationPicker.map.applyCoords" = "Move pin to these coordinates";
+"locationPicker.map.resolving" = "Resolving…";
+"locationPicker.map.resolved" = "Resolved: %@";
+"locationPicker.map.setLocation" = "Use without saving";
+"locationPicker.custom.fallbackName" = "Custom location";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -470,3 +470,42 @@
 
 /* Map preview in exports (US-020) */
 "settings.exportMapPreview" = "导出时包含地图预览";
+
+/* Location picker — custom cities */
+"locationPicker.cities.addCity" = "添加自定义城市";
+"locationPicker.cities.section.places" = "有体验的地点";
+"locationPicker.cities.section.saved" = "已保存的位置";
+"locationPicker.cities.saved.subtitle" = "已保存的位置";
+
+/* Location picker — search tab save flow */
+"locationPicker.search.saveCity.title" = "保存为自定义城市";
+"locationPicker.search.saveCity.message" = "该城市将出现在您的已保存位置列表中。";
+"locationPicker.search.saveCity.namePlaceholder" = "城市名称";
+"locationPicker.search.saveCity.save" = "保存";
+"locationPicker.search.saveCity.swipe" = "保存城市";
+"locationPicker.search.saveCity.confirmed" = "城市已保存！";
+
+/* Location picker — map tab save flow */
+"locationPicker.map.saveCity.title" = "命名此位置";
+"locationPicker.map.saveCity.message" = "已保存的位置将出现在您的城市列表中，方便快速访问。";
+"locationPicker.map.saveCity.namePlaceholder" = "位置名称";
+"locationPicker.map.saveCity.save" = "保存并设置";
+"locationPicker.map.saveAndSet" = "保存并设置位置";
+"locationPicker.map.saveCity.confirmed" = "位置已保存！";
+
+/* Location picker — general UI */
+"locationPicker.picker.a11y" = "位置类型";
+"locationPicker.title" = "选择位置";
+"locationPicker.tab.cities" = "城市";
+"locationPicker.tab.search" = "搜索";
+"locationPicker.tab.map" = "地图";
+"locationPicker.cities.searchPrompt" = "搜索城市";
+"locationPicker.search.prompt" = "城市、地点或地址";
+"locationPicker.search.error.title" = "搜索失败";
+"locationPicker.map.lat" = "纬度";
+"locationPicker.map.lon" = "经度";
+"locationPicker.map.applyCoords" = "将图钉移到这些坐标";
+"locationPicker.map.resolving" = "正在解析…";
+"locationPicker.map.resolved" = "已解析：%@";
+"locationPicker.map.setLocation" = "不保存直接使用";
+"locationPicker.custom.fallbackName" = "自定义位置";

--- a/apps/ios/SoloCompass/Services/CustomCityStore.swift
+++ b/apps/ios/SoloCompass/Services/CustomCityStore.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class CustomCityStore {
+    static let shared = CustomCityStore()
+
+    private let key = "saved_custom_cities"
+
+    private(set) var cities: [SavedCity] = []
+
+    private init() { load() }
+
+    func load() {
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let decoded = try? JSONDecoder().decode([SavedCity].self, from: data) else { return }
+        cities = decoded
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(cities) else { return }
+        UserDefaults.standard.set(data, forKey: key)
+    }
+
+    func add(_ city: SavedCity) {
+        cities.removeAll { $0.id == city.id }
+        cities.insert(city, at: 0)
+        persist()
+    }
+
+    func remove(id: String) {
+        cities.removeAll { $0.id == id }
+        persist()
+    }
+
+    func remove(at offsets: IndexSet) {
+        cities.remove(atOffsets: offsets)
+        persist()
+    }
+}

--- a/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
@@ -3,18 +3,18 @@ import MapKit
 import CoreLocation
 
 /// Rich location picker that replaces `CityPickerSheet`.
-/// Three tabs: Cities (browse / search preset cities), Search (forward
-/// geocoding via MKLocalSearch), Map (drag-a-pin or type coordinates).
+/// Three tabs: Cities (browse / search preset + custom cities), Search
+/// (forward geocoding via MKLocalSearch + save-as-city flow), Map
+/// (drag-a-pin or type coordinates + save-as-city flow).
 struct LocationPickerSheet: View {
     @Bindable var viewModel: MapViewModel
     let onDismiss: () -> Void
 
-    /// `@State` holds the `@Observable` state object.
-    /// Bindings to its properties are created via `@Bindable` inside body.
     @State private var state: LocationPickerState
     @State private var searchService = LocationSearchService()
     @State private var searchDebounceTask: Task<Void, Never>? = nil
     @State private var userLocation: CLLocation?
+    @State private var customCityStore = CustomCityStore.shared
 
     init(viewModel: MapViewModel, onDismiss: @escaping () -> Void) {
         self.viewModel = viewModel
@@ -24,7 +24,6 @@ struct LocationPickerSheet: View {
     }
 
     var body: some View {
-        // @Bindable gives us `$bs.*` bindings into the @Observable state object.
         @Bindable var bs = state
         NavigationStack {
             VStack(spacing: 0) {
@@ -51,6 +50,16 @@ struct LocationPickerSheet: View {
             .navigationTitle(NSLocalizedString("locationPicker.title", comment: "Location picker title"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    if state.selectedTab == .cities {
+                        Button {
+                            state.selectedTab = .search
+                        } label: {
+                            Image(systemName: "plus")
+                                .accessibilityLabel(NSLocalizedString("locationPicker.cities.addCity", comment: "Add custom city"))
+                        }
+                    }
+                }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button(NSLocalizedString("common.cancel", comment: "Cancel")) {
                         onDismiss()
@@ -67,6 +76,40 @@ struct LocationPickerSheet: View {
             searchService.cancelAll()
             searchDebounceTask?.cancel()
         }
+        // Save-city alert for Search tab
+        .alert(
+            NSLocalizedString("locationPicker.search.saveCity.title", comment: "Save as custom city"),
+            isPresented: $bs.isShowingSaveSearchAlert
+        ) {
+            TextField(
+                NSLocalizedString("locationPicker.search.saveCity.namePlaceholder", comment: "City name"),
+                text: $bs.saveNameText
+            )
+            Button(NSLocalizedString("locationPicker.search.saveCity.save", comment: "Save")) {
+                confirmSaveSearchResult()
+            }
+            Button(NSLocalizedString("common.cancel", comment: "Cancel"), role: .cancel) {
+                state.pendingSaveItem = nil
+            }
+        } message: {
+            Text(NSLocalizedString("locationPicker.search.saveCity.message", comment: "This city will appear in your Cities list."))
+        }
+        // Save-city alert for Map tab
+        .alert(
+            NSLocalizedString("locationPicker.map.saveCity.title", comment: "Name this location"),
+            isPresented: $bs.isShowingSaveMapAlert
+        ) {
+            TextField(
+                NSLocalizedString("locationPicker.map.saveCity.namePlaceholder", comment: "Location name"),
+                text: $bs.mapSaveNameText
+            )
+            Button(NSLocalizedString("locationPicker.map.saveCity.save", comment: "Save & Set")) {
+                confirmSaveMapLocation()
+            }
+            Button(NSLocalizedString("common.cancel", comment: "Cancel"), role: .cancel) {}
+        } message: {
+            Text(NSLocalizedString("locationPicker.map.saveCity.message", comment: "Saved cities appear in your Cities list for quick access."))
+        }
     }
 
     // MARK: - Cities Tab
@@ -74,6 +117,7 @@ struct LocationPickerSheet: View {
     @ViewBuilder
     private func citiesContent(bs: Bindable<LocationPickerState>) -> some View {
         List {
+            // "All Cities" row
             Button {
                 commitHaptic()
                 viewModel.selectCity(nil)
@@ -92,27 +136,65 @@ struct LocationPickerSheet: View {
                 }
             }
 
-            ForEach(filteredCities, id: \.code) { city in
-                Button {
-                    commitHaptic()
-                    viewModel.selectCity(city.code)
-                    onDismiss()
-                } label: {
-                    CityRow(
-                        name: city.name,
-                        experienceCount: viewModel.experienceCount(for: city.code),
-                        distanceLabel: distanceLabel(for: city.center),
-                        isSelected: viewModel.selectedCity == city.code
-                    )
+            // Seed-derived cities
+            let seed = filteredCities
+            if !seed.isEmpty {
+                Section(NSLocalizedString("locationPicker.cities.section.places", comment: "Places with experiences")) {
+                    ForEach(seed, id: \.code) { city in
+                        Button {
+                            commitHaptic()
+                            viewModel.selectCity(city.code)
+                            onDismiss()
+                        } label: {
+                            CityRow(
+                                name: city.name,
+                                icon: "mappin",
+                                experienceCount: viewModel.experienceCount(for: city.code),
+                                distanceLabel: distanceLabel(for: city.center),
+                                isSelected: viewModel.selectedCity == city.code
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Custom saved cities
+            let custom = filteredCustomCities
+            if !custom.isEmpty {
+                Section(NSLocalizedString("locationPicker.cities.section.saved", comment: "Saved locations")) {
+                    ForEach(custom) { saved in
+                        Button {
+                            commitHaptic()
+                            viewModel.selectCustomLocation(
+                                coordinate: saved.coordinate,
+                                label: saved.name,
+                                cityCode: saved.id
+                            )
+                            onDismiss()
+                        } label: {
+                            CityRow(
+                                name: saved.name,
+                                icon: "pin.fill",
+                                experienceCount: nil,
+                                distanceLabel: distanceLabel(for: saved.coordinate),
+                                isSelected: viewModel.selectedCity == saved.id
+                            )
+                        }
+                    }
+                    .onDelete { offsets in
+                        let idsToDelete = offsets.map { custom[$0].id }
+                        for id in idsToDelete { customCityStore.remove(id: id) }
+                    }
                 }
             }
         }
-        .listStyle(.plain)
+        .listStyle(.insetGrouped)
         .searchable(
             text: bs.citySearchQuery,
             placement: .navigationBarDrawer(displayMode: .always),
             prompt: NSLocalizedString("locationPicker.cities.searchPrompt", comment: "Search cities")
         )
+        .animation(.easeInOut(duration: 0.2), value: customCityStore.cities.count)
     }
 
     private var filteredCities: [(code: String, name: String, center: CLLocationCoordinate2D)] {
@@ -120,6 +202,13 @@ struct LocationPickerSheet: View {
         guard !state.citySearchQuery.isEmpty else { return cities }
         let query = state.citySearchQuery.lowercased()
         return cities.filter { $0.name.lowercased().contains(query) }
+    }
+
+    private var filteredCustomCities: [SavedCity] {
+        let all = customCityStore.cities
+        guard !state.citySearchQuery.isEmpty else { return all }
+        let query = state.citySearchQuery.lowercased()
+        return all.filter { $0.name.lowercased().contains(query) }
     }
 
     private var sortedCities: [(code: String, name: String, center: CLLocationCoordinate2D)] {
@@ -173,6 +262,18 @@ struct LocationPickerSheet: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 10)
 
+            if state.searchSaveConfirmed {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Text(NSLocalizedString("locationPicker.search.saveCity.confirmed", comment: "City saved!"))
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.green)
+                }
+                .padding(.vertical, 6)
+                .transition(.move(edge: .top).combined(with: .opacity))
+            }
+
             Divider()
 
             if let error = state.searchError {
@@ -192,10 +293,22 @@ struct LocationPickerSheet: View {
                     } label: {
                         SearchResultRow(item: item)
                     }
+                    .swipeActions(edge: .trailing) {
+                        Button {
+                            promptSaveSearchResult(item)
+                        } label: {
+                            Label(
+                                NSLocalizedString("locationPicker.search.saveCity.swipe", comment: "Save city"),
+                                systemImage: "pin.fill"
+                            )
+                        }
+                        .tint(.indigo)
+                    }
                 }
                 .listStyle(.plain)
             }
         }
+        .animation(.easeInOut(duration: 0.3), value: state.searchSaveConfirmed)
     }
 
     // MARK: - Map Tab
@@ -250,6 +363,17 @@ struct LocationPickerSheet: View {
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
+                    } else if state.mapSaveConfirmed {
+                        HStack(spacing: 6) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                                .font(.title3)
+                                .symbolEffect(.bounce, value: state.mapSaveConfirmed)
+                            Text(NSLocalizedString("locationPicker.map.saveCity.confirmed", comment: "Location saved!"))
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(.green)
+                        }
+                        .transition(.scale.combined(with: .opacity))
                     } else if let name = state.resolvedCityName {
                         HStack(spacing: 6) {
                             Image(systemName: "checkmark.circle.fill")
@@ -266,18 +390,37 @@ struct LocationPickerSheet: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 16)
+                .animation(.easeInOut(duration: 0.3), value: state.mapSaveConfirmed)
 
-                Button {
-                    commitMapLocation()
-                } label: {
-                    Text(NSLocalizedString("locationPicker.map.setLocation", comment: "Set this location on the map"))
+                VStack(spacing: 10) {
+                    // Primary: save + set
+                    Button {
+                        promptSaveMapLocation()
+                    } label: {
+                        Label(
+                            NSLocalizedString("locationPicker.map.saveAndSet", comment: "Save & set this location"),
+                            systemImage: "pin.fill"
+                        )
                         .font(.headline)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 4)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .padding(.horizontal, 16)
+
+                    // Secondary: just use it without saving
+                    Button {
+                        commitMapLocation()
+                    } label: {
+                        Text(NSLocalizedString("locationPicker.map.setLocation", comment: "Use without saving"))
+                            .font(.subheadline)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.regular)
+                    .padding(.horizontal, 16)
                 }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-                .padding(.horizontal, 16)
                 .padding(.bottom, 24)
             }
             .padding(.top, 12)
@@ -287,6 +430,7 @@ struct LocationPickerSheet: View {
     // MARK: - Actions
 
     private func commitHaptic() { UIImpactFeedbackGenerator(style: .light).impactOccurred() }
+    private func successHaptic() { UINotificationFeedbackGenerator().notificationOccurred(.success) }
 
     private func selectSearchResult(_ item: MKMapItem) {
         commitHaptic()
@@ -301,6 +445,73 @@ struct LocationPickerSheet: View {
             cityCode: customCode(for: coord)
         )
         onDismiss()
+    }
+
+    private func promptSaveSearchResult(_ item: MKMapItem) {
+        let name = item.name
+            ?? item.placemark.locality
+            ?? item.placemark.administrativeArea
+            ?? ""
+        state.pendingSaveItem = item
+        state.saveNameText = name
+        state.isShowingSaveSearchAlert = true
+    }
+
+    private func confirmSaveSearchResult() {
+        guard let item = state.pendingSaveItem else { return }
+        let name = state.saveNameText.trimmingCharacters(in: .whitespaces)
+        guard !name.isEmpty else { return }
+
+        let coord = item.placemark.coordinate
+        let city = SavedCity(
+            id: "custom_\(UUID().uuidString)",
+            name: name,
+            latitude: coord.latitude,
+            longitude: coord.longitude,
+            countryCode: item.placemark.countryCode,
+            dateAdded: Date()
+        )
+        customCityStore.add(city)
+        state.pendingSaveItem = nil
+        successHaptic()
+
+        withAnimation { state.searchSaveConfirmed = true }
+        Task {
+            try? await Task.sleep(for: .seconds(2))
+            withAnimation { state.searchSaveConfirmed = false }
+        }
+    }
+
+    private func promptSaveMapLocation() {
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        let name = state.resolvedCityName
+            ?? String(format: "%.4f, %.4f", state.pinCoordinate.latitude, state.pinCoordinate.longitude)
+        state.mapSaveNameText = name
+        state.isShowingSaveMapAlert = true
+    }
+
+    private func confirmSaveMapLocation() {
+        let name = state.mapSaveNameText.trimmingCharacters(in: .whitespaces)
+        guard !name.isEmpty else { return }
+
+        let coord = state.pinCoordinate
+        let city = SavedCity(
+            id: "custom_\(UUID().uuidString)",
+            name: name,
+            latitude: coord.latitude,
+            longitude: coord.longitude,
+            countryCode: nil,
+            dateAdded: Date()
+        )
+        customCityStore.add(city)
+        successHaptic()
+
+        withAnimation { state.mapSaveConfirmed = true }
+        Task {
+            try? await Task.sleep(for: .seconds(1.5))
+            viewModel.selectCustomLocation(coordinate: coord, label: name, cityCode: city.id)
+            onDismiss()
+        }
     }
 
     private func commitMapLocation() {
@@ -390,22 +601,34 @@ struct LocationPickerSheet: View {
 
 private struct CityRow: View {
     let name: String
-    let experienceCount: Int
+    let icon: String
+    let experienceCount: Int?
     let distanceLabel: String
     let isSelected: Bool
 
     var body: some View {
-        HStack {
+        HStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.caption)
+                .foregroundStyle(experienceCount != nil ? .tint : .indigo)
+                .frame(width: 18)
+
             VStack(alignment: .leading, spacing: 2) {
                 Text(name)
                     .font(.headline)
                     .foregroundStyle(.primary)
-                Text(String(
-                    format: NSLocalizedString("city.experienceCount", comment: "Experience count in city"),
-                    experienceCount
-                ))
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+                if let count = experienceCount {
+                    Text(String(
+                        format: NSLocalizedString("city.experienceCount", comment: "Experience count in city"),
+                        count
+                    ))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                } else {
+                    Text(NSLocalizedString("locationPicker.cities.saved.subtitle", comment: "Saved location"))
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
             }
             Spacer()
             VStack(alignment: .trailing, spacing: 2) {


### PR DESCRIPTION
## 升级 LocationPickerSheet — 增强城市/位置选择功能

### 新功能

**1️⃣ 自定义城市持久化 (CustomCityStore)**
- 新增  模型 + （UserDefaults 持久化）
- 用户手动添加的城市在重启后保留

**2️⃣ 城市浏览 Tab (Cities) 增强**
- 分区显示："有经历的城市" + "已保存的位置"
- 自定义城市用 pin.fill 图标区分
- 滑动删除自定义城市
- 搜索过滤同时作用于两种城市

**3️⃣ 搜索 Tab (Search) 增强**
- 搜索结果支持滑动（swipe）→ 保存为自定义城市
- 保存前弹出命名弹窗（alert），预填充城市名
- 保存后有绿色 ✓ 动画 + 触感反馈

**4️⃣ 地图 Tab (Map) 增强**
- 主按钮："保存并设置位置"（带命名弹窗 → 保存到 CustomCityStore → 设置）
- 次按钮："使用但不保存"（直接选择，不保存）
- 保存后有弹跳 ✓ 动画

**5️⃣ 工具栏 + 按钮**
- 城市 Tab 左上角 + 号 → 一键切换到搜索 Tab

### 代码变更
- 新文件: , 
- 修改: , ,  (en + zh-Hans)
- pbxproj: 添加新文件