### PR TITLE
fix(ios): repair broken Swift that failed the TestFlight release build

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -15,6 +15,8 @@ public struct ExperienceCardView: View {
 
     @GestureState private var dragState = DragState()
     @State private var dragOffset: CGFloat = 0
+    @State private var heartBounce = 0
+    @State private var heartBurst = false
 
     private enum HapticState { case idle, prepared, fired }
 
@@ -37,7 +39,7 @@ public struct ExperienceCardView: View {
     private static let distanceFormatter: MeasurementFormatter = {
         let f = MeasurementFormatter()
         f.unitOptions = .naturalScale
-        f.unitStyle = .abbreviated
+        f.unitStyle = .short
         f.numberFormatter.maximumFractionDigits = 1
         return f
     }()
@@ -155,7 +157,7 @@ public struct ExperienceCardView: View {
                 if !experience.realInconveniences.isEmpty {
                     inconveniencePill
                 } else if experience.isBestNow() {
-                    bestNowBadge
+                    BestNowBadge()
                 } else if let hint = experience.bestTimeHint() {
                     bestTimeHintPill(hint)
                 }
@@ -202,6 +204,7 @@ public struct ExperienceCardView: View {
                     } else {
                         withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
                             dragOffset = 0
+                        }
                     }
                 }
         )
@@ -289,8 +292,7 @@ public struct ExperienceCardView: View {
             .background(Capsule().fill(tint.opacity(0.12)))
         }
     }
-
-    }
+}
 
 // MARK: - BestNowBadge
 

--- a/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
@@ -610,7 +610,7 @@ private struct CityRow: View {
         HStack(spacing: 10) {
             Image(systemName: icon)
                 .font(.caption)
-                .foregroundStyle(experienceCount != nil ? .tint : .indigo)
+                .foregroundStyle(experienceCount != nil ? Color.accentColor : Color.indigo)
                 .frame(width: 18)
 
             VStack(alignment: .leading, spacing: 2) {

--- a/apps/ios/SoloCompass/Views/Map/MarkerIconView.swift
+++ b/apps/ios/SoloCompass/Views/Map/MarkerIconView.swift
@@ -284,7 +284,7 @@ private struct ObsidianDotGridMarker: View {
         ("upcoming 47", .upcoming(minutes: 47)),
         ("footprinted", .footprinted),
     ]
-    return ScrollView {
+    ScrollView {
         VStack(alignment: .leading, spacing: 16) {
             Text("Reduce Motion OFF").font(.caption.bold()).padding(.horizontal)
             ForEach(states, id: \.0) { name, state in
@@ -310,7 +310,6 @@ private struct ObsidianDotGridMarker: View {
                     Text(name).frame(width: 120, alignment: .leading)
                     ForEach(ExperienceCategory.allCases) { cat in
                         MarkerIconView(category: cat, state: state)
-                            .environment(\.accessibilityReduceMotion, true)
                     }
                 }
             }
@@ -318,7 +317,6 @@ private struct ObsidianDotGridMarker: View {
                 Text("selected").frame(width: 120, alignment: .leading)
                 ForEach(ExperienceCategory.allCases) { cat in
                     MarkerIconView(category: cat, state: .default, isSelected: true)
-                        .environment(\.accessibilityReduceMotion, true)
                 }
             }
         }

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -17,7 +17,6 @@ public struct FavoritesListView: View {
     @State private var animatePulse = false
     @State private var undoProgress: CGFloat = 1
     @State private var undoDragOffset: CGFloat = 0
-    @State private var undoDragOffset: CGFloat = 0
     @State private var undoDragCrossedThreshold = false
     @State private var searchText = ""
     @State private var sortMode: FavSort = .recent
@@ -187,9 +186,9 @@ public struct FavoritesListView: View {
             if isNil { undoDragOffset = 0 }
         }
     }
-
 }
 
+private struct EmptyFavoritesView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isBreathing = false
 
@@ -382,11 +381,11 @@ private extension FavoritesListView {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(2)
-                    if let meters = distanceMeters(for: exp) {
+                    if let distStr {
                         HStack(spacing: 3) {
                             Image(systemName: "location.fill")
                                 .font(.system(size: 9))
-                            Text(distanceBadgeText(meters))
+                            Text(distStr)
                                 .font(.caption2)
                                 .monospacedDigit()
                         }
@@ -438,7 +437,6 @@ private extension FavoritesListView {
             }
         }
     }
-}
 }
 
 #Preview {

--- a/apps/ios/SoloCompass/Views/Shared/OfflineBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/OfflineBanner.swift
@@ -56,5 +56,4 @@ struct OfflineBanner: View {
         OfflineBanner()
             .padding(.top, 60)
     }
-    .environment(\.accessibilityReduceMotion, true)
 }

--- a/apps/ios/SoloCompass/Views/Shared/SkeletonView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SkeletonView.swift
@@ -110,7 +110,6 @@ extension View {
         SkeletonView(lineCount: 4, widthFractions: [1.0, 0.85, 0.9, 0.5])
     }
     .padding()
-    .environment(\.accessibilityReduceMotion, true)
 }
 
 #Preview("3-line text skeleton") {

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -91,7 +91,7 @@ public struct SoloScoreBadge: View {
         hint: "Order at the bar, sit upstairs.",
         basedOnCount: 14
     )
-    return VStack(spacing: 24) {
+    VStack(spacing: 24) {
         SoloScoreBadge(score: score, style: .compact)
         SoloScoreBadge(score: score, style: .full)
             .padding()

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
@@ -289,7 +289,7 @@ public struct SoloScoreRadarChart: View {
         hint: "Great seating and safety, but noisy and few solo patrons.",
         basedOnCount: 22
     )
-    return VStack(spacing: 24) {
+    VStack(spacing: 24) {
         Text("Radar Chart (high variance) — tap to replay, dots at vertices")
             .font(.headline)
             .multilineTextAlignment(.center)
@@ -316,7 +316,7 @@ public struct SoloScoreRadarChart: View {
         hint: "Consistently excellent across all dimensions.",
         basedOnCount: 14
     )
-    return VStack(spacing: 24) {
+    VStack(spacing: 24) {
         Text("Fallback Bars (low variance) — tap to replay")
             .font(.headline)
         SoloScoreRadarChart(score: lowVariance)


### PR DESCRIPTION
The TestFlight (Release) build on main was failing to compile while the Debug iOS CI reported success — Debug almost certainly reused cached object files and never recompiled the damaged sources. A clean Release compile surfaces a chain of errors that auto-dev commits had left on main:

Structural damage (brace/declaration corruption):
- ExperienceCardView: unbalanced .gesture(onEnded:) closure; missing @State heartBounce/heartBurst; bestNowBadge typo'd (now BestNowBadge()); stray brace on the struct's closing line.
- FavoritesListView: duplicate undoDragOffset @State, missing EmptyFavoritesView struct header, an extra top-level }, and a dead distanceBadgeText(_:) call (now uses the already-computed distStr).

iOS 26 SDK incompatibilities (masked by the cache until now):
- MeasurementFormatter.unitStyle .abbreviated -> .short (no such member).
- .environment(\.accessibilityReduceMotion, true) removed from previews — the key is now a read-only (non-writable) environment value.
- Explicit return removed from #Preview ViewBuilder closures (MarkerIconView, SoloScoreBadge, SoloScoreRadarChart).
- CityRow foregroundStyle ternary mixed TintShapeStyle with Color; unified to Color.accentColor / Color.indigo.

Verified with a clean Debug build (xcodebuild clean build) on iPhone 17 Pro / latest. project.pbxproj intentionally left unchanged — CI regenerates it from project.yml via xcodegen.

<!--
Thanks for the PR. Read CONTRIBUTING.md and CLAUDE.md if you haven't.
Skip sections that don't apply.
-->

## What

<!-- One sentence: what does this PR change? -->

## Why

<!-- One paragraph: what problem does this solve? Link the issue. -->

Closes #

## Three-pillar check

Before merging, confirm this change respects:

- [ ] **Map-First** — does not move users away from the map without strong reason
- [ ] **Experience-as-Unit** — does not introduce "place" / "POI" concepts at the domain level
- [ ] **AI doesn't decide** — recommendations remain options + reasons, not single answers

If any is violated, explain in **Why** above why an exception is justified.

## Schema impact

<!-- Did you add/remove/rename a field in packages/core? If yes, the iOS app must mirror. -->

- [ ] No schema change
- [ ] Schema changed — updated TS schema in `packages/core/` to match Swift changes (or vice-versa)
- [ ] Schema changed; iOS parity tracking issue: #

## Testing

<!-- How did you verify? -->

## Screenshots / video

<!-- If UI change. -->
