### PR TITLE
fix: rename duplicate Geohash.swift to GeohashUtils.swift (TestFlight build)

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -49,7 +49,7 @@
 		5C05B87EA78458094612AC01 /* BottomInfoBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13350B81187FB64B252B8A46 /* BottomInfoBar.swift */; };
 		615FCA91C2260950BFE3E4F3 /* ShareCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30705AFFEB819044661EC871 /* ShareCardView.swift */; };
 		62BB74EC16B92899A9A6A44C /* ReverseGeocodeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BDF8B4B7CC82F3845C5068 /* ReverseGeocodeService.swift */; };
-		63AC87E980EFFCFA0D628DF8 /* Geohash.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2289B2A2C8AFA32991B2348 /* Geohash.swift */; };
+		63AC87E980EFFCFA0D628DF8 /* GeohashUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2289B2A2C8AFA32991B2348 /* GeohashUtils.swift */; };
 		641D80BD116D6F255A9ED26A /* PendingSyncRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A92E0AE1868C3A165F3E95 /* PendingSyncRecord.swift */; };
 		65E57E8B02E7889BD8EE8DD4 /* ContextManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1F5F43F42E03BA5F10FA2F /* ContextManager.swift */; };
 		6AA87132BC6ACDDDC6D98735 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF007DB5F72E30021CADA555 /* NetworkMonitor.swift */; };
@@ -214,7 +214,7 @@
 		9A1B839F9F82AFDD50655AAE /* SystemTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemTheme.swift; sourceTree = "<group>"; };
 		9E8ABF85EEFDF9969C94B441 /* VoiceButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceButton.swift; sourceTree = "<group>"; };
 		A1F76E8EBB87A2F70FEA1BB0 /* ExploreCacheRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreCacheRecord.swift; sourceTree = "<group>"; };
-		A2289B2A2C8AFA32991B2348 /* Geohash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Geohash.swift; sourceTree = "<group>"; };
+		A2289B2A2C8AFA32991B2348 /* GeohashUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeohashUtils.swift; sourceTree = "<group>"; };
 		A250916F91C8EF0BE90DF763 /* ExperienceRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceRepository.swift; sourceTree = "<group>"; };
 		A38E5736BF6DF5644D687637 /* AgentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRouter.swift; sourceTree = "<group>"; };
 		A5435FBA9527C07A9FB07D46 /* SoloCompassModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassModelContainer.swift; sourceTree = "<group>"; };
@@ -606,7 +606,7 @@
 		CD349A8744520E6EB084B41A /* Cache */ = {
 			isa = PBXGroup;
 			children = (
-				A2289B2A2C8AFA32991B2348 /* Geohash.swift */,
+				A2289B2A2C8AFA32991B2348 /* GeohashUtils.swift */,
 			);
 			path = Cache;
 			sourceTree = "<group>";
@@ -804,7 +804,7 @@
 				297541149234668D12EAF272 /* FilterBarView.swift in Sources */,
 				E611DCAFD85FC84D6BF6CADD /* FoursquareService.swift in Sources */,
 				391D6B5C48997AD74F367C0C /* GeneratedSecrets.swift in Sources */,
-				63AC87E980EFFCFA0D628DF8 /* Geohash.swift in Sources */,
+				63AC87E980EFFCFA0D628DF8 /* GeohashUtils.swift in Sources */,
 				73A99E8CB82341F557681FCF /* GlassmorphismCapsule.swift in Sources */,
 				FD3636FCB777A292C57B7B06 /* GuideAgent.swift in Sources */,
 				D28FA83853E30AF27C34876F /* IntentAgent.swift in Sources */,

--- a/apps/ios/SoloCompass/Services/Cache/GeohashUtils.swift
+++ b/apps/ios/SoloCompass/Services/Cache/GeohashUtils.swift
@@ -13,7 +13,7 @@ import Foundation
 ///     3 km radius.
 ///
 /// Zero third-party deps — pure Swift, deterministic.
-public enum Geohash {
+public enum GeohashUtils {
     /// Standard geohash base32 alphabet (no a/i/l/o to avoid look-alikes).
     private static let alphabet: [Character] = Array("0123456789bcdefghjkmnpqrstuvwxyz")
 


### PR DESCRIPTION
## Problem
TestFlight build (testflight.yml) fails with:
```
error: filename "Geohash.swift" used twice:
  'Services/Geohash.swift' and 'Services/Cache/Geohash.swift'
```

## Fix
- Renamed `Services/Cache/Geohash.swift` → `Services/Cache/GeohashUtils.swift`
- Updated internal enum from `Geohash` to `GeohashUtils`
- Updated all 4 pbxproj references (PBXBuildFile, PBXFileReference, PBXGroup, PBXSourcesBuildPhase)

## Verification
- Git detected 99% rename similarity
- Created on main branch, no conflicts