### PR TITLE
fix(ios): make CI compile the real source set + fix Companion build errors

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -56,6 +56,18 @@ jobs:
           sudo xcode-select -s "$XCODE_PATH"
           xcodebuild -version
 
+      # Regenerate the project from project.yml so CI compiles the exact same
+      # source set TestFlight does. The committed .xcodeproj drifts out of sync
+      # (xcodegen owns it — see CLAUDE.md), which previously let new files with
+      # compile errors pass CI while failing the TestFlight archive.
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate .xcodeproj
+        run: |
+          cd apps/ios
+          xcodegen generate --spec project.yml
+
       - name: Build iOS App
         run: |
           cd apps/ios

--- a/apps/ios/SoloCompass/Models/UserPreferences.swift
+++ b/apps/ios/SoloCompass/Models/UserPreferences.swift
@@ -347,6 +347,8 @@ public final class UserPreferences {
         self.companionLanguages = snapshot.companionLanguages
         self.companionVisibilityRaw = snapshot.companionVisibilityRaw
         self.activeCompanionPosts = snapshot.activeCompanionPosts
+        self.hasAcceptedCompanionConsent = snapshot.hasAcceptedCompanionConsent
+        self.companionConsentGivenAt = snapshot.companionConsentGivenAt
     }
 
     private static func load(from defaults: UserDefaults) -> Snapshot {

--- a/apps/ios/SoloCompass/Models/UserPreferences.swift
+++ b/apps/ios/SoloCompass/Models/UserPreferences.swift
@@ -539,6 +539,14 @@ public final class UserPreferences {
         exploreConsentGivenAt = nil
     }
 
+    /// Mark the companion safety consent sheet as accepted (US-020). Idempotent.
+    public func acceptCompanionConsent() {
+        hasAcceptedCompanionConsent = true
+        if companionConsentGivenAt == nil {
+            companionConsentGivenAt = Date()
+        }
+    }
+
     /// US-013: bump the Foursquare-fallback usage counter. Rolls the counter
     /// back to 1 (not 0 — we're recording *this* call) when the stored day
     /// stamp differs from the local-calendar start-of-day for `now`.

--- a/apps/ios/SoloCompass/Views/Companion/CompanionProfileView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/CompanionProfileView.swift
@@ -27,13 +27,13 @@ public struct CompanionProfileView: View {
     public init() {}
 
     public var body: some View {
-        var prefs = preferences
+        @Bindable var prefs = preferences
         NavigationStack {
             Form {
-                avatarSection(prefs: prefs)
-                bioSection(prefs: prefs)
-                languagesSection(prefs: prefs)
-                visibilitySection(prefs: prefs)
+                avatarSection(prefs: $prefs)
+                bioSection(prefs: $prefs)
+                languagesSection(prefs: $prefs)
+                visibilitySection(prefs: $prefs)
             }
             .navigationTitle(NSLocalizedString("companion.profile.title", comment: "Companion Profile nav title"))
             .navigationBarTitleDisplayMode(.large)

--- a/apps/ios/SoloCompass/Views/Companion/CompanionSafetyConsentSheet.swift
+++ b/apps/ios/SoloCompass/Views/Companion/CompanionSafetyConsentSheet.swift
@@ -170,7 +170,7 @@ public struct CompanionSafetyConsentSheet: View {
 
     private var consentButton: some View {
         Button {
-            preferences.isSafetyConsentAccepted = true
+            preferences.acceptCompanionConsent()
             onAccepted()
             dismiss()
         } label: {


### PR DESCRIPTION
## Summary

The "Deploy to TestFlight" workflow has been failing repeatedly (commits `e5a43fc`, `e59a529`, `5dbe4c2`, `2fdbe6c` were all attempts to fix it) while iOS CI stayed green. This PR fixes the **root cause** plus two remaining compile errors.

### Root cause: CI was never compiling the Companion files

- `ios-ci.yml` builds the **committed** `apps/ios/SoloCompass.xcodeproj` directly.
- `testflight.yml` runs `xcodegen generate` **first**, which globs every `.swift` under `SoloCompass/` (per `project.yml`).
- The committed `project.pbxproj` had drifted and contained **zero** references to `CompanionService`, `ChatView`, `ItineraryStore`, `CompanionProfileView`, etc.

Result: CI compiled a stale project that excluded the Companion sources → green; the TestFlight archive regenerated the project with `xcodegen` → included them → compile errors → failed at ~4 min. It was never a Debug-vs-Release issue.

### Changes

- **`ios-ci.yml`**: install XcodeGen and run `xcodegen generate` before build/test, so CI compiles the exact same source set as TestFlight. This catches these errors in PR CI on a real macOS compiler instead of silently in TestFlight. (Matches the documented iOS workflow in `CLAUDE.md`: xcodegen owns the project; don't hand-edit `.xcodeproj`.)
- **`UserPreferences.swift`**: add `acceptCompanionConsent()` (mirrors the existing `acceptExploreConsent()`). The consent sheet referenced a member that didn't exist.
- **`CompanionSafetyConsentSheet.swift`**: call `acceptCompanionConsent()` instead of the undefined `isSafetyConsentAccepted` property (introduced by `2fdbe6c`).
- **`CompanionProfileView.swift`**: restore `@Bindable var prefs` and pass `$prefs`. The section helpers take `Bindable<UserPreferences>` (e.g. `bioSection` uses `prefs.companionBio` as a two-way `Binding`), so the `var prefs = preferences` from `2fdbe6c` was a type mismatch at all four call sites.

## Test plan

- [ ] iOS CI now runs `xcodegen generate` and **compiles the Companion sources** — the build must succeed (or surface any remaining compile errors with exact file/line, which I'll address).
- [ ] `pnpm parity:check` (schema-parity job) still passes.
- [ ] Unit tests pass against the regenerated project.
- [ ] Follow-up: once CI is green, the next merge to `main` should produce a successful TestFlight archive.

> Note: I can't run Xcode in this environment, so the two Swift fixes above were found by static analysis. The CI change is the safeguard — it makes the macOS runner report any further errors precisely rather than letting them slip to TestFlight.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjgmma27mABGqikQ8yPdH4)_