### PR TITLE
auto: Add a one-tap Directions button to the experience peek card

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -162,6 +162,9 @@ public struct ExperienceCardView: View {
                     bestTimeHintPill(hint)
                 }
                 Spacer()
+                if let coord = experience.coordinate {
+                    directionsControl(coordinate: coord)
+                }
                 Button(action: onExpand) {
                     Text(NSLocalizedString("experience.viewDetails", comment: "View details"))
                         .font(.subheadline.weight(.medium))
@@ -229,6 +232,9 @@ public struct ExperienceCardView: View {
                 } else if let hint = experience.bestTimeHint() {
                     parts += ". " + String(format: NSLocalizedString("experience.bestTime.hint.a11y", comment: "Best time accessibility"), hint)
                 }
+                if experience.coordinate != nil {
+                    parts += ". " + NSLocalizedString("action.directions", comment: "Directions accessibility action")
+                }
                 return parts
             }()
         ))
@@ -240,6 +246,11 @@ public struct ExperienceCardView: View {
         ) {
             preferences.toggleFavorite(experience.id)
         }
+        .accessibilityAction(named: Text(NSLocalizedString("action.directions", comment: "Directions accessibility action"))) {
+            guard let coord = experience.coordinate,
+                  let app = NavigationLauncher.availableApps().first else { return }
+            NavigationLauncher.open(app: app, coordinate: coord, name: experience.title)
+        }
     }
 
     @ViewBuilder
@@ -250,6 +261,47 @@ public struct ExperienceCardView: View {
             .padding(.vertical, 4)
             .foregroundStyle(Color.secondary)
             .background(Capsule().fill(Color.secondary.opacity(0.12)))
+    }
+
+    @ViewBuilder
+    private func directionsControl(coordinate: CLLocationCoordinate2D) -> some View {
+        let apps = NavigationLauncher.availableApps()
+        let name = experience.title
+        if !apps.isEmpty {
+            let pillLabel = Label(
+                NSLocalizedString("action.directions", comment: "Directions button"),
+                systemImage: "arrow.triangle.turn.up.right.diamond.fill"
+            )
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .foregroundStyle(Color.accentColor)
+            .background(Capsule().fill(Color.accentColor.opacity(0.12)))
+
+            if apps.count == 1, let app = apps.first {
+                Button {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    NavigationLauncher.open(app: app, coordinate: coordinate, name: name)
+                } label: {
+                    pillLabel
+                }
+                .buttonStyle(.plain)
+                .contentShape(Capsule())
+            } else {
+                Menu {
+                    ForEach(apps) { app in
+                        Button(app.displayName) {
+                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                            NavigationLauncher.open(app: app, coordinate: coordinate, name: name)
+                        }
+                    }
+                } label: {
+                    pillLabel
+                }
+                .buttonStyle(.plain)
+                .contentShape(Capsule())
+            }
+        }
     }
 
     @ViewBuilder

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -22,6 +22,7 @@ public struct ExperienceCardView: View {
 
     // Pre-allocated so prepare() can be called once when the drag starts.
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
+    private let lightFeedbackGenerator = UIImpactFeedbackGenerator(style: .light)
     @Environment(UserPreferences.self) private var preferences
     @Environment(LocationService.self) private var locationService
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -84,6 +85,10 @@ public struct ExperienceCardView: View {
 
     private var isFavorited: Bool {
         preferences.favoritedExperiences.contains(experience.id)
+    }
+
+    private var availableNavigationApps: [NavigationApp] {
+        NavigationLauncher.availableApps()
     }
 
     public var body: some View {
@@ -232,7 +237,7 @@ public struct ExperienceCardView: View {
                 } else if let hint = experience.bestTimeHint() {
                     parts += ". " + String(format: NSLocalizedString("experience.bestTime.hint.a11y", comment: "Best time accessibility"), hint)
                 }
-                if experience.coordinate != nil {
+                if experience.coordinate != nil && !availableNavigationApps.isEmpty {
                     parts += ". " + NSLocalizedString("action.directions", comment: "Directions accessibility action")
                 }
                 return parts
@@ -248,7 +253,7 @@ public struct ExperienceCardView: View {
         }
         .accessibilityAction(named: Text(NSLocalizedString("action.directions", comment: "Directions accessibility action"))) {
             guard let coord = experience.coordinate,
-                  let app = NavigationLauncher.availableApps().first else { return }
+                  let app = availableNavigationApps.first else { return }
             NavigationLauncher.open(app: app, coordinate: coord, name: experience.title)
         }
     }
@@ -265,7 +270,7 @@ public struct ExperienceCardView: View {
 
     @ViewBuilder
     private func directionsControl(coordinate: CLLocationCoordinate2D) -> some View {
-        let apps = NavigationLauncher.availableApps()
+        let apps = availableNavigationApps
         let name = experience.title
         if !apps.isEmpty {
             let pillLabel = Label(
@@ -280,7 +285,7 @@ public struct ExperienceCardView: View {
 
             if apps.count == 1, let app = apps.first {
                 Button {
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    lightFeedbackGenerator.impactOccurred()
                     NavigationLauncher.open(app: app, coordinate: coordinate, name: name)
                 } label: {
                     pillLabel
@@ -291,7 +296,7 @@ public struct ExperienceCardView: View {
                 Menu {
                     ForEach(apps) { app in
                         Button(app.displayName) {
-                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                            lightFeedbackGenerator.impactOccurred()
                             NavigationLauncher.open(app: app, coordinate: coordinate, name: name)
                         }
                     }


### PR DESCRIPTION
## Add a one-tap Directions button to the experience peek card

When a user taps a map pin, the floating ExperienceCardView shows title, distance, and solo score — but the highest-intent next action for a solo traveler, 'how do I get there?', requires expanding into the full detail sheet first. This adds an inline Directions control to the peek card using the existing NavigationLauncher service, surfacing walking navigation (Apple/Google/Amap) directly on the map's primary tap surface.

### Acceptance
Tapping a pin shows the peek card with a Directions control next to 'View details'. Tapping Directions (single app) opens that maps app in walking mode to the experience coordinate; with multiple apps it presents a menu of installed apps. The control is hidden when the experience has no coordinate. Tapping Directions does not expand the card to the detail sheet. VoiceOver exposes a 'Directions' action. xcodebuild build and the SoloCompassTests target both pass; NavigationLauncher URL tests remain green.