### PR TITLE
auto: Replace bare ProgressView spinners in companion loading states with shimmer skeleton rows

### DIFF
--- a/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
@@ -64,13 +64,9 @@ public struct DiscoverListView: View {
     // MARK: - Subviews
 
     private var loadingView: some View {
-        VStack(spacing: 16) {
-            ProgressView()
-            Text(NSLocalizedString("companion.discover.loading", comment: "Loading discover posts"))
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+        ScrollView {
+            CompanionSkeletonList(rows: 5)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private func errorView(message: String) -> some View {
@@ -249,6 +245,17 @@ private struct DiscoverPostRow: View {
 #Preview("Empty state") {
     NavigationStack {
         DiscoverListView(cityCode: "DPS")
+    }
+    .environment(UserPreferences())
+}
+
+#Preview("Loading skeleton") {
+    NavigationStack {
+        ScrollView {
+            CompanionSkeletonList(rows: 5)
+        }
+        .navigationTitle(NSLocalizedString("companion.discover.title", comment: "Discover nav title"))
+        .navigationBarTitleDisplayMode(.large)
     }
     .environment(UserPreferences())
 }

--- a/apps/ios/SoloCompass/Views/Companion/RequestInboxView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/RequestInboxView.swift
@@ -18,8 +18,9 @@ public struct RequestInboxView: View {
     public var body: some View {
         Group {
             if service.isLoading {
-                ProgressView()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                ScrollView {
+                    CompanionSkeletonList(rows: 5)
+                }
             } else if service.inboxRequests.isEmpty {
                 emptyStateView
             } else {
@@ -210,5 +211,15 @@ private struct RequestRow: View {
 #Preview("Empty inbox") {
     NavigationStack {
         RequestInboxView()
+    }
+}
+
+#Preview("Loading skeleton") {
+    NavigationStack {
+        ScrollView {
+            CompanionSkeletonList(rows: 5)
+        }
+        .navigationTitle(NSLocalizedString("companion.inbox.title", comment: "Inbox nav title"))
+        .navigationBarTitleDisplayMode(.large)
     }
 }

--- a/apps/ios/SoloCompass/Views/Shared/SkeletonView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SkeletonView.swift
@@ -76,6 +76,52 @@ private struct SkeletonLine: View {
     }
 }
 
+// MARK: - Companion row skeleton
+
+/// Single skeleton row matching the emoji-handle + blurb layout of companion list rows.
+public struct CompanionRowSkeleton: View {
+    public init() {}
+
+    public var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Circle()
+                .fill(Color(uiColor: .systemGray5))
+                .frame(width: 36, height: 36)
+                .accessibilityHidden(true)
+
+            SkeletonView(lineCount: 2, widthFractions: [1.0, 0.5])
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 16)
+    }
+}
+
+/// A non-interactive list of `CompanionRowSkeleton` rows with `.insetGrouped` spacing.
+public struct CompanionSkeletonList: View {
+    let rows: Int
+
+    public init(rows: Int = 5) {
+        self.rows = max(1, rows)
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            ForEach(0..<rows, id: \.self) { _ in
+                CompanionRowSkeleton()
+                Divider().padding(.leading, 64)
+            }
+        }
+        .background(Color(uiColor: .secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(NSLocalizedString("skeleton.loading", comment: "Loading")))
+        .accessibilityAddTraits(.updatesFrequently)
+        .allowsHitTesting(false)
+    }
+}
+
 // MARK: - .redacted integration
 
 extension View {
@@ -110,6 +156,21 @@ extension View {
         SkeletonView(lineCount: 4, widthFractions: [1.0, 0.85, 0.9, 0.5])
     }
     .padding()
+}
+
+#Preview("Companion row skeleton") {
+    ScrollView {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Loading state (5 rows)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 16)
+                .padding(.top, 16)
+
+            CompanionSkeletonList(rows: 5)
+        }
+    }
+    .background(Color(uiColor: .systemGroupedBackground))
 }
 
 #Preview("3-line text skeleton") {


### PR DESCRIPTION
## Replace bare ProgressView spinners in companion loading states with shimmer skeleton rows

DiscoverListView and RequestInboxView show a generic centered ProgressView() while their async fetches run, even though the app already ships a polished SkeletonView shimmer component used for content placeholders elsewhere. Replacing the spinner with row-shaped skeleton placeholders that mirror the real list layout reduces perceived latency and gives the companion screens the same loading polish as the rest of the app.

### Acceptance
xcodebuild build and test for the SoloCompass scheme on iPhone 17 Pro (iOS latest) pass. Launching DiscoverListView and RequestInboxView in the Simulator shows shimmer skeleton rows (animated, or static under Reduce Motion) instead of a centered spinner during fetch, then cross-fades to real content. The skeleton respects accessibilityReduceMotion and exposes the existing 'Loading' accessibility label. No changes to any @Model/SwiftData type; diff under 100 lines across the 3 files.