### PR TITLE
auto: Add a 'Clear search' recovery action to the favorites no-results empty state

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -309,6 +309,9 @@
 "favorites.distance.m" = "%d m";
 "favorites.distance.mi" = "%.1f mi";
 "favorites.search.noResults" = "No matches for \"%@\"";
+"favorites.search.noResults.hint" = "Try a different word, or clear your search.";
+"favorites.search.clear" = "Clear search";
+"favorites.search.clear.hint" = "Clears the search field and shows all favorites";
 "favorites.search.prompt" = "Search favorites";
 "favorites.sort.label" = "Sort";
 "favorites.sort.nearest" = "Nearest";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -98,7 +98,7 @@ public struct FavoritesListView: View {
                     EmptyFavoritesView()
                         .transition(.scale(scale: 0.85).combined(with: .opacity))
                 } else if filteredFavorites.isEmpty {
-                    NoSearchResultsView(query: searchText)
+                    NoSearchResultsView(query: searchText, onClear: { searchText = "" })
                         .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
                 } else {
                     VStack(spacing: 0) {
@@ -222,17 +222,46 @@ private struct EmptyFavoritesView: View {
 
 private struct NoSearchResultsView: View {
     let query: String
+    let onClear: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var appeared = false
 
     var body: some View {
         VStack(spacing: 12) {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 48))
                 .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
             Text(String(format: NSLocalizedString("favorites.search.noResults", comment: "No matches for search query"), query))
                 .font(.headline)
                 .multilineTextAlignment(.center)
+            Text(NSLocalizedString("favorites.search.noResults.hint", comment: "Hint to try different word or clear search"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Button {
+                UISelectionFeedbackGenerator().selectionChanged()
+                withAnimation { onClear() }
+            } label: {
+                Label(NSLocalizedString("favorites.search.clear", comment: "Clear search button"), systemImage: "xmark.circle")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityHint(NSLocalizedString("favorites.search.clear.hint", comment: "Clears the search field and shows all favorites"))
         }
         .padding(32)
+        .scaleEffect(appeared ? 1 : 0.85)
+        .opacity(appeared ? 1 : 0)
+        .onAppear {
+            guard !reduceMotion else {
+                appeared = true
+                return
+            }
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
+                appeared = true
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Add a 'Clear search' recovery action to the favorites no-results empty state

When a favorites search returns no matches, the current NoSearchResultsView is a static dead-end — just a magnifying-glass icon and 'No matches' text, with no way to recover except manually clearing the search field. This adds a tappable 'Clear search' button (which resets searchText), a softer secondary hint line, and a gentle scale-in entrance so the no-results state matches the polish of the sibling EmptyFavoritesView.

### Acceptance
Searching favorites for a non-matching query shows the magnifying-glass icon, 'No matches for "<query>"', a secondary hint line, and a 'Clear search' button; tapping the button clears the search field and returns to the full favorites list. The view scales/fades in on appear (no animation when Reduce Motion is on). VoiceOver reads the no-results message and the button has a descriptive hint. xcodebuild build succeeds and existing FavoritesListView previews/tests still pass.