### PR TITLE
auto: Add an arrived/proximity state to the experience card distance pill

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -187,6 +187,8 @@
 /* Experience card distance pill */
 "card.distance.walk" = "%d min walk";
 "card.distance.walkSub1" = "<1 min walk";
+"card.distance.arrived" = "You're here";
+"card.distance.arrived.a11y" = "You're here";
 
 /* Voice recognition error alert */
 "voice.error.title" = "Voice recognition error";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -17,6 +17,9 @@ public struct ExperienceCardView: View {
     @State private var dragOffset: CGFloat = 0
     @State private var heartBounce = 0
     @State private var heartBurst = false
+    @State private var arrivedPulse = false
+
+    private static let arrivedThresholdMeters = 75.0
 
     private enum HapticState { case idle, prepared, fired }
 
@@ -27,6 +30,10 @@ public struct ExperienceCardView: View {
     @Environment(LocationService.self) private var locationService
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+
+    private var isArrived: Bool {
+        (distanceMeters ?? .greatestFiniteMagnitude) <= Self.arrivedThresholdMeters
+    }
 
     /// Finite distance in meters, or nil when location is unknown.
     private var distanceMeters: Double? {
@@ -162,7 +169,9 @@ public struct ExperienceCardView: View {
 
             HStack {
                 SoloScoreBadge(score: experience.soloScore, style: .compact)
-                if let meters = distanceMeters {
+                if isArrived {
+                    arrivedPill
+                } else if let meters = distanceMeters {
                     let dl = Self.formatDistance(meters)
                     distancePill(dl.text, symbol: dl.symbol)
                 }
@@ -235,7 +244,9 @@ public struct ExperienceCardView: View {
                    String(format: "%.1f", experience.soloScore.overall)) +
             {
                 var parts = ""
-                if let meters = distanceMeters {
+                if isArrived {
+                    parts += ". " + NSLocalizedString("card.distance.arrived.a11y", comment: "You're here accessibility label")
+                } else if let meters = distanceMeters {
                     parts += ". " + Self.formatDistance(meters).text
                 }
                 let count = experience.realInconveniences.count
@@ -273,6 +284,29 @@ public struct ExperienceCardView: View {
             .padding(.vertical, 4)
             .foregroundStyle(Color.secondary)
             .background(Capsule().fill(Color.secondary.opacity(0.12)))
+    }
+
+    @ViewBuilder
+    private var arrivedPill: some View {
+        Label(
+            NSLocalizedString("card.distance.arrived", comment: "You're here pill label"),
+            systemImage: "location.fill"
+        )
+        .font(.caption)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .foregroundStyle(Color.green)
+        .background(Capsule().fill(Color.green.opacity(0.15)))
+        .scaleEffect(arrivedPulse ? 1.0 : 0.85)
+        .onAppear {
+            if reduceMotion {
+                arrivedPulse = true
+            } else {
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.6)) {
+                    arrivedPulse = true
+                }
+            }
+        }
     }
 
     @ViewBuilder
@@ -387,9 +421,9 @@ private struct BestNowBadge: View {
 #Preview {
     if let exp = ExperienceService.hardcodedSeed.first {
         let locationService = LocationService()
-        // Simulate a location ~450 m from the seed experience so the pill is visible in preview.
+        // Simulate a location ~30 m from the seed experience so the arrived pill is visible in preview.
         if let coord = exp.coordinate {
-            let offset = CLLocation(latitude: coord.latitude + 0.004, longitude: coord.longitude)
+            let offset = CLLocation(latitude: coord.latitude + 0.00027, longitude: coord.longitude)
             locationService.simulate(location: offset)
         }
         return AnyView(VStack {


### PR DESCRIPTION
## Add an "arrived"/proximity state to the experience card distance pill

The ExperienceCardView distance pill renders "<1 min walk" identically whether the user is 75 m or 5 m away, missing the most emotionally satisfying moment in a map-first walking app: arrival. Add a distinct ≤75 m "You're here" pill — green accent, location/checkmark glyph, subtle one-shot pulse on appear (respecting Reduce Motion) — so the card visibly rewards reaching an experience, with matching VoiceOver phrasing.

### Acceptance
Build succeeds via xcodebuild for the SoloCompass scheme on iPhone 17 Pro simulator. When the user's simulated location is within 75 m of the experience, the card shows a green "You're here" pill (with location glyph) instead of the walk-time pill; beyond 75 m the existing walk/distance pill is unchanged. The arrived pill pops once on appear and shows statically (no pulse) under Reduce Motion. VoiceOver reads "You're here" in place of the walk distance. No force-unwraps added; no @Model/schema files touched; change is confined to ExperienceCardView.swift and Localizable.strings (well under 100 lines).