### PR TITLE
auto: Add a 'no matches for this filter' overlay when an active filter yields zero experiences

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -150,7 +150,6 @@
 "map.empty.browse" = "Browse %@";
 "map.empty.clearFilters" = "Clear filters";
 "map.filtered.empty.title" = "Nothing matches this filter";
-"map.filtered.empty.hint" = "Try a different filter or move the map.";
 "map.filtered.empty.subtitle" = "No experiences match \"%@\" in this area.";
 
 /* Map empty-state stage machine (US-012). Three distinct labels — no shared "no results" string. */

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -149,6 +149,9 @@
 "map.empty.expand" = "Expand to 25km";
 "map.empty.browse" = "Browse %@";
 "map.empty.clearFilters" = "Clear filters";
+"map.filtered.empty.title" = "Nothing matches this filter";
+"map.filtered.empty.hint" = "Try a different filter or move the map.";
+"map.filtered.empty.subtitle" = "No experiences match \"%@\" in this area.";
 
 /* Map empty-state stage machine (US-012). Three distinct labels — no shared "no results" string. */
 "map.empty.stage.tryExpand" = "Expand to 25 km";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -118,7 +118,6 @@
 "map.empty.browse" = "浏览 %@";
 "map.empty.clearFilters" = "清除筛选";
 "map.filtered.empty.title" = "没有符合此筛选的体验";
-"map.filtered.empty.hint" = "试试换一个筛选条件或拖动地图。";
 "map.filtered.empty.subtitle" = "此区域内没有匹配"%@"的体验。";
 
 /* Map empty-state stage machine (US-012) */

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -117,6 +117,9 @@
 "map.empty.expand" = "扩展到 25 公里";
 "map.empty.browse" = "浏览 %@";
 "map.empty.clearFilters" = "清除筛选";
+"map.filtered.empty.title" = "没有符合此筛选的体验";
+"map.filtered.empty.hint" = "试试换一个筛选条件或拖动地图。";
+"map.filtered.empty.subtitle" = "此区域内没有匹配"%@"的体验。";
 
 /* Map empty-state stage machine (US-012) */
 "map.empty.stage.tryExpand" = "扩展到 25 公里";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -118,7 +118,7 @@
 "map.empty.browse" = "浏览 %@";
 "map.empty.clearFilters" = "清除筛选";
 "map.filtered.empty.title" = "没有符合此筛选的体验";
-"map.filtered.empty.subtitle" = "此区域内没有匹配"%@"的体验。";
+"map.filtered.empty.subtitle" = "此区域内没有匹配\"%@\"的体验。";
 
 /* Map empty-state stage machine (US-012) */
 "map.empty.stage.tryExpand" = "扩展到 25 公里";

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -1224,8 +1224,6 @@ private struct EmptyStateOverlay: View {
 private struct FilteredEmptyOverlay: View {
     var viewModel: MapViewModel
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
     private var activeFilterName: String {
         if let category = viewModel.selectedCategory {
             return category.localizedTitle

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -208,6 +208,10 @@ public struct CompassMapView: View {
                     )
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                     .animation(.easeOut(duration: 0.35), value: viewModel.visibleExperiences.isEmpty)
+                } else if viewModel.visibleExperiences.isEmpty && isFilterActive && viewModel.selectedExperience == nil {
+                    FilteredEmptyOverlay(viewModel: viewModel)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                        .animation(.easeOut(duration: 0.35), value: viewModel.visibleExperiences.isEmpty)
                 }
 
                 // Offline banner (US-041): amber pill when network is unavailable
@@ -1216,3 +1220,66 @@ private struct EmptyStateOverlay: View {
         }
     }
 }
+
+private struct FilteredEmptyOverlay: View {
+    var viewModel: MapViewModel
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var activeFilterName: String {
+        if let category = viewModel.selectedCategory {
+            return category.localizedTitle
+        } else if let tag = viewModel.selectedCustomTag {
+            return tag
+        } else if viewModel.isNowFilter {
+            return NSLocalizedString("filter.now", comment: "Now filter label")
+        }
+        return ""
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text(NSLocalizedString("map.filtered.empty.title", comment: "Nothing matches this filter"))
+                .font(.subheadline.weight(.medium))
+            Text(String(
+                format: NSLocalizedString("map.filtered.empty.subtitle", comment: "Filter name subtitle"),
+                activeFilterName
+            ))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            Button {
+                let feedback = UISelectionFeedbackGenerator()
+                feedback.selectionChanged()
+                viewModel.clearFilters()
+            } label: {
+                Text(NSLocalizedString("map.empty.clearFilters", comment: "Clear all filters"))
+                    .font(.subheadline.weight(.medium))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.regular)
+        }
+        .padding(16)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
+        .padding(.horizontal, 32)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#if DEBUG
+#Preview("FilteredEmptyOverlay") {
+    let vm = MapViewModel(
+        locationService: LocationService(),
+        experienceService: ExperienceService(),
+        aiService: AIService(),
+        preferences: UserPreferences()
+    )
+    vm.selectedCategory = .coffee
+    return FilteredEmptyOverlay(viewModel: vm)
+        .padding()
+}
+#endif


### PR DESCRIPTION
## Add a 'no matches for this filter' overlay when an active filter yields zero experiences

Today the map's EmptyStateOverlay only appears when there are no experiences AND no filter is active (CompassMapView.swift:203 `viewModel.visibleExperiences.isEmpty && !isFilterActive`). When a user selects a category/custom-tag/Now filter that matches nothing in view, the map goes blank with a highlighted-but-zero-count filter pill and no explanation — a dead-end in a map-first app. This adds a lightweight, distinct overlay for that branch that names the active filter and offers a one-tap 'Clear filters' recovery, reusing the existing `viewModel.clearFilters()` action and matching the visual language of the existing EmptyStateOverlay.

### Acceptance
Selecting any category, custom tag, or the 'Now' filter that matches zero visible experiences shows the new overlay naming the active filter; tapping 'Clear filters' calls clearFilters(), removes the overlay, and restores pins. The overlay never shows when an experience is selected or when results exist or when no filter is active (the original EmptyStateOverlay path is unchanged). Both English and Simplified Chinese strings render with no missing-key fallbacks. `xcodebuild build -scheme SoloCompass` succeeds and the existing SoloCompassTests suite still passes.