### PR TITLE
auto: Surface companion request failures with error haptic + inline toast

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -770,6 +770,8 @@
 "companion.request.accept" = "Accept";
 "companion.request.decline" = "Decline";
 "companion.request.withdraw" = "Withdraw";
+"companion.request.send.error" = "Couldn't send request. Please try again.";
+"companion.request.accept.error" = "Couldn't accept request. Please try again.";
 
 /* Companion — inbox (US-012) */
 "companion.inbox.title" = "Requests";

--- a/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
@@ -14,6 +14,7 @@ public struct DiscoverListView: View {
     @State private var selectedPost: DiscoverPost?
     @State private var requestSentPostId: String?
     @State private var reportTarget: DiscoverPost?
+    @State private var errorMessage: String?
 
     public init(cityCode: String, service: CompanionService = .shared) {
         self.cityCode = cityCode
@@ -45,6 +46,24 @@ public struct DiscoverListView: View {
             }
         }
         .task { await loadPosts() }
+        .overlay(alignment: .bottom) {
+            if let msg = errorMessage {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle")
+                    Text(msg)
+                        .font(.subheadline)
+                        .lineLimit(2)
+                }
+                .foregroundStyle(.red)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                .background(.regularMaterial, in: Capsule())
+                .padding(.bottom, 16)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .accessibilityLabel(msg)
+            }
+        }
+        .animation(.easeInOut, value: errorMessage)
         .sheet(item: $selectedPost) { post in
             SendRequestSheet(post: post) { note in
                 Task { await sendRequest(to: post, note: note) }
@@ -123,8 +142,16 @@ public struct DiscoverListView: View {
             recipientId: post.id, // placeholder — resolved server-side
             note: note
         )
-        if case .success = result {
+        switch result {
+        case .success:
             requestSentPostId = post.id
+        case .failure(let err):
+            errorMessage = err.localizedDescription
+            UINotificationFeedbackGenerator().notificationOccurred(.error)
+            Task {
+                try? await Task.sleep(for: .seconds(3))
+                errorMessage = nil
+            }
         }
     }
 }

--- a/apps/ios/SoloCompass/Views/Companion/RequestInboxView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/RequestInboxView.swift
@@ -10,6 +10,7 @@ public struct RequestInboxView: View {
     @State private var acceptedConversation: Conversation?
     @State private var showingAcceptedConfirm = false
     @State private var reportTarget: CompanionRequest?
+    @State private var errorMessage: String?
 
     public init(service: CompanionService = .shared) {
         _service = State(initialValue: service)
@@ -48,6 +49,24 @@ public struct RequestInboxView: View {
         } message: {
             Text(NSLocalizedString("companion.inbox.accepted.message", comment: "Request accepted alert message"))
         }
+        .overlay(alignment: .bottom) {
+            if let msg = errorMessage {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle")
+                    Text(msg)
+                        .font(.subheadline)
+                        .lineLimit(2)
+                }
+                .foregroundStyle(.red)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                .background(.regularMaterial, in: Capsule())
+                .padding(.bottom, 16)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .accessibilityLabel(msg)
+            }
+        }
+        .animation(.easeInOut, value: errorMessage)
         .sheet(item: $reportTarget) { request in
             ReportBlockSheet(
                 targetUserId: request.requesterId,
@@ -90,10 +109,18 @@ public struct RequestInboxView: View {
 
     private func acceptRequest(_ request: CompanionRequest) async {
         let result = await service.acceptRequest(request)
-        if case .success(let conversation) = result {
+        switch result {
+        case .success(let conversation):
             acceptedConversation = conversation
             showingAcceptedConfirm = true
             UINotificationFeedbackGenerator().notificationOccurred(.success)
+        case .failure(let err):
+            errorMessage = err.localizedDescription
+            UINotificationFeedbackGenerator().notificationOccurred(.error)
+            Task {
+                try? await Task.sleep(for: .seconds(3))
+                errorMessage = nil
+            }
         }
     }
 }


### PR DESCRIPTION
## Surface companion request failures with error haptic + inline toast

DiscoverListView.sendRequest and RequestInboxView.acceptRequest both pattern-match only the .success case and silently swallow the .failure branch, so a user tapping 'Send request' or 'Accept' on a flaky network sees nothing happen — no feedback, no retry cue. Add a transient error toast plus an error notification haptic on the .failure path of both call sites so failures are perceivable and recoverable.

### Acceptance
When sendRequest or acceptRequest returns .failure (e.g. companion feature flag off → CompanionServiceError.featureDisabled, or a simulated network error), the view shows a bottom error toast with the message and triggers an .error notification haptic; the toast auto-dismisses after ~3s and animates in/out. The .success paths (requestSentPostId set / accepted-confirm alert + success haptic) remain unchanged. Project builds via xcodebuild and existing #Previews still render.