### PR TITLE
auto: Haptic feedback on network connectivity changes

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -37,6 +37,10 @@ public struct CompassMapView: View {
     @State private var lastPanAt: Date = .distantPast
     @State private var panDebounceTask: Task<Void, Never>? = nil
 
+    // Tracks whether we've seen a disconnect so the success haptic only fires
+    // after a real offline→online transition, never on cold launch.
+    @State private var hasDisconnected: Bool = false
+
     private let networkMonitor = NetworkMonitor.shared
 
     private var isFilterActive: Bool {
@@ -87,6 +91,14 @@ public struct CompassMapView: View {
             }
             .onChange(of: preferences.pendingCheckIns) { _, _ in
                 viewModel?.checkForPendingCheckIns()
+            }
+            .onChange(of: networkMonitor.isConnected) { _, connected in
+                if !connected {
+                    hasDisconnected = true
+                    UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                } else if hasDisconnected {
+                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                }
             }
             .sheet(isPresented: settingsSheetBinding) { settingsSheetContent }
             .sheet(item: $surveyExperience) { exp in surveySheetContent(exp: exp) }


### PR DESCRIPTION
## Haptic feedback on network connectivity changes

The OfflineBanner appears and disappears silently when connectivity drops or returns, even though every other transient banner in the app (PendingCheckInBanner, completion) pairs state changes with haptics. Add a subtle warning haptic when the connection is lost and a success haptic when it's restored, so users feel the state change without staring at the top of the map. Respects the existing banner family's visual language and adds no new UI.

### Acceptance
Toggling the simulator/device offline triggers a single warning haptic as the amber banner slides in; restoring connectivity triggers a success haptic as it slides out. No haptic fires on app launch regardless of starting connectivity. Build passes via `xcodebuild build`; existing tests unaffected.