### PR TITLE
auto: Celebrate geofence check-ins with confetti + success haptic on the map

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -646,6 +646,8 @@ private struct MapOverlayView: View {
     @Binding var dismissedQuotaInfo: String?
     @Binding var isMapPanning: Bool
 
+    @State private var checkInCelebrationTrigger = 0
+
     private var isFilterActive: Bool {
         viewModel.selectedCategory != nil || viewModel.selectedCustomTag != nil || viewModel.isNowFilter
     }
@@ -805,11 +807,19 @@ private struct MapOverlayView: View {
                 .padding(.bottom, 8)
 
             if let pending = viewModel.pendingCheckIn {
-                PendingCheckInBanner(
-                    experienceTitle: pending.title,
-                    onConfirm: { viewModel.confirmCheckIn() },
-                    onDismiss: { viewModel.dismissCheckIn() }
-                )
+                ZStack(alignment: .top) {
+                    PendingCheckInBanner(
+                        experienceTitle: pending.title,
+                        onConfirm: {
+                            UINotificationFeedbackGenerator().notificationOccurred(.success)
+                            checkInCelebrationTrigger += 1
+                            viewModel.confirmCheckIn()
+                        },
+                        onDismiss: { viewModel.dismissCheckIn() }
+                    )
+                    CompletionCelebrationView(trigger: checkInCelebrationTrigger)
+                        .offset(y: -120)
+                }
                 .padding(.bottom, 4)
                 .animation(.spring(response: 0.4), value: viewModel.pendingCheckIn != nil)
             }

--- a/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
@@ -45,7 +45,6 @@ public struct PendingCheckInBanner: View {
 
             HStack(spacing: 8) {
                 Button {
-                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                     onConfirm()
                 } label: {
                     Text(NSLocalizedString("checkin.banner.yes", comment: "Yes!"))


### PR DESCRIPTION
## Celebrate geofence check-ins with confetti + success haptic on the map

When a solo traveler physically arrives at an experience and taps 'Yes, I was there' on the geofence check-in banner, the app silently dismisses the banner with only a soft impact — the single most emotionally meaningful completion moment in the product is its flattest. This wires the existing CompletionCelebrationView confetti burst and a .success notification haptic into the map's confirmCheckIn flow, matching the polish the detail-view 'Mark Done' button already has.

### Acceptance
Tapping 'Yes, I was there' on the geofence check-in banner plays a success haptic and a one-shot confetti burst with checkmark pop over the map, then the banner dismisses. With Reduce Motion enabled, only the checkmark pop shows (no particles), inherited from CompletionCelebrationView. No double-haptic. `xcodebuild build` succeeds and the existing #Preview for CompletionCelebrationView still renders.