### PR TITLE
auto: Smooth skeleton→content cross-fade in ExperienceDetailView's AI sections

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -250,43 +250,55 @@ public struct ExperienceDetailView: View {
 
     // MARK: - Sections
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @ViewBuilder
     private var whyItMattersSection: some View {
         let content = viewModel.experience.whyItMatters.trimmingCharacters(in: .whitespacesAndNewlines)
-        if viewModel.isLoadingWhyItMatters {
+        let isLoading = viewModel.isLoadingWhyItMatters
+        if isLoading || !content.isEmpty {
             sectionContainer(title: NSLocalizedString("section.whyItMatters", comment: "")) {
-                SkeletonView(lineCount: 3)
+                if isLoading {
+                    SkeletonView(lineCount: 3)
+                        .id("whyItMatters-skeleton")
+                        .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
+                } else {
+                    Text(content)
+                        .font(.body)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .id("whyItMatters-content")
+                        .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
+                }
             }
-        } else if !content.isEmpty {
-            sectionContainer(title: NSLocalizedString("section.whyItMatters", comment: "")) {
-                Text(content)
-                    .font(.body)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.35), value: isLoading)
         }
     }
 
     @ViewBuilder
     private var aiInsightSection: some View {
-        if viewModel.isLoadingAIExplanation {
+        let isLoading = viewModel.isLoadingAIExplanation
+        if isLoading || viewModel.aiExplanation != nil {
             sectionContainer(title: NSLocalizedString("ai.explanation.title", comment: "AI Insight section title")) {
-                HStack(spacing: 8) {
-                    ProgressView()
-                    Text(NSLocalizedString("ai.explanation.loading", comment: "AI insight loading indicator"))
+                if isLoading {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                        Text(NSLocalizedString("ai.explanation.loading", comment: "AI insight loading indicator"))
+                            .font(.body)
+                            .foregroundStyle(.secondary)
+                    }
+                    .id("aiInsight-skeleton")
+                    .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
+                } else if let explanation = viewModel.aiExplanation {
+                    Text(explanation)
                         .font(.body)
-                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .id("aiInsight-content")
+                        .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
                 }
             }
-        } else if let explanation = viewModel.aiExplanation {
-            sectionContainer(title: NSLocalizedString("ai.explanation.title", comment: "AI Insight section title")) {
-                Text(explanation)
-                    .font(.body)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.35), value: isLoading)
         }
     }
-
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var bestTimeStatusPill: some View {
         let isNow = viewModel.experience.isBestNow()


### PR DESCRIPTION
## Smooth skeleton→content cross-fade in ExperienceDetailView's AI sections

The 'Why it matters' and 'AI Insight' sections in the experience detail pane swap from a SkeletonView/ProgressView placeholder to loaded text with no transition — content pops in abruptly the moment AI streaming completes. This is a high-frequency, highly-visible moment (every detail open triggers it) and is inconsistent with the spring/fade transitions used everywhere else in the app. Add a cross-fade keyed on the loading state so resolved content fades in gracefully, fully respecting Reduce Motion.

### Acceptance
Open an experience detail while AI content is still loading: the skeleton/progress placeholder fades out and the resolved 'Why it matters' and 'AI Insight' text fades (and gently slides) in over ~0.35s instead of popping. With Reduce Motion enabled (Settings > Accessibility), the swap is a plain cross-fade with no movement. No layout shift or flicker on already-loaded experiences. `xcodebuild build -project apps/ios/SoloCompass.xcodeproj -scheme SoloCompass` succeeds and existing SoloCompassTests pass.