### PR TITLE
auto: Now filter empty state: surface the next experience coming alive

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -16,6 +16,9 @@
 "filter.matches.other" = "%d matches";
 "filter.matches.none" = "No matches";
 "filter.clear" = "Clear filter";
+"filter.now.empty.idle" = "Nothing's at its best now";
+"filter.now.empty.upcoming" = "%@ in %dm";
+"filter.now.empty.a11y" = "Nothing's at its best now. %@ starts in %d minutes. Tap to jump there.";
 
 /* Health */
 "health.healthy" = "Fresh — multiply verified";

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -3714,6 +3714,89 @@ final class SoloCompassTests: XCTestCase {
         XCTAssertEqual(pressCount, 1, "duplicate pressing=true must not call onPress twice")
         XCTAssertEqual(releaseCount, 1, "onRelease fires once on the single release")
     }
+
+    // MARK: - nextBestExperience
+
+    private func makeExperience(id: String, bestTimes: [TimeWindow]) throws -> Experience {
+        let base = try XCTUnwrap(ExperienceService.hardcodedSeed.first)
+        return Experience(
+            id: id,
+            title: id,
+            oneLiner: base.oneLiner,
+            whyItMatters: base.whyItMatters,
+            category: base.category,
+            location: base.location,
+            bestTimes: bestTimes,
+            durationMinutes: base.durationMinutes,
+            howTo: base.howTo,
+            realInconveniences: base.realInconveniences,
+            soloScore: base.soloScore,
+            sources: base.sources,
+            confidence: base.confidence,
+            nearbyExperienceIds: base.nearbyExperienceIds,
+            stats: base.stats,
+            status: base.status,
+            createdAt: base.createdAt,
+            updatedAt: base.updatedAt
+        )
+    }
+
+    /// `nextBestExperience` returns nil when no experience starts within 180 min.
+    func testNextBestExperienceNilWhenNothingUpcomingSoon() throws {
+        let cal = Calendar.current
+        let now = Date()
+        let currentHour = cal.component(.hour, from: now)
+        // Pick a bestTimes window that starts more than 180 min from now.
+        // If we're before hour 21, place the window at 23:00 (≥ 120 min away
+        // at hour 20 or earlier). If already past 21, skip — not enough room.
+        guard currentHour <= 20 else { return }
+        let exp = try makeExperience(id: "far-future", bestTimes: [TimeWindow(startHour: 23, endHour: 24)])
+        let service = ExperienceService(seed: [exp])
+        let vm = MapViewModel(
+            locationService: LocationService(),
+            experienceService: service,
+            aiService: AIService(),
+            preferences: UserPreferences()
+        )
+        // At hour ≤ 20 the window is at least 3 h away, beyond the 180-min cap.
+        XCTAssertNil(vm.nextBestExperience)
+    }
+
+    /// `nextBestExperience` returns the soonest experience within 180 min.
+    func testNextBestExperiencePicksClosestUpcoming() throws {
+        // Two experiences: one starts in 30 min, one in 90 min (both within cap).
+        let cal = Calendar.current
+        let now = Date()
+        let currentHour = cal.component(.hour, from: now)
+        let currentMinute = cal.component(.minute, from: now)
+        let nowMinutes = currentHour * 60 + currentMinute
+
+        // Only set up test if there's room for both windows before midnight.
+        guard nowMinutes + 90 < 24 * 60 else { return }
+
+        let startHour30 = (nowMinutes + 30) / 60
+        let startHour90 = (nowMinutes + 90) / 60
+
+        let expSoon = try makeExperience(
+            id: "soon",
+            bestTimes: [TimeWindow(startHour: startHour30, endHour: startHour30 + 1)]
+        )
+        let expLater = try makeExperience(
+            id: "later",
+            bestTimes: [TimeWindow(startHour: startHour90, endHour: startHour90 + 1)]
+        )
+        let service = ExperienceService(seed: [expLater, expSoon]) // reversed order intentionally
+        let vm = MapViewModel(
+            locationService: LocationService(),
+            experienceService: service,
+            aiService: AIService(),
+            preferences: UserPreferences()
+        )
+        let next = vm.nextBestExperience
+        XCTAssertNotNil(next)
+        XCTAssertEqual(next?.experience.id, "soon", "must pick the soonest, not the first in array")
+        XCTAssertLessThanOrEqual(next?.minutesUntil ?? Int.max, 180)
+    }
 }
 
 // MARK: - URLProtocol stub for HTTP-mocked tests

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -671,7 +671,7 @@ public final class MapViewModel {
         experience.confidence.signals.passiveGpsHits30d
     }
 
-    private func minutesUntilBestTime(for experience: Experience, from date: Date) -> Int? {
+    func minutesUntilBestTime(for experience: Experience, from date: Date) -> Int? {
         let cal = Calendar.current
         let hour = cal.component(.hour, from: date)
         let minute = cal.component(.minute, from: date)
@@ -682,6 +682,30 @@ public final class MapViewModel {
             return startMin > nowMinutes ? (startMin - nowMinutes) : nil
         }
         return upcomingStarts.min()
+    }
+
+    /// The soonest experience (across all loaded experiences in the current city)
+    /// that is not yet at its best but starts within 180 minutes.
+    /// Used by the "Now" filter empty state to offer a one-tap next action.
+    public var nextBestExperience: (experience: Experience, minutesUntil: Int)? {
+        let now = Date()
+        let cityCode = selectedCity
+        let candidates = experienceService.allExperiences.filter { exp in
+            guard !exp.isBestNow(at: now) else { return false }
+            if let code = cityCode, !code.hasPrefix("custom_") {
+                return exp.location.cityCode == code
+            }
+            return true
+        }
+        var best: (experience: Experience, minutesUntil: Int)?
+        for exp in candidates {
+            guard let mins = minutesUntilBestTime(for: exp, from: now),
+                  mins > 0, mins <= 180 else { continue }
+            if best == nil || mins < best!.minutesUntil {
+                best = (exp, mins)
+            }
+        }
+        return best
     }
 
     // MARK: - Bottom info bar

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -671,7 +671,7 @@ public final class MapViewModel {
         experience.confidence.signals.passiveGpsHits30d
     }
 
-    func minutesUntilBestTime(for experience: Experience, from date: Date) -> Int? {
+    private func minutesUntilBestTime(for experience: Experience, from date: Date) -> Int? {
         let cal = Calendar.current
         let hour = cal.component(.hour, from: date)
         let minute = cal.component(.minute, from: date)

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -821,13 +821,64 @@ private struct MapOverlayView: View {
     @ViewBuilder
     private var filterResultBadge: some View {
         let count = viewModel.visibleExperiences.count
+        let accentGold = Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)
         let dotColor: Color = {
             if let cat = viewModel.selectedCategory { return cat.color }
-            if viewModel.isNowFilter { return Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255) }
+            if viewModel.isNowFilter { return accentGold }
             return Color.accentColor
         }()
 
         if count == 0 {
+            if viewModel.isNowFilter, let next = viewModel.nextBestExperience {
+                // "Now" filter is active, nothing is at its best, but something
+                // is coming up soon — offer a one-tap jump to it.
+                let idleText = NSLocalizedString("filter.now.empty.idle", comment: "Nothing's at its best now")
+                let upcomingText = String(
+                    format: NSLocalizedString("filter.now.empty.upcoming", comment: "%@ in %dm"),
+                    next.experience.title, next.minutesUntil
+                )
+                let a11yText = String(
+                    format: NSLocalizedString("filter.now.empty.a11y", comment: ""),
+                    next.experience.title, next.minutesUntil
+                )
+
+                GlassmorphismCapsule(
+                    horizontalPadding: 12,
+                    verticalPadding: 6,
+                    shadowRadius: 6,
+                    shadowY: 3
+                ) {
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(accentGold)
+                            .frame(width: 8, height: 8)
+                        Text(idleText)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.primary)
+                        Text("·")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(upcomingText)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(accentGold)
+                    }
+                }
+                .contentTransition(.opacity)
+                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: count)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text(a11yText))
+                .accessibilityAddTraits(.isButton)
+                .accessibilityAction {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    viewModel.focusOnExperience(next.experience)
+                    viewModel.selectExperience(next.experience)
+                }
+                .onTapGesture {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    viewModel.focusOnExperience(next.experience)
+                    viewModel.selectExperience(next.experience)
+                }
+            } else {
             let noMatchText = NSLocalizedString("filter.matches.none", comment: "No matches")
             let clearText = NSLocalizedString("filter.clear", comment: "Clear filter")
             let a11yLabel = "\(noMatchText) · \(clearText)"
@@ -867,6 +918,7 @@ private struct MapOverlayView: View {
             .accessibilityAction {
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 viewModel.clearFilters()
+            }
             }
         } else {
             let countText = count == 1

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -879,46 +879,46 @@ private struct MapOverlayView: View {
                     viewModel.selectExperience(next.experience)
                 }
             } else {
-            let noMatchText = NSLocalizedString("filter.matches.none", comment: "No matches")
-            let clearText = NSLocalizedString("filter.clear", comment: "Clear filter")
-            let a11yLabel = "\(noMatchText) · \(clearText)"
+                let noMatchText = NSLocalizedString("filter.matches.none", comment: "No matches")
+                let clearText = NSLocalizedString("filter.clear", comment: "Clear filter")
+                let a11yLabel = "\(noMatchText) · \(clearText)"
 
-            GlassmorphismCapsule(
-                horizontalPadding: 12,
-                verticalPadding: 6,
-                shadowRadius: 6,
-                shadowY: 3
-            ) {
-                HStack(spacing: 6) {
-                    Circle()
-                        .fill(dotColor)
-                        .frame(width: 8, height: 8)
-                    Text(noMatchText)
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(.primary)
-                    Text("·")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Button {
-                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                        viewModel.clearFilters()
-                    } label: {
-                        Text(clearText)
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(dotColor)
+                GlassmorphismCapsule(
+                    horizontalPadding: 12,
+                    verticalPadding: 6,
+                    shadowRadius: 6,
+                    shadowY: 3
+                ) {
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(dotColor)
+                            .frame(width: 8, height: 8)
+                        Text(noMatchText)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.primary)
+                        Text("·")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Button {
+                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                            viewModel.clearFilters()
+                        } label: {
+                            Text(clearText)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(dotColor)
+                        }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
                 }
-            }
-            .contentTransition(.opacity)
-            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: count)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(Text(a11yLabel))
-            .accessibilityAddTraits(.isButton)
-            .accessibilityAction {
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                viewModel.clearFilters()
-            }
+                .contentTransition(.opacity)
+                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: count)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text(a11yLabel))
+                .accessibilityAddTraits(.isButton)
+                .accessibilityAction {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    viewModel.clearFilters()
+                }
             }
         } else {
             let countText = count == 1


### PR DESCRIPTION
## "Now" filter empty state: surface the next experience coming alive

When the signature "Now" filter yields zero matches, the map currently shows a generic "No matches · Clear filter" dead-end. This adds a brief-aligned empty state that reuses the existing minutesUntilBestTime logic to tell the user when the soonest experience comes alive and offers a one-tap jump to it (e.g. "Nothing's at its best now — Wat Phra Singh in 45m"), turning a dead-end into a next action.

### Acceptance
Selecting the "Now" filter when no experience is currently at its best shows a gold-dot capsule reading "Nothing's at its best now" and, when at least one experience has an upcoming bestTime, appends its title and minutes-until; tapping the capsule flies the map to that experience and selects it (verified in Simulator). When no upcoming experience exists, the original "No matches · Clear filter" badge still appears. Non-Now filters are unchanged. `xcodebuild build` and the SoloCompassTests suite pass; VoiceOver reads the capsule as a single button with the upcoming-experience label.