### PR TITLE
auto: Make high Solo Scores pop on the experience card with a star affordance + spring entrance

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -141,6 +141,7 @@
 
 /* Solo score accessibility */
 "solo.a11y" = "Solo Score %@ of 10";
+"solo.excellent.a11y" = "Excellent for solo travelers";
 
 /* Map empty / loading */
 "map.empty.title" = "No experiences nearby";

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -8,6 +8,7 @@ public struct SoloScoreBadge: View {
     public enum Style { case compact, full }
 
     @State private var animatedScore: Double = 0
+    @State private var appeared = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     public init(score: SoloScore, style: Style = .compact) {
@@ -22,8 +23,15 @@ public struct SoloScoreBadge: View {
         }
     }
 
+    private var isExcellent: Bool { score.overall >= 8.5 }
+
     private var compactView: some View {
         HStack(spacing: 4) {
+            if isExcellent {
+                Image(systemName: "star.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.white.opacity(0.95))
+            }
             Text(NSLocalizedString("solo.label", comment: "Solo"))
                 .font(.caption2)
                 .foregroundStyle(.white.opacity(0.9))
@@ -36,10 +44,23 @@ public struct SoloScoreBadge: View {
         .background(
             Capsule().fill(score.scoreColor.opacity(0.95))
         )
-        .accessibilityLabel(Text(String(
-            format: NSLocalizedString("solo.a11y", comment: "Solo Score %@ of 10"),
-            formatted(score.overall)
-        )))
+        .scaleEffect(appeared ? 1 : 0.7)
+        .opacity(appeared ? 1 : 0)
+        .onAppear {
+            if reduceMotion {
+                appeared = true
+            } else {
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.6)) {
+                    appeared = true
+                }
+            }
+        }
+        .accessibilityLabel(Text(
+            isExcellent
+                ? String(format: NSLocalizedString("solo.a11y", comment: "Solo Score %@ of 10"), formatted(score.overall))
+                    + ", " + NSLocalizedString("solo.excellent.a11y", comment: "Excellent for solo travelers")
+                : String(format: NSLocalizedString("solo.a11y", comment: "Solo Score %@ of 10"), formatted(score.overall))
+        ))
     }
 
     private var fullView: some View {
@@ -85,15 +106,22 @@ public struct SoloScoreBadge: View {
 }
 
 #Preview {
-    let score = SoloScore(
+    let excellentScore = SoloScore(
         overall: 8.7,
         breakdown: .init(seatingFriendly: 9, soloPatronRatio: 8, staffPressure: 9, soloPortioning: 10, ambianceFit: 8, safety: 9),
         hint: "Order at the bar, sit upstairs.",
         basedOnCount: 14
     )
+    let midScore = SoloScore(
+        overall: 5.2,
+        breakdown: .init(seatingFriendly: 5, soloPatronRatio: 5, staffPressure: 6, soloPortioning: 5, ambianceFit: 5, safety: 5),
+        hint: nil,
+        basedOnCount: 3
+    )
     VStack(spacing: 24) {
-        SoloScoreBadge(score: score, style: .compact)
-        SoloScoreBadge(score: score, style: .full)
+        SoloScoreBadge(score: excellentScore, style: .compact)
+        SoloScoreBadge(score: midScore, style: .compact)
+        SoloScoreBadge(score: excellentScore, style: .full)
             .padding()
             .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
     }


### PR DESCRIPTION
## Make high Solo Scores pop on the experience card with a star affordance + spring entrance

The Solo Score is the product's signature metric, but the compact badge on the card appears instantly with no entrance animation and treats an excellent 8.5 the same as a mediocre 5.2 (only a subtle hue shift differs). Add a gentle spring scale-in when the badge appears and a small filled star glyph for 'excellent' solo scores (overall >= 8.5) so the best solo-friendly experiences are instantly scannable, respecting reduce-motion.

### Acceptance
xcodebuild build succeeds for the SoloCompass scheme; the compact badge springs in on appear and shows a filled star only when overall >= 8.5; with Reduce Motion on the badge appears at full scale instantly with no animation; VoiceOver reads the 'Excellent for solo travelers' clause for high scores; fullView and existing card layout are visually unchanged; en.lproj/Localizable.strings contains the new solo.excellent.a11y key.