### PR TITLE
auto: Add a directional bearing arrow to the experience card distance pill

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -189,6 +189,17 @@
 "card.distance.walkSub1" = "<1 min walk";
 "card.distance.arrived" = "You're here";
 "card.distance.arrived.a11y" = "You're here";
+"card.distance.bearing.a11y" = "toward the %@";
+
+/* Compass directions (8 sectors) for bearing arrow accessibility */
+"compass.N" = "north";
+"compass.NE" = "northeast";
+"compass.E" = "east";
+"compass.SE" = "southeast";
+"compass.S" = "south";
+"compass.SW" = "southwest";
+"compass.W" = "west";
+"compass.NW" = "northwest";
 
 /* Voice recognition error alert */
 "voice.error.title" = "Voice recognition error";

--- a/apps/ios/SoloCompass/Services/LocationService.swift
+++ b/apps/ios/SoloCompass/Services/LocationService.swift
@@ -120,6 +120,19 @@ public final class LocationService: NSObject {
         return here.distance(from: target)
     }
 
+    /// Initial great-circle bearing in degrees (0 = N, clockwise) from the current
+    /// location to `coordinate`. Returns nil when no GPS fix is available.
+    public func bearing(to coordinate: CLLocationCoordinate2D) -> Double? {
+        guard let here = currentLocation else { return nil }
+        let lat1 = here.coordinate.latitude * .pi / 180
+        let lat2 = coordinate.latitude * .pi / 180
+        let dLon = (coordinate.longitude - here.coordinate.longitude) * .pi / 180
+        let y = sin(dLon) * cos(lat2)
+        let x = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(dLon)
+        let bearing = atan2(y, x) * 180 / .pi
+        return (bearing + 360).truncatingRemainder(dividingBy: 360)
+    }
+
     /// Test-only: inject a simulated location. Bypasses CLLocationManager so
     /// tests can exercise ViewModel logic synchronously without real GPS.
     /// Not called in production code — harmless to ship.

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -173,6 +173,34 @@ final class SoloCompassTests: XCTestCase {
         )
     }
 
+    // MARK: - Bearing
+
+    func testBearingDueNorth() {
+        // Target is directly north of the origin → bearing ≈ 0°.
+        let service = LocationService()
+        let origin = CLLocation(latitude: 0.0, longitude: 0.0)
+        service.simulate(location: origin)
+        let north = CLLocationCoordinate2D(latitude: 1.0, longitude: 0.0)
+        let result = try XCTUnwrap(service.bearing(to: north))
+        XCTAssertEqual(result, 0.0, accuracy: 0.5)
+    }
+
+    func testBearingDueEast() {
+        // Target is directly east of the origin → bearing ≈ 90°.
+        let service = LocationService()
+        let origin = CLLocation(latitude: 0.0, longitude: 0.0)
+        service.simulate(location: origin)
+        let east = CLLocationCoordinate2D(latitude: 0.0, longitude: 1.0)
+        let result = try XCTUnwrap(service.bearing(to: east))
+        XCTAssertEqual(result, 90.0, accuracy: 0.5)
+    }
+
+    func testBearingNilWithoutFix() {
+        let service = LocationService()
+        // No simulated fix → bearing must be nil.
+        XCTAssertNil(service.bearing(to: CLLocationCoordinate2D(latitude: 1.0, longitude: 0.0)))
+    }
+
     // MARK: - Distance
 
     func testCLLocationDistanceBetweenChiangMaiPoints() {

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -44,6 +44,28 @@ public struct ExperienceCardView: View {
         return (d.isFinite && d < .greatestFiniteMagnitude) ? d : nil
     }
 
+    /// Bearing in degrees (0 = N, clockwise) from the user to this experience, or nil when no GPS fix.
+    private var bearingDegrees: Double? {
+        guard let coord = experience.coordinate else { return nil }
+        return locationService.bearing(to: coord)
+    }
+
+    /// Maps a bearing in degrees to a localized compass direction string (8 sectors).
+    private static func compassDirection(for degrees: Double) -> String {
+        let directions = [
+            NSLocalizedString("compass.N", comment: "North"),
+            NSLocalizedString("compass.NE", comment: "Northeast"),
+            NSLocalizedString("compass.E", comment: "East"),
+            NSLocalizedString("compass.SE", comment: "Southeast"),
+            NSLocalizedString("compass.S", comment: "South"),
+            NSLocalizedString("compass.SW", comment: "Southwest"),
+            NSLocalizedString("compass.W", comment: "West"),
+            NSLocalizedString("compass.NW", comment: "Northwest"),
+        ]
+        let index = Int((degrees / 45.0).rounded()) % 8
+        return directions[index]
+    }
+
     private static let distanceFormatter: MeasurementFormatter = {
         let f = MeasurementFormatter()
         f.unitOptions = .naturalScale
@@ -278,12 +300,34 @@ public struct ExperienceCardView: View {
 
     @ViewBuilder
     private func distancePill(_ label: String, symbol: String) -> some View {
-        Label(label, systemImage: symbol)
-            .font(.caption)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .foregroundStyle(Color.secondary)
-            .background(Capsule().fill(Color.secondary.opacity(0.12)))
+        let bearing = bearingDegrees
+        HStack(spacing: 4) {
+            if let bearing {
+                Image(systemName: "location.north.fill")
+                    .font(.caption2)
+                    .foregroundStyle(Color.secondary)
+                    .rotationEffect(.degrees(bearing))
+                    .animation(
+                        reduceMotion ? nil : .easeInOut(duration: 0.25),
+                        value: bearing
+                    )
+                    .accessibilityHidden(true)
+            }
+            Label(label, systemImage: symbol)
+                .font(.caption)
+                .foregroundStyle(Color.secondary)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Capsule().fill(Color.secondary.opacity(0.12)))
+        .accessibilityLabel({
+            var text = label
+            if let bearing {
+                let direction = Self.compassDirection(for: bearing)
+                text += ". " + String(format: NSLocalizedString("card.distance.bearing.a11y", comment: "Bearing direction accessibility"), direction)
+            }
+            return text
+        }())
     }
 
     @ViewBuilder
@@ -421,7 +465,7 @@ private struct BestNowBadge: View {
 #Preview {
     if let exp = ExperienceService.hardcodedSeed.first {
         let locationService = LocationService()
-        // Simulate a location ~30 m from the seed experience so the arrived pill is visible in preview.
+        // Simulate a location ~30 m south of the seed experience so the arrived pill is visible; the bearing arrow points north toward the target.
         if let coord = exp.coordinate {
             let offset = CLLocation(latitude: coord.latitude + 0.00027, longitude: coord.longitude)
             locationService.simulate(location: offset)


### PR DESCRIPTION
## Add a directional bearing arrow to the experience card distance pill

Solo Compass is map-first and literally a 'compass,' yet the experience card's distance pill only shows walk-time/distance with no sense of which way the experience lies. Add a small arrow that rotates to point from the user's current location toward the experience's coordinate, turning the static distance pill into a glanceable directional cue. Bearing is computed purely from the two coordinates already available (no Core Location heading hardware or new permissions needed), so it works wherever distance already shows.

### Acceptance
Tapping a marker shows the distance pill with a north-relative arrow that visibly points toward the experience (e.g. user south of target → arrow points up/N); the arrow rotates smoothly as currentLocation changes and is static under Reduce Motion; pills with no GPS fix and the 'arrived' pill show no arrow; VoiceOver reads '... 12 min walk. toward the north'; xcodebuild build and SoloCompassTests pass, including a new test asserting bearing(to:) returns ~0° due north and ~90° due east from a known origin.