### PR TITLE
auto: Give the Now filter pill the same press feedback as every other pill

### DIFF
--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -162,7 +162,7 @@ public struct FilterBarView: View {
                 Capsule().stroke(isSelected ? Color.clear : Color.primary.opacity(0.2), lineWidth: 1)
             )
         }
-        .buttonStyle(.plain)
+        .buttonStyle(PressableButtonStyle())
         .accessibilityLabel(Text(a11yLabel))
         .accessibilityAddTraits(isSelected ? .isSelected : [])
         .onAppear {


### PR DESCRIPTION
## Give the "Now" filter pill the same press feedback as every other pill

In FilterBarView, every category/custom-tag pill uses PressableButtonStyle (an 8% scale-down spring on press) for a physical, satisfying tap, but the "Now" pill — the most important filter, surfacing real-time recommendations — is the lone exception using .buttonStyle(.plain), so it feels flat and inconsistent. Switching it to PressableButtonStyle unifies the tactile feel across the whole filter row. PressableButtonStyle must also be promoted from private to fileprivate-safe usage on the new pill (it already lives in the same file, so no visibility change is needed).

### Acceptance
Build succeeds (xcodebuild build -scheme SoloCompass). In the Simulator, tapping the "Now" pill visibly scales down ~8% and springs back, matching the other pills; the gold-fill selection, pulsing dot, count badge, and selection haptic still work. Existing FilterBarViewTests and CityPillHitTargetTests still pass (the change is presentation-only and does not alter hit targets or selection logic).