### PR TITLE
auto: Add undo bar to itinerary delete — mirror the favorites safety pattern

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -668,6 +668,8 @@
 "itinerary.experienceCount" = "%d experiences";
 "itinerary.action.create.a11y" = "Create new itinerary";
 "itinerary.action.delete" = "Delete";
+"itinerary.undo.named" = "Removed \"%@\"";
+"itinerary.undo.named.a11y" = "Removed itinerary \"%@\". Tap Undo to restore.";
 
 /* Itinerary detail (US-004) */
 "itinerary.detail.city" = "City";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -255,6 +255,9 @@
 "favorites.empty.hint" = "点击任意体验上的爱心即可保存到这里。";
 "favorites.undo.named" = "已移除\"%@\"";
 
+/* Generic actions */
+"action.undo" = "撤销";
+
 /* Notifications */
 "settings.notifications" = "靠近时提醒我";
 "settings.notifications.header" = "通知";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -527,6 +527,8 @@
 "itinerary.experienceCount" = "%d 个体验";
 "itinerary.action.create.a11y" = "新建行程";
 "itinerary.action.delete" = "删除";
+"itinerary.undo.named" = "已移除\"%@\"";
+"itinerary.undo.named.a11y" = "已移除行程\"%@\"。点击撤销可恢复。";
 
 /* Itinerary detail (US-004) */
 "itinerary.detail.city" = "城市";

--- a/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
@@ -9,6 +9,8 @@ public struct ItineraryListView: View {
 
     @State private var itineraries: [Itinerary] = []
     @State private var showingCreateForm = false
+    @State private var lastDeleted: Itinerary?
+    @State private var undoDismissTask: Task<Void, Never>?
 
     /// Production init using the shared on-disk container.
     public init() {
@@ -66,6 +68,14 @@ public struct ItineraryListView: View {
             }
         }
         .onAppear(perform: loadItineraries)
+        .overlay(alignment: .bottom) {
+            if lastDeleted != nil {
+                undoBar
+                    .transition(reduceMotion ? .opacity : .move(edge: .bottom).combined(with: .opacity))
+                    .padding(.bottom, 16)
+            }
+        }
+        .animation(reduceMotion ? nil : .easeInOut, value: lastDeleted != nil)
     }
 
     private func loadItineraries() {
@@ -73,9 +83,66 @@ public struct ItineraryListView: View {
     }
 
     private func delete(_ itinerary: Itinerary) {
+        let captured = itinerary
         try? store.delete(id: itinerary.id)
-        withAnimation(.easeInOut) {
+        withAnimation(reduceMotion ? nil : .easeInOut) {
             itineraries.removeAll { $0.id == itinerary.id }
+        }
+        UINotificationFeedbackGenerator().notificationOccurred(.warning)
+        lastDeleted = captured
+        undoDismissTask?.cancel()
+        undoDismissTask = Task {
+            try? await Task.sleep(for: .seconds(4))
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                withAnimation(reduceMotion ? nil : .easeInOut) {
+                    lastDeleted = nil
+                }
+            }
+        }
+    }
+
+    private func performUndo() {
+        guard let saved = lastDeleted else { return }
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        undoDismissTask?.cancel()
+        undoDismissTask = nil
+        try? store.save(saved)
+        withAnimation(reduceMotion ? nil : .easeInOut) {
+            lastDeleted = nil
+        }
+        loadItineraries()
+    }
+
+    private var undoBar: some View {
+        HStack {
+            Text(String(
+                format: NSLocalizedString("itinerary.undo.named", comment: "Removed named itinerary undo banner"),
+                lastDeleted?.title ?? ""
+            ))
+            .font(.subheadline)
+            .foregroundStyle(.primary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            Spacer()
+            Button {
+                performUndo()
+            } label: {
+                Text(NSLocalizedString("action.undo", comment: "Undo action"))
+                    .font(.subheadline.weight(.semibold))
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 16)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(String(
+            format: NSLocalizedString("itinerary.undo.named.a11y", comment: "Accessibility label for itinerary undo banner"),
+            lastDeleted?.title ?? ""
+        )))
+        .accessibilityAction(named: Text(NSLocalizedString("action.undo", comment: "Undo action"))) {
+            performUndo()
         }
     }
 }


### PR DESCRIPTION
## Add undo bar to itinerary delete — mirror the favorites safety pattern

Swiping to delete an itinerary in ItineraryListView is fully destructive: a full-swipe permanently removes a planned trip (often holding many pinned experiences) with no confirmation and no way back, while the far-less-consequential 'unfavorite' action already has a rich 4-second undo bar. This adds the same undo-bar pattern to itinerary deletion: delete immediately, surface a bottom undo banner with a countdown, and re-save the captured Itinerary via store.save() if the user taps Undo.

### Acceptance
Full-swipe deleting an itinerary removes the row AND shows a bottom undo bar for ~4s; tapping Undo restores the itinerary (same title, city, dates, pinned experienceIds) to the list and it survives a view reload; the bar auto-dismisses after 4s if untouched; warning haptic on delete, light haptic on undo; Reduce Motion disables the bar's animated transitions but undo still works; new strings present in both en and zh-Hans; `xcodebuild build` and `xcodebuild test` (iPhone 17 Pro sim) pass.