### PR TITLE
auto: Live walk-time on the experience card that updates as you approach

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -18,6 +18,7 @@ public struct ExperienceCardView: View {
     @State private var heartBounce = 0
     @State private var heartBurst = false
     @State private var arrivedPulse = false
+    @State private var didFireArrival = false
 
     private static let arrivedThresholdMeters = 75.0
 
@@ -169,12 +170,16 @@ public struct ExperienceCardView: View {
 
             HStack {
                 SoloScoreBadge(score: experience.soloScore, style: .compact)
-                if isArrived {
-                    arrivedPill
-                } else if let meters = distanceMeters {
-                    let dl = Self.formatDistance(meters)
-                    distancePill(dl.text, symbol: dl.symbol)
+                Group {
+                    if isArrived {
+                        arrivedPill
+                    } else if let meters = distanceMeters {
+                        let dl = Self.formatDistance(meters)
+                        distancePill(dl.text, symbol: dl.symbol)
+                    }
                 }
+                .contentTransition(.numericText())
+                .animation(.spring(response: 0.4), value: distanceMeters)
                 if !experience.realInconveniences.isEmpty {
                     inconveniencePill
                 } else if experience.isBestNow() {
@@ -233,6 +238,11 @@ public struct ExperienceCardView: View {
                 }
         )
         .onTapGesture { onExpand() }
+        .onChange(of: isArrived) { _, arrived in
+            guard arrived, !didFireArrival else { return }
+            didFireArrival = true
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        }
         .onAppear {
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
         }


### PR DESCRIPTION
## Live walk-time on the experience card that updates as you approach

The experience card computes its distance/walk-time pill once and never refreshes, so the number goes stale while a solo traveler is actually walking toward the spot — the moment the pill matters most. Make the pill recompute on each LocationService update and animate the changing walk-minutes with a numericText content transition, plus a one-time soft haptic when the 'arrived' threshold is crossed while the card is open.

### Acceptance
Open a card for a nearby experience and physically/simulator-move toward it: the walk-time pill counts down with an animated numeric transition rather than jumping. Crossing within 75m flips the pill to the green 'You're here' state and fires a single success haptic (not repeated). With Reduce Motion on, the pill still updates and the haptic still fires, but without the spring pulse. Build passes `xcodebuild build` and existing SoloCompassTests stay green.