### PR TITLE
auto: Make the completion confetti burst feel physical (per-particle gravity, rotation & staggered fade)

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/CompletionCelebrationView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/CompletionCelebrationView.swift
@@ -11,10 +11,13 @@ public struct CompletionCelebrationView: View {
     private struct Particle: Identifiable {
         let id = UUID()
         let color: Color
-        let angle: Double   // radians
-        let distance: CGFloat
+        let angle: Double       // radians
+        let distance: CGFloat   // launch radius
         let size: CGFloat
         let isCircle: Bool
+        let rotation: Double    // final spin in degrees, random -180...180
+        let delay: Double       // stagger offset, random 0...0.08
+        let gravity: CGFloat    // downward drift, random 28...46
     }
 
     @State private var particles: [Particle] = []
@@ -40,10 +43,15 @@ public struct CompletionCelebrationView: View {
                     )
                     .offset(
                         x: animated ? cos(p.angle) * p.distance : 0,
-                        y: animated ? sin(p.angle) * p.distance + (animated ? 18 : 0) : 0
+                        y: animated ? sin(p.angle) * p.distance + p.gravity : 0
                     )
                     .opacity(animated ? 0 : 0.9)
                     .scaleEffect(animated ? 0.3 : 1.0)
+                    .rotationEffect(.degrees(animated ? p.rotation : 0))
+                    .animation(
+                        .easeOut(duration: 0.8).delay(p.delay),
+                        value: animated
+                    )
                 }
             }
 
@@ -69,7 +77,10 @@ public struct CompletionCelebrationView: View {
                 angle: Double(i) / Double(count) * .pi * 2 + Double.random(in: -0.3...0.3),
                 distance: CGFloat.random(in: 52...92),
                 size: CGFloat.random(in: 6...11),
-                isCircle: Bool.random()
+                isCircle: Bool.random(),
+                rotation: Double.random(in: -180...180),
+                delay: Double.random(in: 0...0.08),
+                gravity: CGFloat.random(in: 28...46)
             )
         }
         animated = false
@@ -85,7 +96,7 @@ public struct CompletionCelebrationView: View {
             }
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.1) {
             particles = []
             animated = false
             checkmarkPop = false


### PR DESCRIPTION
## Make the completion confetti burst feel physical (per-particle gravity, rotation & staggered fade)

CompletionCelebrationView currently fires all 14 confetti particles with one shared easeOut(0.8) curve, no rotation, and a uniform fade — so the app's signature 'I did it' moment reads flat and synthetic. This reworks the burst to give each particle its own launch velocity, gravity-driven arc, spin, and staggered fade-out, turning the highest-emotion interaction (check-in / mark-complete) into a tactile, celebratory beat. Fully gated on Reduce Motion (checkmark-only path unchanged) and self-contained in one file.

### Acceptance
Build succeeds via `xcodebuild build -project apps/ios/SoloCompass.xcodeproj -scheme SoloCompass -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest'`. In Simulator, firing the celebration shows particles launching with varied timing, arcing downward (gravity) and spinning before fading — not a uniform symmetric ring. With Reduce Motion enabled (Settings > Accessibility), only the checkmark pop appears, zero particles. No second haptic fires on check-in/complete (still exactly one .success buzz). Both #Preview variants render. Change is confined to CompletionCelebrationView.swift and under 100 changed lines.