### PR TITLE
auto: Fix mislabeled SoloScore radar axes (WiFi/Noise → Solo Patrons/Ambiance)

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -38,7 +38,7 @@
 "solo.label" = "Solo";
 "solo.scoreTitle" = "Solo Score";
 "solo.seating" = "Seating";
-"solo.patrons" = "Solo patrons";
+"solo.patrons" = "Solo Patrons";
 "solo.staff" = "Staff";
 "solo.portioning" = "Portioning";
 "solo.ambiance" = "Ambiance";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -29,10 +29,10 @@
 "solo.label" = "独行";
 "solo.scoreTitle" = "独行评分";
 "solo.seating" = "座位友好";
-"solo.patrons" = "独行客比例";
+"solo.patrons" = "独行顾客";
 "solo.staff" = "员工不打扰";
 "solo.portioning" = "适合一人份量";
-"solo.ambiance" = "氛围适合独处";
+"solo.ambiance" = "氛围契合";
 "solo.safety" = "独行安全";
 "solo.basedOn" = "基于 %d 位独行者";
 "solo.basedOn.early" = "基于 %d 条早期反馈";
@@ -454,8 +454,6 @@
 /* Solo score */
 "solo.radar.a11y" = "独行评分雷达图";
 "solo.radar.replayHint" = "轻点以重播绘制动画";
-"solo.radar.weakest" = "最弱项：%@ — 预期会是一个权衡点";
-"solo.radar.weakest.a11y" = "注意：%@ 是最弱的维度 — 预期会是一个权衡点。";
 "solo.wifi" = "WiFi";
 "solo.noise" = "噪音";
 

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
@@ -16,8 +16,8 @@ public struct SoloScoreRadarChart: View {
     private static let axes: [(label: String, symbol: String, keyPath: KeyPath<SoloScore.Breakdown, Double>)] = [
         (NSLocalizedString("solo.seating",    comment: ""), "chair",              \.seatingFriendly),
         (NSLocalizedString("solo.staff",      comment: ""), "person.crop.circle", \.staffPressure),
-        (NSLocalizedString("solo.wifi",       comment: ""), "wifi",               \.soloPatronRatio),
-        (NSLocalizedString("solo.noise",      comment: ""), "speaker.slash",      \.ambianceFit),
+        (NSLocalizedString("solo.patrons",    comment: ""), "person.2",           \.soloPatronRatio),
+        (NSLocalizedString("solo.ambiance",   comment: ""), "sparkles",           \.ambianceFit),
         (NSLocalizedString("solo.safety",     comment: ""), "shield",             \.safety),
         (NSLocalizedString("solo.portioning", comment: ""), "fork.knife",         \.soloPortioning),
     ]


### PR DESCRIPTION
## Fix mislabeled SoloScore radar axes (WiFi/Noise → Solo Patrons/Ambiance)

The SoloScore radar chart and fallback bars label two of the six dimensions incorrectly: the `soloPatronRatio` value ("% of patrons who come alone") is shown under a 'WiFi' label with a wifi icon, and `ambianceFit` ("does the ambiance feel okay alone") is shown under a 'Noise' label with a speaker.slash icon. This misrepresents the product's core solo-friendliness metric in its most prominent visualization, including the accessibility label and the honest-tradeoff 'weakest dimension' caption. Fix the axis label keys + SF Symbols and the two localized strings (en + zh-Hans) to match the actual schema dimensions.

### Acceptance
Radar chart and fallback bars display 'Solo Patrons' (person.2 icon) for the soloPatronRatio value and 'Ambiance' for the ambianceFit value, in both English and Chinese; the VoiceOver accessibility label and 'weakest dimension' caption use the corrected names; no 'WiFi'/'Noise' labels remain on the SoloScore chart; iOS target builds and existing tests pass.