### PR TITLE
auto: Make the SoloScore radar chart's honest-tradeoff insight accessible to VoiceOver

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -49,6 +49,7 @@
 "solo.radar.a11y" = "Solo Score radar";
 "solo.radar.replayHint" = "Tap to replay the draw-in animation";
 "solo.radar.weakest" = "Weakest: %@ — expect it to be a tradeoff";
+"solo.radar.weakest.a11y" = "Note: %@ is the weakest dimension — expect it to be a tradeoff.";
 "solo.basedOn.early" = "Based on %d early reports";
 "solo.estimate.pill" = "AI estimate";
 "solo.section.estimate" = "Solo Score (AI estimate)";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -454,6 +454,8 @@
 /* Solo score */
 "solo.radar.a11y" = "独行评分雷达图";
 "solo.radar.replayHint" = "轻点以重播绘制动画";
+"solo.radar.weakest" = "最弱项：%@ — 预期会是一个权衡点";
+"solo.radar.weakest.a11y" = "注意：%@ 是最弱的维度 — 预期会是一个权衡点。";
 "solo.wifi" = "WiFi";
 "solo.noise" = "噪音";
 

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
@@ -202,11 +202,27 @@ public struct SoloScoreRadarChart: View {
     }
 
     private var radarAccessibilityLabel: Text {
-        // Always reports final values regardless of animation state
-        let descriptions = zip(Self.axes, values).map { axis, val in
-            "\(axis.label): \(Int(val))"
+        let overallFormatted = String(format: "%.1f", score.overall)
+        let overallLabel = String(format: NSLocalizedString("solo.a11y", comment: ""), overallFormatted)
+
+        let sortedDimensions = zip(Self.axes, values)
+            .sorted { $0.1 > $1.1 }
+        let dimensionParts = sortedDimensions.map { axis, val in
+            "\(axis.label) \(Int(val)) of 10"
         }.joined(separator: ", ")
-        return Text(NSLocalizedString("solo.radar.a11y", comment: "") + ": " + descriptions)
+
+        var label = "\(overallLabel). \(dimensionParts)."
+
+        if values[weakestIndex] < 6 {
+            let weakestName = Self.axes[weakestIndex].label
+            let weakestSentence = String(
+                format: NSLocalizedString("solo.radar.weakest.a11y", comment: ""),
+                weakestName
+            )
+            label += " \(weakestSentence)"
+        }
+
+        return Text(label)
     }
 
     // MARK: - Replay


### PR DESCRIPTION
## Make the SoloScore radar chart's honest-tradeoff insight accessible to VoiceOver

The radar chart visually highlights the weakest solo-travel dimension in amber and shows an 'honest tradeoff' caption, but VoiceOver users only hear a flat list of raw numbers and the caption is accessibilityHidden. Since the SoloScore is the app's core trust signal, this enriches the spoken label to lead with the overall score and explicitly name the weakest dimension — giving non-sighted users the same insight sighted users get.

### Acceptance
Build succeeds (xcodebuild build, iPhone 17 Pro sim). With VoiceOver, focusing the radar (or fallback bars) speaks the overall score first, then each dimension as 'name N of 10' ordered strongest→weakest, and—only when a dimension scores below 6—a closing sentence naming the weakest one. The new string exists in en.lproj/Localizable.strings; existing SoloScoreRadarChart previews still render unchanged. No @Model/schema files modified.