### PR TITLE
auto: Distance pill in the experience detail hero

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -655,6 +655,10 @@
 "locationPicker.map.saveAndSet" = "Save & Set Location";
 "locationPicker.map.saveCity.confirmed" = "Location saved!";
 
+/* Distance pill in experience detail hero */
+"detail.distance.away" = "%@ away";
+"detail.distance.a11y" = "%@ away";
+
 /* US-015: Multi-source indicator and real signals in detail view */
 "detail.multiSource.indicator" = "Verified by multiple sources";
 "detail.multiSource.indicator.a11y" = "This place was verified by multiple data sources";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -228,10 +228,71 @@ public struct ExperienceDetailView: View {
 
             if let local = viewModel.experience.location.placeNameLocal, !local.isEmpty {
                 let romanized = viewModel.experience.location.placeNameRomanized
-                Text(romanized?.isEmpty == false ? "\(local) · \(romanized ?? "")" : local)
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
+                HStack(spacing: 8) {
+                    Text(romanized?.isEmpty == false ? "\(local) · \(romanized ?? "")" : local)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                    distancePill
+                }
+            } else {
+                distancePill
             }
+        }
+    }
+
+    @ViewBuilder
+    private var distancePill: some View {
+        if locationService.currentLocation != nil,
+           let coord = viewModel.experience.location.clCoordinate {
+            let meters = locationService.distance(to: coord)
+            if meters < .greatestFiniteMagnitude {
+                let distStr = Self.formatDistance(meters)
+                let awayStr = String(
+                    format: NSLocalizedString("detail.distance.away", comment: "Distance away pill"),
+                    distStr
+                )
+                HStack(spacing: 3) {
+                    Image(systemName: "location.fill")
+                        .font(.system(size: 9))
+                    Text(awayStr)
+                        .font(.caption2.monospacedDigit())
+                }
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(Capsule().fill(Color(.tertiarySystemFill)))
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text(String(
+                    format: NSLocalizedString("detail.distance.a11y", comment: "Distance accessibility label"),
+                    distStr
+                )))
+            }
+        }
+    }
+
+    private static let metersFormatter: MeasurementFormatter = {
+        let f = MeasurementFormatter()
+        f.unitOptions = .providedUnit
+        f.numberFormatter.maximumFractionDigits = 0
+        return f
+    }()
+
+    private static let kilometersFormatter: MeasurementFormatter = {
+        let f = MeasurementFormatter()
+        f.unitOptions = .providedUnit
+        f.numberFormatter.maximumFractionDigits = 1
+        f.numberFormatter.minimumFractionDigits = 1
+        return f
+    }()
+
+    private static func formatDistance(_ meters: Double) -> String {
+        if meters < 1000 {
+            let rounded = (meters / 50).rounded() * 50
+            let measurement = Measurement(value: max(50, rounded), unit: UnitLength.meters)
+            return metersFormatter.string(from: measurement)
+        } else {
+            let measurement = Measurement(value: meters / 1000, unit: UnitLength.kilometers)
+            return kilometersFormatter.string(from: measurement)
         }
     }
 


### PR DESCRIPTION
## Distance pill in the experience detail hero

The detail view shows a navigation button but never tells the user how far away the experience is — distance only appears in the favorites list. Add a compact 'X away' pill to the hero (next to the place name) using the existing LocationService.distance(to:), so users get an immediate 'should I go now?' read before tapping directions. Pill is hidden when location is unavailable.

### Acceptance
Build passes (`xcodebuild build -scheme SoloCompass`). With a simulated location set, opening any experience with coordinates shows a distance pill in the hero ('850 m away' / '2.4 km away'); the value matches what the same experience shows in the favorites list. With location services off / no coordinate, the pill is absent and layout is unchanged. VoiceOver reads the distance as a labeled element. #Preview still renders.