### PR TITLE
auto: Add inline Retry button to DiscoverListView error state

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -782,6 +782,8 @@
 "companion.discover.error.config" = "App configuration is missing. Please reinstall.";
 "companion.discover.error.auth" = "Sign in to discover companions.";
 "companion.discover.error.server" = "Server error. Try again later.";
+"companion.discover.error.retry" = "Try again";
+"companion.discover.error.retry.hint" = "Reloads the companion list";
 "companion.discover.empty.title" = "No companions found";
 "companion.discover.empty.description" = "No one is open to companions in this city right now.";
 "companion.discover.coldstart.tip" = "Be the first — open your itinerary to companions and others will find you.";

--- a/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
@@ -89,11 +89,26 @@ public struct DiscoverListView: View {
     }
 
     private func errorView(message: String) -> some View {
-        ContentUnavailableView(
-            NSLocalizedString("companion.discover.error.title", comment: "Error title"),
-            systemImage: "exclamationmark.triangle",
-            description: Text(message)
-        )
+        ContentUnavailableView {
+            Label(
+                NSLocalizedString("companion.discover.error.title", comment: "Error title"),
+                systemImage: "exclamationmark.triangle"
+            )
+        } description: {
+            Text(message)
+        } actions: {
+            Button {
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                Task { await loadPosts() }
+            } label: {
+                Label(
+                    NSLocalizedString("companion.discover.error.retry", comment: "Retry button"),
+                    systemImage: "arrow.clockwise"
+                )
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityHint(NSLocalizedString("companion.discover.error.retry.hint", comment: "Retry accessibility hint"))
+        }
     }
 
     private var emptyStateView: some View {


### PR DESCRIPTION
## Add inline Retry button to DiscoverListView error state

When companion discovery fails to load, DiscoverListView shows a dead-end ContentUnavailableView with the error message but no way to recover except finding the small toolbar refresh icon. Add a prominent inline Retry button (and a localized label) so users can recover from transient network/server errors directly, with a light haptic on tap — matching the recovery affordance the empty and no-search states already provide elsewhere in the app.

### Acceptance
When service.lastError is set, the error state shows the title, the error message, and a visible 'Try again' borderedProminent button. Tapping it re-runs loadPosts() (transitions back to the loading skeleton, then to posts/empty/error) and emits a light haptic. The button is VoiceOver-labeled and hinted. `xcodebuild build -scheme SoloCompass` succeeds and existing DiscoverListView previews still render. No SwiftData/@Model files are touched; change is under ~30 lines across 2 files.