### PR TITLE
auto: Make the distance-pill bearing arrow point where you actually walk (heading-corrected)

### DIFF
--- a/apps/ios/SoloCompass/Services/LocationService.swift
+++ b/apps/ios/SoloCompass/Services/LocationService.swift
@@ -11,6 +11,7 @@ public final class LocationService: NSObject {
     public private(set) var currentLocation: CLLocation?
     public private(set) var authorizationStatus: CLAuthorizationStatus
     public private(set) var lastError: Error?
+    public private(set) var heading: CLHeading?
 
     /// Geohash precision-6 (~600m×600m) of `currentLocation`. Nil when
     /// no location is known. Precise coordinates are never exposed — only
@@ -65,6 +66,9 @@ public final class LocationService: NSObject {
             return
         }
         manager.startUpdatingLocation()
+        if CLLocationManager.headingAvailable() {
+            manager.startUpdatingHeading()
+        }
     }
 
     private func enableBackgroundUpdates() {
@@ -74,6 +78,9 @@ public final class LocationService: NSObject {
 
     public func stopUpdating() {
         manager.stopUpdatingLocation()
+        if CLLocationManager.headingAvailable() {
+            manager.stopUpdatingHeading()
+        }
     }
 
     /// Register CLCircularRegions (200m radius) for each experience so the OS
@@ -133,11 +140,27 @@ public final class LocationService: NSObject {
         return (bearing + 360).truncatingRemainder(dividingBy: 360)
     }
 
+    /// Bearing relative to the device's current heading (0 = straight ahead).
+    /// When a valid heading is available, subtracts `trueHeading` from the
+    /// great-circle bearing so the arrow points where the user should walk.
+    /// Falls back to the absolute bearing when heading is nil or has negative
+    /// accuracy (invalid), so behavior is unchanged on devices without a compass.
+    public func relativeBearing(to coordinate: CLLocationCoordinate2D) -> Double? {
+        guard let absolute = bearing(to: coordinate) else { return nil }
+        guard let h = heading, h.headingAccuracy >= 0 else { return absolute }
+        return (absolute - h.trueHeading + 360).truncatingRemainder(dividingBy: 360)
+    }
+
     /// Test-only: inject a simulated location. Bypasses CLLocationManager so
     /// tests can exercise ViewModel logic synchronously without real GPS.
     /// Not called in production code — harmless to ship.
     public func simulate(location: CLLocation) {
         self.currentLocation = location
+    }
+
+    /// Test-only: inject a simulated heading.
+    public func simulate(heading: CLHeading) {
+        self.heading = heading
     }
 }
 
@@ -168,6 +191,13 @@ extension LocationService: CLLocationManagerDelegate {
     public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         Task { @MainActor in
             self.lastError = error
+        }
+    }
+
+    public func locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
+        guard newHeading.headingAccuracy >= 0 else { return }
+        Task { @MainActor in
+            self.heading = newHeading
         }
     }
 

--- a/apps/ios/SoloCompass/Tests/LocationServiceTests.swift
+++ b/apps/ios/SoloCompass/Tests/LocationServiceTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+import CoreLocation
+@testable import SoloCompass
+
+// CLHeading is not directly instantiable; subclass to inject test values.
+private final class MockHeading: CLHeading {
+    private let _trueHeading: CLLocationDirection
+    private let _headingAccuracy: CLLocationDirection
+
+    init(trueHeading: CLLocationDirection, accuracy: CLLocationDirection = 5) {
+        self._trueHeading = trueHeading
+        self._headingAccuracy = accuracy
+        super.init()
+    }
+
+    required init?(coder: NSCoder) { fatalError("not used in tests") }
+
+    override var trueHeading: CLLocationDirection { _trueHeading }
+    override var headingAccuracy: CLLocationDirection { _headingAccuracy }
+}
+
+@MainActor
+final class LocationServiceTests: XCTestCase {
+
+    // Tokyo Station as the "current" location, Senso-ji as the target.
+    // Great-circle bearing Tokyo Station → Senso-ji ≈ 13.8° (roughly north-northeast).
+    private let tokyoStation = CLLocation(latitude: 35.6812, longitude: 139.7671)
+    private let sensoji = CLLocationCoordinate2D(latitude: 35.7148, longitude: 139.7967)
+
+    // MARK: - Absolute fallback when no heading
+
+    func test_relativeBearing_noHeading_returnsAbsoluteBearing() throws {
+        let svc = LocationService()
+        svc.simulate(location: tokyoStation)
+        // No heading injected — must equal raw bearing(to:).
+        let absolute = try XCTUnwrap(svc.bearing(to: sensoji))
+        let relative = try XCTUnwrap(svc.relativeBearing(to: sensoji))
+        XCTAssertEqual(relative, absolute, accuracy: 0.001)
+    }
+
+    // MARK: - Correct subtraction when heading is set
+
+    func test_relativeBearing_subtractsHeading() throws {
+        let svc = LocationService()
+        svc.simulate(location: tokyoStation)
+
+        // Inject a heading equal to the absolute bearing so the result should be ~0°.
+        let absolute = try XCTUnwrap(svc.bearing(to: sensoji))
+        svc.simulate(heading: MockHeading(trueHeading: absolute))
+
+        let relative = try XCTUnwrap(svc.relativeBearing(to: sensoji))
+        XCTAssertEqual(relative, 0, accuracy: 0.001)
+    }
+
+    func test_relativeBearing_exactSubtraction_90minus90_equals0() throws {
+        // Place current location directly west of a target at the same latitude so
+        // bearing = 90° exactly, then inject heading = 90° → expected result = 0°.
+        let svc = LocationService()
+        let here = CLLocation(latitude: 35.0, longitude: 139.0)
+        let target = CLLocationCoordinate2D(latitude: 35.0, longitude: 139.1) // east
+        svc.simulate(location: here)
+        svc.simulate(heading: MockHeading(trueHeading: 90))
+
+        let relative = try XCTUnwrap(svc.relativeBearing(to: target))
+        // bearing ≈ 90°, heading = 90° → relative ≈ 0°
+        XCTAssertEqual(relative, 0, accuracy: 1.0)
+    }
+
+    // MARK: - Wrap-around past 360°
+
+    func test_relativeBearing_wrapsAroundPast360() throws {
+        let svc = LocationService()
+        svc.simulate(location: tokyoStation)
+
+        let absolute = try XCTUnwrap(svc.bearing(to: sensoji))
+        // Heading is 30° more than the absolute bearing → relative = absolute - (absolute+30) + 360 = 330°
+        let headingValue = (absolute + 30).truncatingRemainder(dividingBy: 360)
+        svc.simulate(heading: MockHeading(trueHeading: headingValue))
+
+        let relative = try XCTUnwrap(svc.relativeBearing(to: sensoji))
+        XCTAssertEqual(relative, 330, accuracy: 0.001)
+    }
+
+    func test_relativeBearing_smallBearingLargeHeading_wrapsCorrectly() throws {
+        // bearing = 10°, heading = 350° → 10 - 350 + 360 = 20°
+        let svc = LocationService()
+        // Place current location so bearing to target ≈ 10°.
+        // A target slightly north (≈ 0°) and slightly east gives ≈ 10° bearing.
+        let here = CLLocation(latitude: 35.0, longitude: 139.0)
+        // Small eastward offset with larger northward offset → bearing ≈ 10°
+        let target = CLLocationCoordinate2D(latitude: 35.1, longitude: 139.0176)
+        svc.simulate(location: here)
+        svc.simulate(heading: MockHeading(trueHeading: 350))
+
+        let absolute = try XCTUnwrap(svc.bearing(to: target))
+        let relative = try XCTUnwrap(svc.relativeBearing(to: target))
+        let expected = (absolute - 350 + 360).truncatingRemainder(dividingBy: 360)
+        XCTAssertEqual(relative, expected, accuracy: 0.001)
+        // Result must be in [0, 360)
+        XCTAssertGreaterThanOrEqual(relative, 0)
+        XCTAssertLessThan(relative, 360)
+    }
+
+    // MARK: - Invalid heading accuracy is ignored (fallback to absolute)
+
+    func test_relativeBearing_negativeAccuracy_fallsBackToAbsolute() throws {
+        let svc = LocationService()
+        svc.simulate(location: tokyoStation)
+        let absolute = try XCTUnwrap(svc.bearing(to: sensoji))
+
+        // headingAccuracy < 0 means invalid — must be ignored.
+        svc.simulate(heading: MockHeading(trueHeading: 45, accuracy: -1))
+
+        let relative = try XCTUnwrap(svc.relativeBearing(to: sensoji))
+        XCTAssertEqual(relative, absolute, accuracy: 0.001)
+    }
+
+    // MARK: - No location returns nil
+
+    func test_relativeBearing_noLocation_returnsNil() {
+        let svc = LocationService()
+        XCTAssertNil(svc.relativeBearing(to: sensoji))
+    }
+}

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -45,10 +45,17 @@ public struct ExperienceCardView: View {
         return (d.isFinite && d < .greatestFiniteMagnitude) ? d : nil
     }
 
-    /// Bearing in degrees (0 = N, clockwise) from the user to this experience, or nil when no GPS fix.
-    private var bearingDegrees: Double? {
+    /// Absolute bearing in degrees (0 = N, clockwise) — used only for VoiceOver cardinal direction.
+    private var absoluteBearingDegrees: Double? {
         guard let coord = experience.coordinate else { return nil }
         return locationService.bearing(to: coord)
+    }
+
+    /// Heading-corrected bearing: 0 = straight ahead. Falls back to absolute bearing
+    /// when the device has no compass or heading accuracy is invalid.
+    private var relativeBearingDegrees: Double? {
+        guard let coord = experience.coordinate else { return nil }
+        return locationService.relativeBearing(to: coord)
     }
 
     /// Maps a bearing in degrees to a localized compass direction string (8 sectors).
@@ -310,16 +317,17 @@ public struct ExperienceCardView: View {
 
     @ViewBuilder
     private func distancePill(_ label: String, symbol: String) -> some View {
-        let bearing = bearingDegrees
+        let relBearing = relativeBearingDegrees
+        let absBearing = absoluteBearingDegrees
         HStack(spacing: 4) {
-            if let bearing {
+            if let relBearing {
                 Image(systemName: "location.north.fill")
                     .font(.caption2)
                     .foregroundStyle(Color.secondary)
-                    .rotationEffect(.degrees(bearing))
+                    .rotationEffect(.degrees(relBearing))
                     .animation(
                         reduceMotion ? nil : .easeInOut(duration: 0.25),
-                        value: bearing
+                        value: relBearing
                     )
                     .accessibilityHidden(true)
             }
@@ -332,8 +340,8 @@ public struct ExperienceCardView: View {
         .background(Capsule().fill(Color.secondary.opacity(0.12)))
         .accessibilityLabel({
             var text = label
-            if let bearing {
-                let direction = Self.compassDirection(for: bearing)
+            if let absBearing {
+                let direction = Self.compassDirection(for: absBearing)
                 text += ". " + String(format: NSLocalizedString("card.distance.bearing.a11y", comment: "Bearing direction accessibility"), direction)
             }
             return text


### PR DESCRIPTION
## Make the distance-pill bearing arrow point where you actually walk (heading-corrected)

The distance pill in ExperienceCardView shows a 'location.north.fill' arrow rotated to the great-circle bearing toward the experience, but that bearing is relative to true north — so the arrow only points correctly when the user happens to be facing north. Adding device heading from CLLocationManager and subtracting trueHeading from the bearing makes the arrow point to the real direction the user should walk, turning a decorative arrow into a usable last-100-meters wayfinder.

### Acceptance
With a simulated location + injected heading, relativeBearing(to:) returns bearing-minus-trueHeading normalized to 0..<360 and falls back to the raw bearing when heading is nil or accuracy is negative; xcodebuild build and the LocationServiceTests pass; in the Simulator the distance-pill arrow rotates as the simulated heading changes; Reduce Motion still disables the rotation animation and VoiceOver still announces a cardinal direction.