### PR TITLE
auto: Fix mislabeled SoloScore radar tooltip breakdown (WiFi/Noise → Solo Patrons/Ambiance)

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -43,8 +43,6 @@
 "solo.portioning" = "Portioning";
 "solo.ambiance" = "Ambiance";
 "solo.safety" = "Safety";
-"solo.wifi" = "WiFi";
-"solo.noise" = "Noise";
 "solo.basedOn" = "Based on %d solo travelers";
 "solo.radar.a11y" = "Solo Score radar";
 "solo.radar.replayHint" = "Tap to replay the draw-in animation";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -454,8 +454,6 @@
 /* Solo score */
 "solo.radar.a11y" = "独行评分雷达图";
 "solo.radar.replayHint" = "轻点以重播绘制动画";
-"solo.wifi" = "WiFi";
-"solo.noise" = "噪音";
 
 /* US-019: Bilingual city picker */
 "city.distanceAway" = "距离 %.1f 公里";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -640,8 +640,8 @@ public struct ExperienceDetailView: View {
             let dims: [(String, String, Double)] = [
                 (NSLocalizedString("solo.seating", comment: ""), "chair", b.seatingFriendly),
                 (NSLocalizedString("solo.staff", comment: ""), "person.crop.circle", b.staffPressure),
-                (NSLocalizedString("solo.wifi", comment: ""), "wifi", b.soloPatronRatio),
-                (NSLocalizedString("solo.noise", comment: ""), "speaker.slash", b.ambianceFit),
+                (NSLocalizedString("solo.patrons", comment: ""), "person.2", b.soloPatronRatio),
+                (NSLocalizedString("solo.ambiance", comment: ""), "sparkles", b.ambianceFit),
                 (NSLocalizedString("solo.safety", comment: ""), "shield", b.safety),
                 (NSLocalizedString("solo.portioning", comment: ""), "fork.knife", b.soloPortioning),
             ]


### PR DESCRIPTION
## Fix mislabeled SoloScore radar tooltip breakdown (WiFi/Noise → Solo Patrons/Ambiance)

The tap-to-expand radar breakdown in ExperienceDetailView still labels the soloPatronRatio dimension as 'WiFi' and ambianceFit as 'Noise' with stale icons — the exact bug fixed in the radar chart itself by commit 5d12ba6, but missed in this sibling tooltip. The result is a detail screen where the radar axes and their expandable breakdown disagree on what two of the six dimensions mean. Fix the labels/icons to match the corrected chart and delete the now-orphaned solo.wifi/solo.noise strings from both locales.

### Acceptance
Tapping the radar chart on an experience detail expands a breakdown whose six rows match the radar axes one-to-one: Seating, Staff, Solo Patrons (person.2 icon), Ambiance (sparkles icon), Safety, Portioning — no 'WiFi' or 'Noise' label anywhere. grep finds zero references to solo.wifi/solo.noise in the iOS app. xcodebuild build succeeds and xcodebuild test passes on iPhone 17 Pro simulator.