### PR TITLE
auto: Add pull-to-refresh to the companion Discover and Itinerary lists

### DIFF
--- a/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
@@ -139,11 +139,13 @@ public struct DiscoverListView: View {
             )
         }
         .listStyle(.insetGrouped)
+        .refreshable { await loadPosts() }
     }
 
     // MARK: - Actions
 
     private func loadPosts() async {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
         let params = CompanionDiscoverParams(cityCode: cityCode)
         await service.fetchDiscovery(params: params)
     }

--- a/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
@@ -48,6 +48,7 @@ public struct ItineraryListView: View {
                     }
                     .listStyle(.plain)
                     .animation(.easeInOut, value: itineraries.count)
+                    .refreshable { await MainActor.run { loadItineraries() } }
                 }
             }
             .animation(.easeInOut, value: itineraries.isEmpty)
@@ -79,6 +80,7 @@ public struct ItineraryListView: View {
     }
 
     private func loadItineraries() {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
         itineraries = store.loadAll()
     }
 


### PR DESCRIPTION
## Add pull-to-refresh to the companion Discover and Itinerary lists

DiscoverListView's post feed and ItineraryListView both rely on a toolbar button or onAppear to refresh, but neither supports the pull-to-refresh gesture iOS users expect on a scrollable feed. Adding `.refreshable` (with a haptic confirmation, matching the app's existing feedback patterns) makes refreshing discoverable and tactile without adding any new chrome.

### Acceptance
Pulling down on the Discover post list triggers a re-fetch with the system spinner and a light haptic; pulling down on the Itinerary list reloads from the store. Both existing refresh paths (Discover toolbar button, Itinerary onAppear) still work. `xcodebuild build` succeeds and Reduce Motion is unaffected (system handles the refresh control).