### PR TITLE
auto: Resolve real experience details in Itinerary detail (replace raw IDs)

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -704,6 +704,7 @@
 "itinerary.detail.experiences.header" = "%d experiences";
 "itinerary.detail.experiences.empty" = "No experiences pinned yet.";
 "itinerary.detail.experience.unavailable" = "Unavailable experience";
+"itinerary.detail.experiences.unknown" = "Unknown experience (%@)";
 
 /* Itinerary — Add to Itinerary sheet error alert */
 "itinerary.addTo.error.title" = "Couldn't add to itinerary";

--- a/apps/ios/SoloCompass/Views/Companion/ItineraryDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ItineraryDetailView.swift
@@ -310,6 +310,56 @@ public struct ItineraryDetailView: View {
         try? store.reorderExperiences(ids, in: itinerary.id)
     }
 
+    @ViewBuilder
+    private func experienceRow(for expId: String) -> some View {
+        if let exp = experienceService.getExperience(id: expId) {
+            HStack(spacing: 10) {
+                Image(systemName: "line.3.horizontal")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                Circle()
+                    .fill(exp.category.color.opacity(0.15))
+                    .frame(width: 32, height: 32)
+                    .overlay {
+                        Image(systemName: exp.category.symbol)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(exp.category.color)
+                    }
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(exp.title)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.primary)
+                    Text(exp.oneLiner)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(exp.title). \(exp.oneLiner)")
+        } else {
+            HStack(spacing: 8) {
+                Image(systemName: "line.3.horizontal")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                Image(systemName: "mappin.circle.fill")
+                    .foregroundStyle(.secondary)
+                Text(String(
+                    format: NSLocalizedString("itinerary.detail.experiences.unknown", comment: "Unknown experience fallback with truncated id"),
+                    String(expId.prefix(12))
+                ))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(String(
+                format: NSLocalizedString("itinerary.detail.experiences.unknown", comment: "Unknown experience fallback with truncated id"),
+                String(expId.prefix(12))
+            ))
+        }
+    }
+
     private func importFavorites() {
         let favIds = preferences.favoritedExperiences
         guard let count = try? store.importFavorites(favIds, into: itinerary.id), count > 0 else { return }


### PR DESCRIPTION
## Resolve real experience details in Itinerary detail (replace raw IDs)

ItineraryDetailView currently renders each pinned experience as its raw ID string (e.g. 'exp_001') instead of the actual title, category icon, and one-liner — a jarring, unfinished-looking list for anyone planning a trip. This change looks up each ID via ExperienceService and renders a proper row with the category-colored icon, title, and one-liner, with a graceful fallback for any ID that can't be resolved.

### Acceptance
Build passes (`xcodebuild build -scheme SoloCompass`). In the Simulator, opening an itinerary with pinned experiences shows each as its real title + category icon + one-liner rather than a raw id like 'exp_001'; drag-to-reorder still works; an unresolved id shows the localized 'Unknown experience' fallback instead of crashing or showing a bare string. `#Preview` for 'With note and experiences' renders resolved rows.