### PR TITLE
auto: Centralized Haptics helper with prepare() + accessibility respect

### DIFF
--- a/apps/ios/SoloCompass/Services/Haptics.swift
+++ b/apps/ios/SoloCompass/Services/Haptics.swift
@@ -1,0 +1,33 @@
+#if canImport(UIKit)
+import UIKit
+
+/// Centralized haptic feedback helper.
+///
+/// Guards on `UIAccessibility.isReduceMotionEnabled` as the closest public
+/// proxy for the user's haptic-reduction intent (no separate "disable haptics"
+/// API is exposed on iOS). Calls `prepare()` before `impactOccurred()` /
+/// `notificationOccurred()` on the same instance so the Taptic Engine is
+/// pre-warmed for low-latency firing.
+@MainActor enum Haptics {
+    static func impact(_ style: UIImpactFeedbackGenerator.FeedbackStyle = .light) {
+        guard !UIAccessibility.isReduceMotionEnabled else { return }
+        let generator = UIImpactFeedbackGenerator(style: style)
+        generator.prepare()
+        generator.impactOccurred()
+    }
+
+    static func selection() {
+        guard !UIAccessibility.isReduceMotionEnabled else { return }
+        let generator = UISelectionFeedbackGenerator()
+        generator.prepare()
+        generator.selectionChanged()
+    }
+
+    static func notify(_ type: UINotificationFeedbackGenerator.FeedbackType) {
+        guard !UIAccessibility.isReduceMotionEnabled else { return }
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(type)
+    }
+}
+#endif

--- a/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
@@ -98,7 +98,7 @@ public struct DiscoverListView: View {
             Text(message)
         } actions: {
             Button {
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                Haptics.impact(.light)
                 Task { await loadPosts() }
             } label: {
                 Label(
@@ -145,7 +145,7 @@ public struct DiscoverListView: View {
     // MARK: - Actions
 
     private func loadPosts() async {
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        Haptics.impact(.light)
         let params = CompanionDiscoverParams(cityCode: cityCode)
         await service.fetchDiscovery(params: params)
     }
@@ -164,7 +164,7 @@ public struct DiscoverListView: View {
             requestSentPostId = post.id
         case .failure(let err):
             errorMessage = err.localizedDescription
-            UINotificationFeedbackGenerator().notificationOccurred(.error)
+            Haptics.notify(.error)
             Task {
                 try? await Task.sleep(for: .seconds(3))
                 errorMessage = nil

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -22,11 +22,6 @@ public struct ExperienceCardView: View {
 
     private static let arrivedThresholdMeters = 75.0
 
-    private enum HapticState { case idle, prepared, fired }
-
-    // Pre-allocated so prepare() can be called once when the drag starts.
-    private let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
-    private let lightFeedbackGenerator = UIImpactFeedbackGenerator(style: .light)
     @Environment(UserPreferences.self) private var preferences
     @Environment(LocationService.self) private var locationService
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -154,7 +149,7 @@ public struct ExperienceCardView: View {
                 Spacer()
                 Button {
                     let wasFavorited = preferences.isFavorited(experience.id)
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    Haptics.impact(.light)
                     withAnimation(.spring(response: 0.3)) {
                         preferences.toggleFavorite(experience.id)
                     }
@@ -241,12 +236,9 @@ public struct ExperienceCardView: View {
             DragGesture(minimumDistance: 10)
                 .updating($dragState) { value, state, _ in
                     let t = value.translation.height
-                    if state.translation == 0 {
-                        feedbackGenerator.prepare()
-                    }
                     state.translation = t
                     if abs(t) > 60 && !state.hapticFired {
-                        feedbackGenerator.impactOccurred()
+                        Haptics.impact(.medium)
                         state.hapticFired = true
                     }
                 }
@@ -270,10 +262,10 @@ public struct ExperienceCardView: View {
         .onChange(of: isArrived) { _, arrived in
             guard arrived, !didFireArrival else { return }
             didFireArrival = true
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            Haptics.notify(.success)
         }
         .onAppear {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            Haptics.impact(.light)
         }
         .transition(.move(edge: .bottom).combined(with: .opacity))
         .accessibilityElement(children: .contain)
@@ -388,7 +380,7 @@ public struct ExperienceCardView: View {
 
             if apps.count == 1, let app = apps.first {
                 Button {
-                    lightFeedbackGenerator.impactOccurred()
+                    Haptics.impact(.light)
                     NavigationLauncher.open(app: app, coordinate: coordinate, name: name)
                 } label: {
                     pillLabel
@@ -399,7 +391,7 @@ public struct ExperienceCardView: View {
                 Menu {
                     ForEach(apps) { app in
                         Button(app.displayName) {
-                            lightFeedbackGenerator.impactOccurred()
+                            Haptics.impact(.light)
                             NavigationLauncher.open(app: app, coordinate: coordinate, name: name)
                         }
                     }


### PR DESCRIPTION
## Centralized Haptics helper with prepare() + accessibility respect

Haptic feedback is duplicated across ~20 view files, each inline-instantiating UIImpactFeedbackGenerator/UINotificationFeedbackGenerator with no prepare() call (causing first-fire latency) and ignoring the system 'no haptics' accessibility preference. Introduce a single `Haptics` enum that wraps the four common patterns (impact light/medium/soft/rigid, selection, success/warning/error), pre-warms the generator before firing for snappier response, and short-circuits when the user has haptics disabled. Migrate two high-traffic call sites as the visible proof.

### Acceptance
App builds via xcodebuild for iPhone 17 Pro simulator. DiscoverListView and ExperienceCardView compile with no inline generator instantiation remaining. Haptics fire on swipe/refresh exactly as before when Reduce Motion is OFF, and are silently skipped when Reduce Motion is ON (verify in Simulator > Settings > Accessibility > Motion). No new SwiftLint/strict-concurrency warnings; existing SoloCompassTests still pass.