### PR TITLE
auto: Surface itinerary-pinning errors in AddToItinerarySheet

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -704,6 +704,9 @@
 "itinerary.detail.experiences.header" = "%d experiences";
 "itinerary.detail.experiences.empty" = "No experiences pinned yet.";
 
+/* Itinerary — Add to Itinerary sheet error alert */
+"itinerary.addTo.error.title" = "Couldn't add to itinerary";
+
 /* Itinerary — Add to Itinerary sheet (US-006) */
 "action.addToItinerary" = "Add to Itinerary";
 "itinerary.addTo.title" = "Add to Itinerary";

--- a/apps/ios/SoloCompass/Views/Companion/AddToItinerarySheet.swift
+++ b/apps/ios/SoloCompass/Views/Companion/AddToItinerarySheet.swift
@@ -62,6 +62,14 @@ public struct AddToItinerarySheet: View {
         .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)
         .onAppear(perform: reload)
+        .alert(
+            NSLocalizedString("itinerary.addTo.error.title", comment: "Error alert title when pinning fails"),
+            isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+        ) {
+            Button(NSLocalizedString("common.ok", comment: "OK")) { errorMessage = nil }
+        } message: {
+            if let msg = errorMessage { Text(msg) }
+        }
     }
 
     // MARK: - Rows
@@ -176,6 +184,7 @@ public struct AddToItinerarySheet: View {
             reload()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { dismiss() }
         } catch {
+            UINotificationFeedbackGenerator().notificationOccurred(.error)
             errorMessage = error.localizedDescription
         }
     }


### PR DESCRIPTION
## Surface itinerary-pinning errors in AddToItinerarySheet

AddToItinerarySheet captures errorMessage when store.addExperience(_:to:) throws but never displays it, so a failed pin silently does nothing and leaves the user confused. This adds an alert (with error haptic) that surfaces the failure, giving the user clear feedback and a retry path. Purely additive UX polish on an existing dead-code path.

### Acceptance
When store.addExperience throws, an alert appears with the localized title and the error description, an error haptic fires, and dismissing the alert clears errorMessage without dismissing the sheet. Successful adds still show the green checkmark and auto-dismiss unchanged. Project builds (xcodebuild build -scheme SoloCompass) and existing ItineraryStoreTests still pass.