### PR TITLE
auto: Live, minute-precise now marker on the experience timeline

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -974,14 +974,16 @@ private struct BestTimesTimeline: View {
     let experience: Experience
 
     @State private var animateFill = false
+    @State private var nowPulse = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let trackHeight: CGFloat = 10
     private let nowMarkerWidth: CGFloat = 2
     private let tickHours = [0, 6, 12, 18]
 
-    private var currentHour: Int {
-        Calendar.current.component(.hour, from: Date())
+    private var nowFraction: CGFloat {
+        let comps = Calendar.current.dateComponents([.hour, .minute], from: Date())
+        return (CGFloat(comps.hour ?? 0) + CGFloat(comps.minute ?? 0) / 60) / 24
     }
 
     private var a11yLabel: String {
@@ -1017,15 +1019,24 @@ private struct BestTimesTimeline: View {
                 }
 
                 // 'Now' marker
-                let nowX = CGFloat(currentHour) / 24.0 * trackWidth
+                let nowX = nowFraction * trackWidth
                 let isBest = experience.isBestNow()
-                VStack(spacing: 0) {
-                    Circle()
-                        .fill(isBest ? Color.yellow : Color.accentColor)
-                        .frame(width: 6, height: 6)
-                    Rectangle()
-                        .fill(isBest ? Color.yellow : Color.accentColor)
-                        .frame(width: nowMarkerWidth, height: trackHeight - 2)
+                ZStack {
+                    if isBest && !reduceMotion {
+                        Circle()
+                            .stroke(Color.yellow, lineWidth: 1.5)
+                            .frame(width: 6, height: 6)
+                            .scaleEffect(nowPulse ? 2.4 : 1)
+                            .opacity(nowPulse ? 0 : 0.7)
+                    }
+                    VStack(spacing: 0) {
+                        Circle()
+                            .fill(isBest ? Color.yellow : Color.accentColor)
+                            .frame(width: 6, height: 6)
+                        Rectangle()
+                            .fill(isBest ? Color.yellow : Color.accentColor)
+                            .frame(width: nowMarkerWidth, height: trackHeight - 2)
+                    }
                 }
                 .offset(x: nowX - 3, y: 0)
             }
@@ -1052,6 +1063,24 @@ private struct BestTimesTimeline: View {
             } else {
                 withAnimation(.easeOut(duration: 0.5)) {
                     animateFill = true
+                }
+                if experience.isBestNow() {
+                    withAnimation(.easeOut(duration: 1.4).repeatForever(autoreverses: false)) {
+                        nowPulse = true
+                    }
+                }
+            }
+        }
+        .onChange(of: experience.isBestNow()) { _, isBest in
+            guard !reduceMotion else { return }
+            if isBest {
+                nowPulse = false
+                withAnimation(.easeOut(duration: 1.4).repeatForever(autoreverses: false)) {
+                    nowPulse = true
+                }
+            } else {
+                withAnimation(nil) {
+                    nowPulse = false
                 }
             }
         }


### PR DESCRIPTION
## Live, minute-precise "now" marker on the experience timeline

The 24-hour bestTimes timeline in ExperienceDetailView positions its "now" marker only to whole-hour granularity (currentHour / 24.0), so at 5:55pm it visibly sits at the 17:00 tick — undercutting the app's core "is this open right now" trust promise. This change moves the marker to minute precision and adds a gentle pulsing halo when the experience isBestNow(), matching the existing pulse pattern already used by BestNowBadge and ConfidenceBadge, so the live moment reads as alive.

### Acceptance
Build succeeds (`xcodebuild build -scheme SoloCompass`). In the Simulator, open any experience detail with bestTimes: the now-marker sits at the correct intra-hour position (verify at a non-:00 minute). When the current time falls inside a bestTimes window the yellow marker shows a repeating expanding halo; outside a window it is the static accent-color line with no halo. With Reduce Motion enabled the halo does not animate and no marker is dropped. Existing #Preview renders without regression.