### PR TITLE
auto: Add haptic feedback to the experience-completion celebration

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/CompletionCelebrationView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/CompletionCelebrationView.swift
@@ -86,6 +86,10 @@ public struct CompletionCelebrationView: View {
         animated = false
         checkmarkPop = false
 
+        #if canImport(UIKit)
+        Haptics.notify(.success)
+        #endif
+
         withAnimation(.spring(response: 0.15, dampingFraction: 0.6)) {
             checkmarkPop = true
         }


### PR DESCRIPTION
## Add haptic feedback to the experience-completion celebration

The confetti-burst CompletionCelebrationView that fires when a user marks an experience complete (the app's core 'win' moment, used from both the detail view and the map check-in) currently plays a purely visual animation with no haptic feedback. Wire the existing Haptics helper into the celebration's fire() so completion delivers a satisfying success notification haptic synchronized with the checkmark pop, reinforcing the moment on every trigger.

### Acceptance
Marking an experience complete from the detail view fires a single .success haptic in sync with the checkmark/confetti; triggering a check-in celebration on the map fires the same haptic. With Reduce Motion enabled, no haptic fires (matching the suppressed particles). The file still builds via 'xcodebuild build -scheme SoloCompass' and both #Preview blocks compile unchanged; no new force-unwraps and no SwiftData/@Model files touched.