### PR TITLE
auto: Make the Solo Score breakdown discoverable, tappable, and VoiceOver-reachable

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -52,6 +52,10 @@
 "solo.estimate.pill" = "AI estimate";
 "solo.section.estimate" = "Solo Score (AI estimate)";
 "solo.section.early" = "Solo Score (early)";
+"solo.breakdown.toggle" = "Per-dimension scores";
+"solo.breakdown.expand.hint" = "Expands or collapses the six-dimension score breakdown";
+"solo.breakdown.expanded" = "expanded";
+"solo.breakdown.collapsed" = "collapsed";
 
 /* Best times timeline */
 "timeline.now.good" = "Right now is a great time.";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -622,9 +622,28 @@ public struct ExperienceDetailView: View {
                 SoloScoreRadarChart(score: score)
                     .padding(.horizontal, 16)
                     .opacity(isEstimate ? 0.7 : 1.0)
-                    .onTapGesture {
-                        showingRadarTooltip.toggle()
+                Button {
+                    Haptics.selection()
+                    showingRadarTooltip.toggle()
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "chevron.right")
+                            .font(.caption.weight(.semibold))
+                            .rotationEffect(reduceMotion ? .zero : (showingRadarTooltip ? .degrees(90) : .degrees(0)))
+                            .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.8), value: showingRadarTooltip)
+                        Text(NSLocalizedString("solo.breakdown.toggle", comment: "Per-dimension scores disclosure toggle"))
+                            .font(.subheadline)
                     }
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityAddTraits(.isButton)
+                .accessibilityValue(Text(showingRadarTooltip
+                    ? NSLocalizedString("solo.breakdown.expanded", comment: "Expanded accessibility value")
+                    : NSLocalizedString("solo.breakdown.collapsed", comment: "Collapsed accessibility value")))
+                .accessibilityHint(Text(NSLocalizedString("solo.breakdown.expand.hint", comment: "Accessibility hint for breakdown toggle")))
                 if showingRadarTooltip {
                     radarDimensionBreakdown(score: score)
                         .transition(.opacity.combined(with: .move(edge: .top)))


### PR DESCRIPTION
## Make the Solo Score breakdown discoverable, tappable, and VoiceOver-reachable

The SoloScore radar chart in ExperienceDetailView hides a six-dimension numeric breakdown behind an invisible onTapGesture — there's no visual cue it's tappable, no haptic feedback (unlike every other interaction in the view), and no accessibility action, so VoiceOver users can never reach the breakdown. Add a clear chevron-labelled 'Show breakdown' toggle row, fire a haptic on toggle, and expose it as an accessibility action so the data is reachable for all users.

### Acceptance
Build succeeds via xcodebuild. In the Simulator, the Solo Score section shows a visibly tappable 'Per-dimension scores' row with a chevron that rotates when expanded; tapping it animates the six-dimension breakdown in/out and fires a selection haptic. With VoiceOver on, the row is announced as a button with expanded/collapsed state and can be activated to reveal the breakdown. Reduce Motion disables the chevron rotation animation but the toggle still works. No new force-unwraps; all strings localized.