### PR TITLE
auto: Show how much longer a 'Best now' window lasts (live countdown on the card badge)

### DIFF
--- a/apps/ios/SoloCompass/Models/Experience.swift
+++ b/apps/ios/SoloCompass/Models/Experience.swift
@@ -480,6 +480,39 @@ public struct Experience: Codable, Hashable, Identifiable {
             return window.contains(hour: hour)
         }
     }
+
+    /// Minutes remaining in the currently-active bestTimes window, or nil when not best now.
+    /// Handles windows that wrap past midnight (endHour < startHour).
+    public func minutesLeftInBestWindow(at date: Date = Date()) -> Int? {
+        let cal = Calendar.current
+        let hour = cal.component(.hour, from: date)
+        let weekday = cal.component(.weekday, from: date) - 1 // Sun=0
+        let month = cal.component(.month, from: date)
+
+        let activeWindow = bestTimes.first { window in
+            if let days = window.dayOfWeek, !days.isEmpty, !days.contains(weekday) { return false }
+            if let seasons = window.season, !seasons.isEmpty, !seasons.contains(month) { return false }
+            return window.contains(hour: hour)
+        }
+
+        guard let window = activeWindow else { return nil }
+
+        // Build the next wall-clock occurrence of endHour from `date`.
+        var components = cal.dateComponents([.year, .month, .day], from: date)
+        components.hour = window.endHour
+        components.minute = 0
+        components.second = 0
+        guard var end = cal.date(from: components) else { return nil }
+
+        // If endHour <= startHour the window crosses midnight; advance by one day
+        // so that `end` is always in the future relative to `date`.
+        if window.endHour <= window.startHour || end <= date {
+            end = cal.date(byAdding: .day, value: 1, to: end) ?? end
+        }
+
+        let minutes = Int(end.timeIntervalSince(date) / 60)
+        return max(1, minutes)
+    }
 }
 
 // MARK: - Best Time Hint

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -96,6 +96,8 @@
 
 /* Experience */
 "experience.bestNow" = "Best now";
+"experience.bestNow.countdown" = "Best now · %dm left";
+"experience.bestNow.countdown.a11y" = "Best now, %d minutes left";
 "experience.viewDetails" = "View details →";
 "experience.bestTime.hint" = "Best %@";
 "experience.bestTime.hint.a11y" = "Best %@";

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -6504,3 +6504,78 @@ final class MockSupabaseClientWithData: SupabaseClientProtocol {
         get async { false }
     }
 }
+
+// MARK: - minutesLeftInBestWindow
+
+final class MinutesLeftInBestWindowTests: XCTestCase {
+
+    private func makeExperience(bestTimes: [TimeWindow]) -> Experience {
+        let breakdown = SoloScore.Breakdown(
+            seatingFriendly: 8, soloPatronRatio: 8, staffPressure: 2,
+            soloPortioning: 8, ambianceFit: 8, safety: 8
+        )
+        let score = SoloScore(overall: 8, breakdown: breakdown, basedOnCount: 1)
+        let confidence = Confidence(
+            level: 3, lastVerifiedAt: Date(), reason: "test",
+            signals: Confidence.Signals(aiScrapeAgeDays: 1, passiveGpsHits30d: 1, activeReports30d: 0, trustedVerifications: 0)
+        )
+        return Experience(
+            id: "test", title: "T", oneLiner: "t", whyItMatters: "t",
+            category: .coffee,
+            location: ExperienceLocation(coordinates: [105.0, 21.0], cityCode: "test"),
+            bestTimes: bestTimes,
+            durationMinutes: Experience.DurationRange(min: 30, max: 60),
+            howTo: [], realInconveniences: [], soloScore: score,
+            sources: [], confidence: confidence, nearbyExperienceIds: [],
+            stats: Experience.Stats(completionCount: 0, averageRating: 0),
+            status: .active, createdAt: Date(), updatedAt: Date()
+        )
+    }
+
+    private func date(hour: Int, minute: Int = 0) -> Date {
+        var c = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+        c.hour = hour
+        c.minute = minute
+        c.second = 0
+        return Calendar.current.date(from: c)!
+    }
+
+    /// Normal window (start < end): returns positive minutes when inside.
+    func testNormalWindowReturnsMinutesLeft() {
+        // window 9–17; test at 09:30 → 7h30m = 450 minutes left
+        let exp = makeExperience(bestTimes: [TimeWindow(startHour: 9, endHour: 17)])
+        let at = date(hour: 9, minute: 30)
+        let result = exp.minutesLeftInBestWindow(at: at)
+        XCTAssertNotNil(result)
+        // 17:00 - 09:30 = 450 minutes
+        XCTAssertEqual(result, 450)
+    }
+
+    /// When not in any best window, returns nil.
+    func testNotBestNowReturnsNil() {
+        let exp = makeExperience(bestTimes: [TimeWindow(startHour: 9, endHour: 11)])
+        let at = date(hour: 14, minute: 0) // outside window
+        XCTAssertNil(exp.minutesLeftInBestWindow(at: at))
+    }
+
+    /// Midnight-wrap window (endHour < startHour): correctly counts across midnight.
+    func testMidnightWrapWindowReturnsMinutesLeft() {
+        // window 22–02; test at 23:00 → end is 02:00 next day = 3 hours = 180 min
+        let exp = makeExperience(bestTimes: [TimeWindow(startHour: 22, endHour: 2)])
+        let at = date(hour: 23, minute: 0)
+        let result = exp.minutesLeftInBestWindow(at: at)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result, 180)
+    }
+
+    /// Returns at least 1 even when the window ends in less than 60 seconds.
+    func testReturnsAtLeastOne() {
+        // window 9–10; test at 09:59:45 → ~15s remaining → clamps to 1
+        let exp = makeExperience(bestTimes: [TimeWindow(startHour: 9, endHour: 10)])
+        var c = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+        c.hour = 9; c.minute = 59; c.second = 45
+        let at = Calendar.current.date(from: c)!
+        let result = exp.minutesLeftInBestWindow(at: at)
+        XCTAssertEqual(result, 1)
+    }
+}

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -207,7 +207,7 @@ public struct ExperienceCardView: View {
                 if !experience.realInconveniences.isEmpty {
                     inconveniencePill
                 } else if experience.isBestNow() {
-                    BestNowBadge()
+                    BestNowBadge(experience: experience)
                 } else if let hint = experience.bestTimeHint() {
                     bestTimeHintPill(hint)
                 }
@@ -449,13 +449,51 @@ public struct ExperienceCardView: View {
 // MARK: - BestNowBadge
 
 private struct BestNowBadge: View {
+    /// The experience to query for live countdown; passed so the badge can call
+    /// minutesLeftInBestWindow() on each TimelineView tick.
+    var experience: Experience
+
     private static let gold = Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)
 
     @State private var pulse = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    private func labelText(at date: Date) -> String {
+        if let minutes = experience.minutesLeftInBestWindow(at: date) {
+            return String(format: NSLocalizedString("experience.bestNow.countdown", comment: "Best now with countdown"), minutes)
+        }
+        return NSLocalizedString("experience.bestNow", comment: "Best now label")
+    }
+
+    private func a11yText(at date: Date) -> String {
+        if let minutes = experience.minutesLeftInBestWindow(at: date) {
+            return String(format: NSLocalizedString("experience.bestNow.countdown.a11y", comment: "Best now accessibility with countdown"), minutes)
+        }
+        return NSLocalizedString("experience.bestNow", comment: "Best now label")
+    }
+
     var body: some View {
-        Label(NSLocalizedString("experience.bestNow", comment: ""), systemImage: "sparkle")
+        Group {
+            if reduceMotion {
+                badgeLabel(at: Date())
+                    .accessibilityLabel(a11yText(at: Date()))
+                    .onAppear { pulse = true }
+            } else {
+                TimelineView(.periodic(from: Date(), by: 60)) { context in
+                    badgeLabel(at: context.date)
+                        .accessibilityLabel(a11yText(at: context.date))
+                }
+                .onAppear {
+                    withAnimation(.easeInOut(duration: 1.1).repeatForever(autoreverses: true)) {
+                        pulse = true
+                    }
+                }
+            }
+        }
+    }
+
+    private func badgeLabel(at date: Date) -> some View {
+        Label(labelText(at: date), systemImage: "sparkle")
             .font(.caption)
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
@@ -463,12 +501,7 @@ private struct BestNowBadge: View {
             .foregroundStyle(Self.gold)
             .scaleEffect(pulse ? 1.06 : 1.0)
             .shadow(color: Self.gold.opacity(pulse ? 0.55 : 0.0), radius: pulse ? 8 : 0)
-            .onAppear {
-                guard !reduceMotion else { return }
-                withAnimation(.easeInOut(duration: 1.1).repeatForever(autoreverses: true)) {
-                    pulse = true
-                }
-            }
+            .contentTransition(.numericText())
     }
 }
 

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -477,7 +477,6 @@ private struct BestNowBadge: View {
             if reduceMotion {
                 badgeLabel(at: Date())
                     .accessibilityLabel(a11yText(at: Date()))
-                    .onAppear { pulse = true }
             } else {
                 TimelineView(.periodic(from: Date(), by: 60)) { context in
                     badgeLabel(at: context.date)

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -449,7 +449,7 @@ public struct ExperienceCardView: View {
 // MARK: - BestNowBadge
 
 private struct BestNowBadge: View {
-    /// The experience to query for live countdown; passed so the badge can call
+    /// The experience to query for live countdown; passed so the live timer can call
     /// minutesLeftInBestWindow() on each TimelineView tick.
     var experience: Experience
 

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -991,6 +991,7 @@ private struct BestTimesTimeline: View {
 
     @State private var animateFill = false
     @State private var nowPulse = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let trackHeight: CGFloat = 10
     private let nowMarkerWidth: CGFloat = 2

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -347,8 +347,6 @@ public struct ExperienceDetailView: View {
 
     // MARK: - Sections
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
     @ViewBuilder
     private var whyItMattersSection: some View {
         let content = viewModel.experience.whyItMatters.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -993,7 +991,6 @@ private struct BestTimesTimeline: View {
 
     @State private var animateFill = false
     @State private var nowPulse = false
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let trackHeight: CGFloat = 10
     private let nowMarkerWidth: CGFloat = 2

--- a/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
@@ -803,7 +803,11 @@ private struct JourneyProgressCard: View {
                 endPoint: .trailing
             ))
         } else if isAlmostThere {
-            return AnyShapeStyle(Color.green.mix(with: .yellow, by: 0.25))
+            if #available(iOS 18.0, *) {
+                return AnyShapeStyle(Color.green.mix(with: .yellow, by: 0.25))
+            } else {
+                return AnyShapeStyle(Color.green)
+            }
         } else {
             return AnyShapeStyle(Color.green)
         }


### PR DESCRIPTION
## Show how much longer a 'Best now' window lasts (live countdown on the card badge)

The card's BestNowBadge currently says only "Best now" with a pulsing sparkle — it conveys that the moment is good but not that it's fleeting, which undercuts the brief's core honest, time-bound 'is this worth doing RIGHT NOW' differentiator. Add a model method that returns the minutes remaining in the currently-active bestTimes window, and surface it in the badge as "Best now · 47m left" (rolling down past the hour boundary). This turns a static label into an urgency signal that no competitor (Google Maps, Lonely Planet) offers.

### Acceptance
An experience whose bestTimes window is active shows "Best now · Nm left" with N decreasing over time; when N would be >90 min show it (or cap display at the window length). When not in a best window the existing bestTimeHint pill is unchanged. minutesLeftInBestWindow returns nil when isBestNow() is false and a positive Int (≥1) when true, including correct handling of windows that wrap past midnight. VoiceOver reads the remaining time. Reduce Motion disables both the pulse and the per-minute timer (static snapshot). `xcodebuild build` and the SoloCompassTests suite pass; add a unit test for minutesLeftInBestWindow covering a normal window, a wrap-around window, and the not-best case.