### PR TITLE
auto: Proximity dot on favorite rows (walk/ride/far triage)

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -343,6 +343,9 @@
 "favorites.sort.recent" = "Recent";
 "favorites.swipe.hint" = "Swipe left to remove";
 "favorites.row.distance.a11y" = "%@ away";
+"favorites.proximity.near" = "walkable";
+"favorites.proximity.mid" = "short ride";
+"favorites.proximity.far" = "far";
 
 /* Generic actions */
 "action.undo" = "Undo";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -991,6 +991,7 @@ private struct BestTimesTimeline: View {
 
     @State private var animateFill = false
     @State private var nowPulse = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let trackHeight: CGFloat = 10
     private let nowMarkerWidth: CGFloat = 2

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -347,8 +347,6 @@ public struct ExperienceDetailView: View {
 
     // MARK: - Sections
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
     @ViewBuilder
     private var whyItMattersSection: some View {
         let content = viewModel.experience.whyItMatters.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -993,7 +991,6 @@ private struct BestTimesTimeline: View {
 
     @State private var animateFill = false
     @State private var nowPulse = false
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let trackHeight: CGFloat = 10
     private let nowMarkerWidth: CGFloat = 2

--- a/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
@@ -803,7 +803,11 @@ private struct JourneyProgressCard: View {
                 endPoint: .trailing
             ))
         } else if isAlmostThere {
-            return AnyShapeStyle(Color.green.mix(with: .yellow, by: 0.25))
+            if #available(iOS 18.0, *) {
+                return AnyShapeStyle(Color.green.mix(with: .yellow, by: 0.25))
+            } else {
+                return AnyShapeStyle(Color.green)
+            }
         } else {
             return AnyShapeStyle(Color.green)
         }

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -26,10 +26,41 @@ public struct FavoritesListView: View {
     private let undoSelectionFeedback = UISelectionFeedbackGenerator()
     private let undoImpactFeedback = UIImpactFeedbackGenerator(style: .soft)
 
+    private enum Proximity {
+        case near, mid, far
+
+        static func from(meters: CLLocationDistance) -> Proximity {
+            if meters <= 1000 { return .near }
+            if meters <= 5000 { return .mid }
+            return .far
+        }
+
+        var color: Color {
+            switch self {
+            case .near: return .green
+            case .mid: return .orange
+            case .far: return Color(.tertiaryLabel)
+            }
+        }
+
+        var a11yWord: String {
+            switch self {
+            case .near: return NSLocalizedString("favorites.proximity.near", comment: "Proximity: walkable")
+            case .mid: return NSLocalizedString("favorites.proximity.mid", comment: "Proximity: short ride")
+            case .far: return NSLocalizedString("favorites.proximity.far", comment: "Proximity: far away")
+            }
+        }
+    }
+
     private func distanceMeters(for exp: Experience) -> CLLocationDistance? {
         guard let coord = exp.coordinate, locationService.currentLocation != nil else { return nil }
         let d = locationService.distance(to: coord)
         return d < .greatestFiniteMagnitude ? d : nil
+    }
+
+    private func proximity(for exp: Experience) -> Proximity? {
+        guard let meters = distanceMeters(for: exp) else { return nil }
+        return Proximity.from(meters: meters)
     }
     private var sortedFavorites: [Experience] {
         let ids = preferences.favoritedExperiences
@@ -388,6 +419,7 @@ private extension FavoritesListView {
     @ViewBuilder
     func favoriteRow(_ exp: Experience) -> some View {
         let distStr = distanceString(for: exp)
+        let prox = proximity(for: exp)
         Button {
             onSelectExperience(exp)
         } label: {
@@ -412,8 +444,12 @@ private extension FavoritesListView {
                         .lineLimit(2)
                     if let distStr {
                         HStack(spacing: 3) {
-                            Image(systemName: "location.fill")
-                                .font(.system(size: 9))
+                            if let prox {
+                                Circle()
+                                    .fill(prox.color)
+                                    .frame(width: 7, height: 7)
+                                    .accessibilityHidden(true)
+                            }
                             Text(distStr)
                                 .font(.caption2)
                                 .monospacedDigit()
@@ -435,7 +471,11 @@ private extension FavoritesListView {
         .accessibilityLabel({
             if let distStr {
                 let awayFmt = NSLocalizedString("favorites.row.distance.a11y", comment: "Distance away accessibility label")
-                return Text("\(exp.title), \(exp.oneLiner), \(String(format: awayFmt, distStr))")
+                let distLabel = String(format: awayFmt, distStr)
+                if let prox {
+                    return Text("\(exp.title), \(exp.oneLiner), \(distLabel), \(prox.a11yWord)")
+                }
+                return Text("\(exp.title), \(exp.oneLiner), \(distLabel)")
             }
             return Text("\(exp.title), \(exp.oneLiner)")
         }())


### PR DESCRIPTION
## Proximity dot on favorite rows (walk/ride/far triage)

When viewing the Favorites list, each row shows only a raw distance string with no at-a-glance read of whether a place is reachable now. Add a small colored proximity dot (green = walkable ≤1km, amber = short ride ≤5km, gray = far) beside the distance label so solo travelers can triage saved spots instantly, with a matching VoiceOver phrase. The dot only renders when a user location fix exists, mirroring the existing distance-label guard.

### Acceptance
Build succeeds (xcodebuild build, iPhone 17 Pro sim). With a simulated location set, opening Favorites and switching the sort picker to 'Nearest' shows each row's distance preceded by a colored dot: green for spots within 1 km, amber within 5 km, gray beyond. Rows with no coordinate or no location fix show no dot (unchanged layout). VoiceOver reads title, one-liner, distance, then the proximity word. Three new keys (favorites.proximity.near/mid/far) exist in en.lproj/Localizable.strings; #Preview still renders.