### PR TITLE
auto: Announce experience completion to VoiceOver

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -90,6 +90,9 @@
 "section.nearby" = "Nearby experiences";
 "section.duration" = "Typical: %d–%d minutes";
 
+/* Celebration */
+"celebration.complete.a11y" = "Experience completed";
+
 /* Actions */
 "action.markDone" = "Mark done";
 "action.completed" = "Completed";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -991,6 +991,7 @@ private struct BestTimesTimeline: View {
 
     @State private var animateFill = false
     @State private var nowPulse = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let trackHeight: CGFloat = 10
     private let nowMarkerWidth: CGFloat = 2

--- a/apps/ios/SoloCompass/Views/Shared/CompletionCelebrationView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/CompletionCelebrationView.swift
@@ -91,6 +91,13 @@ public struct CompletionCelebrationView: View {
 
         #if canImport(UIKit)
         Haptics.notify(.success)
+        UIAccessibility.post(
+            notification: .announcement,
+            argument: NSAttributedString(
+                string: NSLocalizedString("celebration.complete.a11y", comment: "Experience completed celebration announcement"),
+                attributes: [.accessibilitySpeechQueueAnnouncement: true]
+            )
+        )
         #endif
 
         withAnimation(.spring(response: 0.15, dampingFraction: 0.6)) {


### PR DESCRIPTION
## Announce experience completion to VoiceOver

When a user marks an experience complete, sighted users get confetti + a checkmark pop, but VoiceOver users receive no feedback at all — CompletionCelebrationView is purely visual with allowsHitTesting(false) and no accessibility output. Post a UIAccessibility announcement on each completion so the celebration is conveyed non-visually, matching the haptic+visual feedback the moment already provides.

### Acceptance
With VoiceOver enabled, marking an experience complete speaks a 'Experience completed' announcement. The announcement also fires when Reduce Motion is on (no confetti). Build succeeds via xcodebuild; existing CompletionCelebrationView previews still render. The new string key exists in en.lproj/Localizable.strings.