### PR TITLE
auto: Unify the Now-pill selection highlight with the shared gliding matchedGeometryEffect

### DIFF
--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -155,16 +155,29 @@ public struct FilterBarView: View {
             .padding(.horizontal, 14)
             .padding(.vertical, 8)
             .foregroundStyle(isSelected ? .white : .primary)
-            .background(
-                Capsule().fill(isSelected ? Self.accentGold : Color.clear)
-            )
+            .background {
+                if isSelected {
+                    Capsule()
+                        .fill(Self.accentGold)
+                        .matchedGeometryEffect(id: "filterHighlight", in: pillHighlight)
+                }
+            }
             .overlay(
                 Capsule().stroke(isSelected ? Color.clear : Color.primary.opacity(0.2), lineWidth: 1)
             )
+            .overlay(alignment: .topTrailing) {
+                if isSelected && resultCount > 0 {
+                    countBadge(count: resultCount, tint: Self.accentGold)
+                        .offset(x: 6, y: -6)
+                        .transition(.scale.combined(with: .opacity))
+                }
+            }
+            .animation(.spring(response: 0.3, dampingFraction: 0.65), value: resultCount)
         }
         .buttonStyle(PressableButtonStyle())
         .accessibilityLabel(Text(a11yLabel))
         .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityValue(isSelected && resultCount > 0 ? Text("\(resultCount) results") : Text(""))
         .onAppear {
             selectionFeedback.prepare()
             guard !reduceMotion else { return }


### PR DESCRIPTION
## Unify the Now-pill selection highlight with the shared gliding matchedGeometryEffect

The filter bar animates a shared selection highlight across pills via matchedGeometryEffect(id: "filterHighlight"), but the Now pill draws its own static capsule and is excluded — so the highlight pops (no glide) whenever selection enters or leaves Now, breaking the otherwise-smooth bar. It also omits the selected-pill result-count badge that every other pill shows. This change folds the Now pill into the same namespace and badge treatment for a consistent, polished bar.

### Acceptance
Tapping between Now and any category/All pill glides a single highlight capsule smoothly across the bar (no pop/cross-fade) — verified in Simulator. The selected Now pill shows the same corner result-count badge style as other selected pills when resultCount > 0, while preserving the existing pulsing gold dot and inline nowCount chip. Reduce Motion still disables the dot pulse. VoiceOver reports the result count via accessibilityValue. `xcodebuild build` succeeds for the SoloCompass scheme and existing FilterBarView pill-ordering tests still pass.