### PR TITLE
auto: Highlight the currently-active best-time window row in the detail sheet

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -64,6 +64,7 @@
 "timeline.now.tick" = "now";
 "bestTimes.now.pill" = "Good time now";
 "bestTimes.next.pill" = "Better at %@";
+"bestTimes.window.active.a11y" = "happening now";
 
 /* Inconvenience categories */
 "inconvenience.category.scam" = "Scam risk";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -468,17 +468,22 @@ public struct ExperienceDetailView: View {
                     HStack { Spacer(); bestTimeStatusPill }
                     BestTimesTimeline(experience: viewModel.experience)
                         .padding(.bottom, 4)
-                    ForEach(viewModel.experience.bestTimes, id: \.self) { window in
-                        HStack(spacing: 8) {
-                            Image(systemName: "clock")
-                                .foregroundStyle(.secondary)
-                            Text(format(window: window))
-                                .font(.subheadline)
-                            if let note = window.note {
-                                Text(note)
-                                    .font(.caption)
-                                    .foregroundStyle(.tertiary)
-                            }
+                    TimelineView(.periodic(from: .now, by: 60)) { context in
+                        let currentHour = Calendar.current.component(.hour, from: context.date)
+                        ForEach(viewModel.experience.bestTimes, id: \.self) { window in
+                            let isActiveNow: Bool = {
+                                let s = window.startHour, e = window.endHour
+                                return s <= e
+                                    ? currentHour >= s && currentHour < e
+                                    : currentHour >= s || currentHour < e
+                            }()
+                            BestTimeWindowRow(
+                                window: window,
+                                isActiveNow: isActiveNow,
+                                categoryColor: viewModel.experience.category.color,
+                                formatWindow: format(window:),
+                                reduceMotion: reduceMotion
+                            )
                         }
                     }
                     let range = viewModel.experience.durationMinutes
@@ -981,6 +986,68 @@ public struct ExperienceDetailView: View {
 
     private func format(window: TimeWindow) -> String {
         String(format: "%02d:00 – %02d:00", window.startHour, window.endHour)
+    }
+}
+
+// MARK: - Best Time Window Row
+
+private struct BestTimeWindowRow: View {
+    let window: TimeWindow
+    let isActiveNow: Bool
+    let categoryColor: Color
+    let formatWindow: (TimeWindow) -> String
+    let reduceMotion: Bool
+
+    @State private var nowDotPulse = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "clock")
+                .foregroundStyle(isActiveNow ? categoryColor : .secondary)
+            Text(formatWindow(window))
+                .font(isActiveNow ? .subheadline.weight(.semibold) : .subheadline)
+            if let note = window.note {
+                Text(note)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+            if isActiveNow {
+                Spacer()
+                Circle()
+                    .fill(categoryColor)
+                    .frame(width: 6, height: 6)
+                    .scaleEffect(nowDotPulse ? 1.6 : 1.0)
+                    .opacity(nowDotPulse ? 0.4 : 1.0)
+            }
+        }
+        .padding(.horizontal, isActiveNow ? 10 : 0)
+        .padding(.vertical, isActiveNow ? 6 : 0)
+        .background(
+            isActiveNow
+                ? AnyView(RoundedRectangle(cornerRadius: 8).fill(categoryColor.opacity(0.12)))
+                : AnyView(Color.clear)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(isActiveNow
+            ? "\(formatWindow(window)), \(NSLocalizedString("bestTimes.window.active.a11y", comment: "Happening now accessibility suffix"))"
+            : formatWindow(window)
+        ))
+        .onAppear { startPulseIfNeeded() }
+        .onChange(of: isActiveNow) { _, active in
+            if active {
+                startPulseIfNeeded()
+            } else {
+                withAnimation(nil) { nowDotPulse = false }
+            }
+        }
+    }
+
+    private func startPulseIfNeeded() {
+        guard isActiveNow && !reduceMotion else { return }
+        nowDotPulse = false
+        withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+            nowDotPulse = true
+        }
     }
 }
 


### PR DESCRIPTION
## Highlight the currently-active best-time window row in the detail sheet

In ExperienceDetailView's bestTimesSection, the per-window rows (clock icon + time range) are static and visually disconnected from the live BestTimesTimeline above them, so a user reading 'good now' can't tell which of several windows is the active one. Wrap each window row in a live TimelineView so the row whose hour range contains the current time gets a subtle category-tinted highlight (filled background, bolder text, and a small pulsing 'now' dot), matching the timeline's existing yellow/category-color language and respecting Reduce Motion.

### Acceptance
Build succeeds via `xcodebuild build -scheme SoloCompass`. Open an experience whose bestTimes include the current hour in the Simulator: the matching window row is visibly highlighted with the category color and a pulsing now-dot, while other rows stay neutral; the highlight moves to the correct row as time passes (verify by temporarily editing seed hours). With Reduce Motion on, the highlight still appears but the dot does not pulse. VoiceOver reads 'happening now' on the active row. No layout shift or clipping in either the medium or large sheet detent.