### PR TITLE
auto: Distinguish fetch failures from a genuinely empty companion inbox

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -819,6 +819,10 @@
 "companion.inbox.request.from" = "From";
 "companion.inbox.accepted.title" = "You're connected!";
 "companion.inbox.accepted.message" = "Request accepted. You can now message each other.";
+"companion.inbox.error.load" = "Couldn't load requests. Check your connection and try again.";
+"companion.inbox.error.title" = "Could not load inbox";
+"companion.inbox.error.retry" = "Try again";
+"companion.inbox.error.retry.hint" = "Reloads the inbox";
 
 /* Companion — chat (US-013) */
 "companion.chat.title" = "Chat";

--- a/apps/ios/SoloCompass/Services/CompanionService.swift
+++ b/apps/ios/SoloCompass/Services/CompanionService.swift
@@ -262,6 +262,8 @@ public final class CompanionService {
             return
         }
 
+        lastError = nil
+
         guard let userId = client.currentSession?.userId else { return }
 
         let result = await client.get(
@@ -273,10 +275,16 @@ public final class CompanionService {
             ]
         )
 
-        if case .success(let data) = result, !data.isEmpty {
-            if let requests = try? JSONDecoder.iso8601Decoder.decode([CompanionRequest].self, from: data) {
+        switch result {
+        case .success(let data):
+            if !data.isEmpty,
+               let requests = try? JSONDecoder.iso8601Decoder.decode([CompanionRequest].self, from: data) {
                 inboxRequests = requests
+            } else if data.isEmpty {
+                inboxRequests = []
             }
+        case .failure:
+            lastError = NSLocalizedString("companion.inbox.error.load", comment: "Inbox load error")
         }
     }
 

--- a/apps/ios/SoloCompass/Views/Companion/RequestInboxView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/RequestInboxView.swift
@@ -23,6 +23,8 @@ public struct RequestInboxView: View {
                 ScrollView {
                     CompanionSkeletonList(rows: 5)
                 }
+            } else if let error = service.lastError {
+                errorView(message: error)
             } else if service.inboxRequests.isEmpty {
                 EmptyInboxView()
                     .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
@@ -80,6 +82,29 @@ public struct RequestInboxView: View {
     }
 
     // MARK: - Subviews
+
+    private func errorView(message: String) -> some View {
+        ContentUnavailableView {
+            Label(
+                NSLocalizedString("companion.inbox.error.title", comment: "Inbox error title"),
+                systemImage: "exclamationmark.triangle"
+            )
+        } description: {
+            Text(message)
+        } actions: {
+            Button {
+                Haptics.impact(.light)
+                Task { await service.fetchInbox() }
+            } label: {
+                Label(
+                    NSLocalizedString("companion.inbox.error.retry", comment: "Retry button"),
+                    systemImage: "arrow.clockwise"
+                )
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityHint(NSLocalizedString("companion.inbox.error.retry.hint", comment: "Retry accessibility hint"))
+        }
+    }
 
     private var requestList: some View {
         List(service.inboxRequests) { request in
@@ -284,5 +309,13 @@ private struct RequestRow: View {
         }
         .navigationTitle(NSLocalizedString("companion.inbox.title", comment: "Inbox nav title"))
         .navigationBarTitleDisplayMode(.large)
+    }
+}
+
+#Preview("Load error") {
+    let service = CompanionService()
+    service.lastError = NSLocalizedString("companion.inbox.error.load", comment: "Inbox load error")
+    return NavigationStack {
+        RequestInboxView(service: service)
     }
 }


### PR DESCRIPTION
## Distinguish fetch failures from a genuinely empty companion inbox

RequestInboxView shows the 'No requests yet' empty state whenever inboxRequests is empty — including when fetchInbox() fails on a network/server error, which currently swallows the failure silently. This adds proper error tracking to fetchInbox() (setting/clearing CompanionService.lastError, which already exists and is used by DiscoverListView) and a retryable ContentUnavailableView error state in the inbox, so a failed load no longer masquerades as an empty inbox.

### Acceptance
When fetchInbox() returns a failure, RequestInboxView shows a ContentUnavailableView with the error message and a working Retry button (not the 'No requests yet' empty state); a successful fetch returning zero rows still shows the empty inbox; tapping Retry re-runs fetchInbox and clears the error on success; new strings are localized via NSLocalizedString; existing previews still compile and a new 'Load error' preview renders the error state.