### PR TITLE
auto: Add success haptic to the check-in confirm button

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
@@ -45,6 +45,9 @@ public struct PendingCheckInBanner: View {
 
             HStack(spacing: 8) {
                 Button {
+                    #if canImport(UIKit)
+                    Haptics.notify(.success)
+                    #endif
                     onConfirm()
                 } label: {
                     Text(NSLocalizedString("checkin.banner.yes", comment: "Yes!"))


### PR DESCRIPTION
## Add success haptic to the check-in confirm button

The PendingCheckInBanner's drag-to-dismiss gesture fires selection and impact haptics, but the primary positive action — tapping 'Yes, I was there!' — fires onConfirm() with no tactile feedback at all. Add a success notification haptic (via the centralized Haptics helper that respects reduce-motion intent) so the app's most rewarding moment feels confirmed in the hand, matching the celebration that follows.

### Acceptance
Tapping 'Yes, I was there!' produces a single .success haptic on a physical device with reduce-motion off, and produces no haptic when reduce-motion is on. onConfirm() still fires exactly once and the check-in celebration still triggers. xcodebuild build succeeds and the #Preview renders unchanged.