### PR TITLE
auto: Announce filter result counts to VoiceOver

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "filter.now.empty.idle" = "Nothing's at its best now";
 "filter.now.empty.upcoming" = "%@ in %dm";
 "filter.now.empty.a11y" = "Nothing's at its best now. %@ starts in %d minutes. Tap to jump there.";
+"filter.a11y.resultsAnnounce" = "%1$@: %2$d found";
+"filter.a11y.noResultsAnnounce" = "%@: nothing matches";
 
 /* Health */
 "health.healthy" = "Fresh — multiply verified";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -11,6 +11,8 @@
 /* Filters */
 "filter.now" = "此刻";
 "filter.all" = "全部";
+"filter.a11y.resultsAnnounce" = "%1$@：找到 %2$d 个";
+"filter.a11y.noResultsAnnounce" = "%@：无匹配结果";
 
 /* Health */
 "health.healthy" = "状态新鲜 — 多重验证";

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -47,6 +47,17 @@ public struct CompassMapView: View {
         (viewModel?.selectedCategory != nil) || (viewModel?.selectedCustomTag != nil) || (viewModel?.isNowFilter == true)
     }
 
+    private var activeFilterName: String {
+        if let category = viewModel?.selectedCategory {
+            return category.localizedTitle
+        } else if let tag = viewModel?.selectedCustomTag {
+            return tag
+        } else if viewModel?.isNowFilter == true {
+            return NSLocalizedString("filter.now", comment: "Now filter label")
+        }
+        return ""
+    }
+
     /// Idle window after the last pan before POIs refresh. Lowered from 1.5s
     /// to cut the "dragged the map, nothing happened" lag (#133).
     private static let panRefreshDebounce: TimeInterval = 0.8
@@ -91,6 +102,30 @@ public struct CompassMapView: View {
             }
             .onChange(of: preferences.pendingCheckIns) { _, _ in
                 viewModel?.checkForPendingCheckIns()
+            }
+            .onChange(of: viewModel?.visibleExperiences.count) { _, count in
+                guard isFilterActive, UIAccessibility.isVoiceOverRunning,
+                      let count, let filterName = viewModel.map({ _ in activeFilterName })
+                else { return }
+                let argument: NSAttributedString
+                if count == 0 {
+                    argument = NSAttributedString(
+                        string: String(
+                            format: NSLocalizedString("filter.a11y.noResultsAnnounce", comment: "VoiceOver: filter active, no results"),
+                            filterName
+                        ),
+                        attributes: [.accessibilitySpeechQueueAnnouncement: true]
+                    )
+                } else {
+                    argument = NSAttributedString(
+                        string: String(
+                            format: NSLocalizedString("filter.a11y.resultsAnnounce", comment: "VoiceOver: filter active, results count"),
+                            filterName, count
+                        ),
+                        attributes: [.accessibilitySpeechQueueAnnouncement: true]
+                    )
+                }
+                UIAccessibility.post(notification: .announcement, argument: argument)
             }
             .onChange(of: networkMonitor.isConnected) { _, connected in
                 if !connected {


### PR DESCRIPTION
## Announce filter result counts to VoiceOver

When a user taps a filter pill (a category, a custom tag, or 'Now'), the visible experience count on the map changes silently — VoiceOver users get no spoken confirmation of how many results the filter produced. This adds an AccessibilityNotification.Announcement on filter-result changes, making the product's core 'AI filters from many to few and explains' pillar audible, mirroring the pattern already used in CompletionCelebrationView.

### Acceptance
With VoiceOver on: tapping a category/Now/custom-tag pill speaks the filter name plus result count (e.g. 'Coffee: 4 found'); tapping a filter with no matches speaks the no-results phrasing; clearing filters produces no spurious announcement. With VoiceOver off, no announcements are posted. xcodebuild build and existing SoloCompassTests pass; no schema/@Model files touched.