### PR TITLE
auto: Route PendingCheckInBanner haptics through the centralized Haptics helper (fix Reduce Motion bypass)

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
@@ -11,20 +11,6 @@ public struct PendingCheckInBanner: View {
     @State private var dragOffset: CGFloat = 0
     @State private var crossedThreshold = false
     private let dismissThreshold: CGFloat = 80
-    private let selectionFeedback = UISelectionFeedbackGenerator()
-    private let impactFeedback = UIImpactFeedbackGenerator(style: .soft)
-
-    public init(
-        experienceTitle: String,
-        onConfirm: @escaping () -> Void,
-        onDismiss: @escaping () -> Void
-    ) {
-        self.experienceTitle = experienceTitle
-        self.onConfirm = onConfirm
-        self.onDismiss = onDismiss
-        selectionFeedback.prepare()
-        impactFeedback.prepare()
-    }
 
     public var body: some View {
         HStack(spacing: 12) {
@@ -85,14 +71,18 @@ public struct PendingCheckInBanner: View {
                     let overThreshold = -gesture.translation.height > dismissThreshold
                     if overThreshold && !crossedThreshold {
                         crossedThreshold = true
-                        selectionFeedback.selectionChanged()
+                        #if canImport(UIKit)
+                        Haptics.selection()
+                        #endif
                     } else if !overThreshold && crossedThreshold {
                         crossedThreshold = false
                     }
                 }
                 .onEnded { gesture in
                     if gesture.translation.height < -dismissThreshold {
-                        impactFeedback.impactOccurred()
+                        #if canImport(UIKit)
+                        Haptics.impact(.soft)
+                        #endif
                         crossedThreshold = false
                         withAnimation(.easeOut(duration: 0.2)) { dragOffset = -200 }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { onDismiss() }


### PR DESCRIPTION
## Route PendingCheckInBanner haptics through the centralized Haptics helper (fix Reduce Motion bypass)

PendingCheckInBanner is the only floating banner that fires haptics via raw UISelectionFeedbackGenerator/UIImpactFeedbackGenerator instances instead of the centralized Haptics enum. Because Haptics guards every call on UIAccessibility.isReduceMotionEnabled, this banner is the sole component that buzzes during drag-to-dismiss and on dismissal even when the user has Reduce Motion on — inconsistent with ExperienceCardView, FavoritesListView, and CompletionCelebrationView. Replacing the raw generators with Haptics.selection()/Haptics.impact(.soft) restores the accessibility guarantee and removes the stored-property generators.

### Acceptance
PendingCheckInBanner no longer references UISelectionFeedbackGenerator or UIImpactFeedbackGenerator; all haptic calls go through the Haptics enum. With Reduce Motion enabled, dragging the banner past threshold and releasing to dismiss produces no haptic feedback (matching other banners); with Reduce Motion off, the threshold-cross selection tap and dismissal soft impact still fire. iOS target builds clean via xcodebuild build and existing SoloCompassTests pass.