### PR TITLE
auto: Polish MyRequestsListView empty state to match other Companion screens

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1022,6 +1022,7 @@
 
 /* US-033 — MyRequestsListView */
 "my.requests.empty" = "You have not requested to join any routes yet.";
+"my.requests.empty.hint" = "Browse routes in Discover and tap Send Join Request.";
 "my.requests.status.pending" = "Pending";
 "my.requests.status.accepted" = "Accepted";
 "my.requests.status.declined" = "Declined";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1005,6 +1005,7 @@
 "my.hosted.routes.title" = "我主理的路线";
 "my.hosted.routes.empty" = "你目前还没有主理的路线。";
 "my.requests.empty" = "你还没有申请加入任何路线。";
+"my.requests.empty.hint" = "在发现页浏览路线，然后点击发送加入申请。";
 "my.requests.status.pending" = "待确认";
 "my.requests.status.accepted" = "已接受";
 "my.requests.status.declined" = "已拒绝";

--- a/apps/ios/SoloCompass/Views/Companion/MyRequestsListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/MyRequestsListView.swift
@@ -147,15 +147,7 @@ public struct MyRequestsListView: View {
     // MARK: - Empty state
 
     private var emptyState: some View {
-        List {
-            Text(NSLocalizedString(
-                "my.requests.empty",
-                comment: "Empty state — no join requests sent yet"
-            ))
-            .foregroundStyle(.secondary)
-            .font(.subheadline)
-        }
-        .listStyle(.insetGrouped)
+        EmptyMyRequestsView()
     }
 
     // MARK: - Withdraw
@@ -182,6 +174,47 @@ public struct MyRequestsListView: View {
         updated.companion!.joinRequests[idx].status = .withdrawn
         store.save(updated)
         refreshToken = UUID()
+    }
+}
+
+// MARK: - Empty state view
+
+private struct EmptyMyRequestsView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isBreathing = false
+
+    var body: some View {
+        VStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(Color.accentColor.opacity(0.12))
+                    .frame(width: 80, height: 80)
+                Image(systemName: "paperplane.fill")
+                    .font(.system(size: 36))
+                    .foregroundStyle(Color.accentColor.opacity(0.7))
+                    .scaleEffect(isBreathing ? 1.08 : 0.94)
+                    .opacity(isBreathing ? 1.0 : 0.7)
+                    .animation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true), value: isBreathing)
+            }
+            Text(NSLocalizedString(
+                "my.requests.empty",
+                comment: "Empty state — no join requests sent yet"
+            ))
+            .font(.headline)
+            Text(NSLocalizedString(
+                "my.requests.empty.hint",
+                comment: "Empty state hint — explains how to send a join request"
+            ))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+        }
+        .padding(32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear {
+            guard !isBreathing, !reduceMotion else { return }
+            isBreathing = true
+        }
     }
 }
 
@@ -238,5 +271,11 @@ public struct MyRequestsListView: View {
     let store = RouteStore(context: ModelContext(container))
     NavigationStack {
         MyRequestsListView(storeProvider: { store })
+            .navigationTitle(NSLocalizedString("settings.companion.requests", comment: "My recruitment requests title"))
+            .navigationBarTitleDisplayMode(.large)
     }
+}
+
+#Preview("EmptyMyRequestsView — standalone") {
+    EmptyMyRequestsView()
 }


### PR DESCRIPTION
## Polish MyRequestsListView empty state to match other Companion screens

The 'My Requests' screen currently shows a plain gray sentence inside a List when the user has no outgoing join requests, while sibling screens (RequestInboxView, FavoritesListView) use a centered icon + title + hint pattern. Bring this screen up to the same bar with a friendly empty state that explains how to send a join request and a subtle breathing animation that respects Reduce Motion — a small but visible polish that improves first-run feel in the Companion flow.

### Acceptance
1) Building `SoloCompass` succeeds. 2) Launching the empty-state Preview shows centered icon + headline + hint, not a plain List row. 3) With Reduce Motion enabled the icon is static; otherwise it breathes gently. 4) New localization key resolves (no `my.requests.empty.hint` literal visible at runtime). 5) Existing 'with requests' preview unchanged.