### PR TITLE
auto: Haptic feedback on experience pin selection

### DIFF
--- a/apps/ios/SoloCompass/Services/HapticService.swift
+++ b/apps/ios/SoloCompass/Services/HapticService.swift
@@ -1,0 +1,70 @@
+#if canImport(UIKit)
+import UIKit
+
+private extension ProcessInfo {
+    var isPreview: Bool {
+        environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+    }
+}
+
+/// Centralised haptic feedback with a per-user opt-out via UserDefaults.
+///
+/// Wraps `UIImpactFeedbackGenerator` and `UINotificationFeedbackGenerator`.
+/// All methods are no-ops when `hapticsEnabled` is false, when
+/// `UIAccessibility.isReduceMotionEnabled` is true, or when running inside
+/// an Xcode preview.
+@MainActor public final class HapticService {
+    public static let shared = HapticService()
+
+    /// UserDefaults key. Defaults to `true` if the key is absent.
+    static let defaultsKey = "hapticsEnabled"
+
+    /// Whether haptics are enabled. Backed by `UserDefaults.standard` so
+    /// changes made in Settings take effect immediately without an app restart.
+    public var isEnabled: Bool {
+        get { UserDefaults.standard.object(forKey: Self.defaultsKey) as? Bool ?? true }
+        set { UserDefaults.standard.set(newValue, forKey: Self.defaultsKey) }
+    }
+
+    private var impactGenerators: [UIImpactFeedbackGenerator.FeedbackStyle: UIImpactFeedbackGenerator] = [:]
+    private let notificationGenerator = UINotificationFeedbackGenerator()
+
+    private init() {}
+
+    private func shouldFire() -> Bool {
+        guard isEnabled else { return false }
+        guard !ProcessInfo.processInfo.isPreview else { return false }
+        guard !UIAccessibility.isReduceMotionEnabled else { return false }
+        return true
+    }
+
+    private func generator(for style: UIImpactFeedbackGenerator.FeedbackStyle) -> UIImpactFeedbackGenerator {
+        if let cached = impactGenerators[style] { return cached }
+        let gen = UIImpactFeedbackGenerator(style: style)
+        impactGenerators[style] = gen
+        return gen
+    }
+
+    /// Pre-warm the Taptic Engine for the given style. Call before the action
+    /// that will fire `impact(style:)` to minimise latency.
+    public func prepare(style: UIImpactFeedbackGenerator.FeedbackStyle = .light) {
+        guard shouldFire() else { return }
+        generator(for: style).prepare()
+    }
+
+    /// Fire an impact haptic.
+    public func impact(style: UIImpactFeedbackGenerator.FeedbackStyle = .light) {
+        guard shouldFire() else { return }
+        let gen = generator(for: style)
+        gen.prepare()
+        gen.impactOccurred()
+    }
+
+    /// Fire a notification haptic.
+    public func notification(type: UINotificationFeedbackGenerator.FeedbackType) {
+        guard shouldFire() else { return }
+        notificationGenerator.prepare()
+        notificationGenerator.notificationOccurred(type)
+    }
+}
+#endif

--- a/apps/ios/SoloCompass/Tests/HapticServiceTests.swift
+++ b/apps/ios/SoloCompass/Tests/HapticServiceTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import SoloCompass
+
+@MainActor
+final class HapticServiceTests: XCTestCase {
+
+    private let key = HapticService.defaultsKey
+
+    override func setUp() {
+        super.setUp()
+        // Restore default state before each test.
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: key)
+        super.tearDown()
+    }
+
+    func testDefaultsToEnabled() {
+        // Key absent → reads as true.
+        XCTAssertTrue(HapticService.shared.isEnabled)
+    }
+
+    func testDisabledFlagPersists() {
+        HapticService.shared.isEnabled = false
+        XCTAssertFalse(HapticService.shared.isEnabled)
+        // Re-read from UserDefaults directly to confirm persistence.
+        XCTAssertEqual(UserDefaults.standard.bool(forKey: key), false)
+    }
+
+    func testReEnablePersists() {
+        HapticService.shared.isEnabled = false
+        HapticService.shared.isEnabled = true
+        XCTAssertTrue(HapticService.shared.isEnabled)
+    }
+
+    /// Verifies that calling `impact` and `notification` with `isEnabled = false`
+    /// short-circuits before any UIKit generator is touched (no crash or assertion).
+    /// We can't intercept UIKit calls directly in unit tests, so we rely on the
+    /// fact that the methods must return without throwing when the flag is off.
+    func testDisabledFlagShortCircuitsImpact() {
+        HapticService.shared.isEnabled = false
+        // These must complete without crashing.
+        HapticService.shared.impact(style: .light)
+        HapticService.shared.impact(style: .medium)
+        HapticService.shared.impact(style: .heavy)
+    }
+
+    func testDisabledFlagShortCircuitsNotification() {
+        HapticService.shared.isEnabled = false
+        HapticService.shared.notification(type: .success)
+        HapticService.shared.notification(type: .warning)
+        HapticService.shared.notification(type: .error)
+    }
+
+    func testPrepareShortCircuitsWhenDisabled() {
+        HapticService.shared.isEnabled = false
+        HapticService.shared.prepare(style: .light)
+        // No crash → disabled flag short-circuits generator creation correctly.
+    }
+}

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -141,6 +141,11 @@ public struct CompassMapView: View {
                     UINotificationFeedbackGenerator().notificationOccurred(.success)
                 }
             }
+            .onChange(of: viewModel?.isShowingDetail) { _, showing in
+                if showing == true {
+                    HapticService.shared.impact(style: .medium)
+                }
+            }
             .onChange(of: viewModel?.selectedCity) { _, cityCode in
                 refreshNearbyRoutes(cityCode: cityCode)
             }
@@ -604,7 +609,7 @@ public struct CompassMapView: View {
                         Annotation(exp.title, coordinate: coord) {
                             Button {
                                 viewModel.selectExperience(exp)
-                                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                                HapticService.shared.impact(style: .light)
                             } label: {
                                 VStack(spacing: 2) {
                                     MarkerIconView(


### PR DESCRIPTION
## Haptic feedback on experience pin selection

Currently tapping a map pin selects an experience silently. Adding subtle haptic feedback on pin tap and on opening the experience detail sheet provides physical confirmation that aligns with iOS native interaction patterns and makes the map feel more responsive. Solo travelers often use the app one-handed while walking, so tactile cues reduce the need to visually confirm every tap.

### Acceptance
Tapping any pin on the map produces a light haptic tap on a physical device; opening the detail sheet produces a medium tap. Toggling 'hapticsEnabled' to false in UserDefaults silences all haptics. xcodebuild build and xcodebuild test both pass on iPhone 17 Pro simulator. No force-unwraps introduced; all new user-facing strings (if any) go through NSLocalizedString.