### PR TITLE
chore(ralph): seed prd.json with NowScore v1 (10 US)

### DIFF
--- a/prd.json
+++ b/prd.json
@@ -1,106 +1,122 @@
 {
   "project": "Solo Compass",
-  "branchName": "ralph/full-fix-roadmap-58us",
-  "description": "Full Fix Roadmap \u2014 Solo Compass iOS. Executes the 58 user stories captured in tasks/prd-full-fix-roadmap.md across 4 categories: P0 (13 \u2014 crash/data-loss/a11y/perf hot-paths), P1 (29 \u2014 correctness/coverage), P2 (16 \u2014 polish/i18n), and A-Series (8 \u2014 design-token adoption + 800-line file decomposition). Source documents: docs/EVAL_REPORT.md (52 source-level findings) + 6 device findings from e2e-runner v2 (a16a636) + design ground truth at /tmp/compare_design/solocompassapp/. Strict four-way acceptance: iPhone 17 Pro Simulator manual run + XCTest + VoiceOver (a11y stories) + Sentry capture (silent-failure stories). All file:line anchors against main @ 0252ce3 (see PRD \u00a73).",
+  "branchName": "ralph/nowscore-v1-10us",
+  "description": "NowScore v1 — upgrade Experience.isBestNow() from a static boolean (driven by bestTimes: [TimeWindow]) to a continuous nowScore in [0, 1] composed from multiple NowSignal implementations (BestTimes / HourOfDay / Weather / Sunset) with human-readable reason text. Differentiator: BestNowBadge moves from '此刻' to '日落 23 分钟后 · 晴 · 适合' — Google/Apple Maps won't do this. Source: tasks/prd-now-score-v1.md. Parallel to ralph/full-fix-roadmap-58us; coordinate US-NS-007 / US-NS-008 with that PRD's US-P1-003 / US-P2-035 (both touch nowCount + Filter Now). Strict acceptance: every story keeps the 100+ existing BestNow*Tests green, p95 < 5ms, offline-safe, Sentry-instrumented. File:line anchors against main @ a9afa18.",
   "userStories": [
     {
       "id": "US-001",
-      "title": "Replace 6 route.companion! force-unwraps with safe binding",
-      "description": "As an iOS engineer, I want all 6 `route.companion!` force-unwrap sites replaced with safe binding so the app never crashes when companion data is unexpectedly nil.",
+      "title": "Introduce NowScore value type and Experience.nowScore(at:) method",
+      "description": "As an iOS engineer, I need a NowScore value type and an Experience.nowScore(at:) method so downstream views/viewmodels read a continuous [0,1] score instead of a Bool, while preserving isBestNow() semantics for backward compatibility.",
       "acceptanceCriteria": [
-        "grep '\\bcompanion!' across non-Tests Swift files returns 0 hits",
-        "Each of the 6 sites (Services/LocalRouteCompanionRemote.swift:38,119,126,137 + Views/Companion/MyRequestsListView.swift:182 + Views/Companion/ApprovalQueueView.swift:311) rewritten with `guard var companion = updated.companion else { ... }` pattern, mutating the bound copy then assigning back via updated.companion = companion",
-        "Add new XCTest RouteCompanionForceUnwrapTests covering each mutation path with companion == nil input \u2014 operation must no-op cleanly with no crash",
-        "Existing RouteCompanionStateMachineTests still pass",
-        "When the no-op safety path triggers, SentryService.capture(...) reports a warning so production occurrences are visible",
-        "Typecheck passes (xcodebuild build succeeds on iPhone 17 Pro Simulator)",
+        "Create apps/ios/SoloCompass/Models/NowScore.swift with `public struct NowScore: Sendable { public let value: Double /* [0,1] */; public let reason: String?; public let breakdown: [String: Double] }`",
+        "Add `public func nowScore(at date: Date) -> NowScore` to apps/ios/SoloCompass/Models/Experience.swift next to existing isBestNow() at line 472. v1 only consults bestTimes: in-window → value=1.0, out-of-window → value=0.0, empty bestTimes → value=0.5 (neutral)",
+        "Keep `isBestNow(at:)` signature unchanged; rewrite body to `return nowScore(at: date).value >= 0.7`",
+        "Add NowScoreTests in apps/ios/SoloCompass/Tests/ covering: in-window → 1.0, out-of-window → 0.0, empty bestTimes → 0.5",
+        "All existing BestNow*Tests (search `grep -rn 'BestNow' apps/ios/SoloCompass/Tests`) still pass",
+        "Typecheck passes",
         "Tests pass"
       ],
       "priority": 1,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-002",
-      "title": "SyncService.enqueue must report encode failures to Sentry",
-      "description": "As an end user, I want my completions, favorites, and route join requests to never silently disappear so my actions are durable across devices.",
+      "title": "Define NowSignal protocol + register BestTimesSignal and HourOfDaySignal",
+      "description": "As an iOS engineer, I want a NowSignal protocol so future signal contributors (weather, sunset, crowd) plug in without touching Experience.nowScore itself.",
       "acceptanceCriteria": [
-        "Services/SyncService.swift:95-98 `try? JSONEncoder().encode(...)` replaced with `do { try ... } catch { SentryService.capture(error, context: \"SyncService.enqueue\", payload: payloadType) }`",
-        "On failure the queue either rethrows to the caller or falls back gracefully \u2014 but always reports via Sentry; the bare `return` is gone",
-        "Add SyncServiceEnqueueTests injecting a payload that deterministically fails encoding \u2014 assert a SentryService mock receives the capture call",
-        "grep 'try?' inside Services/SyncService.swift returns 0 hits for encode/decode",
+        "Create apps/ios/SoloCompass/Services/NowScore/NowSignal.swift defining `public protocol NowSignal { static var key: String { get }; func score(for experience: Experience, at date: Date) async -> NowSignalContribution }`",
+        "Same file defines `public struct NowSignalContribution: Sendable { public let value: Double /* [0,1] */; public let weight: Double; public let reason: String? }`",
+        "Create apps/ios/SoloCompass/Services/NowScore/BestTimesSignal.swift implementing the protocol; key='bestTimes', weight=0.4; logic mirrors US-001 in-window/out-of-window check",
+        "Create apps/ios/SoloCompass/Services/NowScore/HourOfDaySignal.swift; key='hourOfDay', weight=0.2; gaussian decay centered on experience.bestStartHour with sigma=90min (full width)",
+        "Refactor Experience.nowScore(at:) to iterate registered signals (`[BestTimesSignal(), HourOfDaySignal()]`) and produce weighted average value + concatenated reason. Empty signal list → value=0.5",
+        "Add NowSignalCompositionTests: both signals max → 1.0; only one max → roughly its weight share; both 0 → 0.0; reason text concatenated with ' · '",
+        "All existing BestNow*Tests + US-001 NowScoreTests still pass",
         "Typecheck passes",
         "Tests pass"
       ],
       "priority": 2,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-003",
-      "title": "Add AISynthesisQuality state to AIService",
-      "description": "As an iOS engineer, I need AIService to expose whether the last synthesis was real, skeleton, or cached so the UI can render a transparency badge.",
+      "title": "Build WeatherService with 12-hour SwiftData cache",
+      "description": "As an iOS engineer, I need a WeatherService that fetches and caches current weather for any coordinate so NowScore can read weather without one network call per marker.",
       "acceptanceCriteria": [
-        "Add public enum AISynthesisQuality { case real, skeleton, cached } in Services/AIService.swift",
-        "Add public observable property `lastSynthesisQuality: AISynthesisQuality` updated on every synthesis path (success branch -> .real, fallback branch -> .skeleton, cache-hit branch -> .cached) \u2014 anchor lines 765-768 and 781-791",
-        "Skeleton fallback path also calls SentryService.capture(...) with subsystem 'AIService.skeleton_fallback'",
-        "Add AISynthesisQualityTests injecting each path and asserting lastSynthesisQuality transitions correctly",
+        "Create apps/ios/SoloCompass/Services/WeatherService.swift with `@MainActor @Observable public final class WeatherService` exposing `public func current(at coord: CLLocationCoordinate2D) async throws -> WeatherSnapshot`",
+        "Same file defines `public struct WeatherSnapshot: Sendable { public let tempC: Double; public let condition: WeatherCondition; public let precipChancePct: Int; public let windKph: Double; public let observedAt: Date }` and `public enum WeatherCondition: String, Sendable, Codable { case clear, partlyCloudy, cloudy, rain, storm, snow, fog }`",
+        "Same file defines `public enum WeatherError: Error { case noAPIKey, networkUnavailable, decodingFailed }`",
+        "API key sourced from `Secrets.openWeatherAPIKey`. If nil → throw WeatherError.noAPIKey (callers must handle gracefully)",
+        "Create apps/ios/SoloCompass/Persistence/Models/WeatherCacheRecord.swift as `@Model public final class WeatherCacheRecord { @Attribute(.unique) public var coordKey: String /* '\\(lat.rounded(2))_\\(lon.rounded(2))' */; public var snapshotJSON: Data; public var observedAt: Date; ... }`",
+        "TTL = 12 hours: cache hit if `Date().timeIntervalSince(record.observedAt) < 12 * 3600`",
+        "If NetworkMonitor.shared.isOnline == false → only read cache, return nil snapshot when miss (do not throw)",
+        "Register WeatherCacheRecord in the ModelContainer schema (find existing container init via `grep -rn 'ModelContainer' apps/ios/SoloCompass/App` and add to schema array)",
+        "Add WeatherServiceTests with a mock URLSessionProtocol injection: first call hits network, second call hits cache (verify by asserting URLSession mock call count == 1)",
+        "Add WeatherCacheTTLTests: insert a 13-hour-old record → second call hits network again",
         "Typecheck passes",
         "Tests pass"
       ],
       "priority": 3,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-004",
-      "title": "Add SkeletonBadgeView component (transparency pill)",
-      "description": "As a user, I want a small visible indicator when an experience card is showing skeleton data instead of real AI insight so I don't mistake placeholder text for personalized recommendation.",
+      "title": "Offline + error degradation + Sentry instrumentation in NowScoreEngine",
+      "description": "As a user, I want NowScore to keep working when offline (only bestTimes/hourOfDay signals contribute) and never crash or surface a stack trace, with unexpected errors visible in Sentry.",
       "acceptanceCriteria": [
-        "Create apps/ios/SoloCompass/Views/Shared/SkeletonBadgeView.swift with public struct SkeletonBadgeView: View",
-        "Visual: capsule using CT.fgMuted (NOT accent) and CT.body(10, .medium); text from NSLocalizedString(\"ai.skeleton.pill\", ...) \u2014 add the key to en.lproj and zh-Hans.lproj Localizable.strings (en: \"Limited data\", zh-Hans: \"\u6570\u636e\u6709\u9650\")",
-        "accessibilityLabel reads the localized string + \"placeholder content\" hint",
-        "Wire it into Views/Experience/ExperienceCardView.swift: render only when the bound AIService.lastSynthesisQuality == .skeleton; never render for .real or .cached",
-        "Add SkeletonBadgeViewTests with snapshot of badge + ExperienceCardTests verifying conditional rendering",
-        "Add LocalizableStringsParityTest expectation \u2014 both new keys present in en and zh-Hans, StringsParityTests passes",
+        "Create apps/ios/SoloCompass/Services/NowScore/NowScoreEngine.swift with `@MainActor public final class NowScoreEngine` holding the registered [any NowSignal] array",
+        "Move the signal-iteration + weighted-average logic from Experience.nowScore(at:) into NowScoreEngine.evaluate(for:at:); Experience.nowScore(at:) delegates to the shared engine",
+        "If any individual signal throws or returns an error → engine catches, substitutes `NowSignalContribution(value: 0.5, weight: 0.0, reason: nil)` for that signal, and continues",
+        "Known errors (WeatherError.noAPIKey, WeatherError.networkUnavailable) → silently degrade, no Sentry report",
+        "Unexpected errors → `SentryService.capture(error, context: \"NowScoreEngine.\\(signalKey)\")`",
+        "Add NowScoreOfflineDegradeTest: inject a throwing WeatherSignal stub → engine returns nowScore that excludes weather dimension, no crash",
+        "Add NowScoreSentryReportTest: inject a signal that throws a custom error → verify a SentryService mock receives the capture call with the right context string",
         "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: launch app without ANTHROPIC_API_KEY \u2192 cards display the badge; with key \u2192 badge absent"
+        "Tests pass"
       ],
       "priority": 4,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-005",
-      "title": "Remove AnyView wrapper from CompassMapView.body",
-      "description": "As an iOS engineer, I want the root mapContent to return some View directly so SwiftUI can do incremental diffing on the app's heaviest view.",
+      "title": "WeatherSignal — NowSignal implementation that downgrades outdoor scores in bad weather",
+      "description": "As a user, I want the NowScore to drop when it's raining hard or there's a storm so the app doesn't suggest a 'perfect now' outdoor experience in a thunderstorm.",
       "acceptanceCriteria": [
-        "Views/Map/CompassMapView.swift:76 \u2014 `public var body: some View { mapContent }` returns the @ViewBuilder result without AnyView(...) wrapping",
-        "If init signature constraints fight the return type, add @ViewBuilder to body so the concrete opaque type is inferred",
-        "Add CompassMapViewBodyTypeTests: assert String(describing: type(of: someInstance.body)) does NOT contain \"AnyView\"",
-        "All existing snapshot/unit tests (MarkerIconTests, CityPillHitTargetTests, FilterBarViewTests) still pass",
+        "Create apps/ios/SoloCompass/Services/NowScore/WeatherSignal.swift implementing NowSignal; key='weather', weight=0.15",
+        "Constructor takes WeatherService dependency (so it's injectable for tests)",
+        "score(for:at:) logic: outdoor categories (.nature; .nightlife only if experience.tags contains 'rooftop') consult weather, indoor categories (.coffee, .work, .wellness, .culture, .food) always return value=1.0 with reason=nil",
+        "For outdoor: clear/partlyCloudy → 1.0, cloudy with precipChancePct<30 → 0.9, rain (precipChancePct ≥ 30) → 0.5, storm OR windKph ≥ 30 OR precipChancePct ≥ 70 → 0.0",
+        "reason text examples: '晴 · 27°C · 适合' (clear), '雷雨预警 · 不建议外出' (storm); use NSLocalizedString",
+        "Add localization keys nowscore.weather.sunny / nowscore.weather.cloudy / nowscore.weather.rain / nowscore.weather.storm / nowscore.weather.indoor to both en.lproj and zh-Hans.lproj Localizable.strings",
+        "If WeatherService returns nil snapshot (offline cache miss) → return value=0.5, weight=0.0, reason=nil (neutral, no UI bleed)",
+        "Add WeatherSignalTests covering: indoor → 1.0 regardless; outdoor + clear → 1.0; outdoor + rain → 0.5; outdoor + storm → 0.0; offline+miss → (0.5, 0.0, nil)",
+        "StringsParityTests passes (en + zh-Hans key sets match)",
         "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: pan/zoom map for 30 seconds, no visual regression"
+        "Tests pass"
       ],
       "priority": 5,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-006",
-      "title": "BottomInfoSheet drag handle hit target \u2265 44pt",
-      "description": "As a VoiceOver / Switch Control user, I want the bottom sheet drag handle to have a 44\u00d744pt minimum hit area so I can switch detent levels reliably.",
+      "title": "SolarEvents pure-function module + SunsetSignal",
+      "description": "As a solo traveler, I want viewpoints / parks / rooftop bars to score highest in the 90 minutes before sunset so I'm nudged 'depart now · sunset in 23 min' at the right moment.",
       "acceptanceCriteria": [
-        "Views/Map/BottomInfoSheet.swift:127-131 \u2014 wrap the handle in `.frame(minWidth: 60, minHeight: 44).contentShape(Rectangle())`; the visible pill stays 36\u00d74",
-        "Add `.accessibilityLabel(NSLocalizedString(\"sheet.handle\", ...))` plus `.accessibilityAdjustableAction` that cycles peek \u2192 mid \u2192 full",
-        "Add new localization key sheet.handle to en + zh-Hans Localizable.strings",
-        "Add BottomInfoSheetHandleHitTargetTests asserting hit-area frame \u2265 44 in either dimension",
+        "Create apps/ios/SoloCompass/Services/SolarEvents.swift with `public enum SolarEvents { public static func sunset(at coord: CLLocationCoordinate2D, on date: Date) -> Date?; public static func sunrise(at coord: CLLocationCoordinate2D, on date: Date) -> Date? }`. Implement using NREL Solar Position Algorithm simplified for civil sunset/sunrise (one local file, < 150 lines, NO new SPM dependency)",
+        "Add SolarEventsTests with two latitude/date fixtures: Vientiane (17.97°N, 102.60°E) on 2024-06-21 → sunset within ±5 min of 18:50 local; Beijing (39.90°N, 116.41°E) on 2024-12-22 → sunset within ±5 min of 16:50 local",
+        "Create apps/ios/SoloCompass/Services/NowScore/SunsetSignal.swift implementing NowSignal; key='sunset', weight=0.25",
+        "score(for:at:) only contributes (weight=0.25) for experiences with category ∈ [.nature, .nightlife] OR tags containing 'sunset_friendly'; other experiences return weight=0, value=0.5, reason=nil",
+        "Scoring curve for eligible experiences: 90→30 min before sunset → 1.0; 30→0 min → gaussian decay to 0.7; 0→30 min after sunset (blue hour) → 0.6; otherwise → 0.4",
+        "reason text uses NSLocalizedString; examples: '日落 23 分钟后', '日落 8 分钟后 · 蓝调时刻', '日落已过 47 分钟'. Use stringsdict for plural-aware minute formatting where needed",
+        "Add localization keys nowscore.sunset.before_min / nowscore.sunset.blue_hour / nowscore.sunset.after_min to both locales",
+        "Add SunsetSignalTests sampling at sunset - 60min / -30 / -5 / 0 / +20 / +60 → assert value within expected band",
         "StringsParityTests passes",
         "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator with Accessibility Inspector: hit area visualized \u2265 44pt"
+        "Tests pass"
       ],
       "priority": 6,
       "passes": false,
@@ -108,16 +124,18 @@
     },
     {
       "id": "US-007",
-      "title": "Localize hardcoded 'results' strings in FilterBarView",
-      "description": "As a zh-Hans user, I want the filter result count rendered in my locale instead of English so the UI is consistent.",
+      "title": "BestNowBadge renders NowScore reason as subtitle",
+      "description": "As a user looking at an experience card, I want the 'best now' badge to show a one-line reason like '日落 23 分钟后 · 晴 · 适合' so I understand WHY this is recommended right now.",
       "acceptanceCriteria": [
-        "Views/Filter/FilterBarView.swift:180, 230, 264, 301 \u2014 replace literal \"results\" with String(format: NSLocalizedString(\"filter.results.count\", ...), count)",
-        "Add filter.results.count to en (\"%d results\") and zh-Hans (\"%d \u4e2a\u7ed3\u679c\") Localizable.strings",
-        "Add FilterBarLocalizationTests verifying the resolved string in zh-Hans uses Chinese characters",
-        "grep 'results' inside Views/Filter/FilterBarView.swift produces zero literal hits (excluding comments)",
-        "StringsParityTests passes",
+        "Edit apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift BestNowBadge (currently at lines 267-289). When `experience.nowScore(at: .now).value >= 0.7`, render a subtitle Text below the existing badge label using `nowScore.reason ?? NSLocalizedString(\"badge.now.fallback\", ...)` (existing '此刻' string is the fallback)",
+        "Reason text style: CT.body(11, .medium) in CT.fgMuted color (secondary, does not steal focus from main title)",
+        "Reason composition rule: top-3 contributing signals by weight × value, joined with ' · '; if combined text > 28 chars truncate with '…'",
+        "If `nowScore.value < 0.7` → render NOTHING (badge fully hidden, current behavior preserved)",
+        "Add BestNowBadgeReasonTests with three snapshots: short reason (1 signal), medium reason (2 signals), long reason that requires truncation",
+        "All existing BestNowBadge tests still pass",
         "Typecheck passes",
-        "Tests pass"
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: launch app at a time when a marker satisfies nowScore ≥ 0.7 → screenshot the badge showing the new reason subtitle"
       ],
       "priority": 7,
       "passes": false,
@@ -125,15 +143,16 @@
     },
     {
       "id": "US-008",
-      "title": "voice.processing toast announces via UIAccessibility live region",
-      "description": "As a VoiceOver user, I want voice processing toasts to announce themselves so I stay in sync with app state without manually moving focus.",
+      "title": "MapViewModel.nowCount + markerState sort consume nowScore",
+      "description": "As an iOS engineer, I want MapViewModel.nowCount and markerState sorting to drive off nowScore.value ≥ 0.7 instead of the legacy isBestNow() so the entire app reflects the continuous model.",
       "acceptanceCriteria": [
-        "Views/Map/CompassMapView.swift:868-885 \u2014 the voice.processing toast view chain adds .accessibilityElement().accessibilityAddTraits(.updatesFrequently)",
-        "On the toast's onAppear (and on text change) call UIAccessibility.post(.announcement, argument: localizedText)",
-        "Add VoiceToastA11yTests asserting the view tree contains the .updatesFrequently trait when toast is active",
+        "Edit apps/ios/SoloCompass/ViewModels/MapViewModel.swift nowCount property (line 298): change body to `visibleExperiences.filter { $0.nowScore(at: .now).value >= 0.7 }.count`",
+        "Edit markerState sort order: experiences with nowScore.value ≥ 0.7 come first, then sort by nowScore.value descending, then by distance ascending",
+        "If prd-full-fix-roadmap.md US-P1-003 (nowCount caching) has already merged when this story runs, preserve its caching pattern: invalidate the `_nowCount` cache whenever visibleExperiences changes, then recompute using the new nowScore predicate",
+        "Add MapViewModelNowScoreSortTest injecting 3 mock experiences (scores 0.9 / 0.7 / 0.5) and asserting their order matches",
+        "All existing MarkerIconViewTests and MapViewModelCityCacheTests still pass",
         "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator with VoiceOver on: triggering a voice query causes the system to read the toast text"
+        "Tests pass"
       ],
       "priority": 8,
       "passes": false,
@@ -141,15 +160,16 @@
     },
     {
       "id": "US-009",
-      "title": "Hide Companion-layer toggle behind a feature flag (decision A)",
-      "description": "As a product owner, I want the long-unimplemented companion layer toggle hidden by default so users don't click a dead button that always returns nil.",
+      "title": "Filter 'Now' mode visually grades markers by nowScore intensity",
+      "description": "As a user, when 'Now' filter is on, I want markers visually graded by nowScore intensity (full color / semi / faded) instead of just shown/hidden so I can pick the BEST 'now' option, not just any.",
       "acceptanceCriteria": [
-        "Views/Map/CompassMapView.swift:541 \u2014 wrap the toggle in `if FeatureFlags.companionLayerEnabled { ... }`",
-        "Services/FeatureFlags.swift \u2014 add static var companionLayerEnabled: Bool = false (default off) plus a way to override in DEBUG via UserDefaults",
-        "Update CompassMapViewLayerToggleTests to assert the toggle is NOT in the view hierarchy when the flag is false (and IS when true)",
+        "Edit MarkerIconView (find via `grep -rn 'MarkerIconView' apps/ios/SoloCompass/Views/Map`) so that when MapViewModel's filter is in Now mode, the marker opacity = `min(1.0, max(0.5, nowScore.value))` (floor at 0.5 so markers stay visible)",
+        "Markers with nowScore.value ≥ 0.9 additionally get a 0.6s-cycle pulse animation ring in CT.accent (opacity 0.7 → 1.0)",
+        "Add FilterNowGradientHighlightTest using XCTest + a snapshot of three markers at scores 0.95 / 0.75 / 0.55 in Now mode",
+        "All existing FilterBarViewTests and CompassMapView snapshot tests still pass",
         "Typecheck passes",
         "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: cold launch shows no companion-layer toggle in the top overlay"
+        "Verify in iPhone 17 Pro Simulator: toggle Now filter on → screenshot showing the gradient + pulse highlight on top markers"
       ],
       "priority": 9,
       "passes": false,
@@ -157,802 +177,18 @@
     },
     {
       "id": "US-010",
-      "title": "Resolve SwiftData @Query KeyPath Sendable warning in SettingsView",
-      "description": "As an iOS engineer, I want the SwiftData @Query Sendable warning resolved so strict concurrency stays clean.",
+      "title": "NowScore p95 latency < 5ms with in-memory caches",
+      "description": "As an iOS engineer, I want NowScore evaluation to stay under 5ms p95 so it doesn't tank scrolling perf on a list of 100 markers.",
       "acceptanceCriteria": [
-        "Views/Settings/SettingsView.swift:897 \u2014 replace the bare KeyPath in @Query with an explicit SortDescriptor(\\.field, order: ...) or wrap in @Sendable closure",
-        "Add SettingsViewQuerySortTest asserting the records query returns expected order",
-        "xcodebuild output no longer surfaces the 'sending KeyPath risks data races' warning for this line",
+        "Add an in-memory LRU dict (size 100) inside WeatherService for hot-path cache hits — avoids SwiftData fetch on every nowScore call",
+        "Add an in-memory dict inside SolarEvents keyed by `'\\(lat.rounded(1))_\\(lon.rounded(1))_\\(date.formatted(.iso8601.year().month().day()))'` to memoize same-day same-coord sunset/sunrise",
+        "Add NowScorePerformanceTest in apps/ios/SoloCompass/Tests/: construct 100 fixture experiences spanning all categories, call `nowScore(at: .now)` 1000 times, measure with `measure(metrics: [XCTClockMetric()])` and assert p95 < 5ms",
+        "On test failure, the test message must include a per-signal timing breakdown so developers see which signal regressed",
+        "All other tests still pass",
         "Typecheck passes",
         "Tests pass"
       ],
       "priority": 10,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-011",
-      "title": "Fix ChatSheet voiceService main-actor isolation",
-      "description": "As an iOS engineer, I want main-actor isolated voiceService usage to not race so strict concurrency holds.",
-      "acceptanceCriteria": [
-        "Services/VoiceService.swift \u2014 add @MainActor to the class declaration (or @MainActor to requestPermission()) so Views/Chat/ChatSheet.swift:621 sends a main-actor value to a main-actor method",
-        "Add VoiceServiceActorIsolationTest asserting requestPermission is callable from a @MainActor context without warning",
-        "xcodebuild output no longer surfaces the 'sending self.voiceService risks data races' warning",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 11,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-012",
-      "title": "Gate FavoritesListView BounceSymbolEffect behind iOS 18 availability",
-      "description": "As an iOS engineer, I want the iOS-18-only BounceSymbolEffect API gated by `if #available` so the project stays clean under Swift 6 strict mode.",
-      "acceptanceCriteria": [
-        "Views/Shared/FavoritesListView.swift:327 \u2014 wrap `base.symbolEffect(.bounce, options: .repeating.speed(0.6))` in `if #available(iOS 18, *) { ... } else { base }`",
-        "Add FavoritesBounceAvailabilityTest verifying SwipeHintCapsuleView builds and renders under both iOS 17 and iOS 18 deployment targets",
-        "xcodebuild output no longer surfaces the 'IndefiniteSymbolEffect available only iOS 18+' warning",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 12,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-013",
-      "title": "Fix Onboarding privacy sheet subtitle truncation (V-001)",
-      "description": "As a first-time user, I want the privacy onboarding sheet to show the full subtitle so I understand what services the app calls on my behalf.",
-      "acceptanceCriteria": [
-        "Locate the source file via `grep -rn 'talks to two services' apps/ios/SoloCompass/Views/Onboarding` \u2014 likely Views/Onboarding/PrivacyAcknowledgementSheet.swift",
-        "Either set the sheet to use a self-sizing detent (.medium then .large) OR add `.fixedSize(horizontal: false, vertical: true)` to the subtitle Text",
-        "Subtitle renders the full phrase ending in '...on your behalf' at default AND AX5 Dynamic Type",
-        "Add PrivacyAcknowledgementSheetSnapshotTest with snapshots at .accessibilityMedium and .accessibilityExtraExtraExtraLarge",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: cold launch displays full subtitle on first screen"
-      ],
-      "priority": 13,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-014",
-      "title": "Sync selectedCity \u2192 mapCameraPosition on cold start (V-002)",
-      "description": "As a user, I want the city header label and the map's rendered region to always agree so I'm never confused about where I am.",
-      "acceptanceCriteria": [
-        "ViewModels/MapViewModel.swift \u2014 `selectedCity` didSet must trigger an update to `mapCameraPosition` via defaultCenterForSelectedCity, including on the first set during init (not just user-driven changes)",
-        "Add MapViewModelCityRegionSyncTests: after init with city=\"chiang-mai\" the cameraPosition center is within 1km of Chiang Mai; after switching to city=\"san-francisco\" the camera moves",
-        "Existing MapViewModel tests still pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: cold launch shows city header and map region matching"
-      ],
-      "priority": 14,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-015",
-      "title": "Audit and localize hardcoded English strings in BottomInfoSheet + FilterBar (V-003)",
-      "description": "As a zh-Hans user, I want the entire bottom sheet UI in Chinese so I don't see English copy bleeding through.",
-      "acceptanceCriteria": [
-        "Add scripts/check-hardcoded-strings.sh that greps Views/ for `Text(\"[A-Z]` patterns and prints offenders (excluding #Preview blocks and acceptable proper nouns)",
-        "Run the script and replace each user-visible literal with NSLocalizedString(...)",
-        "Known offender: Views/Map/BottomInfoSheet.swift literal 'Good spots for right now' \u2014 replace with NSLocalizedString(\"sheet.now.headline\", ...) with en/zh-Hans entries",
-        "Add LocalizationCoverageTest invoking the script and asserting 0 offenders remain",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator (zh-Hans locale): no English copy visible in bottom sheet or filter bar"
-      ],
-      "priority": 15,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-016",
-      "title": "Cache markerState(for:) once per ForEach iteration",
-      "description": "As an iOS engineer, I want markerState(for:) called once per ForEach iteration so we don't recompute six conditions twice per visible marker per frame.",
-      "acceptanceCriteria": [
-        "Views/Map/CompassMapView.swift:612-616 \u2014 refactor the ForEach body so `let state = viewModel.markerState(for: exp)` appears once at the top, and both downstream branches reuse `state` instead of calling markerState again",
-        "Add MarkerStatePerformanceTest constructing 100 experiences and measuring 1000 iterations \u2014 p95 latency drops by \u2265 40% vs baseline (record baseline in same test on a non-cached helper)",
-        "Existing MarkerIconViewTests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: marker rendering looks identical (no visual regression)"
-      ],
-      "priority": 16,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-017",
-      "title": "Cache MapViewModel.availableCities",
-      "description": "As an iOS engineer, I want availableCities cached so we don't traverse allExperiences on every body invocation.",
-      "acceptanceCriteria": [
-        "ViewModels/MapViewModel.swift:187-215 \u2014 introduce `@ObservationIgnored private var _cachedCities: [CityInfo]?`",
-        "availableCities returns the cache when non-nil; otherwise recomputes and stores",
-        "Invalidate (_cachedCities = nil) whenever allExperiences or selectedCity change (in their didSet or in the refresh path)",
-        "Add MapViewModelCityCacheTests covering: fresh path computes and stores; second call hits cache (verify by snapshotting allExperiences before second call); invalidation after allExperiences change",
-        "Existing CityPillHitTargetTests pass",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 17,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-018",
-      "title": "Cache MapViewModel.nowCount",
-      "description": "As an iOS engineer, I want nowCount cached and recomputed only on visibleExperiences change so BottomInfoSheet and FilterBarView don't trigger O(n) scans on every render.",
-      "acceptanceCriteria": [
-        "ViewModels/MapViewModel.swift \u2014 add `@ObservationIgnored private var _nowCount: Int = 0`",
-        "Update _nowCount at the end of loadNearbyExperiences, refreshForLocation, and updateBottomInfo",
-        "nowCount property returns _nowCount",
-        "Lines 720 and 736 inside updateBottomInfo no longer recompute via .filter { $0.isBestNow() }",
-        "grep `visibleExperiences\\.filter \\{.*isBestNow` returns at most 1 occurrence (in the single source-of-truth update)",
-        "Add NowCountCacheTests injecting mock experiences and asserting the count updates only at the documented checkpoints",
-        "Existing FilterBarViewTests pass",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 18,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-019",
-      "title": "Hit-target \u2265 44pt for FilterBar icon pill, favorite heart, banner X",
-      "description": "As a VoiceOver / Switch Control user, I want all interactive controls to meet the 44pt HIG minimum.",
-      "acceptanceCriteria": [
-        "Views/Filter/FilterBarView.swift:240 iconPill (36\u00d736) \u2014 wrap in .frame(minWidth: 44, minHeight: 44).contentShape(Rectangle()); keep the visible chip 36\u00d736",
-        "Views/Experience/ExperienceCardView.swift:175 favorite heart (32\u00d732) \u2014 same treatment",
-        "Views/Map/CompassMapView.swift:1124 DismissibleBanner X button \u2014 same treatment",
-        "Add HitTargetSizeTests enumerating each control and asserting hit-area dimensions \u2265 44",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator with Accessibility Inspector: three controls all show \u2265 44pt hit area"
-      ],
-      "priority": 19,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-020",
-      "title": "Parallelize SoloCompassApp.onAppear init chain",
-      "description": "As a user, I want cold start TTI to not block on serial main-thread init so the map appears within 500ms.",
-      "acceptanceCriteria": [
-        "App/SoloCompassApp.swift:43-73 \u2014 move pruneStaleCheckIns, attachRepository, RouteStore.importSeedIfNeeded, and UserDirectory.loadIfNeeded into independent `Task { ... }` blocks; remove the serial await chain",
-        "Break subscriptionService.loadProducts \u2192 refreshEntitlement into its own independent Task",
-        "Add AppLaunchPerformanceTest measuring time from init to first body completion \u2014 assert \u2264 baseline \u00d7 0.5 (record baseline in test setup using the pre-refactor serial path stub)",
-        "Existing app launch tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: cold launch reaches the map screen visibly faster"
-      ],
-      "priority": 20,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-021",
-      "title": "Initialize CompassMapView viewModel eagerly (no Optional)",
-      "description": "As an iOS engineer, I want viewModel initialized eagerly so writes between launch and onAppear don't silently drop.",
-      "acceptanceCriteria": [
-        "Views/Map/CompassMapView.swift:1458 \u2014 change `@State private var viewModel: MapViewModel? = nil` to `@State private var viewModel = MapViewModel(...)` with required dependencies (or use environment injection)",
-        "Remove the lazy creation block inside .onAppear",
-        "All sites that did `if let viewModel = ...` simplify to direct use",
-        "Add MapViewModelEagerInitTest: app launch path can read viewModel.allExperiences before any onAppear fires",
-        "All existing CompassMapView tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: cold launch shows no ProgressView flicker before the map appears"
-      ],
-      "priority": 21,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-022",
-      "title": "Resolve City pill vs. filter bar visual stacking conflict",
-      "description": "As a user, I want city selector and filter bar to not visually fight for attention in the top-left.",
-      "acceptanceCriteria": [
-        "Views/Map/CompassMapView.swift top overlay \u2014 move the city pill into the navigation-bar area OR vertically separate it from the filter bar so the two capsules no longer overlap or hit-test interfere",
-        "Add TopOverlayLayoutTest using snapshot at iPhone 17 Pro size \u2014 assert city pill rect and filter bar rect do not intersect",
-        "VoiceOver order: city pill \u2192 filter bar \u2192 map (manually verified)",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: city pill and filter bar are visually separate"
-      ],
-      "priority": 22,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-023",
-      "title": "Share a single TimelineView clock across BestNowBadge instances",
-      "description": "As an iOS engineer, I want a single periodic timer feeding all BestNowBadge instances instead of 20+ concurrent timelines.",
-      "acceptanceCriteria": [
-        "Create Services/BestNowClock.swift \u2014 an @Observable @MainActor singleton with a tick property updated every 60s via a single Timer or AsyncStream",
-        "Views/Experience/ExperienceCardView.swift:267-289 BestNowBadge \u2014 replace its inline TimelineView(.periodic(by: 60)) with `@Environment(BestNowClock.self)` consumption",
-        "Add BestNowBadgeClockTest constructing 100 badges sharing one clock \u2014 assert only one Timer/AsyncStream is allocated",
-        "Existing BestNow tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: explore view with 20+ best-now badges shows no visible stutter"
-      ],
-      "priority": 23,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-024",
-      "title": "Add accessibilityLabel/value to SoloScoreRadarChart",
-      "description": "As a VoiceOver user, I want the radar chart's 6 dimensions read out loud.",
-      "acceptanceCriteria": [
-        "Views/Shared/SoloScoreRadarChart.swift \u2014 add `.accessibilityElement(children: .combine)` plus an `.accessibilityLabel` that names all 6 dimensions with their values, and `.accessibilityValue` for the overall score",
-        "Add SoloScoreRadarA11yTest asserting accessibilityLabel is non-empty and contains all 6 dimension names",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator with VoiceOver: focus lands on chart and reads e.g. 'Safety 7.5, Food 8.0, Coffee 7.0, ...'"
-      ],
-      "priority": 24,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-025",
-      "title": "Wire 'Ask Solo' gated CTA to Paywall sheet",
-      "description": "As a free-tier user, I want clicking a gated feature to take me to the paywall, not a dead toast.",
-      "acceptanceCriteria": [
-        "Views/Experience/ExperienceDetailView.swift \u2014 the gated 'Ask Solo' CTA now presents PaywallSheet via .sheet(isPresented:) when the user is not subscribed",
-        "Add AskSoloPaywallNavigationTest: tap the gated CTA \u2192 assert sheet appears via ViewInspector or snapshot",
-        "Existing ExperienceDetailView tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator (unsubscribed): tapping Ask Solo opens the paywall"
-      ],
-      "priority": 25,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-026",
-      "title": "Surface LocationService.lastError as dismissible banner",
-      "description": "As a user, I want GPS errors surfaced so I understand why the map defaulted to a region instead of my location.",
-      "acceptanceCriteria": [
-        "Services/LocationService.swift \u2014 confirm lastError is @Observable (Published) so views can react",
-        "ViewModels/MapViewModel.swift \u2014 observe lastError and expose a derived `locationErrorBannerText: String?`",
-        "Views/Map/CompassMapView.swift \u2014 render a dismissible banner using existing DismissibleBanner pattern when locationErrorBannerText != nil; copy from NSLocalizedString(\"location.error.banner\", ...)",
-        "Add en + zh-Hans entries for location.error.banner",
-        "Add LocationErrorSurfaceTests asserting banner appears when lastError set",
-        "When lastError != nil, SentryService.capture reports a warning",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator with Location set to None: banner appears"
-      ],
-      "priority": 26,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-027",
-      "title": "Surface voice recording interruptions in UI",
-      "description": "As a user, I want voice recording interruptions shown in UI instead of silently stopping.",
-      "acceptanceCriteria": [
-        "Views/Chat/ChatSheet.swift:636-638 \u2014 the empty catch is replaced with a toast/alert showing NSLocalizedString(\"voice.interrupted\", ...) with the underlying error description",
-        "Add en + zh-Hans entries for voice.interrupted (format string with %@ placeholder)",
-        "Add VoiceInterruptionToastTest: inject a throwing voice service \u2192 assert toast appears",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: revoking mic permission mid-record surfaces the toast"
-      ],
-      "priority": 27,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-028",
-      "title": "Filter chip selected-state contrast \u2265 4.5:1",
-      "description": "As a low-vision user, I want filter chip text to meet WCAG 4.5:1 contrast.",
-      "acceptanceCriteria": [
-        "Views/Filter/FilterBarView.swift selected state \u2014 replace #D4A843 on white with either CT.accent (#5D3000) text-on-CT.accentSoft (#FBF1E4) background OR white text on CT.accent background; both achieve \u2265 7:1",
-        "Add FilterChipContrastTest computing the WCAG relative luminance for selected state's foreground and background \u2014 assert contrast ratio \u2265 4.5",
-        "Existing FilterBarView tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: selected chip is clearly readable"
-      ],
-      "priority": 28,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-029",
-      "title": "Scale BottomInfoSheet detent heights with Dynamic Type",
-      "description": "As an AX5 Dynamic Type user, I want sheet detent heights to scale so content doesn't overflow.",
-      "acceptanceCriteria": [
-        "Views/Map/BottomInfoSheet.swift \u2014 multiply the three detent heights (peek 170, mid 500, full 800) by UIFontMetrics.default.scaledValue(for: 1.0) or equivalent",
-        "Add BottomSheetDetentDynamicTypeTest snapshotting all three detents at .accessibilityExtraExtraExtraLarge \u2014 content not clipped",
-        "Existing BottomInfoSheet tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator (Dynamic Type AX5): all three detent sizes show content without clipping"
-      ],
-      "priority": 29,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-030",
-      "title": "Sort button announces current mode via accessibilityValue",
-      "description": "As a VoiceOver user, I want the sort button to announce current sort mode.",
-      "acceptanceCriteria": [
-        "Views/Map/BottomInfoSheet.swift:208 \u2014 sort button adds `.accessibilityValue(NSLocalizedString(\"sort.value.\\(currentMode)\", ...))` keyed off the active sort mode",
-        "Add en + zh-Hans entries for sort.value.smart, sort.value.distance, sort.value.recent (whatever modes exist)",
-        "Add SortButtonA11yValueTest asserting accessibilityValue updates when sort mode changes",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator with VoiceOver: tapping sort button announces 'Sort, Sorted by smart'"
-      ],
-      "priority": 30,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-031",
-      "title": "JoinRouteRequestSheet inline error feedback",
-      "description": "As a user submitting a join request, I want inline validation errors so I know which field is missing.",
-      "acceptanceCriteria": [
-        "Views/Companion/JoinRouteRequestSheet.swift \u2014 missing pace or empty message field renders a red hint below the relevant input using NSLocalizedString(\"join.error.\\(field).missing\", ...)",
-        "Add en + zh-Hans entries for join.error.pace.missing and join.error.message.missing",
-        "Submit button stays disabled until both fields validate",
-        "Add JoinRequestValidationTest asserting hints appear/disappear with field state",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: submitting empty form shows hints; filling both clears them and enables submit"
-      ],
-      "priority": 31,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-032",
-      "title": "Approval queue shows trust signals per requester",
-      "description": "As a host reviewing join requests, I want to see opt-in status, walked-count, and group-count next to each requester.",
-      "acceptanceCriteria": [
-        "Views/Companion/ApprovalQueueView.swift \u2014 each request row renders three micro-stats: opt-in badge, walked count icon+number, group count icon+number \u2014 sourced from the existing requester profile object",
-        "If a stat is unknown, show '\u2014' instead of fabricating",
-        "Add ApprovalTrustSignalTest snapshotting three rows with different signal combinations",
-        "Existing ApprovalQueueView tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: approval queue rows show the three micro-stats"
-      ],
-      "priority": 32,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-033",
-      "title": "Diagnose and fix cold-start empty-state at 5km and 25km (V-004)",
-      "description": "As a user, I want the home screen to show experiences for my selected city on cold start so the app doesn't feel broken.",
-      "acceptanceCriteria": [
-        "Investigate the chain: Services/ExperienceService.swift seed import \u2192 MapViewModel.loadNearbyExperiences. Document root cause in PR description (likely candidates: distance filter uses SF user-location while header city is set differently; or seed not imported when SwiftData store exists but is empty)",
-        "Apply the fix that makes selectedCity drive both the camera AND the nearby query origin (depends on US-014)",
-        "Add ColdStartExperienceLoadTests: simulate cold start with selectedCity='chiang-mai' and assert nearby experiences count > 0 after the load completes",
-        "Add a Sentry warning if selectedCity is set but nearby experience count remains 0 for > 5 seconds",
-        "Existing ExperienceService tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: cold launch with each of 5 seed cities \u2192 each shows non-zero nearby count"
-      ],
-      "priority": 33,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-034",
-      "title": "Add scroll affordance to filter chip strip (V-005)",
-      "description": "As a user, I want a visual hint that filter chips scroll horizontally so I can discover all categories.",
-      "acceptanceCriteria": [
-        "Views/Filter/FilterBarView.swift \u2014 add a fade gradient mask on the right edge (using .mask(LinearGradient(...))) when content overflows; OR add a small chevron icon",
-        "Mask/chevron only shows when there is overflow content (not when all chips fit)",
-        "Add FilterBarScrollAffordanceTest snapshotting with > 6 categories (overflow) and \u2264 5 (no overflow)",
-        "Existing FilterBarView tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: with default category set, right-edge fade is visible"
-      ],
-      "priority": 34,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-035",
-      "title": "Sync Filter 'Now' mode and Map 'bestNow' visual highlight",
-      "description": "As a user, I want toggling the 'Now' filter to also highlight 'best now' markers on the map so the two UIs feel connected.",
-      "acceptanceCriteria": [
-        "Views/Map/CompassMapView.swift \u2014 when FilterBarView's 'Now' mode is active, decorate bestNow markers with an additional ring (use CT.accent) or pulse animation",
-        "Add FilterNowMapSyncTest asserting marker style changes when Now filter toggles",
-        "Existing CompassMapView tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: toggling Now \u2192 markers visibly change"
-      ],
-      "priority": 35,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-036",
-      "title": "Add visual separator between Routes and Nearby sections in BottomInfoSheet",
-      "description": "As a user, I want a clear visual division between routes and nearby experiences in the bottom sheet so the information hierarchy is obvious.",
-      "acceptanceCriteria": [
-        "Views/Map/BottomInfoSheet.swift \u2014 insert a section header with the localized title (NSLocalizedString(\"sheet.section.routes\", ...) and \"sheet.section.nearby\") and an inset divider between the two sections",
-        "Add en + zh-Hans entries for the two section titles",
-        "Add BottomSheetSectionSeparationTest snapshotting at mid detent",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: bottom sheet shows section titles + divider"
-      ],
-      "priority": 36,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-037",
-      "title": "Add @available iOS 18 guard to remaining bounce APIs and verify warnings cleared",
-      "description": "As an iOS engineer, I want every IndefiniteSymbolEffect use guarded so xcodebuild emits no related warnings.",
-      "acceptanceCriteria": [
-        "Run xcodebuild and grep for 'IndefiniteSymbolEffect' or 'available only iOS 18' warnings; if any remain (besides US-012's site), add #available guards",
-        "If no remaining offenders, add IOS18AvailabilityGuardTest that scans xcodebuild output for the warning string and asserts 0 occurrences (best-effort heuristic)",
-        "Existing tests pass",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 37,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-038",
-      "title": "Localize ShareCardComponents brand label",
-      "description": "As a non-English user, I want share-card images to render branding in my locale (or stay neutral, but at minimum go through NSLocalizedString).",
-      "acceptanceCriteria": [
-        "Views/Experience/Share/ShareCardComponents.swift:54 \u2014 replace `Text(\"Solo Compass\")` with `Text(NSLocalizedString(\"sharecard.brand\", ...))`",
-        "Add en + zh-Hans entries for sharecard.brand (both currently 'Solo Compass'; intentional but routes through l10n pipeline)",
-        "Add ShareCardComponentsL10nTest asserting the resolved string in both locales",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 38,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-039",
-      "title": "Localize ShareCardView '/100  Solo Score' label",
-      "description": "As a non-English user, I want the share card score label rendered in my locale.",
-      "acceptanceCriteria": [
-        "Views/Experience/Share/ShareCardView.swift:279 \u2014 replace `Text(\"/100  Solo Score\")` with a localized format string NSLocalizedString(\"sharecard.score.suffix\", ...)",
-        "Add en (\"/100  Solo Score\") and zh-Hans (\"/100 Solo \u8bc4\u5206\") entries",
-        "Add ShareCardScoreL10nTest asserting the resolved string in both locales",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 39,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-040",
-      "title": "Migrate production print() calls to os.Logger (batch 1: AgentRouter + MapViewModel + SubscriptionService)",
-      "description": "As an iOS engineer, I want production logging to go through os.Logger so it can be filtered and stripped from release builds.",
-      "acceptanceCriteria": [
-        "Replace print() in Services/Agents/AgentRouter.swift:179, ViewModels/MapViewModel.swift:1185, and Services/SubscriptionService.swift:325 with Logger().debug/info calls",
-        "Use a subsystem of 'com.solocompass' and category matching the file (e.g. 'AgentRouter')",
-        "Do NOT touch print() calls inside #Preview blocks or test targets",
-        "Add a script-based check (scripts/check-no-production-print.sh) that greps for print( in non-Preview, non-Tests Swift files \u2014 count should drop by 3",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 40,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-041",
-      "title": "Fix ForEach String id `\\.self` instability (3 sites)",
-      "description": "As an iOS engineer, I want ForEach over String collections to use stable IDs so duplicate strings don't collapse rows.",
-      "acceptanceCriteria": [
-        "Views/Filter/FilterBarView.swift:103 (customTags) \u2014 wrap each tag in `struct IdentifiableTag: Identifiable { let id = UUID(); let value: String }` or use Array.enumerated() with the index as id",
-        "Views/Experience/Share/ShareCardView.swift:69 and :221 (highlights) \u2014 same treatment",
-        "Add ForEachStringIDStabilityTest constructing a list with duplicate strings and asserting the rendered view has the correct number of rows (not collapsed)",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 41,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-042",
-      "title": "Add 'Skip' affordance to Onboarding flow",
-      "description": "As a returning user or QA tester, I want a Skip option in onboarding so I don't have to tap through every screen.",
-      "acceptanceCriteria": [
-        "Onboarding parent view \u2014 add a 'Skip' button in the top-right corner that completes the onboarding flow (marks onboardingComplete = true in UserDefaults / repository)",
-        "Skip button has NSLocalizedString(\"onboarding.skip\", ...) entries in en + zh-Hans",
-        "Add OnboardingSkipTest asserting Skip dismisses the flow",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: cold launch shows Skip in top-right; tapping it reaches the map"
-      ],
-      "priority": 42,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-043",
-      "title": "Filter 'Now' and Map 'bestNow' visual sync (P2 polish)",
-      "description": "As a user, I want filter and map states to feel coordinated so toggling Now is visibly reflected on the map.",
-      "acceptanceCriteria": [
-        "Refinement of US-035 if needed: ensure deselecting Now removes the highlight; ensure smooth animation between states (.animation(.easeInOut(duration: 0.2)))",
-        "Add FilterNowMapAnimationTest verifying animation modifier presence",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 43,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-044",
-      "title": "Test admin-unlock and language-switch restart flows in SettingsView",
-      "description": "As an iOS engineer, I want test coverage for two undocumented Settings flows so they don't regress silently.",
-      "acceptanceCriteria": [
-        "Add SettingsAdminUnlockTest covering the secret admin unlock sequence (whatever taps trigger it) \u2192 assert admin flag set",
-        "Add SettingsLanguageSwitchRestartTest asserting language change schedules an app-restart prompt",
-        "Both tests reference existing SettingsView code paths without modifying behavior",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 44,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-045",
-      "title": "Audit Color extensions for unintended public scope",
-      "description": "As an iOS engineer, I want SettingsView's private Color(hex:) extension verified as scope-limited so it doesn't collide with global hex helpers.",
-      "acceptanceCriteria": [
-        "Views/Settings/SettingsView.swift:1131-1132 \u2014 confirm the `private extension Color { init(hex: UInt32) }` stays private file-scope; if it's used elsewhere, hoist to Views/Shared/Color+Hex.swift and dedupe",
-        "Add ColorExtensionScopeTest asserting Color(hex: UInt32) is not accessible from outside SettingsView (or alternatively, that the canonical helper is in Color+Hex.swift)",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 45,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-046",
-      "title": "Companion layer placeholder copy (decision B from US-009)",
-      "description": "As a product owner, IF US-009 chose option B (banner instead of hide), I want the placeholder copy localized.",
-      "acceptanceCriteria": [
-        "If FeatureFlags.companionLayerEnabled remains false but UI shows a 'Coming soon' affordance, the copy uses NSLocalizedString(\"companion.layer.coming_soon\", ...)",
-        "Add en + zh-Hans entries",
-        "Add CompanionLayerPlaceholderTest asserting copy rendering",
-        "If US-009 implemented option A (full hide) and no placeholder exists, this story is a no-op \u2014 mark passes:true after verifying nothing references the key",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 46,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-047",
-      "title": "Investigate map top dark band rendering (V-006)",
-      "description": "As a user, I want the map's top region to render street content instead of a flat dark band so the map looks complete.",
-      "acceptanceCriteria": [
-        "Reproduce in iPhone 17 Pro Simulator (cold launch shows NORTH BEACH band) and identify cause: MapKit tile loading delay, search-box backdrop blur covering tiles, or overlay z-order bug \u2014 document in PR description",
-        "Apply the minimum fix: defer overlay rendering until map first-tile-rendered event; or reduce backdrop blur footprint; or correct z-order",
-        "Add MapTopOverlayRenderTest snapshotting the top 200pt of the map at T+5s \u2014 assert non-uniform pixel content (not a flat color band)",
-        "Existing CompassMapView tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: top region of map shows streets, not a dark band"
-      ],
-      "priority": 47,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-048",
-      "title": "Migrate remaining production print() calls to os.Logger (batch 2)",
-      "description": "As an iOS engineer, complete the print() \u2192 Logger migration started in US-040 by handling the remaining offenders.",
-      "acceptanceCriteria": [
-        "scripts/check-no-production-print.sh shows zero print( hits in non-Preview, non-Tests Swift files",
-        "All migrated sites use Logger with appropriate subsystem/category",
-        "Add CI-friendly assertion: a Swift unit test that loads a known offender's containing file and runs the same grep at test-time",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 48,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-049",
-      "title": "Onboarding pages: explicit VoiceOver order",
-      "description": "As a VoiceOver user, I want onboarding pages to have a sensible focus order so I can navigate without getting lost.",
-      "acceptanceCriteria": [
-        "Each onboarding page \u2014 wrap content in a single `.accessibilityElement(children: .contain)` container and set `.accessibilitySortPriority` for title \u2192 subtitle \u2192 primary CTA \u2192 skip",
-        "Add OnboardingA11yOrderTest asserting accessibility element order matches expectation",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator with VoiceOver: swiping through an onboarding page reads in the documented order"
-      ],
-      "priority": 49,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-050",
-      "title": "Empty-state views announce via VoiceOver on appear",
-      "description": "As a VoiceOver user, I want empty-state views to announce themselves so I don't think the UI froze.",
-      "acceptanceCriteria": [
-        "Identify all empty-state views (FilterBarView empty result, BottomInfoSheet empty list, Nearby empty) and add `.onAppear { UIAccessibility.post(.announcement, argument: localizedEmptyText) }`",
-        "Each empty state has a localized announcement key",
-        "Add EmptyStateAnnouncementTest asserting view tree contains the modifier",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 50,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-051",
-      "title": "Calibrate ObsidianTheme dark-mode color values",
-      "description": "As a dark-mode user with ObsidianTheme selected, I want the colors to actually look like the intended obsidian palette.",
-      "acceptanceCriteria": [
-        "Services/Themes/ObsidianTheme.swift \u2014 audit each Color value against the design intent in docs (or chat transcripts); adjust to match",
-        "Add ObsidianThemeContrastTest asserting foreground/background pairs meet WCAG 4.5:1",
-        "Existing Theme tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator (dark mode + ObsidianTheme): visual inspection looks consistent"
-      ],
-      "priority": 51,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-052",
-      "title": "Audit zh-Hans punctuation (half-width vs full-width)",
-      "description": "As a zh-Hans user, I want consistent full-width punctuation so the UI follows Chinese typography conventions.",
-      "acceptanceCriteria": [
-        "Run a script that greps Resources/zh-Hans.lproj/Localizable.strings for half-width punctuation in Chinese contexts (e.g. , ! ? : ; vs \uff0c\uff01\uff1f\uff1a\uff1b)",
-        "Replace each offender with the full-width equivalent",
-        "Add a ZhHansPunctuationTest invoking the same script at test time and asserting 0 offenders",
-        "Existing localization tests pass",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 52,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-053",
-      "title": "Sweep comment-only TODOs across iOS sources",
-      "description": "As an iOS maintainer, I want stale TODO comments either resolved or converted into tracked issues.",
-      "acceptanceCriteria": [
-        "Run `grep -rn 'TODO\\|FIXME' apps/ios/SoloCompass --include='*.swift'` and triage each: resolve if trivial, delete if obsolete, or convert to a GitHub issue + link the issue number in the comment",
-        "After the sweep, every remaining TODO/FIXME has a GitHub issue number referenced",
-        "Add a Swift test that grep-asserts every TODO in production code has the pattern 'TODO(#NNN):'",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 53,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-054",
-      "title": "Sweep unused imports across iOS sources",
-      "description": "As an iOS maintainer, I want unused imports removed so build time and review surface area shrink.",
-      "acceptanceCriteria": [
-        "Use swift-format or a similar tool to detect unused imports (build with -warn-unused-imports if available) and remove them",
-        "If automated detection isn't available, eyeball-audit Views/ and Services/ and remove obvious cases",
-        "After sweep, the project still builds cleanly",
-        "Existing tests pass",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 54,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-055",
-      "title": "Add inline documentation comments to all top-level public APIs",
-      "description": "As an API consumer, I want every public type and function in apps/ios/SoloCompass to have at least a single-line doc comment.",
-      "acceptanceCriteria": [
-        "For every `public class/struct/enum/protocol/func` in Models/, Services/, ViewModels/, that lacks a /// comment, add one (one or two lines, explain purpose not mechanism)",
-        "Skip Views/ (SwiftUI views document themselves via #Preview)",
-        "Add a Swift script-test that fails if any public symbol in the listed directories lacks a doc comment (use regex over compiled symbols or grep)",
-        "Existing tests pass",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 55,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-056",
-      "title": "RouteCard \u2014 add stop-strip breadcrumb (CompareCanvas A-001)",
-      "description": "As a user browsing routes, I want a visual breadcrumb of stops on each route card so I can preview the journey at a glance.",
-      "acceptanceCriteria": [
-        "Views/Companion/Components/RouteCard.swift \u2014 render a horizontal strip of colored discs (one per stop, color from CategoryVisual) connected by 1px CT.fgSubtle connectors; matches design-truth in /tmp/compare_design/solocompassapp/project/route.jsx's `stop-strip` block",
-        "All colors come from CT.* tokens \u2014 no Color.accentColor or failable hex",
-        "Add RouteCardStopStripTest snapshotting cards with 2, 3, and 5 stops",
-        "Existing RouteCard tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: route cards in BottomInfoSheet show the stop-strip"
-      ],
-      "priority": 56,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-057",
-      "title": "RouteCard \u2014 add recruit-mini inline state (CompareCanvas A-002)",
-      "description": "As a user with companion mode on, I want each route card to show the recruiting state inline (host / N filled out of M / departure label) without opening detail.",
-      "acceptanceCriteria": [
-        "Views/Companion/Components/RouteCard.swift \u2014 when route.companion != nil AND status is open/forming/closed/completed, render an inline strip below the title showing: host avatar + `<handle> \u62db\u52df \u00b7 N/M \u00b7 <departure>` (open/forming) or `\u5df2\u6210\u56e2 \u00b7 N \u4eba \u00b7 \u51fa\u53d1\u4e2d` (closed) or `\u5df2\u5b8c\u6210 \u00b7 \u8def\u7ebf\u5347\u7ea7` (completed)",
-        "Uses CT.* tokens; tone color per status \u2014 green for completed, accent for open, amber for forming",
-        "Add RouteCardRecruitMiniTest snapshotting all four status variants",
-        "Existing RouteCard tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: route cards in the recruiting demo show the inline strip with the correct status"
-      ],
-      "priority": 57,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-058",
-      "title": "RouteCard \u2014 add walked-by row (CompareCanvas A-003) and migrate to CT tokens",
-      "description": "As a user browsing routes, I want to see how many travelers walked this route (with avatar stack) so I can gauge social proof.",
-      "acceptanceCriteria": [
-        "Views/Companion/Components/RouteCard.swift \u2014 when companionOn is false OR route.companion is nil, render a walked-by row with AvatarStack(maxVisible: 4) + `<count> \u4f4d\u65c5\u4eba\u8d70\u8fc7` + chevron",
-        "AvatarStack uses CT.fgSubtle ring (current default) on a CT.bgWarm-or-white background \u2014 confirm no Color.accentColor or failable hex remains anywhere in RouteCard",
-        "Add RouteCardWalkedByTest snapshotting with 0, 3, and 12 walkers (the +N more case)",
-        "Existing RouteCard tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: route cards in the recruiting demo show walked-by row with stacked avatars"
-      ],
-      "priority": 58,
       "passes": false,
       "notes": ""
     }

--- a/scripts/ralph/archive/2026-05-29-full-fix-roadmap-58us-snapshot/prd.json
+++ b/scripts/ralph/archive/2026-05-29-full-fix-roadmap-58us-snapshot/prd.json
@@ -1,0 +1,960 @@
+{
+  "project": "Solo Compass",
+  "branchName": "ralph/full-fix-roadmap-58us",
+  "description": "Full Fix Roadmap \u2014 Solo Compass iOS. Executes the 58 user stories captured in tasks/prd-full-fix-roadmap.md across 4 categories: P0 (13 \u2014 crash/data-loss/a11y/perf hot-paths), P1 (29 \u2014 correctness/coverage), P2 (16 \u2014 polish/i18n), and A-Series (8 \u2014 design-token adoption + 800-line file decomposition). Source documents: docs/EVAL_REPORT.md (52 source-level findings) + 6 device findings from e2e-runner v2 (a16a636) + design ground truth at /tmp/compare_design/solocompassapp/. Strict four-way acceptance: iPhone 17 Pro Simulator manual run + XCTest + VoiceOver (a11y stories) + Sentry capture (silent-failure stories). All file:line anchors against main @ 0252ce3 (see PRD \u00a73).",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Replace 6 route.companion! force-unwraps with safe binding",
+      "description": "As an iOS engineer, I want all 6 `route.companion!` force-unwrap sites replaced with safe binding so the app never crashes when companion data is unexpectedly nil.",
+      "acceptanceCriteria": [
+        "grep '\\bcompanion!' across non-Tests Swift files returns 0 hits",
+        "Each of the 6 sites (Services/LocalRouteCompanionRemote.swift:38,119,126,137 + Views/Companion/MyRequestsListView.swift:182 + Views/Companion/ApprovalQueueView.swift:311) rewritten with `guard var companion = updated.companion else { ... }` pattern, mutating the bound copy then assigning back via updated.companion = companion",
+        "Add new XCTest RouteCompanionForceUnwrapTests covering each mutation path with companion == nil input \u2014 operation must no-op cleanly with no crash",
+        "Existing RouteCompanionStateMachineTests still pass",
+        "When the no-op safety path triggers, SentryService.capture(...) reports a warning so production occurrences are visible",
+        "Typecheck passes (xcodebuild build succeeds on iPhone 17 Pro Simulator)",
+        "Tests pass"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "SyncService.enqueue must report encode failures to Sentry",
+      "description": "As an end user, I want my completions, favorites, and route join requests to never silently disappear so my actions are durable across devices.",
+      "acceptanceCriteria": [
+        "Services/SyncService.swift:95-98 `try? JSONEncoder().encode(...)` replaced with `do { try ... } catch { SentryService.capture(error, context: \"SyncService.enqueue\", payload: payloadType) }`",
+        "On failure the queue either rethrows to the caller or falls back gracefully \u2014 but always reports via Sentry; the bare `return` is gone",
+        "Add SyncServiceEnqueueTests injecting a payload that deterministically fails encoding \u2014 assert a SentryService mock receives the capture call",
+        "grep 'try?' inside Services/SyncService.swift returns 0 hits for encode/decode",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Add AISynthesisQuality state to AIService",
+      "description": "As an iOS engineer, I need AIService to expose whether the last synthesis was real, skeleton, or cached so the UI can render a transparency badge.",
+      "acceptanceCriteria": [
+        "Add public enum AISynthesisQuality { case real, skeleton, cached } in Services/AIService.swift",
+        "Add public observable property `lastSynthesisQuality: AISynthesisQuality` updated on every synthesis path (success branch -> .real, fallback branch -> .skeleton, cache-hit branch -> .cached) \u2014 anchor lines 765-768 and 781-791",
+        "Skeleton fallback path also calls SentryService.capture(...) with subsystem 'AIService.skeleton_fallback'",
+        "Add AISynthesisQualityTests injecting each path and asserting lastSynthesisQuality transitions correctly",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-004",
+      "title": "Add SkeletonBadgeView component (transparency pill)",
+      "description": "As a user, I want a small visible indicator when an experience card is showing skeleton data instead of real AI insight so I don't mistake placeholder text for personalized recommendation.",
+      "acceptanceCriteria": [
+        "Create apps/ios/SoloCompass/Views/Shared/SkeletonBadgeView.swift with public struct SkeletonBadgeView: View",
+        "Visual: capsule using CT.fgMuted (NOT accent) and CT.body(10, .medium); text from NSLocalizedString(\"ai.skeleton.pill\", ...) \u2014 add the key to en.lproj and zh-Hans.lproj Localizable.strings (en: \"Limited data\", zh-Hans: \"\u6570\u636e\u6709\u9650\")",
+        "accessibilityLabel reads the localized string + \"placeholder content\" hint",
+        "Wire it into Views/Experience/ExperienceCardView.swift: render only when the bound AIService.lastSynthesisQuality == .skeleton; never render for .real or .cached",
+        "Add SkeletonBadgeViewTests with snapshot of badge + ExperienceCardTests verifying conditional rendering",
+        "Add LocalizableStringsParityTest expectation \u2014 both new keys present in en and zh-Hans, StringsParityTests passes",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: launch app without ANTHROPIC_API_KEY \u2192 cards display the badge; with key \u2192 badge absent"
+      ],
+      "priority": 4,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-005",
+      "title": "Remove AnyView wrapper from CompassMapView.body",
+      "description": "As an iOS engineer, I want the root mapContent to return some View directly so SwiftUI can do incremental diffing on the app's heaviest view.",
+      "acceptanceCriteria": [
+        "Views/Map/CompassMapView.swift:76 \u2014 `public var body: some View { mapContent }` returns the @ViewBuilder result without AnyView(...) wrapping",
+        "If init signature constraints fight the return type, add @ViewBuilder to body so the concrete opaque type is inferred",
+        "Add CompassMapViewBodyTypeTests: assert String(describing: type(of: someInstance.body)) does NOT contain \"AnyView\"",
+        "All existing snapshot/unit tests (MarkerIconTests, CityPillHitTargetTests, FilterBarViewTests) still pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: pan/zoom map for 30 seconds, no visual regression"
+      ],
+      "priority": 5,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-006",
+      "title": "BottomInfoSheet drag handle hit target \u2265 44pt",
+      "description": "As a VoiceOver / Switch Control user, I want the bottom sheet drag handle to have a 44\u00d744pt minimum hit area so I can switch detent levels reliably.",
+      "acceptanceCriteria": [
+        "Views/Map/BottomInfoSheet.swift:127-131 \u2014 wrap the handle in `.frame(minWidth: 60, minHeight: 44).contentShape(Rectangle())`; the visible pill stays 36\u00d74",
+        "Add `.accessibilityLabel(NSLocalizedString(\"sheet.handle\", ...))` plus `.accessibilityAdjustableAction` that cycles peek \u2192 mid \u2192 full",
+        "Add new localization key sheet.handle to en + zh-Hans Localizable.strings",
+        "Add BottomInfoSheetHandleHitTargetTests asserting hit-area frame \u2265 44 in either dimension",
+        "StringsParityTests passes",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator with Accessibility Inspector: hit area visualized \u2265 44pt"
+      ],
+      "priority": 6,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-007",
+      "title": "Localize hardcoded 'results' strings in FilterBarView",
+      "description": "As a zh-Hans user, I want the filter result count rendered in my locale instead of English so the UI is consistent.",
+      "acceptanceCriteria": [
+        "Views/Filter/FilterBarView.swift:180, 230, 264, 301 \u2014 replace literal \"results\" with String(format: NSLocalizedString(\"filter.results.count\", ...), count)",
+        "Add filter.results.count to en (\"%d results\") and zh-Hans (\"%d \u4e2a\u7ed3\u679c\") Localizable.strings",
+        "Add FilterBarLocalizationTests verifying the resolved string in zh-Hans uses Chinese characters",
+        "grep 'results' inside Views/Filter/FilterBarView.swift produces zero literal hits (excluding comments)",
+        "StringsParityTests passes",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 7,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-008",
+      "title": "voice.processing toast announces via UIAccessibility live region",
+      "description": "As a VoiceOver user, I want voice processing toasts to announce themselves so I stay in sync with app state without manually moving focus.",
+      "acceptanceCriteria": [
+        "Views/Map/CompassMapView.swift:868-885 \u2014 the voice.processing toast view chain adds .accessibilityElement().accessibilityAddTraits(.updatesFrequently)",
+        "On the toast's onAppear (and on text change) call UIAccessibility.post(.announcement, argument: localizedText)",
+        "Add VoiceToastA11yTests asserting the view tree contains the .updatesFrequently trait when toast is active",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator with VoiceOver on: triggering a voice query causes the system to read the toast text"
+      ],
+      "priority": 8,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-009",
+      "title": "Hide Companion-layer toggle behind a feature flag (decision A)",
+      "description": "As a product owner, I want the long-unimplemented companion layer toggle hidden by default so users don't click a dead button that always returns nil.",
+      "acceptanceCriteria": [
+        "Views/Map/CompassMapView.swift:541 \u2014 wrap the toggle in `if FeatureFlags.companionLayerEnabled { ... }`",
+        "Services/FeatureFlags.swift \u2014 add static var companionLayerEnabled: Bool = false (default off) plus a way to override in DEBUG via UserDefaults",
+        "Update CompassMapViewLayerToggleTests to assert the toggle is NOT in the view hierarchy when the flag is false (and IS when true)",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: cold launch shows no companion-layer toggle in the top overlay"
+      ],
+      "priority": 9,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-010",
+      "title": "Resolve SwiftData @Query KeyPath Sendable warning in SettingsView",
+      "description": "As an iOS engineer, I want the SwiftData @Query Sendable warning resolved so strict concurrency stays clean.",
+      "acceptanceCriteria": [
+        "Views/Settings/SettingsView.swift:897 \u2014 replace the bare KeyPath in @Query with an explicit SortDescriptor(\\.field, order: ...) or wrap in @Sendable closure",
+        "Add SettingsViewQuerySortTest asserting the records query returns expected order",
+        "xcodebuild output no longer surfaces the 'sending KeyPath risks data races' warning for this line",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 10,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-011",
+      "title": "Fix ChatSheet voiceService main-actor isolation",
+      "description": "As an iOS engineer, I want main-actor isolated voiceService usage to not race so strict concurrency holds.",
+      "acceptanceCriteria": [
+        "Services/VoiceService.swift \u2014 add @MainActor to the class declaration (or @MainActor to requestPermission()) so Views/Chat/ChatSheet.swift:621 sends a main-actor value to a main-actor method",
+        "Add VoiceServiceActorIsolationTest asserting requestPermission is callable from a @MainActor context without warning",
+        "xcodebuild output no longer surfaces the 'sending self.voiceService risks data races' warning",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 11,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-012",
+      "title": "Gate FavoritesListView BounceSymbolEffect behind iOS 18 availability",
+      "description": "As an iOS engineer, I want the iOS-18-only BounceSymbolEffect API gated by `if #available` so the project stays clean under Swift 6 strict mode.",
+      "acceptanceCriteria": [
+        "Views/Shared/FavoritesListView.swift:327 \u2014 wrap `base.symbolEffect(.bounce, options: .repeating.speed(0.6))` in `if #available(iOS 18, *) { ... } else { base }`",
+        "Add FavoritesBounceAvailabilityTest verifying SwipeHintCapsuleView builds and renders under both iOS 17 and iOS 18 deployment targets",
+        "xcodebuild output no longer surfaces the 'IndefiniteSymbolEffect available only iOS 18+' warning",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 12,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-013",
+      "title": "Fix Onboarding privacy sheet subtitle truncation (V-001)",
+      "description": "As a first-time user, I want the privacy onboarding sheet to show the full subtitle so I understand what services the app calls on my behalf.",
+      "acceptanceCriteria": [
+        "Locate the source file via `grep -rn 'talks to two services' apps/ios/SoloCompass/Views/Onboarding` \u2014 likely Views/Onboarding/PrivacyAcknowledgementSheet.swift",
+        "Either set the sheet to use a self-sizing detent (.medium then .large) OR add `.fixedSize(horizontal: false, vertical: true)` to the subtitle Text",
+        "Subtitle renders the full phrase ending in '...on your behalf' at default AND AX5 Dynamic Type",
+        "Add PrivacyAcknowledgementSheetSnapshotTest with snapshots at .accessibilityMedium and .accessibilityExtraExtraExtraLarge",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: cold launch displays full subtitle on first screen"
+      ],
+      "priority": 13,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-014",
+      "title": "Sync selectedCity \u2192 mapCameraPosition on cold start (V-002)",
+      "description": "As a user, I want the city header label and the map's rendered region to always agree so I'm never confused about where I am.",
+      "acceptanceCriteria": [
+        "ViewModels/MapViewModel.swift \u2014 `selectedCity` didSet must trigger an update to `mapCameraPosition` via defaultCenterForSelectedCity, including on the first set during init (not just user-driven changes)",
+        "Add MapViewModelCityRegionSyncTests: after init with city=\"chiang-mai\" the cameraPosition center is within 1km of Chiang Mai; after switching to city=\"san-francisco\" the camera moves",
+        "Existing MapViewModel tests still pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: cold launch shows city header and map region matching"
+      ],
+      "priority": 14,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-015",
+      "title": "Audit and localize hardcoded English strings in BottomInfoSheet + FilterBar (V-003)",
+      "description": "As a zh-Hans user, I want the entire bottom sheet UI in Chinese so I don't see English copy bleeding through.",
+      "acceptanceCriteria": [
+        "Add scripts/check-hardcoded-strings.sh that greps Views/ for `Text(\"[A-Z]` patterns and prints offenders (excluding #Preview blocks and acceptable proper nouns)",
+        "Run the script and replace each user-visible literal with NSLocalizedString(...)",
+        "Known offender: Views/Map/BottomInfoSheet.swift literal 'Good spots for right now' \u2014 replace with NSLocalizedString(\"sheet.now.headline\", ...) with en/zh-Hans entries",
+        "Add LocalizationCoverageTest invoking the script and asserting 0 offenders remain",
+        "StringsParityTests passes",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator (zh-Hans locale): no English copy visible in bottom sheet or filter bar"
+      ],
+      "priority": 15,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-016",
+      "title": "Cache markerState(for:) once per ForEach iteration",
+      "description": "As an iOS engineer, I want markerState(for:) called once per ForEach iteration so we don't recompute six conditions twice per visible marker per frame.",
+      "acceptanceCriteria": [
+        "Views/Map/CompassMapView.swift:612-616 \u2014 refactor the ForEach body so `let state = viewModel.markerState(for: exp)` appears once at the top, and both downstream branches reuse `state` instead of calling markerState again",
+        "Add MarkerStatePerformanceTest constructing 100 experiences and measuring 1000 iterations \u2014 p95 latency drops by \u2265 40% vs baseline (record baseline in same test on a non-cached helper)",
+        "Existing MarkerIconViewTests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: marker rendering looks identical (no visual regression)"
+      ],
+      "priority": 16,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-017",
+      "title": "Cache MapViewModel.availableCities",
+      "description": "As an iOS engineer, I want availableCities cached so we don't traverse allExperiences on every body invocation.",
+      "acceptanceCriteria": [
+        "ViewModels/MapViewModel.swift:187-215 \u2014 introduce `@ObservationIgnored private var _cachedCities: [CityInfo]?`",
+        "availableCities returns the cache when non-nil; otherwise recomputes and stores",
+        "Invalidate (_cachedCities = nil) whenever allExperiences or selectedCity change (in their didSet or in the refresh path)",
+        "Add MapViewModelCityCacheTests covering: fresh path computes and stores; second call hits cache (verify by snapshotting allExperiences before second call); invalidation after allExperiences change",
+        "Existing CityPillHitTargetTests pass",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 17,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-018",
+      "title": "Cache MapViewModel.nowCount",
+      "description": "As an iOS engineer, I want nowCount cached and recomputed only on visibleExperiences change so BottomInfoSheet and FilterBarView don't trigger O(n) scans on every render.",
+      "acceptanceCriteria": [
+        "ViewModels/MapViewModel.swift \u2014 add `@ObservationIgnored private var _nowCount: Int = 0`",
+        "Update _nowCount at the end of loadNearbyExperiences, refreshForLocation, and updateBottomInfo",
+        "nowCount property returns _nowCount",
+        "Lines 720 and 736 inside updateBottomInfo no longer recompute via .filter { $0.isBestNow() }",
+        "grep `visibleExperiences\\.filter \\{.*isBestNow` returns at most 1 occurrence (in the single source-of-truth update)",
+        "Add NowCountCacheTests injecting mock experiences and asserting the count updates only at the documented checkpoints",
+        "Existing FilterBarViewTests pass",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 18,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-019",
+      "title": "Hit-target \u2265 44pt for FilterBar icon pill, favorite heart, banner X",
+      "description": "As a VoiceOver / Switch Control user, I want all interactive controls to meet the 44pt HIG minimum.",
+      "acceptanceCriteria": [
+        "Views/Filter/FilterBarView.swift:240 iconPill (36\u00d736) \u2014 wrap in .frame(minWidth: 44, minHeight: 44).contentShape(Rectangle()); keep the visible chip 36\u00d736",
+        "Views/Experience/ExperienceCardView.swift:175 favorite heart (32\u00d732) \u2014 same treatment",
+        "Views/Map/CompassMapView.swift:1124 DismissibleBanner X button \u2014 same treatment",
+        "Add HitTargetSizeTests enumerating each control and asserting hit-area dimensions \u2265 44",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator with Accessibility Inspector: three controls all show \u2265 44pt hit area"
+      ],
+      "priority": 19,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-020",
+      "title": "Parallelize SoloCompassApp.onAppear init chain",
+      "description": "As a user, I want cold start TTI to not block on serial main-thread init so the map appears within 500ms.",
+      "acceptanceCriteria": [
+        "App/SoloCompassApp.swift:43-73 \u2014 move pruneStaleCheckIns, attachRepository, RouteStore.importSeedIfNeeded, and UserDirectory.loadIfNeeded into independent `Task { ... }` blocks; remove the serial await chain",
+        "Break subscriptionService.loadProducts \u2192 refreshEntitlement into its own independent Task",
+        "Add AppLaunchPerformanceTest measuring time from init to first body completion \u2014 assert \u2264 baseline \u00d7 0.5 (record baseline in test setup using the pre-refactor serial path stub)",
+        "Existing app launch tests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: cold launch reaches the map screen visibly faster"
+      ],
+      "priority": 20,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-021",
+      "title": "Initialize CompassMapView viewModel eagerly (no Optional)",
+      "description": "As an iOS engineer, I want viewModel initialized eagerly so writes between launch and onAppear don't silently drop.",
+      "acceptanceCriteria": [
+        "Views/Map/CompassMapView.swift:1458 \u2014 change `@State private var viewModel: MapViewModel? = nil` to `@State private var viewModel = MapViewModel(...)` with required dependencies (or use environment injection)",
+        "Remove the lazy creation block inside .onAppear",
+        "All sites that did `if let viewModel = ...` simplify to direct use",
+        "Add MapViewModelEagerInitTest: app launch path can read viewModel.allExperiences before any onAppear fires",
+        "All existing CompassMapView tests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: cold launch shows no ProgressView flicker before the map appears"
+      ],
+      "priority": 21,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-022",
+      "title": "Resolve City pill vs. filter bar visual stacking conflict",
+      "description": "As a user, I want city selector and filter bar to not visually fight for attention in the top-left.",
+      "acceptanceCriteria": [
+        "Views/Map/CompassMapView.swift top overlay \u2014 move the city pill into the navigation-bar area OR vertically separate it from the filter bar so the two capsules no longer overlap or hit-test interfere",
+        "Add TopOverlayLayoutTest using snapshot at iPhone 17 Pro size \u2014 assert city pill rect and filter bar rect do not intersect",
+        "VoiceOver order: city pill \u2192 filter bar \u2192 map (manually verified)",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: city pill and filter bar are visually separate"
+      ],
+      "priority": 22,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-023",
+      "title": "Share a single TimelineView clock across BestNowBadge instances",
+      "description": "As an iOS engineer, I want a single periodic timer feeding all BestNowBadge instances instead of 20+ concurrent timelines.",
+      "acceptanceCriteria": [
+        "Create Services/BestNowClock.swift \u2014 an @Observable @MainActor singleton with a tick property updated every 60s via a single Timer or AsyncStream",
+        "Views/Experience/ExperienceCardView.swift:267-289 BestNowBadge \u2014 replace its inline TimelineView(.periodic(by: 60)) with `@Environment(BestNowClock.self)` consumption",
+        "Add BestNowBadgeClockTest constructing 100 badges sharing one clock \u2014 assert only one Timer/AsyncStream is allocated",
+        "Existing BestNow tests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: explore view with 20+ best-now badges shows no visible stutter"
+      ],
+      "priority": 23,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-024",
+      "title": "Add accessibilityLabel/value to SoloScoreRadarChart",
+      "description": "As a VoiceOver user, I want the radar chart's 6 dimensions read out loud.",
+      "acceptanceCriteria": [
+        "Views/Shared/SoloScoreRadarChart.swift \u2014 add `.accessibilityElement(children: .combine)` plus an `.accessibilityLabel` that names all 6 dimensions with their values, and `.accessibilityValue` for the overall score",
+        "Add SoloScoreRadarA11yTest asserting accessibilityLabel is non-empty and contains all 6 dimension names",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator with VoiceOver: focus lands on chart and reads e.g. 'Safety 7.5, Food 8.0, Coffee 7.0, ...'"
+      ],
+      "priority": 24,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-025",
+      "title": "Wire 'Ask Solo' gated CTA to Paywall sheet",
+      "description": "As a free-tier user, I want clicking a gated feature to take me to the paywall, not a dead toast.",
+      "acceptanceCriteria": [
+        "Views/Experience/ExperienceDetailView.swift \u2014 the gated 'Ask Solo' CTA now presents PaywallSheet via .sheet(isPresented:) when the user is not subscribed",
+        "Add AskSoloPaywallNavigationTest: tap the gated CTA \u2192 assert sheet appears via ViewInspector or snapshot",
+        "Existing ExperienceDetailView tests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator (unsubscribed): tapping Ask Solo opens the paywall"
+      ],
+      "priority": 25,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-026",
+      "title": "Surface LocationService.lastError as dismissible banner",
+      "description": "As a user, I want GPS errors surfaced so I understand why the map defaulted to a region instead of my location.",
+      "acceptanceCriteria": [
+        "Services/LocationService.swift \u2014 confirm lastError is @Observable (Published) so views can react",
+        "ViewModels/MapViewModel.swift \u2014 observe lastError and expose a derived `locationErrorBannerText: String?`",
+        "Views/Map/CompassMapView.swift \u2014 render a dismissible banner using existing DismissibleBanner pattern when locationErrorBannerText != nil; copy from NSLocalizedString(\"location.error.banner\", ...)",
+        "Add en + zh-Hans entries for location.error.banner",
+        "Add LocationErrorSurfaceTests asserting banner appears when lastError set",
+        "When lastError != nil, SentryService.capture reports a warning",
+        "StringsParityTests passes",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator with Location set to None: banner appears"
+      ],
+      "priority": 26,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-027",
+      "title": "Surface voice recording interruptions in UI",
+      "description": "As a user, I want voice recording interruptions shown in UI instead of silently stopping.",
+      "acceptanceCriteria": [
+        "Views/Chat/ChatSheet.swift:636-638 \u2014 the empty catch is replaced with a toast/alert showing NSLocalizedString(\"voice.interrupted\", ...) with the underlying error description",
+        "Add en + zh-Hans entries for voice.interrupted (format string with %@ placeholder)",
+        "Add VoiceInterruptionToastTest: inject a throwing voice service \u2192 assert toast appears",
+        "StringsParityTests passes",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: revoking mic permission mid-record surfaces the toast"
+      ],
+      "priority": 27,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-028",
+      "title": "Filter chip selected-state contrast \u2265 4.5:1",
+      "description": "As a low-vision user, I want filter chip text to meet WCAG 4.5:1 contrast.",
+      "acceptanceCriteria": [
+        "Views/Filter/FilterBarView.swift selected state \u2014 replace #D4A843 on white with either CT.accent (#5D3000) text-on-CT.accentSoft (#FBF1E4) background OR white text on CT.accent background; both achieve \u2265 7:1",
+        "Add FilterChipContrastTest computing the WCAG relative luminance for selected state's foreground and background \u2014 assert contrast ratio \u2265 4.5",
+        "Existing FilterBarView tests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: selected chip is clearly readable"
+      ],
+      "priority": 28,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-029",
+      "title": "Scale BottomInfoSheet detent heights with Dynamic Type",
+      "description": "As an AX5 Dynamic Type user, I want sheet detent heights to scale so content doesn't overflow.",
+      "acceptanceCriteria": [
+        "Views/Map/BottomInfoSheet.swift \u2014 multiply the three detent heights (peek 170, mid 500, full 800) by UIFontMetrics.default.scaledValue(for: 1.0) or equivalent",
+        "Add BottomSheetDetentDynamicTypeTest snapshotting all three detents at .accessibilityExtraExtraExtraLarge \u2014 content not clipped",
+        "Existing BottomInfoSheet tests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator (Dynamic Type AX5): all three detent sizes show content without clipping"
+      ],
+      "priority": 29,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-030",
+      "title": "Sort button announces current mode via accessibilityValue",
+      "description": "As a VoiceOver user, I want the sort button to announce current sort mode.",
+      "acceptanceCriteria": [
+        "Views/Map/BottomInfoSheet.swift:208 \u2014 sort button adds `.accessibilityValue(NSLocalizedString(\"sort.value.\\(currentMode)\", ...))` keyed off the active sort mode",
+        "Add en + zh-Hans entries for sort.value.smart, sort.value.distance, sort.value.recent (whatever modes exist)",
+        "Add SortButtonA11yValueTest asserting accessibilityValue updates when sort mode changes",
+        "StringsParityTests passes",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator with VoiceOver: tapping sort button announces 'Sort, Sorted by smart'"
+      ],
+      "priority": 30,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-031",
+      "title": "JoinRouteRequestSheet inline error feedback",
+      "description": "As a user submitting a join request, I want inline validation errors so I know which field is missing.",
+      "acceptanceCriteria": [
+        "Views/Companion/JoinRouteRequestSheet.swift \u2014 missing pace or empty message field renders a red hint below the relevant input using NSLocalizedString(\"join.error.\\(field).missing\", ...)",
+        "Add en + zh-Hans entries for join.error.pace.missing and join.error.message.missing",
+        "Submit button stays disabled until both fields validate",
+        "Add JoinRequestValidationTest asserting hints appear/disappear with field state",
+        "StringsParityTests passes",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: submitting empty form shows hints; filling both clears them and enables submit"
+      ],
+      "priority": 31,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-032",
+      "title": "Approval queue shows trust signals per requester",
+      "description": "As a host reviewing join requests, I want to see opt-in status, walked-count, and group-count next to each requester.",
+      "acceptanceCriteria": [
+        "Views/Companion/ApprovalQueueView.swift \u2014 each request row renders three micro-stats: opt-in badge, walked count icon+number, group count icon+number \u2014 sourced from the existing requester profile object",
+        "If a stat is unknown, show '\u2014' instead of fabricating",
+        "Add ApprovalTrustSignalTest snapshotting three rows with different signal combinations",
+        "Existing ApprovalQueueView tests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: approval queue rows show the three micro-stats"
+      ],
+      "priority": 32,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-033",
+      "title": "Diagnose and fix cold-start empty-state at 5km and 25km (V-004)",
+      "description": "As a user, I want the home screen to show experiences for my selected city on cold start so the app doesn't feel broken.",
+      "acceptanceCriteria": [
+        "Investigate the chain: Services/ExperienceService.swift seed import \u2192 MapViewModel.loadNearbyExperiences. Document root cause in PR description (likely candidates: distance filter uses SF user-location while header city is set differently; or seed not imported when SwiftData store exists but is empty)",
+        "Apply the fix that makes selectedCity drive both the camera AND the nearby query origin (depends on US-014)",
+        "Add ColdStartExperienceLoadTests: simulate cold start with selectedCity='chiang-mai' and assert nearby experiences count > 0 after the load completes",
+        "Add a Sentry warning if selectedCity is set but nearby experience count remains 0 for > 5 seconds",
+        "Existing ExperienceService tests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: cold launch with each of 5 seed cities \u2192 each shows non-zero nearby count"
+      ],
+      "priority": 33,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-034",
+      "title": "Add scroll affordance to filter chip strip (V-005)",
+      "description": "As a user, I want a visual hint that filter chips scroll horizontally so I can discover all categories.",
+      "acceptanceCriteria": [
+        "Views/Filter/FilterBarView.swift \u2014 add a fade gradient mask on the right edge (using .mask(LinearGradient(...))) when content overflows; OR add a small chevron icon",
+        "Mask/chevron only shows when there is overflow content (not when all chips fit)",
+        "Add FilterBarScrollAffordanceTest snapshotting with > 6 categories (overflow) and \u2264 5 (no overflow)",
+        "Existing FilterBarView tests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: with default category set, right-edge fade is visible"
+      ],
+      "priority": 34,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-035",
+      "title": "Sync Filter 'Now' mode and Map 'bestNow' visual highlight",
+      "description": "As a user, I want toggling the 'Now' filter to also highlight 'best now' markers on the map so the two UIs feel connected.",
+      "acceptanceCriteria": [
+        "Views/Map/CompassMapView.swift \u2014 when FilterBarView's 'Now' mode is active, decorate bestNow markers with an additional ring (use CT.accent) or pulse animation",
+        "Add FilterNowMapSyncTest asserting marker style changes when Now filter toggles",
+        "Existing CompassMapView tests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: toggling Now \u2192 markers visibly change"
+      ],
+      "priority": 35,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-036",
+      "title": "Add visual separator between Routes and Nearby sections in BottomInfoSheet",
+      "description": "As a user, I want a clear visual division between routes and nearby experiences in the bottom sheet so the information hierarchy is obvious.",
+      "acceptanceCriteria": [
+        "Views/Map/BottomInfoSheet.swift \u2014 insert a section header with the localized title (NSLocalizedString(\"sheet.section.routes\", ...) and \"sheet.section.nearby\") and an inset divider between the two sections",
+        "Add en + zh-Hans entries for the two section titles",
+        "Add BottomSheetSectionSeparationTest snapshotting at mid detent",
+        "StringsParityTests passes",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: bottom sheet shows section titles + divider"
+      ],
+      "priority": 36,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-037",
+      "title": "Add @available iOS 18 guard to remaining bounce APIs and verify warnings cleared",
+      "description": "As an iOS engineer, I want every IndefiniteSymbolEffect use guarded so xcodebuild emits no related warnings.",
+      "acceptanceCriteria": [
+        "Run xcodebuild and grep for 'IndefiniteSymbolEffect' or 'available only iOS 18' warnings; if any remain (besides US-012's site), add #available guards",
+        "If no remaining offenders, add IOS18AvailabilityGuardTest that scans xcodebuild output for the warning string and asserts 0 occurrences (best-effort heuristic)",
+        "Existing tests pass",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 37,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-038",
+      "title": "Localize ShareCardComponents brand label",
+      "description": "As a non-English user, I want share-card images to render branding in my locale (or stay neutral, but at minimum go through NSLocalizedString).",
+      "acceptanceCriteria": [
+        "Views/Experience/Share/ShareCardComponents.swift:54 \u2014 replace `Text(\"Solo Compass\")` with `Text(NSLocalizedString(\"sharecard.brand\", ...))`",
+        "Add en + zh-Hans entries for sharecard.brand (both currently 'Solo Compass'; intentional but routes through l10n pipeline)",
+        "Add ShareCardComponentsL10nTest asserting the resolved string in both locales",
+        "StringsParityTests passes",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 38,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-039",
+      "title": "Localize ShareCardView '/100  Solo Score' label",
+      "description": "As a non-English user, I want the share card score label rendered in my locale.",
+      "acceptanceCriteria": [
+        "Views/Experience/Share/ShareCardView.swift:279 \u2014 replace `Text(\"/100  Solo Score\")` with a localized format string NSLocalizedString(\"sharecard.score.suffix\", ...)",
+        "Add en (\"/100  Solo Score\") and zh-Hans (\"/100 Solo \u8bc4\u5206\") entries",
+        "Add ShareCardScoreL10nTest asserting the resolved string in both locales",
+        "StringsParityTests passes",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 39,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-040",
+      "title": "Migrate production print() calls to os.Logger (batch 1: AgentRouter + MapViewModel + SubscriptionService)",
+      "description": "As an iOS engineer, I want production logging to go through os.Logger so it can be filtered and stripped from release builds.",
+      "acceptanceCriteria": [
+        "Replace print() in Services/Agents/AgentRouter.swift:179, ViewModels/MapViewModel.swift:1185, and Services/SubscriptionService.swift:325 with Logger().debug/info calls",
+        "Use a subsystem of 'com.solocompass' and category matching the file (e.g. 'AgentRouter')",
+        "Do NOT touch print() calls inside #Preview blocks or test targets",
+        "Add a script-based check (scripts/check-no-production-print.sh) that greps for print( in non-Preview, non-Tests Swift files \u2014 count should drop by 3",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 40,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-041",
+      "title": "Fix ForEach String id `\\.self` instability (3 sites)",
+      "description": "As an iOS engineer, I want ForEach over String collections to use stable IDs so duplicate strings don't collapse rows.",
+      "acceptanceCriteria": [
+        "Views/Filter/FilterBarView.swift:103 (customTags) \u2014 wrap each tag in `struct IdentifiableTag: Identifiable { let id = UUID(); let value: String }` or use Array.enumerated() with the index as id",
+        "Views/Experience/Share/ShareCardView.swift:69 and :221 (highlights) \u2014 same treatment",
+        "Add ForEachStringIDStabilityTest constructing a list with duplicate strings and asserting the rendered view has the correct number of rows (not collapsed)",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 41,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-042",
+      "title": "Add 'Skip' affordance to Onboarding flow",
+      "description": "As a returning user or QA tester, I want a Skip option in onboarding so I don't have to tap through every screen.",
+      "acceptanceCriteria": [
+        "Onboarding parent view \u2014 add a 'Skip' button in the top-right corner that completes the onboarding flow (marks onboardingComplete = true in UserDefaults / repository)",
+        "Skip button has NSLocalizedString(\"onboarding.skip\", ...) entries in en + zh-Hans",
+        "Add OnboardingSkipTest asserting Skip dismisses the flow",
+        "StringsParityTests passes",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: cold launch shows Skip in top-right; tapping it reaches the map"
+      ],
+      "priority": 42,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-043",
+      "title": "Filter 'Now' and Map 'bestNow' visual sync (P2 polish)",
+      "description": "As a user, I want filter and map states to feel coordinated so toggling Now is visibly reflected on the map.",
+      "acceptanceCriteria": [
+        "Refinement of US-035 if needed: ensure deselecting Now removes the highlight; ensure smooth animation between states (.animation(.easeInOut(duration: 0.2)))",
+        "Add FilterNowMapAnimationTest verifying animation modifier presence",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 43,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-044",
+      "title": "Test admin-unlock and language-switch restart flows in SettingsView",
+      "description": "As an iOS engineer, I want test coverage for two undocumented Settings flows so they don't regress silently.",
+      "acceptanceCriteria": [
+        "Add SettingsAdminUnlockTest covering the secret admin unlock sequence (whatever taps trigger it) \u2192 assert admin flag set",
+        "Add SettingsLanguageSwitchRestartTest asserting language change schedules an app-restart prompt",
+        "Both tests reference existing SettingsView code paths without modifying behavior",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 44,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-045",
+      "title": "Audit Color extensions for unintended public scope",
+      "description": "As an iOS engineer, I want SettingsView's private Color(hex:) extension verified as scope-limited so it doesn't collide with global hex helpers.",
+      "acceptanceCriteria": [
+        "Views/Settings/SettingsView.swift:1131-1132 \u2014 confirm the `private extension Color { init(hex: UInt32) }` stays private file-scope; if it's used elsewhere, hoist to Views/Shared/Color+Hex.swift and dedupe",
+        "Add ColorExtensionScopeTest asserting Color(hex: UInt32) is not accessible from outside SettingsView (or alternatively, that the canonical helper is in Color+Hex.swift)",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 45,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-046",
+      "title": "Companion layer placeholder copy (decision B from US-009)",
+      "description": "As a product owner, IF US-009 chose option B (banner instead of hide), I want the placeholder copy localized.",
+      "acceptanceCriteria": [
+        "If FeatureFlags.companionLayerEnabled remains false but UI shows a 'Coming soon' affordance, the copy uses NSLocalizedString(\"companion.layer.coming_soon\", ...)",
+        "Add en + zh-Hans entries",
+        "Add CompanionLayerPlaceholderTest asserting copy rendering",
+        "If US-009 implemented option A (full hide) and no placeholder exists, this story is a no-op \u2014 mark passes:true after verifying nothing references the key",
+        "StringsParityTests passes",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 46,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-047",
+      "title": "Investigate map top dark band rendering (V-006)",
+      "description": "As a user, I want the map's top region to render street content instead of a flat dark band so the map looks complete.",
+      "acceptanceCriteria": [
+        "Reproduce in iPhone 17 Pro Simulator (cold launch shows NORTH BEACH band) and identify cause: MapKit tile loading delay, search-box backdrop blur covering tiles, or overlay z-order bug \u2014 document in PR description",
+        "Apply the minimum fix: defer overlay rendering until map first-tile-rendered event; or reduce backdrop blur footprint; or correct z-order",
+        "Add MapTopOverlayRenderTest snapshotting the top 200pt of the map at T+5s \u2014 assert non-uniform pixel content (not a flat color band)",
+        "Existing CompassMapView tests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: top region of map shows streets, not a dark band"
+      ],
+      "priority": 47,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-048",
+      "title": "Migrate remaining production print() calls to os.Logger (batch 2)",
+      "description": "As an iOS engineer, complete the print() \u2192 Logger migration started in US-040 by handling the remaining offenders.",
+      "acceptanceCriteria": [
+        "scripts/check-no-production-print.sh shows zero print( hits in non-Preview, non-Tests Swift files",
+        "All migrated sites use Logger with appropriate subsystem/category",
+        "Add CI-friendly assertion: a Swift unit test that loads a known offender's containing file and runs the same grep at test-time",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 48,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-049",
+      "title": "Onboarding pages: explicit VoiceOver order",
+      "description": "As a VoiceOver user, I want onboarding pages to have a sensible focus order so I can navigate without getting lost.",
+      "acceptanceCriteria": [
+        "Each onboarding page \u2014 wrap content in a single `.accessibilityElement(children: .contain)` container and set `.accessibilitySortPriority` for title \u2192 subtitle \u2192 primary CTA \u2192 skip",
+        "Add OnboardingA11yOrderTest asserting accessibility element order matches expectation",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator with VoiceOver: swiping through an onboarding page reads in the documented order"
+      ],
+      "priority": 49,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-050",
+      "title": "Empty-state views announce via VoiceOver on appear",
+      "description": "As a VoiceOver user, I want empty-state views to announce themselves so I don't think the UI froze.",
+      "acceptanceCriteria": [
+        "Identify all empty-state views (FilterBarView empty result, BottomInfoSheet empty list, Nearby empty) and add `.onAppear { UIAccessibility.post(.announcement, argument: localizedEmptyText) }`",
+        "Each empty state has a localized announcement key",
+        "Add EmptyStateAnnouncementTest asserting view tree contains the modifier",
+        "StringsParityTests passes",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 50,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-051",
+      "title": "Calibrate ObsidianTheme dark-mode color values",
+      "description": "As a dark-mode user with ObsidianTheme selected, I want the colors to actually look like the intended obsidian palette.",
+      "acceptanceCriteria": [
+        "Services/Themes/ObsidianTheme.swift \u2014 audit each Color value against the design intent in docs (or chat transcripts); adjust to match",
+        "Add ObsidianThemeContrastTest asserting foreground/background pairs meet WCAG 4.5:1",
+        "Existing Theme tests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator (dark mode + ObsidianTheme): visual inspection looks consistent"
+      ],
+      "priority": 51,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-052",
+      "title": "Audit zh-Hans punctuation (half-width vs full-width)",
+      "description": "As a zh-Hans user, I want consistent full-width punctuation so the UI follows Chinese typography conventions.",
+      "acceptanceCriteria": [
+        "Run a script that greps Resources/zh-Hans.lproj/Localizable.strings for half-width punctuation in Chinese contexts (e.g. , ! ? : ; vs \uff0c\uff01\uff1f\uff1a\uff1b)",
+        "Replace each offender with the full-width equivalent",
+        "Add a ZhHansPunctuationTest invoking the same script at test time and asserting 0 offenders",
+        "Existing localization tests pass",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 52,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-053",
+      "title": "Sweep comment-only TODOs across iOS sources",
+      "description": "As an iOS maintainer, I want stale TODO comments either resolved or converted into tracked issues.",
+      "acceptanceCriteria": [
+        "Run `grep -rn 'TODO\\|FIXME' apps/ios/SoloCompass --include='*.swift'` and triage each: resolve if trivial, delete if obsolete, or convert to a GitHub issue + link the issue number in the comment",
+        "After the sweep, every remaining TODO/FIXME has a GitHub issue number referenced",
+        "Add a Swift test that grep-asserts every TODO in production code has the pattern 'TODO(#NNN):'",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 53,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-054",
+      "title": "Sweep unused imports across iOS sources",
+      "description": "As an iOS maintainer, I want unused imports removed so build time and review surface area shrink.",
+      "acceptanceCriteria": [
+        "Use swift-format or a similar tool to detect unused imports (build with -warn-unused-imports if available) and remove them",
+        "If automated detection isn't available, eyeball-audit Views/ and Services/ and remove obvious cases",
+        "After sweep, the project still builds cleanly",
+        "Existing tests pass",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 54,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-055",
+      "title": "Add inline documentation comments to all top-level public APIs",
+      "description": "As an API consumer, I want every public type and function in apps/ios/SoloCompass to have at least a single-line doc comment.",
+      "acceptanceCriteria": [
+        "For every `public class/struct/enum/protocol/func` in Models/, Services/, ViewModels/, that lacks a /// comment, add one (one or two lines, explain purpose not mechanism)",
+        "Skip Views/ (SwiftUI views document themselves via #Preview)",
+        "Add a Swift script-test that fails if any public symbol in the listed directories lacks a doc comment (use regex over compiled symbols or grep)",
+        "Existing tests pass",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 55,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-056",
+      "title": "RouteCard \u2014 add stop-strip breadcrumb (CompareCanvas A-001)",
+      "description": "As a user browsing routes, I want a visual breadcrumb of stops on each route card so I can preview the journey at a glance.",
+      "acceptanceCriteria": [
+        "Views/Companion/Components/RouteCard.swift \u2014 render a horizontal strip of colored discs (one per stop, color from CategoryVisual) connected by 1px CT.fgSubtle connectors; matches design-truth in /tmp/compare_design/solocompassapp/project/route.jsx's `stop-strip` block",
+        "All colors come from CT.* tokens \u2014 no Color.accentColor or failable hex",
+        "Add RouteCardStopStripTest snapshotting cards with 2, 3, and 5 stops",
+        "Existing RouteCard tests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: route cards in BottomInfoSheet show the stop-strip"
+      ],
+      "priority": 56,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-057",
+      "title": "RouteCard \u2014 add recruit-mini inline state (CompareCanvas A-002)",
+      "description": "As a user with companion mode on, I want each route card to show the recruiting state inline (host / N filled out of M / departure label) without opening detail.",
+      "acceptanceCriteria": [
+        "Views/Companion/Components/RouteCard.swift \u2014 when route.companion != nil AND status is open/forming/closed/completed, render an inline strip below the title showing: host avatar + `<handle> \u62db\u52df \u00b7 N/M \u00b7 <departure>` (open/forming) or `\u5df2\u6210\u56e2 \u00b7 N \u4eba \u00b7 \u51fa\u53d1\u4e2d` (closed) or `\u5df2\u5b8c\u6210 \u00b7 \u8def\u7ebf\u5347\u7ea7` (completed)",
+        "Uses CT.* tokens; tone color per status \u2014 green for completed, accent for open, amber for forming",
+        "Add RouteCardRecruitMiniTest snapshotting all four status variants",
+        "Existing RouteCard tests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: route cards in the recruiting demo show the inline strip with the correct status"
+      ],
+      "priority": 57,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-058",
+      "title": "RouteCard \u2014 add walked-by row (CompareCanvas A-003) and migrate to CT tokens",
+      "description": "As a user browsing routes, I want to see how many travelers walked this route (with avatar stack) so I can gauge social proof.",
+      "acceptanceCriteria": [
+        "Views/Companion/Components/RouteCard.swift \u2014 when companionOn is false OR route.companion is nil, render a walked-by row with AvatarStack(maxVisible: 4) + `<count> \u4f4d\u65c5\u4eba\u8d70\u8fc7` + chevron",
+        "AvatarStack uses CT.fgSubtle ring (current default) on a CT.bgWarm-or-white background \u2014 confirm no Color.accentColor or failable hex remains anywhere in RouteCard",
+        "Add RouteCardWalkedByTest snapshotting with 0, 3, and 12 walkers (the +N more case)",
+        "Existing RouteCard tests pass",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: route cards in the recruiting demo show walked-by row with stacked avatars"
+      ],
+      "priority": 58,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/scripts/ralph/archive/2026-05-29-full-fix-roadmap-58us-snapshot/progress.txt
+++ b/scripts/ralph/archive/2026-05-29-full-fix-roadmap-58us-snapshot/progress.txt
@@ -1,0 +1,19 @@
+# Solo Compass — Ralph Progress Log
+Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+Target: ralph/full-fix-roadmap-58us
+Tool: claude
+
+## Codebase Patterns
+- 权威 prd.json 是【仓库根 prd.json】，不是 scripts/ralph/prd.json。ralph.sh:21 `PRD_FILE="$SCRIPT_DIR/../../prd.json"` 读的是根；scripts/ralph/prd.json 只是低优先级副本。改 prd.json 务必改根（或两者同步），改完用 `python3 -c "import json;json.load(open('prd.json'))"` 在【根路径】回读验证。
+- 通用约定：写任何被脚本读取的配置/数据文件（prd.json/config/.env）前，先 grep 出消费它的代码，以代码里的字面量路径为准，不要凭目录结构猜；写完用消费方路径回读确认。
+- 2026-05-29 记录：根 prd.json 与 scripts/ralph/prd.json 字节数曾不一致（55552 vs 55084），疑似只更新了一个 → 以根为准、保持两者同步。
+
+[2026-05-29T05:16:32Z] Story #US-001: Replace 6 route.companion! force-unwraps with safe binding — PASSED
+[2026-05-29T05:57:07Z] Story #US-002: SyncService.enqueue must report encode failures to Sentry — FAILED (iteration 2)
+[2026-05-29T06:01:59Z] Story #US-002: SyncService.enqueue must report encode failures to Sentry — PASSED
+[2026-05-29T06:12:13Z] Story #US-003: Add AISynthesisQuality state to AIService — PASSED
+[2026-05-29T06:24:46Z] Story #US-004: Add SkeletonBadgeView component (transparency pill) — PASSED
+[2026-05-29T06:52:15Z] Story #US-005: Remove AnyView wrapper from CompassMapView.body — FAILED (iteration 4)
+[2026-05-29T06:55:00Z] Story #US-005: Remove AnyView wrapper from CompassMapView.body — PASSED (build + tests green, simulator verified no regression)
+[2026-05-29T06:56:54Z] Story #US-005: Remove AnyView wrapper from CompassMapView.body — PASSED
+[2026-05-29T07:24:51Z] Story #US-006: BottomInfoSheet drag handle hit target ≥ 44pt — FAILED (iteration 6)

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -1,19 +1,19 @@
 {
   "project": "Solo Compass",
-  "branchName": "ralph/full-fix-roadmap-58us",
-  "description": "Full Fix Roadmap — Solo Compass iOS. Executes the 58 user stories captured in tasks/prd-full-fix-roadmap.md across 4 categories: P0 (13 — crash/data-loss/a11y/perf hot-paths), P1 (29 — correctness/coverage), P2 (16 — polish/i18n), and A-Series (8 — design-token adoption + 800-line file decomposition). Source documents: docs/EVAL_REPORT.md (52 source-level findings) + 6 device findings from e2e-runner v2 (a16a636) + design ground truth at /tmp/compare_design/solocompassapp/. Strict four-way acceptance: iPhone 17 Pro Simulator manual run + XCTest + VoiceOver (a11y stories) + Sentry capture (silent-failure stories). All file:line anchors against main @ 0252ce3 (see PRD §3).",
+  "branchName": "ralph/nowscore-v1-10us",
+  "description": "NowScore v1 — upgrade Experience.isBestNow() from a static boolean (driven by bestTimes: [TimeWindow]) to a continuous nowScore in [0, 1] composed from multiple NowSignal implementations (BestTimes / HourOfDay / Weather / Sunset) with human-readable reason text. Differentiator: BestNowBadge moves from '此刻' to '日落 23 分钟后 · 晴 · 适合' — Google/Apple Maps won't do this. Source: tasks/prd-now-score-v1.md. Parallel to ralph/full-fix-roadmap-58us; coordinate US-NS-007 / US-NS-008 with that PRD's US-P1-003 / US-P2-035 (both touch nowCount + Filter Now). Strict acceptance: every story keeps the 100+ existing BestNow*Tests green, p95 < 5ms, offline-safe, Sentry-instrumented. File:line anchors against main @ a9afa18.",
   "userStories": [
     {
       "id": "US-001",
-      "title": "Replace 6 route.companion! force-unwraps with safe binding",
-      "description": "As an iOS engineer, I want all 6 `route.companion!` force-unwrap sites replaced with safe binding so the app never crashes when companion data is unexpectedly nil.",
+      "title": "Introduce NowScore value type and Experience.nowScore(at:) method",
+      "description": "As an iOS engineer, I need a NowScore value type and an Experience.nowScore(at:) method so downstream views/viewmodels read a continuous [0,1] score instead of a Bool, while preserving isBestNow() semantics for backward compatibility.",
       "acceptanceCriteria": [
-        "grep '\\bcompanion!' across non-Tests Swift files returns 0 hits",
-        "Each of the 6 sites (Services/LocalRouteCompanionRemote.swift:38,119,126,137 + Views/Companion/MyRequestsListView.swift:182 + Views/Companion/ApprovalQueueView.swift:311) rewritten with `guard var companion = updated.companion else { ... }` pattern, mutating the bound copy then assigning back via updated.companion = companion",
-        "Add new XCTest RouteCompanionForceUnwrapTests covering each mutation path with companion == nil input — operation must no-op cleanly with no crash",
-        "Existing RouteCompanionStateMachineTests still pass",
-        "When the no-op safety path triggers, SentryService.capture(...) reports a warning so production occurrences are visible",
-        "Typecheck passes (xcodebuild build succeeds on iPhone 17 Pro Simulator)",
+        "Create apps/ios/SoloCompass/Models/NowScore.swift with `public struct NowScore: Sendable { public let value: Double /* [0,1] */; public let reason: String?; public let breakdown: [String: Double] }`",
+        "Add `public func nowScore(at date: Date) -> NowScore` to apps/ios/SoloCompass/Models/Experience.swift next to existing isBestNow() at line 472. v1 only consults bestTimes: in-window → value=1.0, out-of-window → value=0.0, empty bestTimes → value=0.5 (neutral)",
+        "Keep `isBestNow(at:)` signature unchanged; rewrite body to `return nowScore(at: date).value >= 0.7`",
+        "Add NowScoreTests in apps/ios/SoloCompass/Tests/ covering: in-window → 1.0, out-of-window → 0.0, empty bestTimes → 0.5",
+        "All existing BestNow*Tests (search `grep -rn 'BestNow' apps/ios/SoloCompass/Tests`) still pass",
+        "Typecheck passes",
         "Tests pass"
       ],
       "priority": 1,
@@ -22,13 +22,16 @@
     },
     {
       "id": "US-002",
-      "title": "SyncService.enqueue must report encode failures to Sentry",
-      "description": "As an end user, I want my completions, favorites, and route join requests to never silently disappear so my actions are durable across devices.",
+      "title": "Define NowSignal protocol + register BestTimesSignal and HourOfDaySignal",
+      "description": "As an iOS engineer, I want a NowSignal protocol so future signal contributors (weather, sunset, crowd) plug in without touching Experience.nowScore itself.",
       "acceptanceCriteria": [
-        "Services/SyncService.swift:95-98 `try? JSONEncoder().encode(...)` replaced with `do { try ... } catch { SentryService.capture(error, context: \"SyncService.enqueue\", payload: payloadType) }`",
-        "On failure the queue either rethrows to the caller or falls back gracefully — but always reports via Sentry; the bare `return` is gone",
-        "Add SyncServiceEnqueueTests injecting a payload that deterministically fails encoding — assert a SentryService mock receives the capture call",
-        "grep 'try?' inside Services/SyncService.swift returns 0 hits for encode/decode",
+        "Create apps/ios/SoloCompass/Services/NowScore/NowSignal.swift defining `public protocol NowSignal { static var key: String { get }; func score(for experience: Experience, at date: Date) async -> NowSignalContribution }`",
+        "Same file defines `public struct NowSignalContribution: Sendable { public let value: Double /* [0,1] */; public let weight: Double; public let reason: String? }`",
+        "Create apps/ios/SoloCompass/Services/NowScore/BestTimesSignal.swift implementing the protocol; key='bestTimes', weight=0.4; logic mirrors US-001 in-window/out-of-window check",
+        "Create apps/ios/SoloCompass/Services/NowScore/HourOfDaySignal.swift; key='hourOfDay', weight=0.2; gaussian decay centered on experience.bestStartHour with sigma=90min (full width)",
+        "Refactor Experience.nowScore(at:) to iterate registered signals (`[BestTimesSignal(), HourOfDaySignal()]`) and produce weighted average value + concatenated reason. Empty signal list → value=0.5",
+        "Add NowSignalCompositionTests: both signals max → 1.0; only one max → roughly its weight share; both 0 → 0.0; reason text concatenated with ' · '",
+        "All existing BestNow*Tests + US-001 NowScoreTests still pass",
         "Typecheck passes",
         "Tests pass"
       ],
@@ -38,13 +41,19 @@
     },
     {
       "id": "US-003",
-      "title": "Add AISynthesisQuality state to AIService",
-      "description": "As an iOS engineer, I need AIService to expose whether the last synthesis was real, skeleton, or cached so the UI can render a transparency badge.",
+      "title": "Build WeatherService with 12-hour SwiftData cache",
+      "description": "As an iOS engineer, I need a WeatherService that fetches and caches current weather for any coordinate so NowScore can read weather without one network call per marker.",
       "acceptanceCriteria": [
-        "Add public enum AISynthesisQuality { case real, skeleton, cached } in Services/AIService.swift",
-        "Add public observable property `lastSynthesisQuality: AISynthesisQuality` updated on every synthesis path (success branch -> .real, fallback branch -> .skeleton, cache-hit branch -> .cached) — anchor lines 765-768 and 781-791",
-        "Skeleton fallback path also calls SentryService.capture(...) with subsystem 'AIService.skeleton_fallback'",
-        "Add AISynthesisQualityTests injecting each path and asserting lastSynthesisQuality transitions correctly",
+        "Create apps/ios/SoloCompass/Services/WeatherService.swift with `@MainActor @Observable public final class WeatherService` exposing `public func current(at coord: CLLocationCoordinate2D) async throws -> WeatherSnapshot`",
+        "Same file defines `public struct WeatherSnapshot: Sendable { public let tempC: Double; public let condition: WeatherCondition; public let precipChancePct: Int; public let windKph: Double; public let observedAt: Date }` and `public enum WeatherCondition: String, Sendable, Codable { case clear, partlyCloudy, cloudy, rain, storm, snow, fog }`",
+        "Same file defines `public enum WeatherError: Error { case noAPIKey, networkUnavailable, decodingFailed }`",
+        "API key sourced from `Secrets.openWeatherAPIKey`. If nil → throw WeatherError.noAPIKey (callers must handle gracefully)",
+        "Create apps/ios/SoloCompass/Persistence/Models/WeatherCacheRecord.swift as `@Model public final class WeatherCacheRecord { @Attribute(.unique) public var coordKey: String /* '\\(lat.rounded(2))_\\(lon.rounded(2))' */; public var snapshotJSON: Data; public var observedAt: Date; ... }`",
+        "TTL = 12 hours: cache hit if `Date().timeIntervalSince(record.observedAt) < 12 * 3600`",
+        "If NetworkMonitor.shared.isOnline == false → only read cache, return nil snapshot when miss (do not throw)",
+        "Register WeatherCacheRecord in the ModelContainer schema (find existing container init via `grep -rn 'ModelContainer' apps/ios/SoloCompass/App` and add to schema array)",
+        "Add WeatherServiceTests with a mock URLSessionProtocol injection: first call hits network, second call hits cache (verify by asserting URLSession mock call count == 1)",
+        "Add WeatherCacheTTLTests: insert a 13-hour-old record → second call hits network again",
         "Typecheck passes",
         "Tests pass"
       ],
@@ -54,18 +63,18 @@
     },
     {
       "id": "US-004",
-      "title": "Add SkeletonBadgeView component (transparency pill)",
-      "description": "As a user, I want a small visible indicator when an experience card is showing skeleton data instead of real AI insight so I don't mistake placeholder text for personalized recommendation.",
+      "title": "Offline + error degradation + Sentry instrumentation in NowScoreEngine",
+      "description": "As a user, I want NowScore to keep working when offline (only bestTimes/hourOfDay signals contribute) and never crash or surface a stack trace, with unexpected errors visible in Sentry.",
       "acceptanceCriteria": [
-        "Create apps/ios/SoloCompass/Views/Shared/SkeletonBadgeView.swift with public struct SkeletonBadgeView: View",
-        "Visual: capsule using CT.fgMuted (NOT accent) and CT.body(10, .medium); text from NSLocalizedString(\"ai.skeleton.pill\", ...) — add the key to en.lproj and zh-Hans.lproj Localizable.strings (en: \"Limited data\", zh-Hans: \"数据有限\")",
-        "accessibilityLabel reads the localized string + \"placeholder content\" hint",
-        "Wire it into Views/Experience/ExperienceCardView.swift: render only when the bound AIService.lastSynthesisQuality == .skeleton; never render for .real or .cached",
-        "Add SkeletonBadgeViewTests with snapshot of badge + ExperienceCardTests verifying conditional rendering",
-        "Add LocalizableStringsParityTest expectation — both new keys present in en and zh-Hans, StringsParityTests passes",
+        "Create apps/ios/SoloCompass/Services/NowScore/NowScoreEngine.swift with `@MainActor public final class NowScoreEngine` holding the registered [any NowSignal] array",
+        "Move the signal-iteration + weighted-average logic from Experience.nowScore(at:) into NowScoreEngine.evaluate(for:at:); Experience.nowScore(at:) delegates to the shared engine",
+        "If any individual signal throws or returns an error → engine catches, substitutes `NowSignalContribution(value: 0.5, weight: 0.0, reason: nil)` for that signal, and continues",
+        "Known errors (WeatherError.noAPIKey, WeatherError.networkUnavailable) → silently degrade, no Sentry report",
+        "Unexpected errors → `SentryService.capture(error, context: \"NowScoreEngine.\\(signalKey)\")`",
+        "Add NowScoreOfflineDegradeTest: inject a throwing WeatherSignal stub → engine returns nowScore that excludes weather dimension, no crash",
+        "Add NowScoreSentryReportTest: inject a signal that throws a custom error → verify a SentryService mock receives the capture call with the right context string",
         "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: launch app without ANTHROPIC_API_KEY → cards display the badge; with key → badge absent"
+        "Tests pass"
       ],
       "priority": 4,
       "passes": false,
@@ -73,16 +82,20 @@
     },
     {
       "id": "US-005",
-      "title": "Remove AnyView wrapper from CompassMapView.body",
-      "description": "As an iOS engineer, I want the root mapContent to return some View directly so SwiftUI can do incremental diffing on the app's heaviest view.",
+      "title": "WeatherSignal — NowSignal implementation that downgrades outdoor scores in bad weather",
+      "description": "As a user, I want the NowScore to drop when it's raining hard or there's a storm so the app doesn't suggest a 'perfect now' outdoor experience in a thunderstorm.",
       "acceptanceCriteria": [
-        "Views/Map/CompassMapView.swift:76 — `public var body: some View { mapContent }` returns the @ViewBuilder result without AnyView(...) wrapping",
-        "If init signature constraints fight the return type, add @ViewBuilder to body so the concrete opaque type is inferred",
-        "Add CompassMapViewBodyTypeTests: assert String(describing: type(of: someInstance.body)) does NOT contain \"AnyView\"",
-        "All existing snapshot/unit tests (MarkerIconTests, CityPillHitTargetTests, FilterBarViewTests) still pass",
+        "Create apps/ios/SoloCompass/Services/NowScore/WeatherSignal.swift implementing NowSignal; key='weather', weight=0.15",
+        "Constructor takes WeatherService dependency (so it's injectable for tests)",
+        "score(for:at:) logic: outdoor categories (.nature; .nightlife only if experience.tags contains 'rooftop') consult weather, indoor categories (.coffee, .work, .wellness, .culture, .food) always return value=1.0 with reason=nil",
+        "For outdoor: clear/partlyCloudy → 1.0, cloudy with precipChancePct<30 → 0.9, rain (precipChancePct ≥ 30) → 0.5, storm OR windKph ≥ 30 OR precipChancePct ≥ 70 → 0.0",
+        "reason text examples: '晴 · 27°C · 适合' (clear), '雷雨预警 · 不建议外出' (storm); use NSLocalizedString",
+        "Add localization keys nowscore.weather.sunny / nowscore.weather.cloudy / nowscore.weather.rain / nowscore.weather.storm / nowscore.weather.indoor to both en.lproj and zh-Hans.lproj Localizable.strings",
+        "If WeatherService returns nil snapshot (offline cache miss) → return value=0.5, weight=0.0, reason=nil (neutral, no UI bleed)",
+        "Add WeatherSignalTests covering: indoor → 1.0 regardless; outdoor + clear → 1.0; outdoor + rain → 0.5; outdoor + storm → 0.0; offline+miss → (0.5, 0.0, nil)",
+        "StringsParityTests passes (en + zh-Hans key sets match)",
         "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: pan/zoom map for 30 seconds, no visual regression"
+        "Tests pass"
       ],
       "priority": 5,
       "passes": false,
@@ -90,17 +103,20 @@
     },
     {
       "id": "US-006",
-      "title": "BottomInfoSheet drag handle hit target ≥ 44pt",
-      "description": "As a VoiceOver / Switch Control user, I want the bottom sheet drag handle to have a 44×44pt minimum hit area so I can switch detent levels reliably.",
+      "title": "SolarEvents pure-function module + SunsetSignal",
+      "description": "As a solo traveler, I want viewpoints / parks / rooftop bars to score highest in the 90 minutes before sunset so I'm nudged 'depart now · sunset in 23 min' at the right moment.",
       "acceptanceCriteria": [
-        "Views/Map/BottomInfoSheet.swift:127-131 — wrap the handle in `.frame(minWidth: 60, minHeight: 44).contentShape(Rectangle())`; the visible pill stays 36×4",
-        "Add `.accessibilityLabel(NSLocalizedString(\"sheet.handle\", ...))` plus `.accessibilityAdjustableAction` that cycles peek → mid → full",
-        "Add new localization key sheet.handle to en + zh-Hans Localizable.strings",
-        "Add BottomInfoSheetHandleHitTargetTests asserting hit-area frame ≥ 44 in either dimension",
+        "Create apps/ios/SoloCompass/Services/SolarEvents.swift with `public enum SolarEvents { public static func sunset(at coord: CLLocationCoordinate2D, on date: Date) -> Date?; public static func sunrise(at coord: CLLocationCoordinate2D, on date: Date) -> Date? }`. Implement using NREL Solar Position Algorithm simplified for civil sunset/sunrise (one local file, < 150 lines, NO new SPM dependency)",
+        "Add SolarEventsTests with two latitude/date fixtures: Vientiane (17.97°N, 102.60°E) on 2024-06-21 → sunset within ±5 min of 18:50 local; Beijing (39.90°N, 116.41°E) on 2024-12-22 → sunset within ±5 min of 16:50 local",
+        "Create apps/ios/SoloCompass/Services/NowScore/SunsetSignal.swift implementing NowSignal; key='sunset', weight=0.25",
+        "score(for:at:) only contributes (weight=0.25) for experiences with category ∈ [.nature, .nightlife] OR tags containing 'sunset_friendly'; other experiences return weight=0, value=0.5, reason=nil",
+        "Scoring curve for eligible experiences: 90→30 min before sunset → 1.0; 30→0 min → gaussian decay to 0.7; 0→30 min after sunset (blue hour) → 0.6; otherwise → 0.4",
+        "reason text uses NSLocalizedString; examples: '日落 23 分钟后', '日落 8 分钟后 · 蓝调时刻', '日落已过 47 分钟'. Use stringsdict for plural-aware minute formatting where needed",
+        "Add localization keys nowscore.sunset.before_min / nowscore.sunset.blue_hour / nowscore.sunset.after_min to both locales",
+        "Add SunsetSignalTests sampling at sunset - 60min / -30 / -5 / 0 / +20 / +60 → assert value within expected band",
         "StringsParityTests passes",
         "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator with Accessibility Inspector: hit area visualized ≥ 44pt"
+        "Tests pass"
       ],
       "priority": 6,
       "passes": false,
@@ -108,16 +124,18 @@
     },
     {
       "id": "US-007",
-      "title": "Localize hardcoded 'results' strings in FilterBarView",
-      "description": "As a zh-Hans user, I want the filter result count rendered in my locale instead of English so the UI is consistent.",
+      "title": "BestNowBadge renders NowScore reason as subtitle",
+      "description": "As a user looking at an experience card, I want the 'best now' badge to show a one-line reason like '日落 23 分钟后 · 晴 · 适合' so I understand WHY this is recommended right now.",
       "acceptanceCriteria": [
-        "Views/Filter/FilterBarView.swift:180, 230, 264, 301 — replace literal \"results\" with String(format: NSLocalizedString(\"filter.results.count\", ...), count)",
-        "Add filter.results.count to en (\"%d results\") and zh-Hans (\"%d 个结果\") Localizable.strings",
-        "Add FilterBarLocalizationTests verifying the resolved string in zh-Hans uses Chinese characters",
-        "grep 'results' inside Views/Filter/FilterBarView.swift produces zero literal hits (excluding comments)",
-        "StringsParityTests passes",
+        "Edit apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift BestNowBadge (currently at lines 267-289). When `experience.nowScore(at: .now).value >= 0.7`, render a subtitle Text below the existing badge label using `nowScore.reason ?? NSLocalizedString(\"badge.now.fallback\", ...)` (existing '此刻' string is the fallback)",
+        "Reason text style: CT.body(11, .medium) in CT.fgMuted color (secondary, does not steal focus from main title)",
+        "Reason composition rule: top-3 contributing signals by weight × value, joined with ' · '; if combined text > 28 chars truncate with '…'",
+        "If `nowScore.value < 0.7` → render NOTHING (badge fully hidden, current behavior preserved)",
+        "Add BestNowBadgeReasonTests with three snapshots: short reason (1 signal), medium reason (2 signals), long reason that requires truncation",
+        "All existing BestNowBadge tests still pass",
         "Typecheck passes",
-        "Tests pass"
+        "Tests pass",
+        "Verify in iPhone 17 Pro Simulator: launch app at a time when a marker satisfies nowScore ≥ 0.7 → screenshot the badge showing the new reason subtitle"
       ],
       "priority": 7,
       "passes": false,
@@ -125,15 +143,16 @@
     },
     {
       "id": "US-008",
-      "title": "voice.processing toast announces via UIAccessibility live region",
-      "description": "As a VoiceOver user, I want voice processing toasts to announce themselves so I stay in sync with app state without manually moving focus.",
+      "title": "MapViewModel.nowCount + markerState sort consume nowScore",
+      "description": "As an iOS engineer, I want MapViewModel.nowCount and markerState sorting to drive off nowScore.value ≥ 0.7 instead of the legacy isBestNow() so the entire app reflects the continuous model.",
       "acceptanceCriteria": [
-        "Views/Map/CompassMapView.swift:868-885 — the voice.processing toast view chain adds .accessibilityElement().accessibilityAddTraits(.updatesFrequently)",
-        "On the toast's onAppear (and on text change) call UIAccessibility.post(.announcement, argument: localizedText)",
-        "Add VoiceToastA11yTests asserting the view tree contains the .updatesFrequently trait when toast is active",
+        "Edit apps/ios/SoloCompass/ViewModels/MapViewModel.swift nowCount property (line 298): change body to `visibleExperiences.filter { $0.nowScore(at: .now).value >= 0.7 }.count`",
+        "Edit markerState sort order: experiences with nowScore.value ≥ 0.7 come first, then sort by nowScore.value descending, then by distance ascending",
+        "If prd-full-fix-roadmap.md US-P1-003 (nowCount caching) has already merged when this story runs, preserve its caching pattern: invalidate the `_nowCount` cache whenever visibleExperiences changes, then recompute using the new nowScore predicate",
+        "Add MapViewModelNowScoreSortTest injecting 3 mock experiences (scores 0.9 / 0.7 / 0.5) and asserting their order matches",
+        "All existing MarkerIconViewTests and MapViewModelCityCacheTests still pass",
         "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator with VoiceOver on: triggering a voice query causes the system to read the toast text"
+        "Tests pass"
       ],
       "priority": 8,
       "passes": false,
@@ -141,15 +160,16 @@
     },
     {
       "id": "US-009",
-      "title": "Hide Companion-layer toggle behind a feature flag (decision A)",
-      "description": "As a product owner, I want the long-unimplemented companion layer toggle hidden by default so users don't click a dead button that always returns nil.",
+      "title": "Filter 'Now' mode visually grades markers by nowScore intensity",
+      "description": "As a user, when 'Now' filter is on, I want markers visually graded by nowScore intensity (full color / semi / faded) instead of just shown/hidden so I can pick the BEST 'now' option, not just any.",
       "acceptanceCriteria": [
-        "Views/Map/CompassMapView.swift:541 — wrap the toggle in `if FeatureFlags.companionLayerEnabled { ... }`",
-        "Services/FeatureFlags.swift — add static var companionLayerEnabled: Bool = false (default off) plus a way to override in DEBUG via UserDefaults",
-        "Update CompassMapViewLayerToggleTests to assert the toggle is NOT in the view hierarchy when the flag is false (and IS when true)",
+        "Edit MarkerIconView (find via `grep -rn 'MarkerIconView' apps/ios/SoloCompass/Views/Map`) so that when MapViewModel's filter is in Now mode, the marker opacity = `min(1.0, max(0.5, nowScore.value))` (floor at 0.5 so markers stay visible)",
+        "Markers with nowScore.value ≥ 0.9 additionally get a 0.6s-cycle pulse animation ring in CT.accent (opacity 0.7 → 1.0)",
+        "Add FilterNowGradientHighlightTest using XCTest + a snapshot of three markers at scores 0.95 / 0.75 / 0.55 in Now mode",
+        "All existing FilterBarViewTests and CompassMapView snapshot tests still pass",
         "Typecheck passes",
         "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: cold launch shows no companion-layer toggle in the top overlay"
+        "Verify in iPhone 17 Pro Simulator: toggle Now filter on → screenshot showing the gradient + pulse highlight on top markers"
       ],
       "priority": 9,
       "passes": false,
@@ -157,802 +177,18 @@
     },
     {
       "id": "US-010",
-      "title": "Resolve SwiftData @Query KeyPath Sendable warning in SettingsView",
-      "description": "As an iOS engineer, I want the SwiftData @Query Sendable warning resolved so strict concurrency stays clean.",
+      "title": "NowScore p95 latency < 5ms with in-memory caches",
+      "description": "As an iOS engineer, I want NowScore evaluation to stay under 5ms p95 so it doesn't tank scrolling perf on a list of 100 markers.",
       "acceptanceCriteria": [
-        "Views/Settings/SettingsView.swift:897 — replace the bare KeyPath in @Query with an explicit SortDescriptor(\\.field, order: ...) or wrap in @Sendable closure",
-        "Add SettingsViewQuerySortTest asserting the records query returns expected order",
-        "xcodebuild output no longer surfaces the 'sending KeyPath risks data races' warning for this line",
+        "Add an in-memory LRU dict (size 100) inside WeatherService for hot-path cache hits — avoids SwiftData fetch on every nowScore call",
+        "Add an in-memory dict inside SolarEvents keyed by `'\\(lat.rounded(1))_\\(lon.rounded(1))_\\(date.formatted(.iso8601.year().month().day()))'` to memoize same-day same-coord sunset/sunrise",
+        "Add NowScorePerformanceTest in apps/ios/SoloCompass/Tests/: construct 100 fixture experiences spanning all categories, call `nowScore(at: .now)` 1000 times, measure with `measure(metrics: [XCTClockMetric()])` and assert p95 < 5ms",
+        "On test failure, the test message must include a per-signal timing breakdown so developers see which signal regressed",
+        "All other tests still pass",
         "Typecheck passes",
         "Tests pass"
       ],
       "priority": 10,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-011",
-      "title": "Fix ChatSheet voiceService main-actor isolation",
-      "description": "As an iOS engineer, I want main-actor isolated voiceService usage to not race so strict concurrency holds.",
-      "acceptanceCriteria": [
-        "Services/VoiceService.swift — add @MainActor to the class declaration (or @MainActor to requestPermission()) so Views/Chat/ChatSheet.swift:621 sends a main-actor value to a main-actor method",
-        "Add VoiceServiceActorIsolationTest asserting requestPermission is callable from a @MainActor context without warning",
-        "xcodebuild output no longer surfaces the 'sending self.voiceService risks data races' warning",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 11,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-012",
-      "title": "Gate FavoritesListView BounceSymbolEffect behind iOS 18 availability",
-      "description": "As an iOS engineer, I want the iOS-18-only BounceSymbolEffect API gated by `if #available` so the project stays clean under Swift 6 strict mode.",
-      "acceptanceCriteria": [
-        "Views/Shared/FavoritesListView.swift:327 — wrap `base.symbolEffect(.bounce, options: .repeating.speed(0.6))` in `if #available(iOS 18, *) { ... } else { base }`",
-        "Add FavoritesBounceAvailabilityTest verifying SwipeHintCapsuleView builds and renders under both iOS 17 and iOS 18 deployment targets",
-        "xcodebuild output no longer surfaces the 'IndefiniteSymbolEffect available only iOS 18+' warning",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 12,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-013",
-      "title": "Fix Onboarding privacy sheet subtitle truncation (V-001)",
-      "description": "As a first-time user, I want the privacy onboarding sheet to show the full subtitle so I understand what services the app calls on my behalf.",
-      "acceptanceCriteria": [
-        "Locate the source file via `grep -rn 'talks to two services' apps/ios/SoloCompass/Views/Onboarding` — likely Views/Onboarding/PrivacyAcknowledgementSheet.swift",
-        "Either set the sheet to use a self-sizing detent (.medium then .large) OR add `.fixedSize(horizontal: false, vertical: true)` to the subtitle Text",
-        "Subtitle renders the full phrase ending in '...on your behalf' at default AND AX5 Dynamic Type",
-        "Add PrivacyAcknowledgementSheetSnapshotTest with snapshots at .accessibilityMedium and .accessibilityExtraExtraExtraLarge",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: cold launch displays full subtitle on first screen"
-      ],
-      "priority": 13,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-014",
-      "title": "Sync selectedCity → mapCameraPosition on cold start (V-002)",
-      "description": "As a user, I want the city header label and the map's rendered region to always agree so I'm never confused about where I am.",
-      "acceptanceCriteria": [
-        "ViewModels/MapViewModel.swift — `selectedCity` didSet must trigger an update to `mapCameraPosition` via defaultCenterForSelectedCity, including on the first set during init (not just user-driven changes)",
-        "Add MapViewModelCityRegionSyncTests: after init with city=\"chiang-mai\" the cameraPosition center is within 1km of Chiang Mai; after switching to city=\"san-francisco\" the camera moves",
-        "Existing MapViewModel tests still pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: cold launch shows city header and map region matching"
-      ],
-      "priority": 14,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-015",
-      "title": "Audit and localize hardcoded English strings in BottomInfoSheet + FilterBar (V-003)",
-      "description": "As a zh-Hans user, I want the entire bottom sheet UI in Chinese so I don't see English copy bleeding through.",
-      "acceptanceCriteria": [
-        "Add scripts/check-hardcoded-strings.sh that greps Views/ for `Text(\"[A-Z]` patterns and prints offenders (excluding #Preview blocks and acceptable proper nouns)",
-        "Run the script and replace each user-visible literal with NSLocalizedString(...)",
-        "Known offender: Views/Map/BottomInfoSheet.swift literal 'Good spots for right now' — replace with NSLocalizedString(\"sheet.now.headline\", ...) with en/zh-Hans entries",
-        "Add LocalizationCoverageTest invoking the script and asserting 0 offenders remain",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator (zh-Hans locale): no English copy visible in bottom sheet or filter bar"
-      ],
-      "priority": 15,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-016",
-      "title": "Cache markerState(for:) once per ForEach iteration",
-      "description": "As an iOS engineer, I want markerState(for:) called once per ForEach iteration so we don't recompute six conditions twice per visible marker per frame.",
-      "acceptanceCriteria": [
-        "Views/Map/CompassMapView.swift:612-616 — refactor the ForEach body so `let state = viewModel.markerState(for: exp)` appears once at the top, and both downstream branches reuse `state` instead of calling markerState again",
-        "Add MarkerStatePerformanceTest constructing 100 experiences and measuring 1000 iterations — p95 latency drops by ≥ 40% vs baseline (record baseline in same test on a non-cached helper)",
-        "Existing MarkerIconViewTests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: marker rendering looks identical (no visual regression)"
-      ],
-      "priority": 16,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-017",
-      "title": "Cache MapViewModel.availableCities",
-      "description": "As an iOS engineer, I want availableCities cached so we don't traverse allExperiences on every body invocation.",
-      "acceptanceCriteria": [
-        "ViewModels/MapViewModel.swift:187-215 — introduce `@ObservationIgnored private var _cachedCities: [CityInfo]?`",
-        "availableCities returns the cache when non-nil; otherwise recomputes and stores",
-        "Invalidate (_cachedCities = nil) whenever allExperiences or selectedCity change (in their didSet or in the refresh path)",
-        "Add MapViewModelCityCacheTests covering: fresh path computes and stores; second call hits cache (verify by snapshotting allExperiences before second call); invalidation after allExperiences change",
-        "Existing CityPillHitTargetTests pass",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 17,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-018",
-      "title": "Cache MapViewModel.nowCount",
-      "description": "As an iOS engineer, I want nowCount cached and recomputed only on visibleExperiences change so BottomInfoSheet and FilterBarView don't trigger O(n) scans on every render.",
-      "acceptanceCriteria": [
-        "ViewModels/MapViewModel.swift — add `@ObservationIgnored private var _nowCount: Int = 0`",
-        "Update _nowCount at the end of loadNearbyExperiences, refreshForLocation, and updateBottomInfo",
-        "nowCount property returns _nowCount",
-        "Lines 720 and 736 inside updateBottomInfo no longer recompute via .filter { $0.isBestNow() }",
-        "grep `visibleExperiences\\.filter \\{.*isBestNow` returns at most 1 occurrence (in the single source-of-truth update)",
-        "Add NowCountCacheTests injecting mock experiences and asserting the count updates only at the documented checkpoints",
-        "Existing FilterBarViewTests pass",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 18,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-019",
-      "title": "Hit-target ≥ 44pt for FilterBar icon pill, favorite heart, banner X",
-      "description": "As a VoiceOver / Switch Control user, I want all interactive controls to meet the 44pt HIG minimum.",
-      "acceptanceCriteria": [
-        "Views/Filter/FilterBarView.swift:240 iconPill (36×36) — wrap in .frame(minWidth: 44, minHeight: 44).contentShape(Rectangle()); keep the visible chip 36×36",
-        "Views/Experience/ExperienceCardView.swift:175 favorite heart (32×32) — same treatment",
-        "Views/Map/CompassMapView.swift:1124 DismissibleBanner X button — same treatment",
-        "Add HitTargetSizeTests enumerating each control and asserting hit-area dimensions ≥ 44",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator with Accessibility Inspector: three controls all show ≥ 44pt hit area"
-      ],
-      "priority": 19,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-020",
-      "title": "Parallelize SoloCompassApp.onAppear init chain",
-      "description": "As a user, I want cold start TTI to not block on serial main-thread init so the map appears within 500ms.",
-      "acceptanceCriteria": [
-        "App/SoloCompassApp.swift:43-73 — move pruneStaleCheckIns, attachRepository, RouteStore.importSeedIfNeeded, and UserDirectory.loadIfNeeded into independent `Task { ... }` blocks; remove the serial await chain",
-        "Break subscriptionService.loadProducts → refreshEntitlement into its own independent Task",
-        "Add AppLaunchPerformanceTest measuring time from init to first body completion — assert ≤ baseline × 0.5 (record baseline in test setup using the pre-refactor serial path stub)",
-        "Existing app launch tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: cold launch reaches the map screen visibly faster"
-      ],
-      "priority": 20,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-021",
-      "title": "Initialize CompassMapView viewModel eagerly (no Optional)",
-      "description": "As an iOS engineer, I want viewModel initialized eagerly so writes between launch and onAppear don't silently drop.",
-      "acceptanceCriteria": [
-        "Views/Map/CompassMapView.swift:1458 — change `@State private var viewModel: MapViewModel? = nil` to `@State private var viewModel = MapViewModel(...)` with required dependencies (or use environment injection)",
-        "Remove the lazy creation block inside .onAppear",
-        "All sites that did `if let viewModel = ...` simplify to direct use",
-        "Add MapViewModelEagerInitTest: app launch path can read viewModel.allExperiences before any onAppear fires",
-        "All existing CompassMapView tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: cold launch shows no ProgressView flicker before the map appears"
-      ],
-      "priority": 21,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-022",
-      "title": "Resolve City pill vs. filter bar visual stacking conflict",
-      "description": "As a user, I want city selector and filter bar to not visually fight for attention in the top-left.",
-      "acceptanceCriteria": [
-        "Views/Map/CompassMapView.swift top overlay — move the city pill into the navigation-bar area OR vertically separate it from the filter bar so the two capsules no longer overlap or hit-test interfere",
-        "Add TopOverlayLayoutTest using snapshot at iPhone 17 Pro size — assert city pill rect and filter bar rect do not intersect",
-        "VoiceOver order: city pill → filter bar → map (manually verified)",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: city pill and filter bar are visually separate"
-      ],
-      "priority": 22,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-023",
-      "title": "Share a single TimelineView clock across BestNowBadge instances",
-      "description": "As an iOS engineer, I want a single periodic timer feeding all BestNowBadge instances instead of 20+ concurrent timelines.",
-      "acceptanceCriteria": [
-        "Create Services/BestNowClock.swift — an @Observable @MainActor singleton with a tick property updated every 60s via a single Timer or AsyncStream",
-        "Views/Experience/ExperienceCardView.swift:267-289 BestNowBadge — replace its inline TimelineView(.periodic(by: 60)) with `@Environment(BestNowClock.self)` consumption",
-        "Add BestNowBadgeClockTest constructing 100 badges sharing one clock — assert only one Timer/AsyncStream is allocated",
-        "Existing BestNow tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: explore view with 20+ best-now badges shows no visible stutter"
-      ],
-      "priority": 23,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-024",
-      "title": "Add accessibilityLabel/value to SoloScoreRadarChart",
-      "description": "As a VoiceOver user, I want the radar chart's 6 dimensions read out loud.",
-      "acceptanceCriteria": [
-        "Views/Shared/SoloScoreRadarChart.swift — add `.accessibilityElement(children: .combine)` plus an `.accessibilityLabel` that names all 6 dimensions with their values, and `.accessibilityValue` for the overall score",
-        "Add SoloScoreRadarA11yTest asserting accessibilityLabel is non-empty and contains all 6 dimension names",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator with VoiceOver: focus lands on chart and reads e.g. 'Safety 7.5, Food 8.0, Coffee 7.0, ...'"
-      ],
-      "priority": 24,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-025",
-      "title": "Wire 'Ask Solo' gated CTA to Paywall sheet",
-      "description": "As a free-tier user, I want clicking a gated feature to take me to the paywall, not a dead toast.",
-      "acceptanceCriteria": [
-        "Views/Experience/ExperienceDetailView.swift — the gated 'Ask Solo' CTA now presents PaywallSheet via .sheet(isPresented:) when the user is not subscribed",
-        "Add AskSoloPaywallNavigationTest: tap the gated CTA → assert sheet appears via ViewInspector or snapshot",
-        "Existing ExperienceDetailView tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator (unsubscribed): tapping Ask Solo opens the paywall"
-      ],
-      "priority": 25,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-026",
-      "title": "Surface LocationService.lastError as dismissible banner",
-      "description": "As a user, I want GPS errors surfaced so I understand why the map defaulted to a region instead of my location.",
-      "acceptanceCriteria": [
-        "Services/LocationService.swift — confirm lastError is @Observable (Published) so views can react",
-        "ViewModels/MapViewModel.swift — observe lastError and expose a derived `locationErrorBannerText: String?`",
-        "Views/Map/CompassMapView.swift — render a dismissible banner using existing DismissibleBanner pattern when locationErrorBannerText != nil; copy from NSLocalizedString(\"location.error.banner\", ...)",
-        "Add en + zh-Hans entries for location.error.banner",
-        "Add LocationErrorSurfaceTests asserting banner appears when lastError set",
-        "When lastError != nil, SentryService.capture reports a warning",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator with Location set to None: banner appears"
-      ],
-      "priority": 26,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-027",
-      "title": "Surface voice recording interruptions in UI",
-      "description": "As a user, I want voice recording interruptions shown in UI instead of silently stopping.",
-      "acceptanceCriteria": [
-        "Views/Chat/ChatSheet.swift:636-638 — the empty catch is replaced with a toast/alert showing NSLocalizedString(\"voice.interrupted\", ...) with the underlying error description",
-        "Add en + zh-Hans entries for voice.interrupted (format string with %@ placeholder)",
-        "Add VoiceInterruptionToastTest: inject a throwing voice service → assert toast appears",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: revoking mic permission mid-record surfaces the toast"
-      ],
-      "priority": 27,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-028",
-      "title": "Filter chip selected-state contrast ≥ 4.5:1",
-      "description": "As a low-vision user, I want filter chip text to meet WCAG 4.5:1 contrast.",
-      "acceptanceCriteria": [
-        "Views/Filter/FilterBarView.swift selected state — replace #D4A843 on white with either CT.accent (#5D3000) text-on-CT.accentSoft (#FBF1E4) background OR white text on CT.accent background; both achieve ≥ 7:1",
-        "Add FilterChipContrastTest computing the WCAG relative luminance for selected state's foreground and background — assert contrast ratio ≥ 4.5",
-        "Existing FilterBarView tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: selected chip is clearly readable"
-      ],
-      "priority": 28,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-029",
-      "title": "Scale BottomInfoSheet detent heights with Dynamic Type",
-      "description": "As an AX5 Dynamic Type user, I want sheet detent heights to scale so content doesn't overflow.",
-      "acceptanceCriteria": [
-        "Views/Map/BottomInfoSheet.swift — multiply the three detent heights (peek 170, mid 500, full 800) by UIFontMetrics.default.scaledValue(for: 1.0) or equivalent",
-        "Add BottomSheetDetentDynamicTypeTest snapshotting all three detents at .accessibilityExtraExtraExtraLarge — content not clipped",
-        "Existing BottomInfoSheet tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator (Dynamic Type AX5): all three detent sizes show content without clipping"
-      ],
-      "priority": 29,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-030",
-      "title": "Sort button announces current mode via accessibilityValue",
-      "description": "As a VoiceOver user, I want the sort button to announce current sort mode.",
-      "acceptanceCriteria": [
-        "Views/Map/BottomInfoSheet.swift:208 — sort button adds `.accessibilityValue(NSLocalizedString(\"sort.value.\\(currentMode)\", ...))` keyed off the active sort mode",
-        "Add en + zh-Hans entries for sort.value.smart, sort.value.distance, sort.value.recent (whatever modes exist)",
-        "Add SortButtonA11yValueTest asserting accessibilityValue updates when sort mode changes",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator with VoiceOver: tapping sort button announces 'Sort, Sorted by smart'"
-      ],
-      "priority": 30,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-031",
-      "title": "JoinRouteRequestSheet inline error feedback",
-      "description": "As a user submitting a join request, I want inline validation errors so I know which field is missing.",
-      "acceptanceCriteria": [
-        "Views/Companion/JoinRouteRequestSheet.swift — missing pace or empty message field renders a red hint below the relevant input using NSLocalizedString(\"join.error.\\(field).missing\", ...)",
-        "Add en + zh-Hans entries for join.error.pace.missing and join.error.message.missing",
-        "Submit button stays disabled until both fields validate",
-        "Add JoinRequestValidationTest asserting hints appear/disappear with field state",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: submitting empty form shows hints; filling both clears them and enables submit"
-      ],
-      "priority": 31,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-032",
-      "title": "Approval queue shows trust signals per requester",
-      "description": "As a host reviewing join requests, I want to see opt-in status, walked-count, and group-count next to each requester.",
-      "acceptanceCriteria": [
-        "Views/Companion/ApprovalQueueView.swift — each request row renders three micro-stats: opt-in badge, walked count icon+number, group count icon+number — sourced from the existing requester profile object",
-        "If a stat is unknown, show '—' instead of fabricating",
-        "Add ApprovalTrustSignalTest snapshotting three rows with different signal combinations",
-        "Existing ApprovalQueueView tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: approval queue rows show the three micro-stats"
-      ],
-      "priority": 32,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-033",
-      "title": "Diagnose and fix cold-start empty-state at 5km and 25km (V-004)",
-      "description": "As a user, I want the home screen to show experiences for my selected city on cold start so the app doesn't feel broken.",
-      "acceptanceCriteria": [
-        "Investigate the chain: Services/ExperienceService.swift seed import → MapViewModel.loadNearbyExperiences. Document root cause in PR description (likely candidates: distance filter uses SF user-location while header city is set differently; or seed not imported when SwiftData store exists but is empty)",
-        "Apply the fix that makes selectedCity drive both the camera AND the nearby query origin (depends on US-014)",
-        "Add ColdStartExperienceLoadTests: simulate cold start with selectedCity='chiang-mai' and assert nearby experiences count > 0 after the load completes",
-        "Add a Sentry warning if selectedCity is set but nearby experience count remains 0 for > 5 seconds",
-        "Existing ExperienceService tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: cold launch with each of 5 seed cities → each shows non-zero nearby count"
-      ],
-      "priority": 33,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-034",
-      "title": "Add scroll affordance to filter chip strip (V-005)",
-      "description": "As a user, I want a visual hint that filter chips scroll horizontally so I can discover all categories.",
-      "acceptanceCriteria": [
-        "Views/Filter/FilterBarView.swift — add a fade gradient mask on the right edge (using .mask(LinearGradient(...))) when content overflows; OR add a small chevron icon",
-        "Mask/chevron only shows when there is overflow content (not when all chips fit)",
-        "Add FilterBarScrollAffordanceTest snapshotting with > 6 categories (overflow) and ≤ 5 (no overflow)",
-        "Existing FilterBarView tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: with default category set, right-edge fade is visible"
-      ],
-      "priority": 34,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-035",
-      "title": "Sync Filter 'Now' mode and Map 'bestNow' visual highlight",
-      "description": "As a user, I want toggling the 'Now' filter to also highlight 'best now' markers on the map so the two UIs feel connected.",
-      "acceptanceCriteria": [
-        "Views/Map/CompassMapView.swift — when FilterBarView's 'Now' mode is active, decorate bestNow markers with an additional ring (use CT.accent) or pulse animation",
-        "Add FilterNowMapSyncTest asserting marker style changes when Now filter toggles",
-        "Existing CompassMapView tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: toggling Now → markers visibly change"
-      ],
-      "priority": 35,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-036",
-      "title": "Add visual separator between Routes and Nearby sections in BottomInfoSheet",
-      "description": "As a user, I want a clear visual division between routes and nearby experiences in the bottom sheet so the information hierarchy is obvious.",
-      "acceptanceCriteria": [
-        "Views/Map/BottomInfoSheet.swift — insert a section header with the localized title (NSLocalizedString(\"sheet.section.routes\", ...) and \"sheet.section.nearby\") and an inset divider between the two sections",
-        "Add en + zh-Hans entries for the two section titles",
-        "Add BottomSheetSectionSeparationTest snapshotting at mid detent",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: bottom sheet shows section titles + divider"
-      ],
-      "priority": 36,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-037",
-      "title": "Add @available iOS 18 guard to remaining bounce APIs and verify warnings cleared",
-      "description": "As an iOS engineer, I want every IndefiniteSymbolEffect use guarded so xcodebuild emits no related warnings.",
-      "acceptanceCriteria": [
-        "Run xcodebuild and grep for 'IndefiniteSymbolEffect' or 'available only iOS 18' warnings; if any remain (besides US-012's site), add #available guards",
-        "If no remaining offenders, add IOS18AvailabilityGuardTest that scans xcodebuild output for the warning string and asserts 0 occurrences (best-effort heuristic)",
-        "Existing tests pass",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 37,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-038",
-      "title": "Localize ShareCardComponents brand label",
-      "description": "As a non-English user, I want share-card images to render branding in my locale (or stay neutral, but at minimum go through NSLocalizedString).",
-      "acceptanceCriteria": [
-        "Views/Experience/Share/ShareCardComponents.swift:54 — replace `Text(\"Solo Compass\")` with `Text(NSLocalizedString(\"sharecard.brand\", ...))`",
-        "Add en + zh-Hans entries for sharecard.brand (both currently 'Solo Compass'; intentional but routes through l10n pipeline)",
-        "Add ShareCardComponentsL10nTest asserting the resolved string in both locales",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 38,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-039",
-      "title": "Localize ShareCardView '/100  Solo Score' label",
-      "description": "As a non-English user, I want the share card score label rendered in my locale.",
-      "acceptanceCriteria": [
-        "Views/Experience/Share/ShareCardView.swift:279 — replace `Text(\"/100  Solo Score\")` with a localized format string NSLocalizedString(\"sharecard.score.suffix\", ...)",
-        "Add en (\"/100  Solo Score\") and zh-Hans (\"/100 Solo 评分\") entries",
-        "Add ShareCardScoreL10nTest asserting the resolved string in both locales",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 39,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-040",
-      "title": "Migrate production print() calls to os.Logger (batch 1: AgentRouter + MapViewModel + SubscriptionService)",
-      "description": "As an iOS engineer, I want production logging to go through os.Logger so it can be filtered and stripped from release builds.",
-      "acceptanceCriteria": [
-        "Replace print() in Services/Agents/AgentRouter.swift:179, ViewModels/MapViewModel.swift:1185, and Services/SubscriptionService.swift:325 with Logger().debug/info calls",
-        "Use a subsystem of 'com.solocompass' and category matching the file (e.g. 'AgentRouter')",
-        "Do NOT touch print() calls inside #Preview blocks or test targets",
-        "Add a script-based check (scripts/check-no-production-print.sh) that greps for print( in non-Preview, non-Tests Swift files — count should drop by 3",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 40,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-041",
-      "title": "Fix ForEach String id `\\.self` instability (3 sites)",
-      "description": "As an iOS engineer, I want ForEach over String collections to use stable IDs so duplicate strings don't collapse rows.",
-      "acceptanceCriteria": [
-        "Views/Filter/FilterBarView.swift:103 (customTags) — wrap each tag in `struct IdentifiableTag: Identifiable { let id = UUID(); let value: String }` or use Array.enumerated() with the index as id",
-        "Views/Experience/Share/ShareCardView.swift:69 and :221 (highlights) — same treatment",
-        "Add ForEachStringIDStabilityTest constructing a list with duplicate strings and asserting the rendered view has the correct number of rows (not collapsed)",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 41,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-042",
-      "title": "Add 'Skip' affordance to Onboarding flow",
-      "description": "As a returning user or QA tester, I want a Skip option in onboarding so I don't have to tap through every screen.",
-      "acceptanceCriteria": [
-        "Onboarding parent view — add a 'Skip' button in the top-right corner that completes the onboarding flow (marks onboardingComplete = true in UserDefaults / repository)",
-        "Skip button has NSLocalizedString(\"onboarding.skip\", ...) entries in en + zh-Hans",
-        "Add OnboardingSkipTest asserting Skip dismisses the flow",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: cold launch shows Skip in top-right; tapping it reaches the map"
-      ],
-      "priority": 42,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-043",
-      "title": "Filter 'Now' and Map 'bestNow' visual sync (P2 polish)",
-      "description": "As a user, I want filter and map states to feel coordinated so toggling Now is visibly reflected on the map.",
-      "acceptanceCriteria": [
-        "Refinement of US-035 if needed: ensure deselecting Now removes the highlight; ensure smooth animation between states (.animation(.easeInOut(duration: 0.2)))",
-        "Add FilterNowMapAnimationTest verifying animation modifier presence",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 43,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-044",
-      "title": "Test admin-unlock and language-switch restart flows in SettingsView",
-      "description": "As an iOS engineer, I want test coverage for two undocumented Settings flows so they don't regress silently.",
-      "acceptanceCriteria": [
-        "Add SettingsAdminUnlockTest covering the secret admin unlock sequence (whatever taps trigger it) → assert admin flag set",
-        "Add SettingsLanguageSwitchRestartTest asserting language change schedules an app-restart prompt",
-        "Both tests reference existing SettingsView code paths without modifying behavior",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 44,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-045",
-      "title": "Audit Color extensions for unintended public scope",
-      "description": "As an iOS engineer, I want SettingsView's private Color(hex:) extension verified as scope-limited so it doesn't collide with global hex helpers.",
-      "acceptanceCriteria": [
-        "Views/Settings/SettingsView.swift:1131-1132 — confirm the `private extension Color { init(hex: UInt32) }` stays private file-scope; if it's used elsewhere, hoist to Views/Shared/Color+Hex.swift and dedupe",
-        "Add ColorExtensionScopeTest asserting Color(hex: UInt32) is not accessible from outside SettingsView (or alternatively, that the canonical helper is in Color+Hex.swift)",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 45,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-046",
-      "title": "Companion layer placeholder copy (decision B from US-009)",
-      "description": "As a product owner, IF US-009 chose option B (banner instead of hide), I want the placeholder copy localized.",
-      "acceptanceCriteria": [
-        "If FeatureFlags.companionLayerEnabled remains false but UI shows a 'Coming soon' affordance, the copy uses NSLocalizedString(\"companion.layer.coming_soon\", ...)",
-        "Add en + zh-Hans entries",
-        "Add CompanionLayerPlaceholderTest asserting copy rendering",
-        "If US-009 implemented option A (full hide) and no placeholder exists, this story is a no-op — mark passes:true after verifying nothing references the key",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 46,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-047",
-      "title": "Investigate map top dark band rendering (V-006)",
-      "description": "As a user, I want the map's top region to render street content instead of a flat dark band so the map looks complete.",
-      "acceptanceCriteria": [
-        "Reproduce in iPhone 17 Pro Simulator (cold launch shows NORTH BEACH band) and identify cause: MapKit tile loading delay, search-box backdrop blur covering tiles, or overlay z-order bug — document in PR description",
-        "Apply the minimum fix: defer overlay rendering until map first-tile-rendered event; or reduce backdrop blur footprint; or correct z-order",
-        "Add MapTopOverlayRenderTest snapshotting the top 200pt of the map at T+5s — assert non-uniform pixel content (not a flat color band)",
-        "Existing CompassMapView tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: top region of map shows streets, not a dark band"
-      ],
-      "priority": 47,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-048",
-      "title": "Migrate remaining production print() calls to os.Logger (batch 2)",
-      "description": "As an iOS engineer, complete the print() → Logger migration started in US-040 by handling the remaining offenders.",
-      "acceptanceCriteria": [
-        "scripts/check-no-production-print.sh shows zero print( hits in non-Preview, non-Tests Swift files",
-        "All migrated sites use Logger with appropriate subsystem/category",
-        "Add CI-friendly assertion: a Swift unit test that loads a known offender's containing file and runs the same grep at test-time",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 48,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-049",
-      "title": "Onboarding pages: explicit VoiceOver order",
-      "description": "As a VoiceOver user, I want onboarding pages to have a sensible focus order so I can navigate without getting lost.",
-      "acceptanceCriteria": [
-        "Each onboarding page — wrap content in a single `.accessibilityElement(children: .contain)` container and set `.accessibilitySortPriority` for title → subtitle → primary CTA → skip",
-        "Add OnboardingA11yOrderTest asserting accessibility element order matches expectation",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator with VoiceOver: swiping through an onboarding page reads in the documented order"
-      ],
-      "priority": 49,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-050",
-      "title": "Empty-state views announce via VoiceOver on appear",
-      "description": "As a VoiceOver user, I want empty-state views to announce themselves so I don't think the UI froze.",
-      "acceptanceCriteria": [
-        "Identify all empty-state views (FilterBarView empty result, BottomInfoSheet empty list, Nearby empty) and add `.onAppear { UIAccessibility.post(.announcement, argument: localizedEmptyText) }`",
-        "Each empty state has a localized announcement key",
-        "Add EmptyStateAnnouncementTest asserting view tree contains the modifier",
-        "StringsParityTests passes",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 50,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-051",
-      "title": "Calibrate ObsidianTheme dark-mode color values",
-      "description": "As a dark-mode user with ObsidianTheme selected, I want the colors to actually look like the intended obsidian palette.",
-      "acceptanceCriteria": [
-        "Services/Themes/ObsidianTheme.swift — audit each Color value against the design intent in docs (or chat transcripts); adjust to match",
-        "Add ObsidianThemeContrastTest asserting foreground/background pairs meet WCAG 4.5:1",
-        "Existing Theme tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator (dark mode + ObsidianTheme): visual inspection looks consistent"
-      ],
-      "priority": 51,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-052",
-      "title": "Audit zh-Hans punctuation (half-width vs full-width)",
-      "description": "As a zh-Hans user, I want consistent full-width punctuation so the UI follows Chinese typography conventions.",
-      "acceptanceCriteria": [
-        "Run a script that greps Resources/zh-Hans.lproj/Localizable.strings for half-width punctuation in Chinese contexts (e.g. , ! ? : ; vs ，！？：；)",
-        "Replace each offender with the full-width equivalent",
-        "Add a ZhHansPunctuationTest invoking the same script at test time and asserting 0 offenders",
-        "Existing localization tests pass",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 52,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-053",
-      "title": "Sweep comment-only TODOs across iOS sources",
-      "description": "As an iOS maintainer, I want stale TODO comments either resolved or converted into tracked issues.",
-      "acceptanceCriteria": [
-        "Run `grep -rn 'TODO\\|FIXME' apps/ios/SoloCompass --include='*.swift'` and triage each: resolve if trivial, delete if obsolete, or convert to a GitHub issue + link the issue number in the comment",
-        "After the sweep, every remaining TODO/FIXME has a GitHub issue number referenced",
-        "Add a Swift test that grep-asserts every TODO in production code has the pattern 'TODO(#NNN):'",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 53,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-054",
-      "title": "Sweep unused imports across iOS sources",
-      "description": "As an iOS maintainer, I want unused imports removed so build time and review surface area shrink.",
-      "acceptanceCriteria": [
-        "Use swift-format or a similar tool to detect unused imports (build with -warn-unused-imports if available) and remove them",
-        "If automated detection isn't available, eyeball-audit Views/ and Services/ and remove obvious cases",
-        "After sweep, the project still builds cleanly",
-        "Existing tests pass",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 54,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-055",
-      "title": "Add inline documentation comments to all top-level public APIs",
-      "description": "As an API consumer, I want every public type and function in apps/ios/SoloCompass to have at least a single-line doc comment.",
-      "acceptanceCriteria": [
-        "For every `public class/struct/enum/protocol/func` in Models/, Services/, ViewModels/, that lacks a /// comment, add one (one or two lines, explain purpose not mechanism)",
-        "Skip Views/ (SwiftUI views document themselves via #Preview)",
-        "Add a Swift script-test that fails if any public symbol in the listed directories lacks a doc comment (use regex over compiled symbols or grep)",
-        "Existing tests pass",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 55,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-056",
-      "title": "RouteCard — add stop-strip breadcrumb (CompareCanvas A-001)",
-      "description": "As a user browsing routes, I want a visual breadcrumb of stops on each route card so I can preview the journey at a glance.",
-      "acceptanceCriteria": [
-        "Views/Companion/Components/RouteCard.swift — render a horizontal strip of colored discs (one per stop, color from CategoryVisual) connected by 1px CT.fgSubtle connectors; matches design-truth in /tmp/compare_design/solocompassapp/project/route.jsx's `stop-strip` block",
-        "All colors come from CT.* tokens — no Color.accentColor or failable hex",
-        "Add RouteCardStopStripTest snapshotting cards with 2, 3, and 5 stops",
-        "Existing RouteCard tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: route cards in BottomInfoSheet show the stop-strip"
-      ],
-      "priority": 56,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-057",
-      "title": "RouteCard — add recruit-mini inline state (CompareCanvas A-002)",
-      "description": "As a user with companion mode on, I want each route card to show the recruiting state inline (host / N filled out of M / departure label) without opening detail.",
-      "acceptanceCriteria": [
-        "Views/Companion/Components/RouteCard.swift — when route.companion != nil AND status is open/forming/closed/completed, render an inline strip below the title showing: host avatar + `<handle> 招募 · N/M · <departure>` (open/forming) or `已成团 · N 人 · 出发中` (closed) or `已完成 · 路线升级` (completed)",
-        "Uses CT.* tokens; tone color per status — green for completed, accent for open, amber for forming",
-        "Add RouteCardRecruitMiniTest snapshotting all four status variants",
-        "Existing RouteCard tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: route cards in the recruiting demo show the inline strip with the correct status"
-      ],
-      "priority": 57,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "US-058",
-      "title": "RouteCard — add walked-by row (CompareCanvas A-003) and migrate to CT tokens",
-      "description": "As a user browsing routes, I want to see how many travelers walked this route (with avatar stack) so I can gauge social proof.",
-      "acceptanceCriteria": [
-        "Views/Companion/Components/RouteCard.swift — when companionOn is false OR route.companion is nil, render a walked-by row with AvatarStack(maxVisible: 4) + `<count> 位旅人走过` + chevron",
-        "AvatarStack uses CT.fgSubtle ring (current default) on a CT.bgWarm-or-white background — confirm no Color.accentColor or failable hex remains anywhere in RouteCard",
-        "Add RouteCardWalkedByTest snapshotting with 0, 3, and 12 walkers (the +N more case)",
-        "Existing RouteCard tests pass",
-        "Typecheck passes",
-        "Tests pass",
-        "Verify in iPhone 17 Pro Simulator: route cards in the recruiting demo show walked-by row with stacked avatars"
-      ],
-      "priority": 58,
       "passes": false,
       "notes": ""
     }

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -1,19 +1,4 @@
 # Solo Compass — Ralph Progress Log
 Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)
-Target: ralph/full-fix-roadmap-58us
+Target: ralph/nowscore-v1-10us
 Tool: claude
-
-## Codebase Patterns
-- 权威 prd.json 是【仓库根 prd.json】，不是 scripts/ralph/prd.json。ralph.sh:21 `PRD_FILE="$SCRIPT_DIR/../../prd.json"` 读的是根；scripts/ralph/prd.json 只是低优先级副本。改 prd.json 务必改根（或两者同步），改完用 `python3 -c "import json;json.load(open('prd.json'))"` 在【根路径】回读验证。
-- 通用约定：写任何被脚本读取的配置/数据文件（prd.json/config/.env）前，先 grep 出消费它的代码，以代码里的字面量路径为准，不要凭目录结构猜；写完用消费方路径回读确认。
-- 2026-05-29 记录：根 prd.json 与 scripts/ralph/prd.json 字节数曾不一致（55552 vs 55084），疑似只更新了一个 → 以根为准、保持两者同步。
-
-[2026-05-29T05:16:32Z] Story #US-001: Replace 6 route.companion! force-unwraps with safe binding — PASSED
-[2026-05-29T05:57:07Z] Story #US-002: SyncService.enqueue must report encode failures to Sentry — FAILED (iteration 2)
-[2026-05-29T06:01:59Z] Story #US-002: SyncService.enqueue must report encode failures to Sentry — PASSED
-[2026-05-29T06:12:13Z] Story #US-003: Add AISynthesisQuality state to AIService — PASSED
-[2026-05-29T06:24:46Z] Story #US-004: Add SkeletonBadgeView component (transparency pill) — PASSED
-[2026-05-29T06:52:15Z] Story #US-005: Remove AnyView wrapper from CompassMapView.body — FAILED (iteration 4)
-[2026-05-29T06:55:00Z] Story #US-005: Remove AnyView wrapper from CompassMapView.body — PASSED (build + tests green, simulator verified no regression)
-[2026-05-29T06:56:54Z] Story #US-005: Remove AnyView wrapper from CompassMapView.body — PASSED
-[2026-05-29T07:24:51Z] Story #US-006: BottomInfoSheet drag handle hit target ≥ 44pt — FAILED (iteration 6)


### PR DESCRIPTION
## Summary

把 PR #298 的 \`tasks/prd-now-score-v1.md\` (10 US) 转成 Ralph autonomous loop 执行队列，让 \`./ralph.sh\` 能直接驱动 NowScore v1 实现。

**⚠️ 这个 PR 覆盖了根 \`prd.json\` 当前的 58-US 队列**——用户明确选择 "覆盖当前 prd.json (中断 58-US batch)"。58-US 状态已归档：\`scripts/ralph/archive/2026-05-29-full-fix-roadmap-58us-snapshot/\`

## Pipeline

| 文件 | 改动 | 说明 |
|---|---|---|
| \`prd.json\` (根) | 改写 | NowScore 10 US 队列（ralph.sh:21 读这里） |
| \`scripts/ralph/prd.json\` | 改写 | 镜像；与根 md5 一致 |
| \`scripts/ralph/progress.txt\` | 重置 | Fresh header for ralph/nowscore-v1-10us |
| \`scripts/ralph/archive/2026-05-29-full-fix-roadmap-58us-snapshot/\` | 新增 | 旧 58-US 队列 + progress 快照（main 状态 5/58 PASSED） |

## US 编排（依赖顺序）

| US | 主题 |
|---|---|
| 001 | NowScore value type + Experience.nowScore(at:) |
| 002 | NowSignal 协议 + BestTimes/HourOfDay 内置信号 |
| 003 | WeatherService + 12h SwiftData 缓存 |
| 004 | NowScoreEngine 离线降级 + Sentry 上报 |
| 005 | WeatherSignal 实现 |
| 006 | SolarEvents + SunsetSignal |
| 007 | BestNowBadge reason 副标题 |
| 008 | MapViewModel.nowCount + markerState 排序接入 |
| 009 | Filter "Now" 渐变高亮 |
| 010 | p95 < 5ms 性能保障 |

## Validation

\`\`\`
branchName: ralph/nowscore-v1-10us
US count: 10
unique priorities: 10
all passes=false: 10/10
all have Typecheck AC: 10/10
md5 root vs scripts/ralph: 183fdf8ecc34df188cdbb8f81c9ff71f (matches)
anti-pattern-lint: clean ✓
\`\`\`

## 与 58-US 的协调

main 上 58-US prd.json 已被 archive；**Linux 上正在跑的 ralph 不受影响**——它在本地 working tree，本 PR merge 不会影响那边。但下次启动 ralph：
- **方案 A（推荐）**：Linux 跑完手头的 US 后 push（PR #297），再 \`git pull\` + 重启 ralph 进入 NowScore 队列
- **方案 B**：Linux 立刻 stash + pull + 重启 ralph

US-NS-008 与 prd-full-fix-roadmap.md 的 US-P1-003 都改 \`MapViewModel.nowCount\`——建议 PR #297 (含 US-P1-003) 先 merge，本 PRD 在 main 上 rebase 之后跑。

## Test plan

- [ ] CI typecheck + lint + format pass
- [ ] Reviewer 抽样看 3 个 US（建议 001 / 003 / 006），确认 AC 可单 iteration 完成、grep 锚点真实
- [ ] 决策：本 PR merge 时是否同步通知 Linux ralph 进程切换队列
- [ ] PR #298 (PRD doc) 也需要被 review；本 PR 是它的可执行版

## Related

- PR #298 — \`tasks/prd-now-score-v1.md\` PRD 文档（本 prd.json 的源）
- PR #297 — 58-US Phase 1 (含 US-P1-003 nowCount cache，与本 PRD US-008 冲突点)
- Issue #296 — Ralph Linux 接力流程