### PR TITLE
auto: Route LocationCard haptics through the centralized Haptics helper

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/LocationCard.swift
+++ b/apps/ios/SoloCompass/Views/Experience/LocationCard.swift
@@ -76,7 +76,7 @@ struct LocationCard: View {
                 // US-010: Primary navigate button with gradient; 44pt HIG minimum
                 Button {
                     isShowingPicker = true
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    Haptics.impact(.light)
                 } label: {
                     Label(
                         NSLocalizedString("location.navigate", comment: "Open external navigation app"),
@@ -100,7 +100,7 @@ struct LocationCard: View {
                 // US-010: Ghost copy button — icon only, no fill
                 Button {
                     UIPasteboard.general.string = "\(coordinate.latitude), \(coordinate.longitude)"
-                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                    Haptics.notify(.success)
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                         didCopy = true
                     }


### PR DESCRIPTION
## Route LocationCard haptics through the centralized Haptics helper

LocationCard's Navigate and Copy buttons fire haptics via raw UIImpactFeedbackGenerator/UINotificationFeedbackGenerator, bypassing the centralized Haptics enum. This means those taps still buzz when the user has Reduce Motion enabled (the app's proxy for haptic-reduction intent) and skip the Taptic Engine pre-warm that every other view gets. Replacing the two raw calls with Haptics.impact(.light) and Haptics.notify(.success) restores accessibility consistency and low-latency firing.

### Acceptance
Build succeeds via `xcodebuild build -scheme SoloCompass`. With Reduce Motion OFF, tapping Navigate gives a light impact and tapping Copy gives a success notification haptic (unchanged feel). With Reduce Motion ON (Settings > Accessibility > Motion), neither button produces haptic feedback, matching the rest of the app. No remaining raw UIImpactFeedbackGenerator/UINotificationFeedbackGenerator references in LocationCard.swift.