### PR TITLE
auto: Empty-filter state banner on the map

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -160,6 +160,14 @@
 "solo.a11y" = "Solo Score %@ of 10";
 "solo.excellent.a11y" = "Excellent for solo travelers";
 
+/* Empty filter banner (below FilterBarView) */
+"filter.empty.title" = "No matches";
+"filter.empty.message" = "Nothing matches \"%@\" in this area.";
+"filter.empty.showAll" = "Show all";
+"filter.empty.title.a11y" = "No matches for %@";
+"filter.empty.message.a11y" = "Nothing matches the active filter in this area. Double tap Show all to reset.";
+"filter.empty.showAll.a11y" = "Show all experiences";
+
 /* Map empty / loading */
 "map.empty.title" = "No experiences nearby";
 "map.empty.hint" = "Try clearing filters or moving the map.";

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -786,9 +786,21 @@ private struct MapOverlayView: View {
     @Binding var isMapPanning: Bool
 
     @State private var checkInCelebrationTrigger = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var isFilterActive: Bool {
         viewModel.selectedCategory != nil || viewModel.selectedCustomTag != nil || viewModel.isNowFilter
+    }
+
+    private var activeFilterName: String {
+        if let category = viewModel.selectedCategory {
+            return category.localizedTitle
+        } else if let tag = viewModel.selectedCustomTag {
+            return tag
+        } else if viewModel.isNowFilter {
+            return NSLocalizedString("filter.now", comment: "Now filter label")
+        }
+        return ""
     }
 
     var body: some View {
@@ -813,6 +825,21 @@ private struct MapOverlayView: View {
                 resultCount: viewModel.visibleExperiences.count
             )
             .padding(.top, 4)
+
+            let showEmptyFilterBanner = isFilterActive && viewModel.visibleExperiences.isEmpty
+            if showEmptyFilterBanner {
+                EmptyFilterBanner(
+                    filterName: activeFilterName,
+                    onShowAll: {
+                        viewModel.clearFilters()
+                    }
+                )
+                .padding(.top, 2)
+                .transition(reduceMotion
+                    ? .opacity
+                    : .move(edge: .top).combined(with: .opacity)
+                )
+            }
 
             if isFilterActive {
                 filterResultBadge
@@ -961,6 +988,7 @@ private struct MapOverlayView: View {
         }
         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isFilterActive)
         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: viewModel.visibleExperiences.count)
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: viewModel.visibleExperiences.isEmpty && isFilterActive)
     }
 
     @ViewBuilder
@@ -1126,6 +1154,65 @@ private struct MapOverlayView: View {
         }
         .accessibilityLabel(Text(cityName))
         .accessibilityHint(Text(NSLocalizedString("city.picker.title", comment: "City picker sheet title")))
+    }
+}
+
+private struct EmptyFilterBanner: View {
+    let filterName: String
+    let onShowAll: () -> Void
+
+    var body: some View {
+        GlassmorphismCapsule(
+            horizontalPadding: 12,
+            verticalPadding: 8,
+            shadowRadius: 6,
+            shadowY: 3
+        ) {
+            HStack(spacing: 8) {
+                Image(systemName: "line.3.horizontal.decrease.circle")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text(String(
+                    format: NSLocalizedString("filter.empty.message", comment: "No experiences match filter name"),
+                    filterName
+                ))
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                Spacer(minLength: 4)
+                Button {
+                    UISelectionFeedbackGenerator().selectionChanged()
+                    onShowAll()
+                } label: {
+                    Text(NSLocalizedString("filter.empty.showAll", comment: "Show all experiences button"))
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Color.accentColor)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Text(NSLocalizedString("filter.empty.showAll.a11y", comment: "Show all experiences")))
+            }
+        }
+        .padding(.horizontal, 16)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(String(
+            format: NSLocalizedString("filter.empty.title.a11y", comment: "VoiceOver: no matches for filter"),
+            filterName
+        )))
+        .accessibilityHint(Text(NSLocalizedString("filter.empty.message.a11y", comment: "VoiceOver hint for empty filter banner")))
+        .onAppear {
+            guard UIAccessibility.isVoiceOverRunning else { return }
+            let message = String(
+                format: NSLocalizedString("filter.empty.title.a11y", comment: "VoiceOver: no matches for filter"),
+                filterName
+            )
+            UIAccessibility.post(
+                notification: .announcement,
+                argument: NSAttributedString(
+                    string: message,
+                    attributes: [.accessibilitySpeechQueueAnnouncement: true]
+                )
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Empty-filter state banner on the map

When an active filter (category, Now, or custom tag) matches zero visible experiences, the map currently goes blank with no explanation. Add a lightweight, auto-appearing banner that names the active filter, explains there are no matches in view, and offers a one-tap 'Show all' reset — closing a confusing dead-end in the core map flow.

### Acceptance
Selecting a filter that has no experiences in the current map view shows the banner within one animation frame; tapping 'Show all' clears the filter, dismisses the banner, and repopulates pins. The banner never appears when results > 0 or when no filter is active. VoiceOver announces the empty state on appearance and the 'Show all' control is reachable. Reduce Motion replaces the slide with a fade. `xcodebuild build` and existing FilterBarView/MapViewModel tests pass.