### PR TITLE
auto: Add a 'Post your availability' CTA to the Discover empty state

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -811,6 +811,8 @@
 "companion.discover.empty.title" = "No companions found";
 "companion.discover.empty.description" = "No one is open to companions in this city right now.";
 "companion.discover.coldstart.tip" = "Be the first — open your itinerary to companions and others will find you.";
+"companion.discover.empty.cta" = "Be the first — post your trip";
+"companion.discover.empty.cta.hint" = "Opens a form to post your trip availability for this city";
 
 /* Companion — send request (US-012) */
 "companion.request.send" = "Send request";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -649,6 +649,8 @@
 "companion.discover.empty.title" = "暂无同伴";
 "companion.discover.empty.description" = "这座城市目前没有公开找同伴的旅行者。";
 "companion.discover.coldstart.tip" = "试着发一条自己的同伴帖,让其他人发现你。";
+"companion.discover.empty.cta" = "抢先发布 — 分享你的行程";
+"companion.discover.empty.cta.hint" = "打开表单，发布你在这座城市的出行时间";
 
 /* ============================================================
  * Request inbox (RequestInboxView)

--- a/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
@@ -71,19 +71,7 @@ public struct DiscoverListView: View {
             }
         }
         .sheet(isPresented: $showPostSheet) {
-            OpenForCompanionsSheet(itinerary: Itinerary(
-                id: ItineraryId(rawValue: "discover_cta_\(cityCode)"),
-                ownerId: DeviceIdentityService.shared.deviceID,
-                title: cityCode,
-                cityCode: cityCode,
-                startDate: "",
-                endDate: "",
-                experienceIds: [],
-                note: nil,
-                openToCompanions: true,
-                createdAt: "",
-                updatedAt: ""
-            ))
+            OpenForCompanionsSheet(itinerary: Self.newAvailabilityItinerary(cityCode: cityCode))
         }
         .sheet(item: $reportTarget) { post in
             ReportBlockSheet(
@@ -167,6 +155,30 @@ public struct DiscoverListView: View {
     }
 
     // MARK: - Actions
+
+    private static func newAvailabilityItinerary(cityCode: String) -> Itinerary {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd"
+        fmt.timeZone = TimeZone(identifier: "UTC")
+        let now = Date()
+        let startDate = fmt.string(from: now)
+        let endDate = fmt.string(from: now.addingTimeInterval(86400 * 7))
+        let isoFmt = ISO8601DateFormatter()
+        let ts = isoFmt.string(from: now)
+        return Itinerary(
+            id: ItineraryId(rawValue: "cta_\(cityCode)_\(UUID().uuidString)"),
+            ownerId: DeviceIdentityService.shared.deviceID,
+            title: cityCode,
+            cityCode: cityCode,
+            startDate: startDate,
+            endDate: endDate,
+            experienceIds: [],
+            note: nil,
+            openToCompanions: true,
+            createdAt: ts,
+            updatedAt: ts
+        )
+    }
 
     private func loadPosts() async {
         Haptics.impact(.light)

--- a/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
@@ -15,6 +15,7 @@ public struct DiscoverListView: View {
     @State private var requestSentPostId: String?
     @State private var reportTarget: DiscoverPost?
     @State private var errorMessage: String?
+    @State private var showPostSheet = false
 
     public init(cityCode: String, service: CompanionService = .shared) {
         self.cityCode = cityCode
@@ -69,6 +70,21 @@ public struct DiscoverListView: View {
                 Task { await sendRequest(to: post, note: note) }
             }
         }
+        .sheet(isPresented: $showPostSheet) {
+            OpenForCompanionsSheet(itinerary: Itinerary(
+                id: ItineraryId(rawValue: "discover_cta_\(cityCode)"),
+                ownerId: DeviceIdentityService.shared.deviceID,
+                title: cityCode,
+                cityCode: cityCode,
+                startDate: "",
+                endDate: "",
+                experienceIds: [],
+                note: nil,
+                openToCompanions: true,
+                createdAt: "",
+                updatedAt: ""
+            ))
+        }
         .sheet(item: $reportTarget) { post in
             ReportBlockSheet(
                 targetUserId: post.id,
@@ -120,11 +136,19 @@ public struct DiscoverListView: View {
         } description: {
             Text(NSLocalizedString("companion.discover.empty.description", comment: "No companions found description"))
         } actions: {
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(spacing: 16) {
                 Text(NSLocalizedString("companion.discover.coldstart.tip", comment: "Cold start tip"))
                     .font(.footnote)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
+                Button {
+                    Haptics.impact(.light)
+                    showPostSheet = true
+                } label: {
+                    Text(NSLocalizedString("companion.discover.empty.cta", comment: "Post your availability CTA"))
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityHint(NSLocalizedString("companion.discover.empty.cta.hint", comment: "Post your availability accessibility hint"))
             }
         }
     }


### PR DESCRIPTION
## Add a 'Post your availability' CTA to the Discover empty state

The companion Discover screen's empty state currently shows only a passive cold-start tip text, leaving travelers at a dead-end when no companions are listed for their city. Since an `OpenForCompanionsSheet` already exists, wiring an actionable button into the empty state turns the most common cold-start moment into a conversion path that lets the user be the first to post their availability.

### Acceptance
Building the SoloCompass scheme succeeds. In the Simulator, opening Discover for a city with no companion posts shows the empty state with a tappable 'post your trip' button that presents OpenForCompanionsSheet; tapping triggers a light haptic. Both en and zh-Hans have the new string keys (no raw key fallback visible). Reduce Motion and VoiceOver: button is reachable with a descriptive label/hint. No force-unwraps; no @Model/schema files touched.