### PR TITLE
auto: Wrap the experience-card pill row so it survives large Dynamic Type

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -201,7 +201,7 @@ public struct ExperienceCardView: View {
                 SkeletonBadgeView()
             }
 
-            HStack {
+            FlowLayout(spacing: 8) {
                 SoloScoreBadge(score: experience.soloScore, style: .compact)
                 Group {
                     if isArrived {
@@ -220,7 +220,6 @@ public struct ExperienceCardView: View {
                 } else if let hint = experience.bestTimeHint() {
                     bestTimeHintPill(hint)
                 }
-                Spacer()
                 if let coord = experience.coordinate {
                     directionsControl(coordinate: coord)
                 }
@@ -532,6 +531,31 @@ private struct BestNowBadge: View {
         .environment(UserPreferences(defaults: UserDefaults(suiteName: "preview")!))
         .environment(locationService)
         .environment(AIService()))
+    } else {
+        return AnyView(Text("No seed data"))
+    }
+}
+
+#Preview("Accessibility3 — pills wrap") {
+    if let exp = ExperienceService.hardcodedSeed.first {
+        let locationService = LocationService()
+        if let coord = exp.coordinate {
+            let offset = CLLocation(latitude: coord.latitude + 0.00027, longitude: coord.longitude)
+            locationService.simulate(location: offset)
+        }
+        return AnyView(VStack {
+            Spacer()
+            ExperienceCardView(
+                experience: exp,
+                onExpand: {},
+                onDismiss: {}
+            )
+        }
+        .background(Color(red: 0xF5/255, green: 0xF0/255, blue: 0xE8/255))
+        .environment(UserPreferences(defaults: UserDefaults(suiteName: "preview-a11y")!))
+        .environment(locationService)
+        .environment(AIService())
+        .environment(\.dynamicTypeSize, .accessibility3))
     } else {
         return AnyView(Text("No seed data"))
     }

--- a/apps/ios/SoloCompass/Views/Shared/FlowLayout.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FlowLayout.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// A SwiftUI `Layout` that places subviews left-to-right, wrapping to a new
+/// row when the next item would exceed the available width.
+public struct FlowLayout: Layout {
+    /// Horizontal and vertical spacing between items.
+    var spacing: CGFloat
+
+    public init(spacing: CGFloat = 8) {
+        self.spacing = spacing
+    }
+
+    public func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = (proposal.width.flatMap { $0.isFinite ? $0 : nil }) ?? .greatestFiniteMagnitude
+        var totalHeight: CGFloat = 0
+        var rowWidth: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var isFirstInRow = true
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            let neededWidth = isFirstInRow ? size.width : rowWidth + spacing + size.width
+
+            if !isFirstInRow && neededWidth > maxWidth {
+                // Wrap: commit current row and start a new one.
+                totalHeight += rowHeight + spacing
+                rowWidth = size.width
+                rowHeight = size.height
+            } else {
+                rowWidth = isFirstInRow ? size.width : rowWidth + spacing + size.width
+                rowHeight = max(rowHeight, size.height)
+                isFirstInRow = false
+            }
+        }
+        // Commit the final row.
+        totalHeight += rowHeight
+
+        return CGSize(width: maxWidth == .greatestFiniteMagnitude ? rowWidth : maxWidth,
+                      height: totalHeight)
+    }
+
+    public func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+        var isFirstInRow = true
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+
+            if !isFirstInRow && x + size.width > bounds.maxX {
+                // Wrap to next row.
+                y += rowHeight + spacing
+                x = bounds.minX
+                rowHeight = 0
+            }
+
+            subview.place(at: CGPoint(x: x, y: y), proposal: .unspecified)
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+            isFirstInRow = false
+        }
+    }
+}
+
+#Preview("FlowLayout wrapping") {
+    FlowLayout(spacing: 8) {
+        ForEach(["Short", "A bit longer", "Tiny", "Medium label", "Another", "Wrap me"], id: \.self) { text in
+            Text(text)
+                .font(.caption)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Capsule().fill(Color.secondary.opacity(0.15)))
+        }
+    }
+    .padding()
+    .frame(width: 200)
+}

--- a/apps/ios/SoloCompass/Views/Shared/FlowLayout.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FlowLayout.swift
@@ -26,6 +26,7 @@ public struct FlowLayout: Layout {
                 totalHeight += rowHeight + spacing
                 rowWidth = size.width
                 rowHeight = size.height
+                isFirstInRow = true
             } else {
                 rowWidth = isFirstInRow ? size.width : rowWidth + spacing + size.width
                 rowHeight = max(rowHeight, size.height)


### PR DESCRIPTION
## Wrap the experience-card pill row so it survives large Dynamic Type

In ExperienceCardView the metadata row (Solo Score + distance/bearing + best-now/inconvenience + directions + 'View Details') is a single non-wrapping HStack, so at large accessibility text sizes the pills clip or shove the 'View Details' button off-screen. Add a lightweight FlowLayout that wraps pills onto multiple lines when horizontal space runs out, keeping every pill and the details affordance reachable.

### Acceptance
At default text size the card looks identical to today (pills on one row). At Dynamic Type sizes .xxxLarge through .accessibility5 the pills wrap onto additional lines with no clipping and the 'View Details' control stays fully visible and tappable. Reduce Motion behavior and all existing VoiceOver labels/actions are unchanged. `xcodebuild build` and the SoloCompassTests suite pass; the new #Preview renders wrapped pills under accessibility3.