### PR TITLE
auto: Swipe-to-navigate action on favorite rows

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -367,6 +367,7 @@
 "favorites.proximity.near" = "walkable";
 "favorites.proximity.mid" = "short ride";
 "favorites.proximity.far" = "far";
+"favorites.row.directions" = "Directions";
 
 /* Generic actions */
 "action.undo" = "Undo";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -511,6 +511,38 @@ private extension FavoritesListView {
                       systemImage: "heart.slash")
             }
         }
+        .modifier(DirectionsSwipeModifier(exp: exp))
+        .accessibilityAction(named: Text(NSLocalizedString("favorites.row.directions", comment: "Directions accessibility action"))) {
+            guard let coord = exp.coordinate,
+                  let app = NavigationLauncher.availableApps().first else { return }
+            Haptics.impact(.light)
+            NavigationLauncher.open(app: app, coordinate: coord, name: exp.title)
+        }
+    }
+}
+
+private struct DirectionsSwipeModifier: ViewModifier {
+    let exp: Experience
+
+    func body(content: Content) -> some View {
+        let coord = exp.coordinate
+        let firstApp = NavigationLauncher.availableApps().first
+        if let coord, let app = firstApp {
+            content.swipeActions(edge: .leading, allowsFullSwipe: true) {
+                Button {
+                    Haptics.impact(.light)
+                    NavigationLauncher.open(app: app, coordinate: coord, name: exp.title)
+                } label: {
+                    Label(
+                        NSLocalizedString("favorites.row.directions", comment: "Directions swipe action"),
+                        systemImage: "arrow.triangle.turn.up.right.diamond.fill"
+                    )
+                }
+                .tint(.accentColor)
+            }
+        } else {
+            content
+        }
     }
 }
 


### PR DESCRIPTION
## Swipe-to-navigate action on favorite rows

Each favorite row shows distance but offers no quick way to start navigation — users must open the detail view to find the directions control. Add a leading swipe action that opens the user's preferred maps app directly from the list, mirroring the existing trailing unfavorite swipe and reusing the app's NavigationLauncher. This turns the Favorites list into an actionable 'where to next' shortlist for a solo traveler standing on a street corner.

### Acceptance
Swiping a favorite row from the leading edge reveals a tinted 'Directions' action that, on tap (or full swipe), launches the preferred maps app to that experience's coordinate with a light haptic; rows lacking a coordinate or with no installed nav app show no leading action; VoiceOver exposes an equivalent 'Directions' custom action; the project builds via xcodebuild and existing FavoritesListView tests pass.