### PR TITLE
auto: Auto-scroll the filter bar to reveal the active pill

### DIFF
--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -83,34 +83,48 @@ public struct FilterBarView: View {
 
     public var body: some View {
         GlassmorphismCapsule(horizontalPadding: 0, verticalPadding: 0) {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    nowPill(isSelected: isNowSelected, action: onSelectNow)
-                    pill(
-                        id: "all",
-                        label: NSLocalizedString("filter.all", comment: "All"),
-                        isSelected: !isNowSelected && selectedCategory == nil && selectedCustomTag == nil,
-                        color: Color.primary,
-                        action: onSelectAll
-                    )
-                    ForEach(visibleCategories) { category in
-                        iconPill(
-                            category: category,
-                            isSelected: selectionID == category.rawValue,
-                            action: { onSelectCategory(category) }
+            ScrollViewReader { proxy in
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        nowPill(isSelected: isNowSelected, action: onSelectNow)
+                            .id("now")
+                        pill(
+                            id: "all",
+                            label: NSLocalizedString("filter.all", comment: "All"),
+                            isSelected: !isNowSelected && selectedCategory == nil && selectedCustomTag == nil,
+                            color: Color.primary,
+                            action: onSelectAll
                         )
+                        .id("all")
+                        ForEach(visibleCategories) { category in
+                            iconPill(
+                                category: category,
+                                isSelected: selectionID == category.rawValue,
+                                action: { onSelectCategory(category) }
+                            )
+                            .id(category.rawValue)
+                        }
+                        ForEach(preferences.customTags, id: \.self) { tag in
+                            customTagPill(
+                                tag: tag,
+                                isSelected: selectionID == "tag-\(tag)",
+                                action: { onSelectCustomTag(tag) }
+                            )
+                            .id("tag-\(tag)")
+                        }
                     }
-                    ForEach(preferences.customTags, id: \.self) { tag in
-                        customTagPill(
-                            tag: tag,
-                            isSelected: selectionID == "tag-\(tag)",
-                            action: { onSelectCustomTag(tag) }
-                        )
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .animation(.spring(response: 0.4, dampingFraction: 0.75), value: selectionID)
+                }
+                .onAppear {
+                    proxy.scrollTo(selectionID, anchor: .center)
+                }
+                .onChange(of: selectionID) { _, id in
+                    withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.3)) {
+                        proxy.scrollTo(id, anchor: .center)
                     }
                 }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-                .animation(.spring(response: 0.4, dampingFraction: 0.75), value: selectionID)
             }
         }
         .padding(.horizontal, 16)


### PR DESCRIPTION
## Auto-scroll the filter bar to reveal the active pill

In FilterBarView the horizontal pill row can overflow off-screen once the user adds categories and custom tags, so a selection made programmatically (e.g. via voice command or a deep link) or a previously-scrolled-away pill stays hidden — the user sees no visible feedback that their filter applied. Wrap the pill HStack in a ScrollViewReader and scroll the currently-selected pill into view whenever selectionID changes, giving immediate spatial confirmation of which filter is active.

### Acceptance
Selecting a category/tag/Now pill that is partially or fully off-screen smoothly scrolls it to center; with VoiceOver/Reduce Motion enabled the pill jumps into view without animation; on first appearance a restored non-default selection is already centered; existing matchedGeometryEffect highlight, count badges, and press animations are unchanged; iOS target builds and FilterBarView previews render correctly.