### PR TITLE
auto: Milestone celebration: surface completion-count milestones in CompletionCelebrationView

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -95,6 +95,8 @@
 
 /* Celebration */
 "celebration.complete.a11y" = "Experience completed";
+"celebration.milestone.first" = "Your 1st experience!";
+"celebration.milestone.count" = "%d explored";
 
 /* Actions */
 "action.markDone" = "Mark done";

--- a/apps/ios/SoloCompass/ViewModels/ExperienceDetailViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/ExperienceDetailViewModel.swift
@@ -87,6 +87,10 @@ public final class ExperienceDetailViewModel {
         )
     }
 
+    /// Count of all completed experiences after the last toggleComplete() call.
+    /// Updated synchronously inside toggleComplete so callers can read it immediately.
+    public private(set) var completedCount: Int = 0
+
     public func toggleComplete() {
         if isCompleted {
             preferences.completedExperiences.remove(experience.id)
@@ -98,6 +102,7 @@ public final class ExperienceDetailViewModel {
             visitCount += 1
             isCompleted = true
         }
+        completedCount = preferences.completedExperiences.count
     }
 
     public func toggleFavorite() {

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -30,6 +30,7 @@ public struct ExperienceDetailView: View {
     @State private var exportMarkdown: String? = nil
     @State private var heartPop = false
     @State private var celebrationTrigger = 0
+    @State private var celebrationMilestone: Int? = nil
     @State private var isShowingNavPicker = false
     @State private var isShowingAddToItinerary = false
     @State private var heroTitleVisible: Bool = true
@@ -1019,6 +1020,8 @@ public struct ExperienceDetailView: View {
                 let wasCompleted = viewModel.isCompleted
                 viewModel.toggleComplete()
                 if !wasCompleted {
+                    let count = viewModel.completedCount
+                    celebrationMilestone = (count == 1 || count % 5 == 0) ? count : nil
                     celebrationTrigger += 1
                     onMarkDone?(viewModel.experience)
                 } else {
@@ -1073,7 +1076,7 @@ public struct ExperienceDetailView: View {
             Button(NSLocalizedString("action.cancel", comment: "Cancel picker"), role: .cancel) { }
         }
 
-        CompletionCelebrationView(trigger: celebrationTrigger)
+        CompletionCelebrationView(trigger: celebrationTrigger, milestone: celebrationMilestone)
             .frame(maxWidth: .infinity)
             .offset(y: -28)
         }

--- a/apps/ios/SoloCompass/Views/Shared/CompletionCelebrationView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/CompletionCelebrationView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// Respects Reduce Motion: skips particles, only shows the checkmark pop.
 public struct CompletionCelebrationView: View {
     let trigger: Int
+    var milestone: Int? = nil
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -23,6 +24,7 @@ public struct CompletionCelebrationView: View {
     @State private var particles: [Particle] = []
     @State private var animated = false
     @State private var checkmarkPop = false
+    @State private var milestoneVisible = false
 
     private static let palette: [Color] = ExperienceCategory.allCases.map(\.color)
 
@@ -61,6 +63,25 @@ public struct CompletionCelebrationView: View {
                 .scaleEffect(checkmarkPop ? 1.0 : 0.01)
                 .opacity(checkmarkPop ? 1.0 : 0.0)
                 .symbolEffect(.bounce, value: checkmarkPop)
+
+            if let count = milestone {
+                let label = count == 1
+                    ? NSLocalizedString("celebration.milestone.first", comment: "First experience milestone")
+                    : String(format: NSLocalizedString("celebration.milestone.count", comment: "Nth experience milestone"), count)
+                Text(label)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(.thinMaterial, in: Capsule())
+                    .offset(y: 36)
+                    .scaleEffect(reduceMotion ? 1.0 : (milestoneVisible ? 1.0 : 0.5))
+                    .opacity(milestoneVisible ? 1.0 : 0.0)
+                    .animation(
+                        reduceMotion ? .none : .spring(response: 0.35, dampingFraction: 0.6),
+                        value: milestoneVisible
+                    )
+            }
         }
         .allowsHitTesting(false)
         .onChange(of: trigger) { _, _ in
@@ -88,6 +109,7 @@ public struct CompletionCelebrationView: View {
         }
         animated = false
         checkmarkPop = false
+        milestoneVisible = false
 
         #if canImport(UIKit)
         Haptics.notify(.success)
@@ -98,10 +120,27 @@ public struct CompletionCelebrationView: View {
                 attributes: [.accessibilitySpeechQueueAnnouncement: true]
             )
         )
+        if let count = milestone {
+            let milestoneText = count == 1
+                ? NSLocalizedString("celebration.milestone.first", comment: "First experience milestone")
+                : String(format: NSLocalizedString("celebration.milestone.count", comment: "Nth experience milestone"), count)
+            UIAccessibility.post(
+                notification: .announcement,
+                argument: NSAttributedString(
+                    string: milestoneText,
+                    attributes: [.accessibilitySpeechQueueAnnouncement: true]
+                )
+            )
+        }
         #endif
 
         withAnimation(.spring(response: 0.15, dampingFraction: 0.6)) {
             checkmarkPop = true
+        }
+        if milestone != nil {
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.6)) {
+                milestoneVisible = true
+            }
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
             Haptics.impact(.soft)
@@ -117,6 +156,9 @@ public struct CompletionCelebrationView: View {
             particles = []
             animated = false
             checkmarkPop = false
+            withAnimation(.easeOut(duration: 0.2)) {
+                milestoneVisible = false
+            }
         }
     }
 }


### PR DESCRIPTION
## Milestone celebration: surface completion-count milestones in CompletionCelebrationView

When a user marks an experience complete, the confetti burst is identical every time and never acknowledges their growing journey. This adds a brief milestone banner ("Your 1st experience!", "5 experiences explored", "10!") that fades in above the checkmark on the 1st completion and every 5th thereafter, turning a generic animation into a personal moment of progress that reinforces the PHASES 'emotional weight' goal — using the already-persisted UserPreferences.completedExperiences count with no schema change.

### Acceptance
Marking an experience complete for the 1st time shows the confetti burst plus a 'Your 1st experience!' capsule that fades out with the burst; the 2nd–4th completions show only the normal burst (no capsule); the 5th and 10th show a '5 explored' / '10 explored' capsule. The capsule respects Reduce Motion (appears without scale animation, no particles), VoiceOver announces the milestone text, the iOS target builds via xcodebuild and existing tests pass.