### PR TITLE
auto: Add an actionable CTA to the Favorites empty state

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -345,6 +345,7 @@
 "favorites.title" = "Favorites";
 "favorites.empty.title" = "No favorites yet";
 "favorites.empty.hint" = "Tap the heart on any experience to save it here.";
+"favorites.empty.cta" = "Explore the map";
 "favorites.undo" = "Removed — Undo";
 "favorites.undo.named" = "Removed \"%@\"";
 /* Plural forms handled by Localizable.stringsdict */

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -505,11 +505,14 @@ public struct CompassMapView: View {
 
     @ViewBuilder
     private var favoritesSheetContent: some View {
-        FavoritesListView { exp in
-            isShowingFavorites = false
-            viewModel?.selectExperience(exp)
-            viewModel?.isShowingDetail = true
-        }
+        FavoritesListView(
+            onSelectExperience: { exp in
+                isShowingFavorites = false
+                viewModel?.selectExperience(exp)
+                viewModel?.isShowingDetail = true
+            },
+            onExplore: { isShowingFavorites = false }
+        )
         .environment(experienceService)
         .environment(preferences)
     }

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -11,6 +11,7 @@ public struct FavoritesListView: View {
     @Environment(LocationService.self) private var locationService
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let onSelectExperience: (Experience) -> Void
+    var onExplore: (() -> Void)? = nil
 
     @State private var lastUnfavorited: (id: String, title: String, date: Date)?
     @State private var undoDismissTask: Task<Void, Never>?
@@ -124,7 +125,7 @@ public struct FavoritesListView: View {
         NavigationStack {
             Group {
                 if sortedFavorites.isEmpty && lastUnfavorited == nil {
-                    EmptyFavoritesView()
+                    EmptyFavoritesView(onExplore: onExplore)
                         .transition(.scale(scale: 0.85).combined(with: .opacity))
                 } else if filteredFavorites.isEmpty {
                     NoSearchResultsView(query: searchText, onClear: { searchText = "" })
@@ -226,6 +227,8 @@ public struct FavoritesListView: View {
 }
 
 private struct EmptyFavoritesView: View {
+    var onExplore: (() -> Void)? = nil
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isBreathing = false
 
@@ -248,6 +251,17 @@ private struct EmptyFavoritesView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
+            if let onExplore {
+                Button {
+                    Haptics.selection()
+                    onExplore()
+                } label: {
+                    Label(NSLocalizedString("favorites.empty.cta", comment: "Explore the map button in empty favorites state"), systemImage: "map")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+                .padding(.top, 4)
+            }
         }
         .padding(32)
         .onAppear {


### PR DESCRIPTION
## Add an actionable CTA to the Favorites empty state

The FavoritesListView empty state currently tells users to 'tap the heart on any experience' but offers no way to act on it — it's a dead end. Add a prominent 'Explore the map' button that dismisses the sheet and returns the user to the map's home screen, turning a passive hint into a clear next step.

### Acceptance
With zero favorites, the empty state shows a tappable 'Explore the map' button that dismisses the Favorites sheet and returns to the map. Tapping it fires a selection haptic. When onExplore is nil (e.g. in #Preview) no button appears and the view compiles. The new string is localized via NSLocalizedString and present in en.lproj/Localizable.strings. Project still builds via xcodebuild and existing FavoritesListView call sites compile unchanged.