### PR TITLE
auto: Make the Haptics facade respect the user's haptic opt-out

### DIFF
--- a/apps/ios/SoloCompass/Services/HapticService.swift
+++ b/apps/ios/SoloCompass/Services/HapticService.swift
@@ -28,6 +28,7 @@ private extension ProcessInfo {
 
     private var impactGenerators: [UIImpactFeedbackGenerator.FeedbackStyle: UIImpactFeedbackGenerator] = [:]
     private let notificationGenerator = UINotificationFeedbackGenerator()
+    private let selectionGenerator = UISelectionFeedbackGenerator()
 
     private init() {}
 
@@ -58,6 +59,13 @@ private extension ProcessInfo {
         let gen = generator(for: style)
         gen.prepare()
         gen.impactOccurred()
+    }
+
+    /// Fire a selection-changed haptic.
+    public func selectionChanged() {
+        guard shouldFire() else { return }
+        selectionGenerator.prepare()
+        selectionGenerator.selectionChanged()
     }
 
     /// Fire a notification haptic.

--- a/apps/ios/SoloCompass/Services/Haptics.swift
+++ b/apps/ios/SoloCompass/Services/Haptics.swift
@@ -1,33 +1,19 @@
 #if canImport(UIKit)
 import UIKit
 
-/// Centralized haptic feedback helper.
-///
-/// Guards on `UIAccessibility.isReduceMotionEnabled` as the closest public
-/// proxy for the user's haptic-reduction intent (no separate "disable haptics"
-/// API is exposed on iOS). Calls `prepare()` before `impactOccurred()` /
-/// `notificationOccurred()` on the same instance so the Taptic Engine is
-/// pre-warmed for low-latency firing.
+/// Thin compatibility shim so existing call sites are unchanged but now obey
+/// `hapticsEnabled`, Reduce Motion, and preview suppression via `HapticService`.
 @MainActor enum Haptics {
     static func impact(_ style: UIImpactFeedbackGenerator.FeedbackStyle = .light) {
-        guard !UIAccessibility.isReduceMotionEnabled else { return }
-        let generator = UIImpactFeedbackGenerator(style: style)
-        generator.prepare()
-        generator.impactOccurred()
+        HapticService.shared.impact(style: style)
     }
 
     static func selection() {
-        guard !UIAccessibility.isReduceMotionEnabled else { return }
-        let generator = UISelectionFeedbackGenerator()
-        generator.prepare()
-        generator.selectionChanged()
+        HapticService.shared.selectionChanged()
     }
 
     static func notify(_ type: UINotificationFeedbackGenerator.FeedbackType) {
-        guard !UIAccessibility.isReduceMotionEnabled else { return }
-        let generator = UINotificationFeedbackGenerator()
-        generator.prepare()
-        generator.notificationOccurred(type)
+        HapticService.shared.notification(type: type)
     }
 }
 #endif

--- a/apps/ios/SoloCompass/Tests/HapticServiceTests.swift
+++ b/apps/ios/SoloCompass/Tests/HapticServiceTests.swift
@@ -59,4 +59,17 @@ final class HapticServiceTests: XCTestCase {
         HapticService.shared.prepare(style: .light)
         // No crash → disabled flag short-circuits generator creation correctly.
     }
+
+    func testDisabledFlagShortCircuitsSelection() {
+        HapticService.shared.isEnabled = false
+        XCTAssertFalse(HapticService.shared.isEnabled)
+        // Must complete without crashing — isEnabled gate is respected.
+        HapticService.shared.selectionChanged()
+    }
+
+    func testSelectionEnabledByDefault() {
+        // Key absent → isEnabled is true, selectionChanged must not crash.
+        XCTAssertTrue(HapticService.shared.isEnabled)
+        HapticService.shared.selectionChanged()
+    }
 }

--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -30,11 +30,10 @@ public struct FilterBarView: View {
     @Environment(UserPreferences.self) private var preferences
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isPulsing: Bool = false
-    @State private var selectionFeedback = UISelectionFeedbackGenerator()
 
     private func fireSelectionHaptic(alreadySelected: Bool) {
         guard !alreadySelected else { return }
-        selectionFeedback.selectionChanged()
+        Haptics.selection()
     }
 
     public init(
@@ -179,7 +178,6 @@ public struct FilterBarView: View {
         .accessibilityAddTraits(isSelected ? .isSelected : [])
         .accessibilityValue(isSelected && resultCount > 0 ? Text("\(resultCount) results") : Text(""))
         .onAppear {
-            selectionFeedback.prepare()
             guard !reduceMotion else { return }
             withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
                 isPulsing = true


### PR DESCRIPTION
## Make the Haptics facade respect the user's haptic opt-out

The app has two haptic paths: HapticService.shared honors the user's hapticsEnabled toggle (Settings) plus Reduce Motion, but the widely-used Haptics enum only checks Reduce Motion — so users who turn haptics OFF still feel taps from favorites swipes, the completion celebration, and dozens of other call sites. This routes Haptics through HapticService.shared so the single opt-out is respected app-wide, and points FilterBarView's direct UISelectionFeedbackGenerator through the same path.

### Acceptance
With Settings > haptics toggled OFF, tapping filter pills, swiping a favorite to remove/undo, and completing an experience produce NO haptic feedback; with it ON they behave exactly as before. `xcodebuild build` and `xcodebuild test` (scheme SoloCompass, iPhone 17 Pro) pass, including HapticServiceTests. Reduce Motion and Xcode-preview suppression continue to no-op all three Haptics methods. No call sites outside the 3 listed files need edits.