### PR TITLE
auto: Make the compact ConfidenceBadge fully VoiceOver-accessible

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -35,6 +35,8 @@
 "confidence.reports" = "User reports (30d)";
 "confidence.trusted" = "Trusted verifications";
 "confidence.lastVerified" = "Verified %@";
+"confidence.a11y.label" = "%@, level %d, %d signals";
+"confidence.a11y.hint" = "Double tap to see trust signals";
 
 /* Solo Score */
 "solo.label" = "Solo";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -916,6 +916,8 @@
 
 /* Confidence */
 "confidence.lastVerified" = "验证于 %@";
+"confidence.a11y.label" = "%@，第 %d 级，%d 个信号";
+"confidence.a11y.hint" = "双击查看信任信号";
 
 /* Detail */
 "detail.distance.away" = "%@外";

--- a/apps/ios/SoloCompass/Views/Shared/ConfidenceBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/ConfidenceBadge.swift
@@ -28,14 +28,17 @@ public struct ConfidenceBadge: View {
                             .frame(width: 8, height: 8)
                             .scaleEffect(isPulsing ? 1.8 : 1.0)
                             .opacity(isPulsing ? 0.0 : 0.6)
+                            .accessibilityHidden(true)
                     }
                     Circle()
                         .fill(confidence.health.color)
                         .frame(width: 8, height: 8)
+                        .accessibilityHidden(true)
                     if let symbol = confidence.health.accessibilitySymbol {
                         Image(systemName: symbol)
                             .font(.system(size: 4, weight: .bold))
                             .foregroundColor(.white)
+                            .accessibilityHidden(true)
                     }
                 }
                 if !compact {
@@ -51,7 +54,10 @@ public struct ConfidenceBadge: View {
         .popover(isPresented: $showSignals) {
             PopoverContent(confidence: confidence)
         }
-        .accessibilityLabel(Text(confidence.health.localizedDescription))
+        .accessibilityLabel(Text(String(format: NSLocalizedString("confidence.a11y.label", comment: ""), confidence.health.localizedDescription, confidence.level, confidence.signals.totalCount)))
+        .accessibilityValue(Text(confidenceRelativeVerifiedString(confidence) ?? ""))
+        .accessibilityHint(Text(NSLocalizedString("confidence.a11y.hint", comment: "")))
+        .accessibilityAddTraits(.isButton)
         .onAppear {
             guard shouldPulse else { return }
             withAnimation(.easeOut(duration: 1.4).repeatForever(autoreverses: false)) {
@@ -155,11 +161,7 @@ private struct PopoverContent: View {
     }
 
     private var relativeVerifiedString: String? {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .full
-        let relative = formatter.localizedString(for: confidence.lastVerifiedAt, relativeTo: Date())
-        let format = NSLocalizedString("confidence.lastVerified", comment: "")
-        return String(format: format, relative)
+        confidenceRelativeVerifiedString(confidence)
     }
 
     private func signalRow(symbol: String, label: String, value: String) -> some View {
@@ -172,6 +174,14 @@ private struct PopoverContent: View {
             Text(value).fontWeight(.medium)
         }
     }
+}
+
+fileprivate func confidenceRelativeVerifiedString(_ confidence: Confidence) -> String? {
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .full
+    let relative = formatter.localizedString(for: confidence.lastVerifiedAt, relativeTo: Date())
+    let format = NSLocalizedString("confidence.lastVerified", comment: "")
+    return String(format: format, relative)
 }
 
 #Preview {


### PR DESCRIPTION
## Make the compact ConfidenceBadge fully VoiceOver-accessible

The compact ConfidenceBadge (shown on every experience card and the map) announces only the health word like "Questioned" to VoiceOver, dropping the trust level, signal count, and the fact that it's a button that reveals details. Since confidence is the app's core trust signal, this leaves VoiceOver users unable to gauge how much to trust an experience or know the badge is tappable. Add a descriptive accessibilityLabel/value/hint and the button trait so the badge speaks its full meaning in both compact and expanded forms.

### Acceptance
With VoiceOver on, focusing a compact ConfidenceBadge announces something like "Questioned, level 1, 5 signals, button" plus a verified-recency value and a 'double tap to see trust signals' hint; the decorative dot/symbol no longer produce separate announcements. Both en and zh-Hans Localizable.strings contain the new keys with no missing-string fallbacks. `xcodebuild build -project apps/ios/SoloCompass.xcodeproj -scheme SoloCompass` succeeds and existing SoloCompassTests still pass. Visual appearance and the tap-to-open popover behavior are unchanged in the Simulator.