### PR TITLE
auto: Proximity-tinted bearing arrow on the experience card

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -222,6 +222,9 @@
 "card.distance.arrived.a11y" = "You're here";
 "card.distance.bearing.a11y" = "toward the %@";
 
+/* Proximity cue appended to bearing arrow a11y label when user is ≤300 m away */
+"card.distance.proximity.near" = "getting close";
+
 /* Compass directions (8 sectors) for bearing arrow accessibility */
 "compass.N" = "north";
 "compass.NE" = "northeast";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -72,6 +72,28 @@ public struct ExperienceCardView: View {
         return directions[index]
     }
 
+    private enum ProximityTint {
+        case near, mid, far
+
+        static func from(meters: Double) -> ProximityTint {
+            if meters <= 300 { return .near }
+            if meters <= 1000 { return .mid }
+            return .far
+        }
+
+        var color: Color {
+            switch self {
+            case .near: return .green
+            case .mid: return Color(red: 0xF5/255, green: 0x9E/255, blue: 0x0B/255)
+            case .far: return Color.secondary
+            }
+        }
+    }
+
+    private func proximityTint(for meters: Double) -> Color {
+        ProximityTint.from(meters: meters).color
+    }
+
     private static let distanceFormatter: MeasurementFormatter = {
         let f = MeasurementFormatter()
         f.unitOptions = .naturalScale
@@ -319,15 +341,20 @@ public struct ExperienceCardView: View {
     @ViewBuilder
     private func distancePill(_ label: String, symbol: String) -> some View {
         let relBearing = relativeBearingDegrees
+        let arrowTint = distanceMeters.map { proximityTint(for: $0) } ?? Color.secondary
         HStack(spacing: 4) {
             if let relBearing {
                 Image(systemName: "location.north.fill")
                     .font(.caption2)
-                    .foregroundStyle(Color.secondary)
+                    .foregroundStyle(arrowTint)
                     .rotationEffect(.degrees(relBearing))
                     .animation(
                         reduceMotion ? nil : .easeInOut(duration: 0.25),
                         value: relBearing
+                    )
+                    .animation(
+                        reduceMotion ? nil : .easeInOut(duration: 0.3),
+                        value: distanceMeters
                     )
                     .accessibilityHidden(true)
             }
@@ -343,6 +370,9 @@ public struct ExperienceCardView: View {
             if let relBearing {
                 let direction = Self.compassDirection(for: relBearing)
                 text += ". " + String(format: NSLocalizedString("card.distance.bearing.a11y", comment: "Bearing direction accessibility"), direction)
+            }
+            if let meters = distanceMeters, ProximityTint.from(meters: meters) == .near {
+                text += ". " + NSLocalizedString("card.distance.proximity.near", comment: "VoiceOver proximity cue when close")
             }
             return text
         }())


### PR DESCRIPTION
## Proximity-tinted bearing arrow on the experience card

The floating ExperienceCardView already shows a heading-corrected bearing arrow next to the distance pill, but it's always Color.secondary regardless of how close you are. Tint the arrow (and distance label) on a neutral→amber→green gradient keyed to distance bands, so the compass metaphor reinforces 'you're getting warmer' as a solo traveler walks toward an experience — a visible, on-brand feedback loop the app currently lacks.

### Acceptance
Build succeeds via xcodebuild for iPhone 17 Pro. With a simulated location ≤300m from a seed experience the bearing arrow renders green; between 300–1000m it renders amber; beyond 1000m it stays neutral secondary. The color transition animates smoothly and is suppressed under Reduce Motion. VoiceOver reads the proximity cue for the near band. Existing #Preview still renders, and the distance label text remains unchanged.