### PR TITLE
auto: Add an inviting empty state to MyWalkedRoutesListView

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1044,6 +1044,7 @@
 /* US-030 — Companion Profile walked routes section */
 "profile.walkedRoutes.header" = "走过的路线 (%d)";
 "profile.walkedRoutes.viewAll" = "查看全部 ->";
+
 /* Empty state for MyWalkedRoutesListView */
 "profile.walkedRoutes.empty.title" = "No routes walked yet";
 "profile.walkedRoutes.empty.hint" = "Complete a companion route to see your journeys here.";

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1044,6 +1044,10 @@
 /* US-030 — Companion Profile walked routes section */
 "profile.walkedRoutes.header" = "走过的路线 (%d)";
 "profile.walkedRoutes.viewAll" = "查看全部 ->";
+/* Empty state for MyWalkedRoutesListView */
+"profile.walkedRoutes.empty.title" = "No routes walked yet";
+"profile.walkedRoutes.empty.hint" = "Complete a companion route to see your journeys here.";
+"profile.walkedRoutes.empty.cta" = "Discover routes";
 
 /* US-032 — DiscoverRecruitingRoutesView */
 "discover.recruiting.title" = "发现招募路线";

--- a/apps/ios/SoloCompass/Views/Companion/MyWalkedRoutesListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/MyWalkedRoutesListView.swift
@@ -59,6 +59,7 @@ private struct WalkedRoutesEmptyState: View {
                     .scaleEffect(isBreathing ? 1.08 : 0.94)
                     .opacity(isBreathing ? 1.0 : 0.7)
                     .animation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true), value: isBreathing)
+                    .accessibilityHidden(true)
             }
             Text(NSLocalizedString("profile.walkedRoutes.empty.title", comment: "No walked routes yet"))
                 .font(.headline)
@@ -76,6 +77,7 @@ private struct WalkedRoutesEmptyState: View {
                 .buttonStyle(.borderedProminent)
                 .controlSize(.regular)
                 .padding(.top, 4)
+                .accessibilityLabel(Text(NSLocalizedString("profile.walkedRoutes.empty.cta", comment: "Discover routes button in empty walked routes state")))
             }
         }
         .padding(32)

--- a/apps/ios/SoloCompass/Views/Companion/MyWalkedRoutesListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/MyWalkedRoutesListView.swift
@@ -6,22 +6,30 @@ import SwiftUI
 /// in CompanionProfileView but in a vertical list layout.
 public struct MyWalkedRoutesListView: View {
     let routes: [Route]
+    var onExplore: (() -> Void)? = nil
 
-    public init(routes: [Route]) {
+    public init(routes: [Route], onExplore: (() -> Void)? = nil) {
         self.routes = routes
+        self.onExplore = onExplore
     }
 
     public var body: some View {
-        List(routes) { route in
-            VStack(alignment: .leading, spacing: 4) {
-                Text(route.title)
-                    .font(.headline)
-                Text(route.summary)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
+        Group {
+            if routes.isEmpty {
+                WalkedRoutesEmptyState(onExplore: onExplore)
+            } else {
+                List(routes) { route in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(route.title)
+                            .font(.headline)
+                        Text(route.summary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                    .padding(.vertical, 4)
+                }
             }
-            .padding(.vertical, 4)
         }
         .navigationTitle(
             String(
@@ -33,8 +41,86 @@ public struct MyWalkedRoutesListView: View {
     }
 }
 
-#Preview {
+private struct WalkedRoutesEmptyState: View {
+    var onExplore: (() -> Void)? = nil
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isBreathing = false
+
+    var body: some View {
+        VStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(Color.teal.opacity(0.12))
+                    .frame(width: 80, height: 80)
+                Image(systemName: "figure.walk")
+                    .font(.system(size: 48))
+                    .foregroundStyle(Color.teal.opacity(0.7))
+                    .scaleEffect(isBreathing ? 1.08 : 0.94)
+                    .opacity(isBreathing ? 1.0 : 0.7)
+                    .animation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true), value: isBreathing)
+            }
+            Text(NSLocalizedString("profile.walkedRoutes.empty.title", comment: "No walked routes yet"))
+                .font(.headline)
+            Text(NSLocalizedString("profile.walkedRoutes.empty.hint", comment: "Hint to explore routes"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            if let onExplore {
+                Button {
+                    Haptics.selection()
+                    onExplore()
+                } label: {
+                    Label(NSLocalizedString("profile.walkedRoutes.empty.cta", comment: "Discover routes button in empty walked routes state"), systemImage: "map")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+                .padding(.top, 4)
+            }
+        }
+        .padding(32)
+        .onAppear {
+            guard !isBreathing, !reduceMotion else { return }
+            isBreathing = true
+        }
+    }
+}
+
+#Preview("MyWalkedRoutesListView — empty") {
     NavigationStack {
         MyWalkedRoutesListView(routes: [])
+    }
+}
+
+#Preview("MyWalkedRoutesListView — with routes") {
+    NavigationStack {
+        MyWalkedRoutesListView(routes: [
+            Route(
+                id: RouteId(rawValue: "mekong-sunset"),
+                title: "Mekong Sunset Walk",
+                summary: "Dawn at the river, dusk by the ferry.",
+                experienceIds: ["e1", "e2"],
+                cityCode: "VTE",
+                region: "Riverfront",
+                estimatedDuration: 90,
+                distanceMeters: 1200,
+                pace: .relaxed,
+                tags: ["nature"],
+                source: .editorial
+            ),
+            Route(
+                id: RouteId(rawValue: "old-quarter-coffee"),
+                title: "Old Quarter Coffee Circuit",
+                summary: "Four independent cafés in the heart of Hanoi.",
+                experienceIds: ["e3", "e4"],
+                cityCode: "HAN",
+                region: "Old Quarter",
+                estimatedDuration: 120,
+                distanceMeters: 2200,
+                pace: .standard,
+                tags: ["coffee"],
+                source: .editorial
+            ),
+        ])
     }
 }


### PR DESCRIPTION
## Add an inviting empty state to MyWalkedRoutesListView

MyWalkedRoutesListView is a stub that renders a bare List, so when a solo traveler has not yet completed any companion routes they see a blank white screen below the nav title — a jarring dead end on what should be an aspirational 'your journeys' surface. Add a polished, motivating empty state (icon, headline, hint, and optional explore CTA) matching the quality bar set by EmptyFavoritesView, with a Reduce Motion-aware gentle animation.

### Acceptance
Building SoloCompass succeeds (xcodebuild build). Opening MyWalkedRoutesListView with routes == [] shows the icon + title + hint empty state (not a blank list); with Reduce Motion off the icon breathes, with it on the view is static. With routes present, the existing list renders unchanged. New string keys exist in en.lproj/Localizable.strings and StringsParityTests still passes. Both #Preview variants compile.