### PR TITLE
auto: Make VoiceButton operable and announced for VoiceOver users

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -121,6 +121,12 @@
 /* Voice */
 "voice.processing" = "Thinking: %@";
 "voice.button" = "Voice input";
+"voice.button.hint" = "Double tap to start recording, double tap again to stop";
+"voice.button.value.recording" = "Recording";
+"voice.button.value.idle" = "Idle";
+"voice.a11y.toggle" = "Start/Stop voice input";
+"voice.announcement.listening" = "Listening…";
+"voice.announcement.stopped" = "Recording stopped";
 "voice.recording.timer.a11y" = "Recording — %d seconds elapsed";
 "voice.result.found" = "Found %d matching places";
 "voice.result.filtered" = "Showing %@ nearby";

--- a/apps/ios/SoloCompass/Tests/VoiceButtonA11yTests.swift
+++ b/apps/ios/SoloCompass/Tests/VoiceButtonA11yTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import SoloCompass
+
+/// Tests the accessibility toggle logic introduced for VoiceOver / Switch Control support.
+///
+/// VoiceButton's isRecording state is private @State, so we test an equivalent
+/// harness that mirrors startRecording / stopRecording toggling logic.
+@MainActor
+final class VoiceButtonA11yTests: XCTestCase {
+
+    // MARK: - Stub VoiceService
+
+    /// Minimal stub so startRecording / stopRecording can be called without a real
+    /// microphone or speech recognizer.
+    final class StubVoiceService: VoiceService {
+        var startListeningCallCount = 0
+        var stopListeningCallCount = 0
+        var permissionResult = true
+
+        override func requestPermission() async -> Bool { permissionResult }
+
+        override func startListening() throws -> AsyncThrowingStream<String, Error> {
+            startListeningCallCount += 1
+            return AsyncThrowingStream { _ in }
+        }
+
+        override func stopListening() {
+            stopListeningCallCount += 1
+        }
+    }
+
+    // MARK: - Toggle harness
+
+    /// Lightweight harness that mirrors VoiceButton's isRecording toggle logic
+    /// without the SwiftUI / Task machinery.
+    @MainActor
+    final class ToggleHarness {
+        private(set) var isRecording = false
+        private(set) var listeningAnnouncementFired = false
+        private(set) var stoppedAnnouncementFired = false
+        var transcriptFired: String? = nil
+        var liveTranscript: String = ""
+
+        func startRecording() {
+            isRecording = true
+            listeningAnnouncementFired = true   // mirrors the UIAccessibility.post branch
+        }
+
+        func stopRecording() {
+            isRecording = false
+            stoppedAnnouncementFired = true     // mirrors the UIAccessibility.post branch
+            let final_ = liveTranscript
+            if !final_.isEmpty { transcriptFired = final_ }
+            liveTranscript = ""
+        }
+
+        /// Simulates what the accessibilityAction does: toggle via isRecording.
+        func toggleViaA11yAction() {
+            if isRecording { stopRecording() } else { startRecording() }
+        }
+    }
+
+    // MARK: - Tests
+
+    func testA11yActionStartsRecordingWhenIdle() {
+        let h = ToggleHarness()
+        XCTAssertFalse(h.isRecording)
+
+        h.toggleViaA11yAction()
+
+        XCTAssertTrue(h.isRecording, "first a11y activation should start recording")
+    }
+
+    func testA11yActionStopsRecordingWhenActive() {
+        let h = ToggleHarness()
+        h.toggleViaA11yAction()   // start
+        XCTAssertTrue(h.isRecording)
+
+        h.toggleViaA11yAction()   // stop
+
+        XCTAssertFalse(h.isRecording, "second a11y activation should stop recording")
+    }
+
+    func testListeningAnnouncementFiresOnStart() {
+        let h = ToggleHarness()
+        h.toggleViaA11yAction()
+
+        XCTAssertTrue(h.listeningAnnouncementFired, "Listening… announcement must post when recording starts")
+    }
+
+    func testStoppedAnnouncementFiresOnStop() {
+        let h = ToggleHarness()
+        h.toggleViaA11yAction()   // start
+        h.toggleViaA11yAction()   // stop
+
+        XCTAssertTrue(h.stoppedAnnouncementFired, "Recording stopped announcement must post when recording stops")
+    }
+
+    func testTranscriptDeliveredOnStop() {
+        let h = ToggleHarness()
+        h.toggleViaA11yAction()   // start
+        h.liveTranscript = "quiet café nearby"
+        h.toggleViaA11yAction()   // stop
+
+        XCTAssertEqual(h.transcriptFired, "quiet café nearby")
+    }
+
+    func testDoubleToggleLeavesRecordingFalse() {
+        let h = ToggleHarness()
+        h.toggleViaA11yAction()
+        h.toggleViaA11yAction()
+
+        XCTAssertFalse(h.isRecording, "two activations must leave recording stopped")
+    }
+
+    func testLocalizationKeysExist() {
+        let keys = [
+            "voice.button.hint",
+            "voice.button.value.recording",
+            "voice.button.value.idle",
+            "voice.a11y.toggle",
+            "voice.announcement.listening",
+            "voice.announcement.stopped",
+        ]
+        for key in keys {
+            let value = NSLocalizedString(key, comment: "")
+            XCTAssertNotEqual(value, key, "Localizable.strings is missing key: \(key)")
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
+++ b/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
@@ -73,6 +73,14 @@ public struct VoiceButton: View {
                 }
         )
         .accessibilityLabel(Text(NSLocalizedString("voice.button", comment: "Voice input")))
+        .accessibilityHint(Text(NSLocalizedString("voice.button.hint", comment: "Double tap to start recording, double tap again to stop")))
+        .accessibilityValue(Text(isRecording
+            ? NSLocalizedString("voice.button.value.recording", comment: "Recording")
+            : NSLocalizedString("voice.button.value.idle", comment: "Idle")))
+        .accessibilityAddTraits(.startsMediaSession)
+        .accessibilityAction(named: Text(NSLocalizedString("voice.a11y.toggle", comment: "Start/Stop voice input"))) {
+            if isRecording { stopRecording() } else { startRecording() }
+        }
         .alert(NSLocalizedString("voice.permission.title", comment: ""), isPresented: $showPermissionAlert) {
             Button(NSLocalizedString("common.ok", comment: ""), role: .cancel) { }
         } message: {
@@ -148,6 +156,10 @@ public struct VoiceButton: View {
                 didAutoStop = false
                 autoStopMessage = nil
                 recordStartGenerator.impactOccurred()
+                if UIAccessibility.isVoiceOverRunning {
+                    UIAccessibility.post(notification: .announcement,
+                        argument: NSLocalizedString("voice.announcement.listening", comment: "Listening…"))
+                }
                 startElapsedTimer()
                 let stream = try voiceService.startListening()
                 streamTask = Task {
@@ -181,6 +193,10 @@ public struct VoiceButton: View {
         isRecording = false
         pulse = false
         stopElapsedTimer()
+        if UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .announcement,
+                argument: NSLocalizedString("voice.announcement.stopped", comment: "Recording stopped"))
+        }
         let final = liveTranscript
         streamTask?.cancel()
         streamTask = nil


### PR DESCRIPTION
## Make VoiceButton operable and announced for VoiceOver users

VoiceButton is driven solely by a LongPressGesture, so VoiceOver and Switch Control users have no way to start or stop voice input — a core app feature is entirely inaccessible to them. This adds an accessibility custom action to toggle recording, an accessibilityHint, and an accessibilityValue/announcement reflecting the recording state, with no change to the existing touch behavior.

### Acceptance
With VoiceOver enabled, focusing the mic button announces its label, hint, and idle/recording value; a single VoiceOver activation starts recording (with a 'Listening…' announcement) and a second activation stops it and delivers the transcript. Touch users see identical long-press behavior as before. All new user-facing strings are NSLocalizedString-backed with entries in en.lproj/Localizable.strings, the iOS target builds (`xcodebuild build`), and SoloCompassTests pass.