### PR TITLE
auto: Extend favorites undo window for VoiceOver users

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -384,6 +384,7 @@
 /* Generic actions */
 "action.undo" = "Undo";
 "favorites.undo.swipeHint" = "Swipe down to dismiss";
+"favorites.undo.announcement" = "Removed %@. Undo available.";
 
 /* Notifications */
 "settings.notifications" = "Notify me when I'm nearby";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -10,6 +10,7 @@ public struct FavoritesListView: View {
     @Environment(UserPreferences.self) private var preferences
     @Environment(LocationService.self) private var locationService
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityVoiceOverEnabled) private var voiceOverOn
     let onSelectExperience: (Experience) -> Void
     var onExplore: (() -> Void)? = nil
 
@@ -24,6 +25,8 @@ public struct FavoritesListView: View {
     @State private var showSwipeHint = false
     @State private var hintDismissTask: Task<Void, Never>?
     @AppStorage("favorites.swipeHintSeen") private var swipeHintSeen = false
+
+    private var undoDismissSeconds: Double { voiceOverOn ? 12 : 4 }
 
     private enum Proximity {
         case near, mid, far
@@ -416,8 +419,8 @@ private extension FavoritesListView {
         .onAppear {
             undoProgress = 1
             undoDragOffset = 0
-            if !reduceMotion {
-                withAnimation(.linear(duration: 4)) {
+            if !reduceMotion && !voiceOverOn {
+                withAnimation(.linear(duration: undoDismissSeconds)) {
                     undoProgress = 0
                 }
             }
@@ -510,9 +513,14 @@ private extension FavoritesListView {
                     preferences.toggleFavorite(expId)
                 }
                 lastUnfavorited = (id: expId, title: expTitle, date: savedDate)
+                UIAccessibility.post(
+                    notification: .announcement,
+                    argument: String(format: NSLocalizedString("favorites.undo.announcement", comment: "VoiceOver announcement after unfavoriting"), expTitle)
+                )
                 undoDismissTask?.cancel()
+                let dismissSeconds = undoDismissSeconds
                 undoDismissTask = Task {
-                    try? await Task.sleep(for: .seconds(4))
+                    try? await Task.sleep(for: .seconds(dismissSeconds))
                     guard !Task.isCancelled else { return }
                     await MainActor.run {
                         withAnimation(.easeInOut) {


### PR DESCRIPTION
## Extend favorites undo window for VoiceOver users

The FavoritesListView undo bar auto-dismisses after a fixed 4 seconds, which is too fast for VoiceOver users who need time to hear the announcement and locate the Undo control. This change lengthens the dismiss window (and pauses the progress bar) when VoiceOver is active, and announces the removal via UIAccessibility so screen-reader users learn an experience was unfavorited and can act on it.

### Acceptance
With VoiceOver off, behavior is unchanged (4s dismiss, animated progress bar). With VoiceOver on, the undo bar stays ~12s, the progress bar is hidden/static, and removing a favorite triggers a spoken announcement naming the experience. App builds via xcodebuild and existing FavoritesListView previews render without regression.