### PR TITLE
auto: Surface a 'N nearby' tappable summary chip in the favorites footer

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -386,6 +386,9 @@
 "favorites.proximity.mid" = "short ride";
 "favorites.proximity.far" = "far";
 "favorites.row.directions" = "Directions";
+"favorites.nearby.count" = "%d nearby";
+"favorites.nearby.count.a11y" = "%d nearby favorites";
+"favorites.nearby.hint" = "Sorts favorites by distance";
 
 /* Generic actions */
 "action.undo" = "Undo";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -121,6 +121,10 @@ public struct FavoritesListView: View {
         }
     }
 
+    private var nearbyCount: Int {
+        sortedFavorites.filter { proximity(for: $0) == .near }.count
+    }
+
     public var body: some View {
         NavigationStack {
             Group {
@@ -142,14 +146,47 @@ public struct FavoritesListView: View {
                                     return String(format: NSLocalizedString("favorites.count.matching", comment: "M of N matching"), filteredFavorites.count, sortedFavorites.count)
                                 }
                             }()
-                            Text(countLabel)
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                            let showNearbyChip = locationService.currentLocation != nil
+                                && nearbyCount > 0
+                                && searchText.trimmingCharacters(in: .whitespaces).isEmpty
+                            HStack(spacing: 8) {
+                                Text(countLabel)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                                    .animation(.easeInOut, value: filteredFavorites.count)
+                                    .contentTransition(.numericText())
+                                Spacer()
+                                if showNearbyChip {
+                                    Button {
+                                        Haptics.selection()
+                                        withAnimation(reduceMotion ? nil : .easeInOut) {
+                                            sortMode = .nearest
+                                        }
+                                    } label: {
+                                        HStack(spacing: 4) {
+                                            Circle()
+                                                .fill(Color.green)
+                                                .frame(width: 7, height: 7)
+                                                .accessibilityHidden(true)
+                                            Text(String(format: NSLocalizedString("favorites.nearby.count", comment: "N nearby chip"), nearbyCount))
+                                                .font(.caption2)
+                                                .foregroundStyle(Color.green)
+                                        }
+                                        .padding(.horizontal, 10)
+                                        .padding(.vertical, 5)
+                                        .background(Color.green.opacity(0.12), in: Capsule())
+                                    }
+                                    .buttonStyle(.plain)
+                                    .accessibilityLabel(String(format: NSLocalizedString("favorites.nearby.count.a11y", comment: "N nearby chip accessibility label"), nearbyCount))
+                                    .accessibilityHint(NSLocalizedString("favorites.nearby.hint", comment: "Nearby chip sorts by distance"))
+                                    .accessibilityAddTraits(.isButton)
+                                    .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
+                                }
+                            }
                             .padding(.horizontal, 16)
                             .padding(.vertical, 6)
-                            .animation(.easeInOut, value: filteredFavorites.count)
-                            .contentTransition(.numericText())
+                            .animation(reduceMotion ? nil : .easeInOut, value: showNearbyChip)
+                            .animation(.easeInOut, value: nearbyCount)
                         }
 
                         List {


### PR DESCRIPTION
## Surface a 'N nearby' tappable summary chip in the favorites footer

The favorites list already computes per-row proximity (near/mid/far) but the footer only shows a flat 'N saved' count, burying the most actionable signal for a solo traveler deciding where to go next. Add a green 'N nearby' chip beside the count that, when tapped, switches the sort to .nearest and (if needed) clears the search — turning passive information into a one-tap action. It reuses the existing Proximity enum, distanceMeters(), and sortMode state, so it adds no new data plumbing.

### Acceptance
With location available and ≥1 favorite within 1km, the footer shows a green 'N nearby' chip next to the saved count; tapping it animates the segmented sort control to 'Nearest' and re-sorts the list, firing a selection haptic. The chip is hidden when no location, zero nearby, or an active search filter. VoiceOver reads the chip as a button with a hint about sorting by distance. xcodebuild build and the SoloCompassTests suite both pass; existing favorites snapshot/preview behavior is unchanged when the chip is absent.