### PR TITLE
auto: Make the BottomInfoSheet clock live and locale-aware

### DIFF
--- a/apps/ios/SoloCompass/Tests/BottomInfoSheetTests.swift
+++ b/apps/ios/SoloCompass/Tests/BottomInfoSheetTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import SoloCompass
+
+final class BottomInfoSheetTests: XCTestCase {
+    // Fixed instant: 2024-01-15 14:05:00 UTC
+    private let fixedDate: Date = {
+        var comps = DateComponents()
+        comps.year = 2024; comps.month = 1; comps.day = 15
+        comps.hour = 14; comps.minute = 5; comps.second = 0
+        comps.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: comps)!
+    }()
+
+    func testTimeStringUsLocaleContainsAmPm() {
+        let result = NowHintRow.timeString(for: fixedDate, locale: Locale(identifier: "en_US"))
+        let lower = result.lowercased()
+        XCTAssertTrue(
+            lower.contains("am") || lower.contains("pm"),
+            "en_US should produce a 12-hour string with AM/PM, got: \(result)"
+        )
+    }
+
+    func testTimeStringFrFrLocaleIs24Hour() {
+        let result = NowHintRow.timeString(for: fixedDate, locale: Locale(identifier: "fr_FR"))
+        let lower = result.lowercased()
+        XCTAssertFalse(
+            lower.contains("am") || lower.contains("pm"),
+            "fr_FR should produce a 24-hour string without AM/PM, got: \(result)"
+        )
+    }
+
+    func testTimeStringEnGbLocaleIs24Hour() {
+        let result = NowHintRow.timeString(for: fixedDate, locale: Locale(identifier: "en_GB"))
+        let lower = result.lowercased()
+        XCTAssertFalse(
+            lower.contains("am") || lower.contains("pm"),
+            "en_GB should produce a 24-hour string without AM/PM, got: \(result)"
+        )
+    }
+
+    @MainActor
+    func testClockTickAdvancesTimeString() async {
+        let clock = BestNowClock(startDate: fixedDate)
+        let before = NowHintRow.timeString(for: clock.tick, locale: Locale(identifier: "en_US"))
+
+        var laterComps = DateComponents()
+        laterComps.year = 2024; laterComps.month = 1; laterComps.day = 15
+        laterComps.hour = 15; laterComps.minute = 6; laterComps.second = 0
+        laterComps.timeZone = TimeZone(identifier: "UTC")
+        let laterDate = Calendar(identifier: .gregorian).date(from: laterComps)!
+
+        clock.advance(to: laterDate)
+        let after = NowHintRow.timeString(for: clock.tick, locale: Locale(identifier: "en_US"))
+
+        XCTAssertNotEqual(before, after, "Time string should change after clock advances")
+    }
+}

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -307,10 +307,28 @@ public struct BottomInfoSheet<Content: View>: View {
 struct NowHintRow: View {
     let hint: String
 
-    private var timeString: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        return formatter.string(from: Date())
+    @Environment(BestNowClock.self) private var clock
+
+    /// Locale-aware short time string (respects the device's 12/24h preference).
+    /// Cached as a static so a single formatter is reused across re-evaluations.
+    private static let formatter: DateFormatter = {
+        let f = DateFormatter()
+        f.timeStyle = .short
+        f.dateStyle = .none
+        return f
+    }()
+
+    /// Testable helper — formats `date` using the given locale.
+    static func timeString(for date: Date, locale: Locale = .current) -> String {
+        let f = DateFormatter()
+        f.timeStyle = .short
+        f.dateStyle = .none
+        f.locale = locale
+        return f.string(from: date)
+    }
+
+    private var formattedTime: String {
+        Self.timeString(for: clock.tick)
     }
 
     var body: some View {
@@ -323,12 +341,12 @@ struct NowHintRow: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
             Spacer(minLength: 4)
-            Text(timeString)
+            Text(formattedTime)
                 .font(.caption.monospacedDigit())
                 .foregroundStyle(.secondary)
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(Text("\(hint) \(timeString)"))
+        .accessibilityLabel(Text("\(hint) \(formattedTime)"))
     }
 }
 
@@ -799,5 +817,6 @@ struct EmptySheetListView: View {
                     .padding()
             }
         }
+        .environment(BestNowClock.shared)
     }
 }


### PR DESCRIPTION
## Make the BottomInfoSheet clock live and locale-aware

The 'now hint' row in the map's bottom sheet renders a clock time (HH:mm) that is computed once at render and then goes stale — it never advances while the sheet stays open, and it hardcodes 24-hour format ignoring the user's locale. Wire it to the existing shared BestNowClock singleton so the time refreshes every minute with zero extra timers, and format it via the device's locale so 12-hour users see the correct format.

### Acceptance
Build passes (`xcodebuild build -scheme SoloCompass`). With the sheet open, the displayed time advances within 60s of the minute rolling over (driven by BestNowClock.advance in a unit test). A new unit test asserts `NowHintRow.timeString(for:locale:)` yields a 12-hour string (e.g. contains AM/PM) for a US locale and a 24-hour string for a locale like fr_FR / en_GB at a fixed instant. No additional Timer is allocated (relies on the shared clock — BestNowClock.activeTimerCount stays 1). Existing BottomInfoSheet tests still pass; `#Preview` still renders.