### PR TITLE
auto: Route companion haptics ignore the haptics-off & Reduce Motion settings — route them through HapticService

### DIFF
--- a/apps/ios/SoloCompass/Views/Companion/AddToItinerarySheet.swift
+++ b/apps/ios/SoloCompass/Views/Companion/AddToItinerarySheet.swift
@@ -188,7 +188,7 @@ public struct AddToItinerarySheet: View {
     private func addExperience(to itin: Itinerary) {
         do {
             try store.addExperience(experienceId, to: itin.id)
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            Haptics.notify(.success)
             withAnimation { addedToId = itin.id }
             reload()
             // Capture the updated itinerary for the success callback.
@@ -200,7 +200,7 @@ public struct AddToItinerarySheet: View {
                 }
             }
         } catch {
-            UINotificationFeedbackGenerator().notificationOccurred(.error)
+            Haptics.notify(.error)
             errorMessage = error.localizedDescription
         }
     }

--- a/apps/ios/SoloCompass/Views/Companion/OpenForCompanionsSheet.swift
+++ b/apps/ios/SoloCompass/Views/Companion/OpenForCompanionsSheet.swift
@@ -229,7 +229,7 @@ public struct OpenForCompanionsSheet: View {
         )
 
         storeProvider().save(route)
-        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        Haptics.notify(.success)
         dismiss()
     }
 

--- a/apps/ios/SoloCompass/Views/Companion/RequestInboxView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/RequestInboxView.swift
@@ -135,10 +135,10 @@ public struct RequestInboxView: View {
         case .success(let conversation):
             acceptedConversation = conversation
             showingAcceptedConfirm = true
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            Haptics.notify(.success)
         case .failure(let err):
             errorMessage = err.localizedDescription
-            UINotificationFeedbackGenerator().notificationOccurred(.error)
+            Haptics.notify(.error)
             Task {
                 try? await Task.sleep(for: .seconds(3))
                 errorMessage = nil


### PR DESCRIPTION
## Route companion haptics ignore the haptics-off & Reduce Motion settings — route them through HapticService

Several Companion-flow views (RequestInboxView, AddToItinerarySheet, OpenForCompanionsSheet) fire UINotificationFeedbackGenerator/UIImpactFeedbackGenerator directly instead of via the Haptics shim. This bypasses the user's hapticsEnabled toggle in Settings and the Reduce Motion accessibility gate that HapticService.shouldFire() enforces, so accept/decline/add-stop actions still buzz even when the user has turned haptics off. Routing them through Haptics.notify(...)/Haptics.impact(...) makes companion feedback obey the same rules as the rest of the app.

### Acceptance
Grepping the three modified files for `UINotificationFeedbackGenerator(` and `UIImpactFeedbackGenerator(` returns no matches; all companion accept/decline/add-stop feedback now goes through Haptics → HapticService. Manual check: with Settings → Haptics toggled off (hapticsEnabled=false), accepting a companion request and adding a stop to an itinerary produce no haptic. `xcodebuild build` succeeds and `CompanionPhase3Tests`/`ItineraryStoreTests` still pass.