### PR TITLE
auto: Add haptic + tap-scale feedback to the ConfidenceBadge trust dot

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/ConfidenceBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/ConfidenceBadge.swift
@@ -7,6 +7,7 @@ public struct ConfidenceBadge: View {
 
     @State private var showSignals = false
     @State private var isPulsing = false
+    @State private var pressed = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     public init(confidence: Confidence, compact: Bool = true) {
@@ -19,7 +20,16 @@ public struct ConfidenceBadge: View {
     }
 
     public var body: some View {
-        Button { showSignals.toggle() } label: {
+        Button {
+            Haptics.selection()
+            if !reduceMotion {
+                withAnimation(.spring(response: 0.18, dampingFraction: 0.5)) { pressed = true }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
+                    withAnimation(.spring(response: 0.18, dampingFraction: 0.5)) { pressed = false }
+                }
+            }
+            showSignals.toggle()
+        } label: {
             HStack(spacing: 4) {
                 ZStack {
                     if shouldPulse {
@@ -49,6 +59,7 @@ public struct ConfidenceBadge: View {
             }
             .contentShape(Rectangle())
             .frame(minWidth: 44, minHeight: 32, alignment: .leading)
+            .scaleEffect(pressed ? 0.86 : 1.0)
         }
         .buttonStyle(.plain)
         .popover(isPresented: $showSignals) {


### PR DESCRIPTION
## Add haptic + tap-scale feedback to the ConfidenceBadge trust dot

The ConfidenceBadge is the core trust signal rendered across the entire app (map pins, experience cards, detail views) and is a tappable button that opens a signals popover, yet tapping it fires no haptic and gives no visual press feedback — inconsistent with every other interactive control in the app, which uses Haptics.selection()/impact(). This adds a light selection haptic and a subtle spring scale-down on tap so the badge feels responsive and confirms the popover action.

### Acceptance
Tapping any ConfidenceBadge dot fires a selection haptic (respecting the HapticService opt-out and Reduce Motion no-op) and shows a quick scale-down/spring-back; the signals popover still opens as before; with Reduce Motion enabled no scale animation runs; existing ConfidenceBadge previews and tests still build (xcodebuild build succeeds).