### PR TITLE
auto: Animate POILoadingBanner to match its OfflineBanner sibling + add VoiceOver progress announcement

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -207,6 +207,7 @@
 "map.empty.stage.browseCity" = "Browse %@";
 "map.loading" = "Loading map";
 "map.loadingPOIs" = "Finding nearby places…";
+"map.loadingPOIs.a11yAnnouncement" = "Finding nearby places";
 
 /* City picker */
 "city.all" = "All Cities";

--- a/apps/ios/SoloCompass/Views/Map/POILoadingBanner.swift
+++ b/apps/ios/SoloCompass/Views/Map/POILoadingBanner.swift
@@ -5,12 +5,17 @@ import SwiftUI
 /// read as one visual family; uses a small spinner so the fetch reads as
 /// "in progress" rather than an error/offline state.
 struct POILoadingBanner: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isPulsing = false
+
     var body: some View {
         GlassmorphismCapsule(
             verticalPadding: 8,
             leading: {
                 ProgressView()
                     .controlSize(.mini)
+                    .scaleEffect(isPulsing ? 1.08 : 0.92)
+                    .opacity(isPulsing ? 1.0 : 0.6)
             },
             content: {
                 Text(NSLocalizedString("map.loadingPOIs", comment: "Loading nearby places banner"))
@@ -21,6 +26,25 @@ struct POILoadingBanner: View {
         .transition(.move(edge: .top).combined(with: .opacity))
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(NSLocalizedString("map.loadingPOIs", comment: "Loading nearby places banner")))
+        .onAppear {
+            UIAccessibility.post(
+                notification: .announcement,
+                argument: NSLocalizedString("map.loadingPOIs.a11yAnnouncement", comment: "VoiceOver announcement when POI fetch begins")
+            )
+            guard !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
+                isPulsing = true
+            }
+        }
+        .onChange(of: reduceMotion) { _, reduced in
+            if reduced {
+                withAnimation(.default) { isPulsing = false }
+            } else {
+                withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
+                    isPulsing = true
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Animate POILoadingBanner to match its OfflineBanner sibling + add VoiceOver progress announcement

POILoadingBanner's own header comment says it should 'mirror OfflineBanner so the two top banners read as one visual family,' but it's visually flatter — the spinner is static-feeling and, unlike OfflineBanner, it posts no VoiceOver announcement when it appears, so blind users get no signal that nearby places are being fetched. This adds a subtle reduce-motion-aware pulse to the leading slot and a one-time accessibility announcement on appear, bringing it to parity with the established banner family.

### Acceptance
xcodebuild build succeeds for the SoloCompass scheme. With reduce-motion OFF the loading banner's spinner gently pulses while POIs fetch; with reduce-motion ON it is static (no animation started). Toggling reduce-motion live starts/stops the pulse without restarting the view. VoiceOver announces 'Finding nearby places' (localized) once when the banner appears. #Preview still renders. No new force-unwraps; all strings via NSLocalizedString.