### PR TITLE
auto: Route shared-component haptics through the Haptics facade so they honor the Settings opt-out

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
@@ -11,7 +11,7 @@ public struct CityPickerSheet: View {
     @State private var justSelectedCode: String? = nil
 
     private func selectCity(_ code: String?) {
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        Haptics.impact(.light)
         withAnimation(.spring(response: 0.3, dampingFraction: 0.6)) {
             justSelectedCode = code ?? "all"
             viewModel.selectCity(code)

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -29,9 +29,7 @@ public struct SoloScoreBadge: View {
     private var compactView: some View {
         Button {
             showBreakdown.toggle()
-            if !reduceMotion {
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            }
+            Haptics.impact(.light)
         } label: {
             HStack(spacing: 4) {
                 if isExcellent {


### PR DESCRIPTION
## Route shared-component haptics through the Haptics facade so they honor the Settings opt-out

SoloScoreBadge and CityPickerSheet fire raw UIImpactFeedbackGenerator(style:).impactOccurred() directly, bypassing the centralized Haptics/HapticService shim that every other call site uses. This means tapping the Solo Score pill or selecting a city still vibrates even when the user has disabled haptics in Settings or enabled Reduce Motion — a real accessibility/consistency bug. Replacing the raw calls with Haptics.impact(.light) makes them obey the global opt-out, Reduce Motion, and preview suppression, and lets the now-redundant inline reduceMotion guard in SoloScoreBadge be removed.

### Acceptance
With haptics disabled in Settings (HapticService.shared.isEnabled == false), tapping the Solo Score pill and selecting a city in CityPickerSheet produce no haptic feedback, while the existing scale/checkmark animations still play. With haptics enabled, a light impact fires as before. No raw UIImpactFeedbackGenerator references remain in SoloScoreBadge.swift or CityPickerSheet.swift. `xcodebuild build -project apps/ios/SoloCompass.xcodeproj -scheme SoloCompass -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest'` succeeds and existing SoloCompassTests pass.