### PR TITLE
auto: Add a 'Discover routes' CTA to the empty My Requests state

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1113,6 +1113,7 @@
 /* US-033 — MyRequestsListView */
 "my.requests.empty" = "You have not requested to join any routes yet.";
 "my.requests.empty.hint" = "Browse routes in Discover and tap Send Join Request.";
+"my.requests.empty.cta" = "Find a route to join";
 "my.requests.status.pending" = "Pending";
 "my.requests.status.accepted" = "Accepted";
 "my.requests.status.declined" = "Declined";

--- a/apps/ios/SoloCompass/Views/Companion/MyRequestsListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/MyRequestsListView.swift
@@ -17,6 +17,7 @@ public struct MyRequestsListView: View {
 
     @State private var refreshToken: UUID = UUID()
     @State private var pulse = false
+    @State private var showDiscover = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     public init(
@@ -58,6 +59,9 @@ public struct MyRequestsListView: View {
             comment: "My recruitment requests title"
         ))
         .navigationBarTitleDisplayMode(.large)
+        .navigationDestination(isPresented: $showDiscover) {
+            DiscoverRecruitingRoutesView()
+        }
         .onReceive(NotificationCenter.default.publisher(for: RouteStore.didChange)) { _ in
             refreshToken = UUID()
         }
@@ -206,7 +210,7 @@ public struct MyRequestsListView: View {
     // MARK: - Empty state
 
     private var emptyState: some View {
-        EmptyMyRequestsView()
+        EmptyMyRequestsView(onDiscover: { showDiscover = true })
     }
 
     // MARK: - Withdraw
@@ -247,6 +251,8 @@ public struct MyRequestsListView: View {
 // MARK: - Empty state view
 
 private struct EmptyMyRequestsView: View {
+    var onDiscover: (() -> Void)? = nil
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isBreathing = false
 
@@ -275,6 +281,20 @@ private struct EmptyMyRequestsView: View {
             .font(.caption)
             .foregroundStyle(.secondary)
             .multilineTextAlignment(.center)
+            if let onDiscover {
+                Button {
+                    Haptics.selection()
+                    onDiscover()
+                } label: {
+                    Label(
+                        NSLocalizedString("my.requests.empty.cta", comment: "Discover recruiting routes CTA"),
+                        systemImage: "figure.walk"
+                    )
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+                .padding(.top, 4)
+            }
         }
         .padding(32)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -344,5 +364,5 @@ private struct EmptyMyRequestsView: View {
 }
 
 #Preview("EmptyMyRequestsView — standalone") {
-    EmptyMyRequestsView()
+    EmptyMyRequestsView(onDiscover: {})
 }


### PR DESCRIPTION
## Add a 'Discover routes' CTA to the empty My Requests state

The MyRequestsListView empty state shows a breathing paperplane icon and explanatory text but, unlike the FavoritesListView empty state (which offers an 'Explore the map' button), it gives the user no actionable next step. Add a borderedProminent CTA button that navigates to DiscoverRecruitingRoutesView so a user who has sent no join requests can immediately find recruiting routes to join, matching the established empty-state pattern.

### Acceptance
When the user has sent zero join requests, the My Requests empty state shows a prominent 'Find a route to join' button beneath the existing icon and hint; tapping it triggers a selection haptic and navigates to DiscoverRecruitingRoutesView. The button uses NSLocalizedString, respects the existing breathing-icon layout, and Reduce Motion behavior is unchanged. The standalone EmptyMyRequestsView preview and both MyRequestsListView previews still compile and render. `xcodebuild build` and the SoloCompassTests suite pass.