### PR TITLE
auto: Add icons and one-line descriptions to the sort-mode picker

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1045,6 +1045,12 @@
 "sort.value.soloScore" = "Sorted by Solo score";
 "sort.value.now" = "Sorted by now";
 
+/* Sort mode subtitles in SortModeSheet */
+"sort.subtitle.smart" = "AI picks tuned to you";
+"sort.subtitle.distance" = "Closest first";
+"sort.subtitle.soloScore" = "Best for going solo";
+"sort.subtitle.now" = "Good right now";
+
 /* US-022 — VerifiedBadge */
 "verified.title.verified" = "已验证路线";
 "verified.title.watching" = "社群观察中";

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -29,6 +29,17 @@ public enum SortMode: String, CaseIterable, Identifiable {
     var accessibilityValue: String {
         NSLocalizedString("sort.value.\(rawValue)", comment: "Sort accessibility value: current mode")
     }
+
+    var symbol: String {
+        switch self {
+        case .smart:     return "sparkles"
+        case .distance:  return "location.fill"
+        case .soloScore: return "person.fill"
+        case .now:       return "sunset.fill"
+        }
+    }
+
+    var subtitleKey: String { "sort.subtitle.\(rawValue)" }
 }
 
 // MARK: - Constants
@@ -423,13 +434,24 @@ struct SortModeSheet: View {
 
             ForEach(SortMode.allCases) { mode in
                 Button {
+                    #if canImport(UIKit)
+                    Haptics.selection()
+                    #endif
                     sortMode = mode
                     dismiss()
                 } label: {
-                    HStack {
-                        Text(mode.localizedTitle)
-                            .font(.body)
-                            .foregroundStyle(.primary)
+                    HStack(spacing: 12) {
+                        Image(systemName: mode.symbol)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 28)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(mode.localizedTitle)
+                                .font(.body)
+                                .foregroundStyle(.primary)
+                            Text(NSLocalizedString(mode.subtitleKey, comment: "Sort mode subtitle"))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
                         Spacer()
                         if sortMode == mode {
                             Image(systemName: "checkmark")
@@ -442,6 +464,7 @@ struct SortModeSheet: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .accessibilityElement(children: .combine)
 
                 if mode.id != SortMode.allCases.last?.id {
                     Divider()


### PR DESCRIPTION
## Add icons and one-line descriptions to the sort-mode picker

The SortModeSheet in BottomInfoSheet is the one under-polished surface in the sheet: each sort option ('Smart', 'Distance', 'Solo Score', 'Now') is bare text with no icon or explanation of what it does, so a solo traveler can't tell them apart. This adds an SF Symbol and a localized one-line subtitle to each row, matching the icon+subtitle pattern used by NearbyExperienceRow and the rest of the app, plus a light haptic on selection.

### Acceptance
Opening the sort sheet from the BottomInfoSheet shows each of the four modes with a distinct SF Symbol on the left and a one-line description below the title; the active mode still shows a trailing checkmark; tapping a row fires a selection haptic and dismisses the sheet; VoiceOver reads the title and subtitle as one element; xcodebuild build and the existing SoloCompassTests suite both pass.