### PR TITLE
auto: Celebrate arrival on the experience card with a one-shot glow ring

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -19,6 +19,7 @@ public struct ExperienceCardView: View {
     @State private var heartBurst = false
     @State private var arrivedPulse = false
     @State private var didFireArrival = false
+    @State private var arrivalGlow = false
 
     private static let arrivedThresholdMeters = 75.0
 
@@ -259,9 +260,17 @@ public struct ExperienceCardView: View {
         }
         .padding(16)
         .background(
-            RoundedRectangle(cornerRadius: 20)
-                .fill(.regularMaterial)
-                .shadow(color: .black.opacity(0.1), radius: 12, y: -2)
+            ZStack {
+                RoundedRectangle(cornerRadius: 20)
+                    .stroke(Color.green.opacity(arrivalGlow ? 0 : 0.7), lineWidth: 3)
+                    .scaleEffect(arrivalGlow ? 1.25 : 1.0)
+                    .animation(.easeOut(duration: 0.8), value: arrivalGlow)
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(.regularMaterial)
+                    .shadow(color: .black.opacity(0.1), radius: 12, y: -2)
+            }
         )
         .offset(y: totalOffset)
         .opacity(dragOpacity)
@@ -299,6 +308,13 @@ public struct ExperienceCardView: View {
             guard arrived, !didFireArrival else { return }
             didFireArrival = true
             Haptics.notify(.success)
+            if !reduceMotion {
+                arrivalGlow = true
+                Task {
+                    try? await Task.sleep(nanoseconds: 800_000_000)
+                    arrivalGlow = false
+                }
+            }
         }
         .onAppear {
             Haptics.impact(.light)


### PR DESCRIPTION
## Celebrate arrival on the experience card with a one-shot glow ring

When a user physically arrives at an experience (within 75m), ExperienceCardView fires a success haptic but offers almost no visual reward — just the small green 'You're here' pill scaling in. Add a one-shot expanding green glow ring that radiates from behind the card the moment arrival is detected, turning the most emotionally meaningful moment in the app (you made it!) into a satisfying micro-celebration, fully gated behind reduceMotion.

### Acceptance
Building with `xcodebuild build` succeeds. In the Simulator, simulating a location within 75m of an experience makes a green ring expand and fade once from behind the card simultaneously with the success haptic, and the 'You're here' pill still appears. Toggling Reduce Motion suppresses the ring (pill still scales in per its existing reduceMotion branch). The ring fires only once per card appearance (guarded by didFireArrival) and does not re-trigger on subsequent location updates while still arrived.