### PR TITLE
auto: Animate Solo Score breakdown bars on popover open

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -143,6 +143,7 @@ public struct SoloScoreBadge: View {
 private struct SoloScorePopoverContent: View {
     let score: SoloScore
     @State private var appeared = false
+    @State private var barsFilled = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private struct DimensionRow {
@@ -181,8 +182,8 @@ private struct SoloScorePopoverContent: View {
 
             Divider()
 
-            ForEach(Array(dimensions.enumerated()), id: \.offset) { _, row in
-                dimensionRow(label: NSLocalizedString(row.labelKey, comment: ""), value: row.value)
+            ForEach(Array(dimensions.enumerated()), id: \.offset) { index, row in
+                dimensionRow(label: NSLocalizedString(row.labelKey, comment: ""), value: row.value, index: index)
             }
         }
         .padding()
@@ -192,16 +193,19 @@ private struct SoloScorePopoverContent: View {
         .onAppear {
             if reduceMotion {
                 appeared = true
+                barsFilled = true
             } else {
                 withAnimation(.easeIn(duration: 0.2)) {
                     appeared = true
                 }
+                barsFilled = true
             }
         }
     }
 
-    private func dimensionRow(label: String, value: Double) -> some View {
-        VStack(alignment: .leading, spacing: 3) {
+    private func dimensionRow(label: String, value: Double, index: Int) -> some View {
+        let clamped = max(0, min(10, value))
+        return VStack(alignment: .leading, spacing: 3) {
             HStack {
                 Text(label)
                     .font(.caption)
@@ -217,7 +221,12 @@ private struct SoloScorePopoverContent: View {
                     .overlay(alignment: .leading) {
                         Capsule()
                             .fill(score.scoreColor.opacity(0.8))
-                            .frame(width: geo.size.width * CGFloat(max(0, min(10, value)) / 10))
+                            .frame(width: barsFilled ? geo.size.width * CGFloat(clamped / 10) : 0)
+                            .animation(
+                                reduceMotion ? nil : .spring(response: 0.5, dampingFraction: 0.8)
+                                    .delay(Double(index) * 0.05),
+                                value: barsFilled
+                            )
                     }
             }
             .frame(height: 4)


### PR DESCRIPTION
## Animate Solo Score breakdown bars on popover open

When a user taps the compact Solo Score badge, the breakdown popover's six dimension bars (seating, ratio, staff pressure, portioning, ambiance, safety) snap to full width instantly — inconsistent with the app's animated score reveals (count-up, spring entry, numericText). Add a staggered left-to-right fill animation so each bar grows from zero when the popover appears, reinforcing the score-as-measurement metaphor. Fully respects reduceMotion (bars render at final width with no animation).

### Acceptance
Tapping the compact SoloScoreBadge opens the popover and the six dimension bars fill left-to-right with a slight top-to-bottom stagger, settling at widths proportional to each dimension value. With Reduce Motion enabled, bars appear at final width instantly with no growth animation. Bar track, labels, numeric values, and final widths are unchanged from before. Existing #Preview "Score Breakdown Popover" demonstrates the animation. iOS build succeeds and SoloCompassTests pass.