### PR TITLE
auto: Polish the sort-mode picker: highlighted selected row, press feedback, and animated checkmark

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -418,11 +418,23 @@ struct SortCountToolbar: View {
     }
 }
 
+// MARK: - SortRowButtonStyle
+
+/// Scales down ~4% on press for tactile feedback matching FilterBarView's PressableButtonStyle.
+private struct SortRowButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.96 : 1.0)
+            .animation(.spring(response: 0.25, dampingFraction: 0.6), value: configuration.isPressed)
+    }
+}
+
 // MARK: - SortModeSheet
 
 struct SortModeSheet: View {
     @Binding var sortMode: SortMode
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -437,7 +449,9 @@ struct SortModeSheet: View {
                     #if canImport(UIKit)
                     Haptics.selection()
                     #endif
-                    sortMode = mode
+                    withAnimation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7)) {
+                        sortMode = mode
+                    }
                     dismiss()
                 } label: {
                     HStack(spacing: 12) {
@@ -456,14 +470,24 @@ struct SortModeSheet: View {
                         if sortMode == mode {
                             Image(systemName: "checkmark")
                                 .font(.body.weight(.semibold))
-                                .foregroundStyle(.blue)
+                                .foregroundStyle(Color.accentColor)
+                                .transition(.scale.combined(with: .opacity))
                         }
                     }
                     .padding(.horizontal, 20)
                     .padding(.vertical, 14)
+                    .background(
+                        Group {
+                            if sortMode == mode {
+                                RoundedRectangle(cornerRadius: 10)
+                                    .fill(Color.accentColor.opacity(0.10))
+                                    .padding(.horizontal, 8)
+                            }
+                        }
+                    )
                     .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(SortRowButtonStyle())
                 .accessibilityElement(children: .combine)
 
                 if mode.id != SortMode.allCases.last?.id {


### PR DESCRIPTION
## Polish the sort-mode picker: highlighted selected row, press feedback, and animated checkmark

The SortModeSheet rows in BottomInfoSheet.swift currently show selection with only a bare checkmark in a hardcoded .blue (off-brand) and offer no press-scale feedback, unlike every other tappable surface in the app. This adds a tinted highlight capsule behind the selected row, a spring press-scale, and an animated accent-colored checkmark so the picker matches the app's tactile, on-brand interaction language.

### Acceptance
Opening the sort sheet shows the active mode's row with a faint accent-tinted highlight and an accent-colored checkmark (not blue). Tapping a different mode springs the checkmark/highlight to the new row, fires a selection haptic, and dismisses; rows scale down slightly while pressed. With Reduce Motion on, the selection updates instantly with no scale or spring. xcodebuild build and the existing SoloCompassTests pass; #Preview renders.