### PR TITLE
auto: Animated completion progress ring in Favorites footer

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -406,6 +406,7 @@
 "favorites.nearby.hint" = "Sorts favorites by distance";
 "favorites.completed.count" = "%1$d of %2$d done";
 "favorites.completed.count.a11y" = "%1$d of %2$d favorites completed";
+"favorites.completed.allDone.a11y" = "All saved experiences completed";
 "favorites.row.done.a11y" = "completed";
 
 /* Generic actions */

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -25,6 +25,7 @@ public struct FavoritesListView: View {
     @State private var showSwipeHint = false
     @State private var hintDismissTask: Task<Void, Never>?
     @AppStorage("favorites.swipeHintSeen") private var swipeHintSeen = false
+    @State private var ringDidCelebrate = false
 
     private var undoDismissSeconds: Double { voiceOverOn ? 12 : 4 }
 
@@ -166,21 +167,11 @@ public struct FavoritesListView: View {
                                     .contentTransition(.numericText())
                                 Spacer()
                                 if showCompletedChip {
-                                    HStack(spacing: 4) {
-                                        Image(systemName: "checkmark.circle.fill")
-                                            .font(.caption2)
-                                            .foregroundStyle(Color.green)
-                                            .accessibilityHidden(true)
-                                        Text(String(format: NSLocalizedString("favorites.completed.count", comment: "N of M done chip"), completedCount, sortedFavorites.count))
-                                            .font(.caption2)
-                                            .foregroundStyle(Color.green)
-                                            .contentTransition(.numericText())
-                                            .animation(reduceMotion ? nil : .easeInOut, value: completedCount)
-                                    }
-                                    .padding(.horizontal, 10)
-                                    .padding(.vertical, 5)
-                                    .background(Color.green.opacity(0.12), in: Capsule())
-                                    .accessibilityLabel(String(format: NSLocalizedString("favorites.completed.count.a11y", comment: "N of M done chip accessibility label"), completedCount, sortedFavorites.count))
+                                    CompletionRing(
+                                        done: completedCount,
+                                        total: sortedFavorites.count,
+                                        didCelebrate: $ringDidCelebrate
+                                    )
                                     .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
                                 }
                                 if showNearbyChip {
@@ -287,6 +278,83 @@ public struct FavoritesListView: View {
         .animation(.easeInOut, value: lastUnfavorited != nil)
         .onChange(of: lastUnfavorited == nil) { _, isNil in
             if isNil { undoDragOffset = 0 }
+        }
+    }
+}
+
+private struct CompletionRing: View {
+    let done: Int
+    let total: Int
+    @Binding var didCelebrate: Bool
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var animatedFraction: CGFloat = 0
+    @State private var bloomScale: CGFloat = 1
+
+    private var isAllDone: Bool { total > 0 && done == total }
+    private var fraction: CGFloat { total > 0 ? CGFloat(done) / CGFloat(total) : 0 }
+    private var pctLabel: String { String(format: "%.0f%%", fraction * 100) }
+    private var a11yLabel: String {
+        isAllDone
+            ? NSLocalizedString("favorites.completed.allDone.a11y", comment: "All favorites completed accessibility label")
+            : String(format: NSLocalizedString("favorites.completed.count.a11y", comment: "N of M done chip accessibility label"), done, total)
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.green.opacity(0.15), lineWidth: 2.5)
+            Circle()
+                .trim(from: 0, to: animatedFraction)
+                .stroke(Color.green, style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+            if isAllDone {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Color.green)
+                    .scaleEffect(bloomScale)
+            } else {
+                Text(pctLabel)
+                    .font(.system(size: 7, weight: .semibold).monospacedDigit())
+                    .foregroundStyle(Color.green)
+                    .contentTransition(.numericText())
+                    .animation(reduceMotion ? nil : .easeInOut, value: done)
+            }
+        }
+        .frame(width: 22, height: 22)
+        .accessibilityLabel(a11yLabel)
+        .accessibilityValue(pctLabel)
+        .onAppear {
+            let target = fraction
+            if reduceMotion {
+                animatedFraction = target
+            } else {
+                withAnimation(.easeInOut(duration: 0.5)) { animatedFraction = target }
+            }
+            if isAllDone && !didCelebrate {
+                triggerCelebration()
+            }
+        }
+        .onChange(of: done) { _, _ in
+            let target = fraction
+            if reduceMotion {
+                animatedFraction = target
+            } else {
+                withAnimation(.easeInOut(duration: 0.5)) { animatedFraction = target }
+            }
+            if isAllDone && !didCelebrate {
+                triggerCelebration()
+            }
+        }
+    }
+
+    private func triggerCelebration() {
+        didCelebrate = true
+        Haptics.notify(.success)
+        guard !reduceMotion else { return }
+        withAnimation(.easeOut(duration: 0.15)) { bloomScale = 1.15 }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            withAnimation(.easeIn(duration: 0.15)) { bloomScale = 1 }
         }
     }
 }


### PR DESCRIPTION
## Animated completion progress ring in Favorites footer

The Favorites footer currently shows completion only as a flat 'N of M done' green text chip, which reads as a static stat rather than progress. Replace it with a compact animated ring that fills to the completion fraction on appear and re-animates as experiences are completed, turning the saved list into a visible journey toward 'all done'. When every favorite is completed the ring becomes a celebratory filled checkmark with a one-shot bloom.

### Acceptance
Opening Favorites with some completed experiences shows a ring that animates from empty to the completion fraction; completing another experience re-animates the ring upward with a numeric label transition; completing the last one swaps to a green checkmark with a single bloom + success haptic that does not repeat on scroll; Reduce Motion shows the final state instantly with no animation or bloom; VoiceOver reads the existing 'N of M done' label plus the percentage value; xcodebuild build and the SoloCompassTests target both pass.