### PR TITLE
auto: Add an actionable CTA button to the empty Itineraries state

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -764,6 +764,7 @@
 "itinerary.list.title" = "My Itineraries";
 "itinerary.empty.title" = "No itineraries yet";
 "itinerary.empty.hint" = "Tap + to plan your first trip.";
+"itinerary.empty.cta" = "Plan a trip";
 "itinerary.experienceCount" = "%d experiences";
 "itinerary.action.create.a11y" = "Create new itinerary";
 "itinerary.action.delete" = "Delete";

--- a/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
@@ -29,7 +29,7 @@ public struct ItineraryListView: View {
         NavigationStack {
             Group {
                 if itineraries.isEmpty {
-                    EmptyItineraryView()
+                    EmptyItineraryView(onCreate: { showingCreateForm = true })
                         .transition(.scale(scale: 0.85).combined(with: .opacity))
                 } else {
                     List(itineraries) { itinerary in
@@ -221,6 +221,8 @@ private struct ItineraryRow: View {
 // MARK: - Empty state
 
 private struct EmptyItineraryView: View {
+    var onCreate: (() -> Void)? = nil
+
     @State private var isBreathing = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -246,6 +248,17 @@ private struct EmptyItineraryView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
+            if let onCreate {
+                Button {
+                    Haptics.selection()
+                    onCreate()
+                } label: {
+                    Label(NSLocalizedString("itinerary.empty.cta", comment: "Plan a trip button in empty itinerary state"), systemImage: "plus")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+                .padding(.top, 4)
+            }
         }
         .padding(32)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -289,7 +302,9 @@ private func iso8601Date(_ string: String) -> Date? {
 }
 
 #Preview("Empty state") {
-    ItineraryListView(store: ItineraryStore(context: ModelContext(SoloCompassModelContainer.makeInMemory())))
-        .environment(ExperienceService(seed: []))
-        .environment(UserPreferences())
+    EmptyItineraryView(onCreate: { })
+}
+
+#Preview("Empty state — no CTA") {
+    EmptyItineraryView()
 }


### PR DESCRIPTION
## Add an actionable CTA button to the empty Itineraries state

ItineraryListView's empty state tells users to 'Tap + to plan your first trip' but offers no tappable button — the only path forward is a small toolbar '+' that's easy to miss, leaving the screen a dead-end. This mirrors the proven pattern already in FavoritesListView's EmptyFavoritesView (which has an 'Explore the map' CTA) by giving EmptyItineraryView a prominent 'Plan a trip' button that directly opens the create form. It turns a passive instruction into a one-tap action, improving first-run conversion into itinerary creation.

### Acceptance
Build succeeds via `xcodebuild build`. With zero saved itineraries, the empty state shows a tappable 'Plan a trip' borderedProminent button; tapping it fires a selection haptic and presents ItineraryFormView (showingCreateForm sheet). The button is hidden/absent only when no onCreate closure is supplied (preserving the existing 'With itineraries' preview). VoiceOver reads the button as a labelled control, and the new localized string resolves (no raw key shown). Respects reduce-motion (no behavioral change needed; button is static).