### PR TITLE
auto: Add a circular countdown ring to VoiceButton as recording nears the 60s cap

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
+++ b/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
@@ -14,6 +14,7 @@ public struct VoiceButton: View {
     @State private var showPermissionAlert = false
     @State private var recognitionError: String? = nil
     @State private var pulse = false
+    @State private var ringPulse = false
     @State private var streamTask: Task<Void, Never>?
     @State private var elapsed: TimeInterval = 0
     @State private var timerTask: Task<Void, Never>?
@@ -43,6 +44,25 @@ public struct VoiceButton: View {
                         reduceMotion ? nil : .easeOut(duration: 1.0).repeatForever(autoreverses: false),
                         value: pulse
                     )
+
+                let progress = CGFloat(min(elapsed / maxRecordingDuration, 1.0))
+                let nearEnd = elapsed >= 50
+                Circle()
+                    .trim(from: 0, to: progress)
+                    .stroke(
+                        nearEnd ? Color.orange : Color.red.opacity(0.6),
+                        style: StrokeStyle(lineWidth: 3, lineCap: .round)
+                    )
+                    .frame(width: 64, height: 64)
+                    .rotationEffect(.degrees(-90))
+                    .scaleEffect(nearEnd && !reduceMotion ? (ringPulse ? 1.06 : 1.0) : 1.0)
+                    .animation(reduceMotion ? nil : .linear(duration: 1), value: progress)
+                    .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: nearEnd)
+                    .animation(
+                        nearEnd && !reduceMotion ? .easeInOut(duration: 0.7).repeatForever(autoreverses: true) : nil,
+                        value: ringPulse
+                    )
+                    .accessibilityHidden(true)
             }
 
             Circle()
@@ -216,6 +236,9 @@ public struct VoiceButton: View {
                 try? await Task.sleep(for: .seconds(1))
                 guard !Task.isCancelled else { break }
                 elapsed += 1
+                if elapsed >= 50 && !ringPulse && !reduceMotion {
+                    ringPulse = true
+                }
                 if elapsed >= maxRecordingDuration && !didAutoStop {
                     didAutoStop = true
                     autoStopMessage = NSLocalizedString("voice.recording.maxReached", comment: "Maximum recording length reached")
@@ -231,6 +254,7 @@ public struct VoiceButton: View {
         timerTask = nil
         elapsed = 0
         autoStopMessage = nil
+        ringPulse = false
     }
 }
 


### PR DESCRIPTION
## Add a circular countdown ring to VoiceButton as recording nears the 60s cap

VoiceButton auto-stops at 60s but only warns via a small orange timer turning amber at 50s — easy to miss while focused on speaking. Add a thin circular progress ring around the mic that fills as the 60s limit approaches and pulses amber in the final 10 seconds, giving a glanceable, non-verbal cue that recording is about to end (respecting Reduce Motion and keeping the existing accessibility timer label).

### Acceptance
Long-pressing the mic shows a ring that visibly fills as seconds pass; at 50s the ring turns amber and (with Motion on) pulses gently; at 60s recording auto-stops as before. With Reduce Motion enabled the ring still fills but does not pulse, and no animation is applied. Existing timer text, auto-stop message, haptics, and VoiceOver timer announcement are unchanged. `xcodebuild build` succeeds and the SoloCompassTests target still passes.