### PR TITLE
fix(ios): resolve broken main build — content-view scope, clock isolation, viewbuilder & preview keypath

### DIFF
--- a/apps/ios/SoloCompass/Models/ChatMessage.swift
+++ b/apps/ios/SoloCompass/Models/ChatMessage.swift
@@ -1,4 +1,3 @@
-
 /// ChatMessage — a single message within a Conversation.
 ///
 /// Mirrors `packages/core/src/companion.ts`. Keep field names in sync.

--- a/apps/ios/SoloCompass/Models/ChatUIState.swift
+++ b/apps/ios/SoloCompass/Models/ChatUIState.swift
@@ -1,4 +1,3 @@
-
 /// Strict state machine for the chat overlay UI.
 /// Each case maps to a distinct visual presentation in ChatStateModifier.
 public enum ChatUIState: Equatable {

--- a/apps/ios/SoloCompass/Models/City.swift
+++ b/apps/ios/SoloCompass/Models/City.swift
@@ -1,4 +1,3 @@
-
 /// Canonical city record mirroring packages/core/src/city.ts.
 /// geonameId is the stable deduplication key across language variants.
 public struct City: Codable, Identifiable, Hashable {

--- a/apps/ios/SoloCompass/Models/CompanionBlock.swift
+++ b/apps/ios/SoloCompass/Models/CompanionBlock.swift
@@ -1,4 +1,3 @@
-
 /// CompanionBlock — a block record between two users (US-014).
 ///
 /// Mirrors the `companion_blocks` table in 0003_companion.sql.

--- a/apps/ios/SoloCompass/Models/CompanionPost.swift
+++ b/apps/ios/SoloCompass/Models/CompanionPost.swift
@@ -1,4 +1,3 @@
-
 /// CompanionPost — a discoverable post signalling openness to meeting companions.
 ///
 /// Mirrors `packages/core/src/companion.ts`. Keep field names in sync.

--- a/apps/ios/SoloCompass/Models/CompanionProfile.swift
+++ b/apps/ios/SoloCompass/Models/CompanionProfile.swift
@@ -1,4 +1,3 @@
-
 /// CompanionProfile — the user's public-facing companion identity.
 ///
 /// Mirrors `packages/core/src/companion.ts`. Keep field names in sync.

--- a/apps/ios/SoloCompass/Models/CompanionReport.swift
+++ b/apps/ios/SoloCompass/Models/CompanionReport.swift
@@ -1,4 +1,3 @@
-
 /// CompanionReport — a safety report filed against another user.
 ///
 /// Mirrors `packages/core/src/companion.ts`. Keep field names in sync.

--- a/apps/ios/SoloCompass/Models/CompanionRequest.swift
+++ b/apps/ios/SoloCompass/Models/CompanionRequest.swift
@@ -1,4 +1,3 @@
-
 /// CompanionRequest — a request from one user to another to travel together.
 ///
 /// Mirrors `packages/core/src/companion.ts`. Keep field names in sync.

--- a/apps/ios/SoloCompass/Models/Conversation.swift
+++ b/apps/ios/SoloCompass/Models/Conversation.swift
@@ -1,4 +1,3 @@
-
 /// Conversation — a messaging thread opened after a CompanionRequest is accepted,
 /// or a group chat formed around a Route companion slot.
 ///

--- a/apps/ios/SoloCompass/Models/Itinerary.swift
+++ b/apps/ios/SoloCompass/Models/Itinerary.swift
@@ -1,4 +1,3 @@
-
 /// Itinerary — a named trip plan owned by one user.
 ///
 /// Mirrors `packages/core/src/companion.ts`. Keep field names in sync.

--- a/apps/ios/SoloCompass/Models/Route.swift
+++ b/apps/ios/SoloCompass/Models/Route.swift
@@ -1,4 +1,3 @@
-
 /// Route — an ordered sequence of experiences plus metadata describing how
 /// to walk it, who has walked it, and (optionally) which companion slot is
 /// attached.

--- a/apps/ios/SoloCompass/Models/RouteItineraryBridge.swift
+++ b/apps/ios/SoloCompass/Models/RouteItineraryBridge.swift
@@ -1,4 +1,3 @@
-
 /// Bidirectional converters between Itinerary and Route.
 ///
 /// Story #US-005. Route is becoming the canonical core; Itinerary is the

--- a/apps/ios/SoloCompass/Models/SeedUser.swift
+++ b/apps/ios/SoloCompass/Models/SeedUser.swift
@@ -1,4 +1,3 @@
-
 /// A lightweight user fixture loaded from `seed_users.json`.
 ///
 /// Used only by `UserDirectory` for in-memory lookup during development and


### PR DESCRIPTION
## Summary

Minimal **build-only hotfix** for `main`. The iOS app (and TestFlight deploy) failed to compile due to **five independent pre-existing compile errors**. Swift batches files during compilation, so earlier failures masked later ones — each is fixed here with a surgical change. **No feature or design work is included.**

## Root causes & fixes

1. **`CompassMapView.swift` / `ExploreProgressBar.swift`** — `enum ChatStartMode` and `static func progressText` live in `CompassMapContentView`, but three call sites referenced them as `CompassMapView.*` (the thin wrapper struct, which owns neither). Re-qualified to `CompassMapContentView.*` (`CompassMapView.swift:1106`, `:1459`; `ExploreProgressBar.swift:13`).
2. **`CompassMapView.swift`** — the `String.truncated(limit:)` helper was `private`, so module sibling `VoiceProcessingToast` couldn't call it. Relaxed to internal access.
3. **`BestNowClock.swift`** — the nonisolated `deinit` calls `timer?.invalidate()`, but `timer` was main-actor-isolated → error under `SWIFT_STRICT_CONCURRENCY: complete`. Marked the property `nonisolated` (`Timer.invalidate()` is thread-safe; all other access stays on the main actor).
4. **`ApprovalQueueView.swift`** — `optInBadge` was `@ViewBuilder` but led with a `let`+`switch` that made the builder infer `()` ("type '()' cannot conform to 'View'"). Extracted resolution into a non-builder helper so the builder body is a single view expression.
5. **`VoiceProcessingToast.swift`** — the `#Preview` used `.environment(\.accessibilityReduceMotion, true)`, but that key is a read-only `KeyPath`, not `WritableKeyPath`. Added a preview-only `forceReduceMotion` hook; also fixed the `UIAccessibility.post(notification:)` argument label and the `truncated` access cascade.

## Verification

```
cd apps/ios && xcodegen generate --spec project.yml && \
xcodebuild build -project SoloCompass.xcodeproj -scheme SoloCompass \
  -destination 'generic/platform=iOS Simulator' -configuration Debug \
  CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/hotfix_build
```
→ **`** BUILD SUCCEEDED **`**, 0 errors, no warnings. This proves the 5 fixes are self-sufficient without any feature/design changes.

## Excluded (intentionally)

Design-handoff work (`RouteDetailView.swift`, new `CompareTokens` tokens) and `project.pbxproj` (CI regenerates it via xcodegen) are **not** part of this hotfix.