### PR TITLE
auto: Surface the evidence base in the Solo Score popover

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -185,6 +185,20 @@ private struct SoloScorePopoverContent: View {
             ForEach(Array(dimensions.enumerated()), id: \.offset) { index, row in
                 dimensionRow(label: NSLocalizedString(row.labelKey, comment: ""), value: row.value, index: index)
             }
+
+            if score.basedOnCount > 0 {
+                Divider()
+                HStack(spacing: 6) {
+                    Image(systemName: "person.2.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(String(format: NSLocalizedString("solo.basedOn", comment: "Based on N solo travelers"), score.basedOnCount))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(Text(String(format: NSLocalizedString("solo.basedOn", comment: "Based on N solo travelers"), score.basedOnCount)))
+            }
         }
         .padding()
         .frame(minWidth: 240)


### PR DESCRIPTION
## Surface the evidence base in the Solo Score popover

The compact Solo Score badge — the most-tapped score surface, present on every experience card — opens a breakdown popover that shows the six sub-dimensions but never reveals basedOnCount, the number of solo visits the score is derived from. Adding a localized 'Based on N solo visits' footer (matching the pattern already used in ExperienceDetailView) grounds the score in evidence and reinforces the product's confidence-and-transparency ethos at the exact moment the user is scrutinizing it.

### Acceptance
Tapping the compact Solo Score badge on any experience card opens the breakdown popover showing the six dimension bars followed by a divider and a 'Based on 11 solo visits' footer with a person.2 icon. The footer is hidden when basedOnCount is 0, reads correctly under VoiceOver as a single combined element, respects reduce-motion (no new animation), and all strings resolve via NSLocalizedString. xcodebuild build and the SoloCompassTests target both pass; the '#Preview("Score Breakdown Popover")' renders the footer.