### PR TITLE
auto: Make the offline banner tap-to-retry

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -670,6 +670,8 @@
 
 /* Offline banner (US-041) */
 "offline.banner" = "Offline mode · showing cached data";
+"offline.banner.retry" = "Tap to retry";
+"offline.banner.retry.hint" = "Double tap to retry connection";
 
 /* Theme picker (US-039) */
 "settings.appearance" = "Appearance";

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -411,8 +411,10 @@ struct CompassMapContentView: View {
                 // Offline banner (US-041): amber pill when network is unavailable
                 if !networkMonitor.isConnected {
                     VStack {
-                        OfflineBanner()
-                            .padding(.top, 8)
+                        OfflineBanner(onRetry: {
+                            viewModel.loadNearbyExperiences()
+                        })
+                        .padding(.top, 8)
                         Spacer()
                     }
                     .animation(.easeInOut, value: networkMonitor.isConnected)

--- a/apps/ios/SoloCompass/Views/Shared/OfflineBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/OfflineBanner.swift
@@ -1,44 +1,93 @@
 import SwiftUI
 
 /// Amber pill banner shown in CompassMapView when the app is offline and showing cached data (US-041).
+/// When `onRetry` is non-nil the banner becomes a tappable button that re-runs the experience load.
 struct OfflineBanner: View {
+    var onRetry: (() async -> Void)? = nil
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isPulsing = false
+    @State private var isRetrying = false
 
     var body: some View {
-        GlassmorphismCapsule(
-            verticalPadding: 8,
-            leading: {
-                Image(systemName: "wifi.slash")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(Color.orange)
-                    .scaleEffect(isPulsing ? 1.12 : 0.96)
-                    .opacity(isPulsing ? 1.0 : 0.65)
-            },
-            content: {
-                Text(NSLocalizedString("offline.banner", comment: "Offline mode banner"))
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(Color.orange)
-            }
-        )
-        .transition(.move(edge: .top).combined(with: .opacity))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(Text(NSLocalizedString("offline.banner", comment: "Offline mode banner")))
-        .onAppear {
-            guard !reduceMotion else { return }
-            withAnimation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true)) {
-                isPulsing = true
-            }
-        }
-        .onChange(of: reduceMotion) { _, reduced in
-            if reduced {
-                withAnimation(.default) { isPulsing = false }
-            } else {
+        pillContent
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(Text(NSLocalizedString("offline.banner", comment: "Offline mode banner")))
+            .onAppear {
+                guard !reduceMotion else { return }
                 withAnimation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true)) {
                     isPulsing = true
                 }
             }
+            .onChange(of: reduceMotion) { _, reduced in
+                if reduced {
+                    withAnimation(.default) { isPulsing = false }
+                } else {
+                    withAnimation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true)) {
+                        isPulsing = true
+                    }
+                }
+            }
+    }
+
+    @ViewBuilder
+    private var pillContent: some View {
+        if let onRetry {
+            Button {
+                guard !isRetrying else { return }
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                isRetrying = true
+                Task {
+                    await onRetry()
+                    isRetrying = false
+                }
+            } label: {
+                capsuleView
+            }
+            .buttonStyle(.plain)
+            .accessibilityAddTraits(.isButton)
+            .accessibilityHint(Text(NSLocalizedString("offline.banner.retry.hint", comment: "Double tap to retry connection")))
+        } else {
+            capsuleView
         }
+    }
+
+    @ViewBuilder
+    private var capsuleView: some View {
+        GlassmorphismCapsule(
+            verticalPadding: 8,
+            leading: {
+                Group {
+                    if isRetrying {
+                        ProgressView()
+                            .controlSize(.mini)
+                            .tint(Color.orange)
+                    } else {
+                        Image(systemName: "wifi.slash")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(Color.orange)
+                            .scaleEffect(isPulsing ? 1.12 : 0.96)
+                            .opacity(isPulsing ? 1.0 : 0.65)
+                    }
+                }
+            },
+            content: {
+                HStack(spacing: 4) {
+                    Text(NSLocalizedString("offline.banner", comment: "Offline mode banner"))
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Color.orange)
+                    if onRetry != nil && !isRetrying {
+                        Text("·")
+                            .font(.caption)
+                            .foregroundStyle(Color.orange.opacity(0.7))
+                        Text(NSLocalizedString("offline.banner.retry", comment: "Tap to retry connection"))
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(Color.orange.opacity(0.85))
+                    }
+                }
+            }
+        )
     }
 }
 
@@ -47,6 +96,16 @@ struct OfflineBanner: View {
         Color(.systemBackground).ignoresSafeArea()
         OfflineBanner()
             .padding(.top, 60)
+    }
+}
+
+#Preview("With Retry") {
+    ZStack {
+        Color(.systemBackground).ignoresSafeArea()
+        OfflineBanner(onRetry: {
+            try? await Task.sleep(for: .seconds(1))
+        })
+        .padding(.top, 60)
     }
 }
 


### PR DESCRIPTION
## Make the offline banner tap-to-retry

The amber OfflineBanner in CompassMapView is currently purely informational — a solo traveler who regains signal has no way to manually trigger a data refresh and must wait for an automatic retry. Make the banner an actionable button that re-runs the experience load on tap, with a brief spinner and haptic feedback, so users can recover the moment their connection returns.

### Acceptance
Building with `xcodebuild build -scheme SoloCompass` succeeds. When offline, the banner shows a 'tap to retry' affordance, is exposed as a button to VoiceOver with the retry hint, and tapping it fires a light haptic, shows a brief spinner, and re-runs the experience refresh. With Reduce Motion on, no extra animation is added beyond the existing pulse handling. New strings are present in Localizable.strings and existing OfflineBanner previews still render.