### PR TITLE
auto: Live Compass Heading Overlay in Experience Detail

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1204,3 +1204,7 @@
 
 /* Empty Nearby CTA — nudges the traveler to recenter/zoom out */
 "empty.nearby.cta" = "Explore another area";
+
+/* Compass direction overlay in ExperienceDetailView hero */
+"compass.pointing.title" = "Pointing toward";
+"compass.direction.a11y" = "%1$@ away, pointing %2$@";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -59,6 +59,7 @@ public struct ExperienceDetailView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 heroSection
+                compassDirectionView
                 askSoloSection
                 if let coord = viewModel.experience.location.clCoordinate {
                     LocationCard(
@@ -205,6 +206,7 @@ public struct ExperienceDetailView: View {
             }
         }
         .task {
+            locationService.startUpdating()
             await viewModel.loadAIExplanation()
             await viewModel.loadRemoteSoloScore()
         }
@@ -348,6 +350,35 @@ public struct ExperienceDetailView: View {
                     return label
                 }()))
             }
+        }
+    }
+
+    // MARK: - Compass Direction Overlay
+
+    /// Live compass ring that rotates to point toward the selected experience.
+    /// Rendered only when a GPS fix is available — gracefully absent otherwise.
+    @ViewBuilder
+    private var compassDirectionView: some View {
+        if locationService.currentLocation != nil,
+           let coord = viewModel.experience.location.clCoordinate {
+            let relBearing = relativeBearing(to: coord) ?? 0
+            let distStr = Self.formatDistance(locationService.distance(to: coord))
+            let cardinalDir = Self.compassDirection(for: relBearing)
+            let a11yLabel = String(
+                format: NSLocalizedString("compass.direction.a11y", comment: "Distance + cardinal direction accessibility label"),
+                distStr,
+                cardinalDir
+            )
+            CompassDirectionView(
+                relBearing: relBearing,
+                distanceString: distStr,
+                cardinalDirection: cardinalDir,
+                reduceMotion: reduceMotion
+            )
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(Text(a11yLabel))
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
         }
     }
 
@@ -1129,6 +1160,82 @@ public struct ExperienceDetailView: View {
     private func format(window: TimeWindow) -> String {
         String(format: "%02d:00 – %02d:00", window.startHour, window.endHour)
     }
+}
+
+// MARK: - Compass Direction View
+
+private struct CompassDirectionView: View {
+    let relBearing: Double
+    let distanceString: String
+    let cardinalDirection: String
+    let reduceMotion: Bool
+
+    private let ringSize: CGFloat = 120
+    private let tickLength: CGFloat = 8
+
+    var body: some View {
+        VStack(spacing: 6) {
+            ZStack {
+                // Cardinal tick marks and labels
+                ForEach(["N", "E", "S", "W"], id: \.self) { label in
+                    let angle: Double = label == "N" ? 0 : label == "E" ? 90 : label == "S" ? 180 : 270
+                    VStack(spacing: 2) {
+                        Text(NSLocalizedString("compass.\(label)", comment: "Cardinal direction"))
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(.tertiary)
+                        Spacer()
+                    }
+                    .frame(width: ringSize, height: ringSize)
+                    .rotationEffect(.degrees(angle))
+                }
+
+                // Outer ring
+                Circle()
+                    .strokeBorder(Color.secondary.opacity(0.25), lineWidth: 1.5)
+                    .frame(width: ringSize, height: ringSize)
+
+                // Arrow pointing toward the experience
+                Image(systemName: "location.north.fill")
+                    .font(.system(size: 28, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+                    .rotationEffect(.degrees(relBearing))
+                    .animation(
+                        reduceMotion ? nil : .easeInOut(duration: 0.25),
+                        value: relBearing
+                    )
+                    .accessibilityHidden(true)
+
+                // Distance label inside the ring
+                VStack(spacing: 2) {
+                    Spacer()
+                    Text(distanceString)
+                        .font(.system(size: 10, weight: .medium).monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+                .frame(width: ringSize * 0.6, height: ringSize * 0.6)
+            }
+
+            // "Pointing toward" + cardinal direction label below the ring
+            HStack(spacing: 4) {
+                Text(NSLocalizedString("compass.pointing.title", comment: "Compass pointing toward label"))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                Text(cardinalDirection)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+#Preview("CompassDirectionView") {
+    CompassDirectionView(
+        relBearing: 45,
+        distanceString: "1.2 km",
+        cardinalDirection: "northeast",
+        reduceMotion: false
+    )
+    .padding()
 }
 
 // MARK: - Best Time Window Row

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -206,7 +206,6 @@ public struct ExperienceDetailView: View {
             }
         }
         .task {
-            locationService.startUpdating()
             await viewModel.loadAIExplanation()
             await viewModel.loadRemoteSoloScore()
         }
@@ -1171,7 +1170,6 @@ private struct CompassDirectionView: View {
     let reduceMotion: Bool
 
     private let ringSize: CGFloat = 120
-    private let tickLength: CGFloat = 8
 
     var body: some View {
         VStack(spacing: 6) {
@@ -1180,7 +1178,7 @@ private struct CompassDirectionView: View {
                 ForEach(["N", "E", "S", "W"], id: \.self) { label in
                     let angle: Double = label == "N" ? 0 : label == "E" ? 90 : label == "S" ? 180 : 270
                     VStack(spacing: 2) {
-                        Text(NSLocalizedString("compass.\(label)", comment: "Cardinal direction"))
+                        Text(label)
                             .font(.system(size: 9, weight: .semibold))
                             .foregroundStyle(.tertiary)
                         Spacer()


### PR DESCRIPTION
## Live Compass Heading Overlay in Experience Detail

Add a glanceable, live-updating compass arrow to the ExperienceDetailView hero that rotates to point at the selected experience as the user physically turns — turning the app's namesake 'compass' metaphor into a real on-device affordance. It reuses the existing LocationService.heading and relativeBearing(to:) plumbing already used by the small distance-pill arrow, promoting it into a proper compass ring with the live distance and cardinal direction.

### Acceptance
ExperienceDetailView builds via xcodebuild for iPhone 17 Pro sim with no warnings; a #Preview shows the compass ring with a rotated arrow; with LocationService.simulate(location:) + simulate(heading:) the arrow rotation reflects relativeBearing and updates on heading change; the compass is absent (no crash, no empty ring) when currentLocation is nil; reduceMotion disables the rotation animation; VoiceOver reads a single combined distance+direction label; pnpm parity:check and StringsParityTests pass; change stays within ExperienceDetailView.swift + Localizable.strings and under 100 lines.