### PR TITLE
auto: Pending-count badge in the companion Request Inbox toolbar

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -902,6 +902,8 @@
 "companion.inbox.error.title" = "Could not load inbox";
 "companion.inbox.error.retry" = "Try again";
 "companion.inbox.error.retry.hint" = "Reloads the inbox";
+"companion.inbox.pending.count" = "%d pending";
+"companion.inbox.pending.count.a11y" = "%d requests awaiting your reply";
 
 /* Companion — chat (US-013) */
 "companion.chat.title" = "Chat";

--- a/apps/ios/SoloCompass/Views/Companion/RequestInboxView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/RequestInboxView.swift
@@ -11,10 +11,15 @@ public struct RequestInboxView: View {
     @State private var showingAcceptedConfirm = false
     @State private var reportTarget: CompanionRequest?
     @State private var errorMessage: String?
+    @State private var pulse = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     public init(service: CompanionService = .shared) {
         _service = State(initialValue: service)
+    }
+
+    private var pendingCount: Int {
+        service.inboxRequests.filter { $0.status == .pending }.count
     }
 
     public var body: some View {
@@ -35,6 +40,32 @@ public struct RequestInboxView: View {
         .navigationTitle(NSLocalizedString("companion.inbox.title", comment: "Inbox nav title"))
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
+            if pendingCount > 0 {
+                ToolbarItem(placement: .topBarLeading) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "bell.badge.fill")
+                            .accessibilityHidden(true)
+                        Text(String(format: NSLocalizedString("companion.inbox.pending.count", comment: "Pending request count pill"), pendingCount))
+                            .contentTransition(.numericText())
+                    }
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color.orange)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(Color.orange.opacity(0.15), in: Capsule())
+                    .opacity(!reduceMotion ? (pulse ? 1.0 : 0.65) : 1.0)
+                    .animation(
+                        !reduceMotion ? .easeInOut(duration: 1.2).repeatForever(autoreverses: true) : .none,
+                        value: pulse
+                    )
+                    .animation(.easeInOut, value: pendingCount)
+                    .accessibilityLabel(String(format: NSLocalizedString("companion.inbox.pending.count.a11y", comment: "VoiceOver: pending requests count"), pendingCount))
+                    .onAppear {
+                        guard !pulse, !reduceMotion else { return }
+                        pulse = true
+                    }
+                }
+            }
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     Task { await service.fetchInbox() }


### PR DESCRIPTION
## Pending-count badge in the companion Request Inbox toolbar

The host-side RequestInboxView shows a flat list of join requests but no at-a-glance count of how many still await a reply. Add a numeric pending-count pill to the navigation toolbar that animates (numericText content transition) as requests are accepted or declined, with a gentle pulse while any are outstanding and VoiceOver support. This mirrors the count footers already used in MyRequestsListView and the Favorites list, giving the host instant feedback on their action backlog.

### Acceptance
Build passes (xcodebuild build, iPhone 17 Pro sim). With ≥1 pending request the inbox toolbar shows an orange pill with the live count; accepting or declining a request animates the number down with a numericText transition and the pill disappears at zero. The pill pulses subtly while requests remain and stops/omits the animation under Reduce Motion. VoiceOver reads "N requests awaiting your reply" and the bell symbol is not separately announced. No new force-unwraps; all strings via NSLocalizedString; existing previews still render.