### PR TITLE
auto: Confirm a successful companion request with a haptic + toast (match the existing error feedback)

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -877,6 +877,7 @@
 /* Companion — send request (US-012) */
 "companion.request.send" = "Send request";
 "companion.request.sent" = "Request sent";
+"companion.request.sent.confirm" = "Request sent — they'll be notified";
 "companion.request.send.action" = "Send";
 "companion.request.sheet.title" = "Send Companion Request";
 "companion.request.post.header" = "Traveling with";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -681,6 +681,7 @@
 "companion.request.send" = "发送请求";
 "companion.request.send.action" = "发送";
 "companion.request.sent" = "请求已发送";
+"companion.request.sent.confirm" = "请求已发送 — 对方将收到通知";
 "companion.request.accept" = "接受";
 "companion.request.decline" = "拒绝";
 

--- a/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
@@ -15,6 +15,7 @@ public struct DiscoverListView: View {
     @State private var requestSentPostId: String?
     @State private var reportTarget: DiscoverPost?
     @State private var errorMessage: String?
+    @State private var successMessage: String?
     @State private var showPostSheet = false
 
     public init(cityCode: String, service: CompanionService = .shared) {
@@ -65,6 +66,24 @@ public struct DiscoverListView: View {
             }
         }
         .animation(.easeInOut, value: errorMessage)
+        .overlay(alignment: .bottom) {
+            if let msg = successMessage {
+                HStack(spacing: 8) {
+                    Image(systemName: "checkmark.circle.fill")
+                    Text(msg)
+                        .font(.subheadline)
+                        .lineLimit(2)
+                }
+                .foregroundStyle(.green)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                .background(.regularMaterial, in: Capsule())
+                .padding(.bottom, 16)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .accessibilityLabel(msg)
+            }
+        }
+        .animation(.easeInOut, value: successMessage)
         .sheet(item: $selectedPost) { post in
             SendRequestSheet(post: post) { note in
                 Task { await sendRequest(to: post, note: note) }
@@ -198,6 +217,14 @@ public struct DiscoverListView: View {
         switch result {
         case .success:
             requestSentPostId = post.id
+            Haptics.notify(.success)
+            let msg = NSLocalizedString("companion.request.sent.confirm", comment: "Companion request sent confirmation toast")
+            successMessage = msg
+            UIAccessibility.post(notification: .announcement, argument: msg)
+            Task {
+                try? await Task.sleep(for: .seconds(3))
+                successMessage = nil
+            }
         case .failure(let err):
             errorMessage = err.localizedDescription
             Haptics.notify(.error)


### PR DESCRIPTION
## Confirm a successful companion request with a haptic + toast (match the existing error feedback)

In DiscoverListView, sending a companion request only changes the button to green inline — the success branch is silent, while the failure branch fires Haptics.notify(.error) and shows a banner. This adds a symmetric success path: a .success haptic, a brief bottom confirmation toast reusing the existing overlay/animation pattern, and a VoiceOver announcement, so the most important positive action in the companion flow gets the same feedback weight as its failure.

### Acceptance
Sending a companion request that succeeds plays a success notification haptic, briefly shows a green 'Request sent' confirmation toast at the bottom that auto-dismisses after ~3s, and posts a VoiceOver announcement; the failure path is unchanged. The new localized string is present so StringsParityTests still passes, the iOS target builds (xcodebuild build), and the change is verified visually in the Simulator via the 'With posts' preview / Discover flow.