### PR TITLE
fix(ios): repair FilterBarView compile error keeping main CI red

### DIFF
--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -325,8 +325,7 @@ public struct FilterBarView: View {
 
     private func pill(id: String, label: String, isSelected: Bool, color: Color, action: @escaping () -> Void) -> some View {
         Button {
-            fireSelectionHaptic(alreadySelected: isSelected)
-            action()
+            handleTap(isSelected: isSelected, select: action)
         } label: {
             Text(label)
                 .font(.subheadline.weight(.medium))


### PR DESCRIPTION
## What was actually red

main's iOS CI (`Run Unit Tests`) is failing on current main (17ad8a9). The brief asked me to fix the previously-diagnosed `BestNowClock` XCTest-host crash — but **that fix already landed on main** earlier (commits 88f394a, 21c43e8, 536416f, 09e8164). All 5 view tests already inject `.environment(BestNowClock.shared)`, and the host-crash count is now **0**.

CI is red for a **different, newer reason**: a compile error that breaks the whole app target.

## Root cause

`FilterBarView.pill(...)` calls `fireSelectionHaptic(alreadySelected:)` — a helper that **does not exist anywhere in the iOS target** (1 reference, 0 definitions). A stale/renamed identifier left behind during a refactor. Because the app target fails to compile, `xcodebuild test` aborts at the **build** step (exit 65) before any test runs:

```
FilterBarView.swift:328:13: error: cannot find 'fireSelectionHaptic' in scope
```

The three sibling pill builders (`nowPill`, `iconPill`, `customTagPill`) all route taps through the existing `handleTap(isSelected:select:)` helper, which fires `Haptics.selection()` on select and `Haptics.impact(.light)` + `onClear()` on toggle-off.

## Fix

One-function change: make `pill(...)` use the same `handleTap` helper as its siblings. Behavior-preserving (selection haptic on select), covered by `FilterBarSelectionHapticTests`. No production behavior change beyond restoring compilation.

```diff
     private func pill(...) -> some View {
         Button {
-            fireSelectionHaptic(alreadySelected: isSelected)
-            action()
+            handleTap(isSelected: isSelected, select: action)
         } label: {
```

## Verification

`xcodebuild test` on iPhone 17 Pro (iOS latest), Debug, `CODE_SIGNING_ALLOWED=NO`:

- App target now **compiles** (was exit 65 at build).
- BestNowClock host-crash count: **0**.
- Suite ran: **727 tests, 9 skipped, 6 failures (0 unexpected)**.

## Remaining failures (NOT addressed here — pre-existing, separate work)

These 6 tests still fail. They are unrelated to this compile fix (my change only touches filter-pill haptic routing) and are tied to the in-progress design-handoff localization / view-model work. Listed for the owner, intentionally left as-is:

- `StringsParityTests.testEnAndZhHansHaveSameKeys` — 57 keys exist in `en` but are missing from `zh-Hans` Localizable.strings
- `EmptyStateAnnouncementTest.testEmptyAnnouncementKeysExistInEnglish` — empty-state announcement keys missing from the English Localizable.strings bundle
- `EmptyStateAnnouncementTest.testNearbySectionRendersEmptyStateWhenNoExperiences` — empty NearbySection still renders the experience-list branch instead of the empty state
- `NowCountCacheTests.testInitialCountIsZero` — `nowCount` is 1 before the first load (expected 0)
- `MapViewModelCityRegionSyncTests.testColdStartCameraMatchesSelectedCity` — cold-start camera is 2.59 km off Chiang Mai (expected < 1 km)
- `VoiceToastA11yTests.testToastViewTreeContainsUpdatesFrequentlyTrait` — active voice-processing toast missing the `.updatesFrequently` accessibility trait
