### PR TITLE
auto: Route bypassed haptic call sites through the Reduce-Motion-aware Haptics shim

### DIFF
--- a/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
@@ -470,7 +470,7 @@ public struct ChatSheet: View {
         VStack(spacing: 8) {
             ForEach(Array(Self.starterPrompts.enumerated()), id: \.offset) { index, prompt in
                 Button {
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    Haptics.impact(.light)
                     handleSend(prompt)
                 } label: {
                     Text(prompt)
@@ -542,7 +542,7 @@ public struct ChatSheet: View {
         switch outcome {
         case .accepted:
             clearSendHint()
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            Haptics.impact(.light)
         case .empty:
             // The input bar already guards on empty; nothing to do.
             break
@@ -570,7 +570,7 @@ public struct ChatSheet: View {
             if orchestrator.restartIfNeeded(),
                orchestrator.handleTextInput(text) == .accepted {
                 clearSendHint()
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                Haptics.impact(.light)
             } else {
                 showSendHint(
                     NSLocalizedString(
@@ -667,7 +667,7 @@ public struct ChatSheet: View {
             do {
                 liveTranscript = ""
                 let stream = try voiceService.startListening()
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                Haptics.impact(.light)
                 voiceStreamTask = Task { @MainActor in
                     do {
                         for try await text in stream {
@@ -699,7 +699,7 @@ public struct ChatSheet: View {
         guard send, !final.isEmpty else { return }
         lastUserTranscript = final
         orchestrator.handleTranscript(final)
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        Haptics.impact(.light)
     }
 
     private func teardownVoiceStream() {

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -432,7 +432,7 @@ public struct ExperienceDetailView: View {
     private var askSoloSection: some View {
         if let onAskSolo {
             Button {
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                Haptics.impact(.light)
                 switch Self.askSoloAction(canAskSolo: viewModel.canAskSolo) {
                 case .openChat:
                     onAskSolo(viewModel.experience)
@@ -922,7 +922,7 @@ public struct ExperienceDetailView: View {
                 }
             }
             .simultaneousGesture(TapGesture().onEnded {
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                Haptics.impact(.light)
             })
             .accessibilityAddTraits(.isLink)
             .accessibilityHint(Text(NSLocalizedString("detail.source.openHint", comment: "Opens the original source")))

--- a/apps/ios/SoloCompass/Views/Shared/OfflineBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/OfflineBanner.swift
@@ -36,7 +36,7 @@ struct OfflineBanner: View {
         if let onRetry {
             Button {
                 guard !isRetrying else { return }
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                Haptics.impact(.light)
                 isRetrying = true
                 Task {
                     await onRetry()


### PR DESCRIPTION
## Route bypassed haptic call sites through the Reduce-Motion-aware Haptics shim

The app has a centralized `Haptics` shim (Services/Haptics.swift) that routes through `HapticService`, which respects the user's `hapticsEnabled` setting, Reduce Motion, and preview suppression. But ~30 call sites bypass it with raw `UIImpactFeedbackGenerator(style:).impactOccurred()` / `UINotificationFeedbackGenerator().notificationOccurred(_:)`, so those haptics still fire when a user has Reduce Motion or haptics disabled — an accessibility regression. This converts the bypassed sites in three high-traffic view files to the shim for consistent, accessibility-respecting feedback.

### Acceptance
All eight listed call sites use `Haptics.impact`/`Haptics.notify` instead of raw generators. With Settings > Accessibility > Reduce Motion ON (or haptics disabled in-app), tapping the offline banner retry, the detail-view actions, and the chat actions produces NO haptic; with it OFF, haptics fire as before. `xcodebuild build -project apps/ios/SoloCompass.xcodeproj -scheme SoloCompass` succeeds and existing `SoloCompassTests` pass. No change to net line count beyond ~8 single-line edits.