### PR TITLE
auto: Fix Discover: only one companion request can show as 'sent' at a time

### DIFF
--- a/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
@@ -12,7 +12,7 @@ public struct DiscoverListView: View {
     @Environment(UserPreferences.self) private var preferences
     @State private var service: CompanionService
     @State private var selectedPost: DiscoverPost?
-    @State private var requestSentPostId: String?
+    @State private var sentRequestIds: Set<String> = []
     @State private var reportTarget: DiscoverPost?
     @State private var errorMessage: String?
     @State private var successMessage: String?
@@ -164,7 +164,7 @@ public struct DiscoverListView: View {
         List(service.discoverPosts) { post in
             DiscoverPostRow(
                 post: post,
-                hasSentRequest: requestSentPostId == post.id,
+                hasSentRequest: sentRequestIds.contains(post.id),
                 onSendRequest: { selectedPost = post },
                 onReport: { reportTarget = post }
             )
@@ -216,7 +216,7 @@ public struct DiscoverListView: View {
         )
         switch result {
         case .success:
-            requestSentPostId = post.id
+            withAnimation(.easeInOut) { sentRequestIds.insert(post.id) }
             Haptics.notify(.success)
             let msg = NSLocalizedString("companion.request.sent.confirm", comment: "Companion request sent confirmation toast")
             successMessage = msg


### PR DESCRIPTION
## Fix Discover: only one companion request can show as 'sent' at a time

In DiscoverListView, sent-request state is tracked with a single `requestSentPostId: String?`, so sending a request to a second post silently resets the first post's button back to its un-sent state — even though that request was already sent. Replacing it with a `Set<String>` lets every post the user has requested correctly and persistently show its green 'Request sent' confirmation for the lifetime of the list.

### Acceptance
Sending a companion request to post A then post B leaves BOTH rows showing the disabled green 'Request sent' button with checkmark.circle.fill. Existing #Previews still compile; `xcodebuild build -scheme SoloCompass` succeeds and the SoloCompassTests target passes. No new force-unwraps; all strings remain NSLocalizedString-backed.