### PR TITLE
auto: Live-tick the 'Now' filter empty-state countdown on the map home screen

### DIFF
--- a/apps/ios/SoloCompass/Tests/NextBestExperienceClockTest.swift
+++ b/apps/ios/SoloCompass/Tests/NextBestExperienceClockTest.swift
@@ -1,0 +1,128 @@
+import XCTest
+import CoreLocation
+import SwiftData
+@testable import SoloCompass
+
+/// Verifies that `nextBestExperience(now:)` accepts an injectable clock so
+/// the "Now" filter empty-state countdown can be driven by `TimelineView`
+/// and stays unit-testable without real wall-clock dependencies.
+@MainActor
+final class NextBestExperienceClockTest: XCTestCase {
+
+    private func makeIsolatedDefaults() -> UserDefaults {
+        let suite = "nexbest.\(UUID().uuidString)"
+        let ud = UserDefaults(suiteName: suite)!
+        ud.removePersistentDomain(forName: suite)
+        return ud
+    }
+
+    /// Build an experience whose best window starts `startHour`..`endHour` (local).
+    private func makeExperience(id: String, startHour: Int, endHour: Int) -> Experience {
+        let now = Date()
+        return Experience(
+            id: id,
+            title: "Clock Fixture \(id)",
+            oneLiner: "fixture",
+            whyItMatters: "clock test fixture",
+            category: .nature,
+            location: ExperienceLocation(coordinates: [98.99, 18.79], cityCode: "cmi"),
+            bestTimes: [TimeWindow(startHour: startHour, endHour: endHour)],
+            durationMinutes: .init(min: 30, max: 60),
+            howTo: [],
+            realInconveniences: [],
+            soloScore: SoloScore(
+                overall: 5,
+                breakdown: .init(
+                    seatingFriendly: 7, soloPatronRatio: 7, staffPressure: 7,
+                    soloPortioning: 7, ambianceFit: 7, safety: 7
+                ),
+                basedOnCount: 1
+            ),
+            sources: [InformationSource(type: .user, attribution: "test", verifiedAt: now)],
+            confidence: Confidence(
+                level: 3,
+                lastVerifiedAt: now,
+                reason: "Test fixture",
+                signals: .init(aiScrapeAgeDays: 1, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)
+            ),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .active,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    private func makeViewModel(seed: [Experience]) -> MapViewModel {
+        let prefs = UserPreferences(defaults: makeIsolatedDefaults())
+        let repo = ExperienceRepository(
+            context: ModelContext(SoloCompassModelContainer.makeInMemory()),
+            preferences: nil
+        )
+        _ = repo.appendGenerated(seed)
+        let service = ExperienceService(seed: seed, repository: repo)
+        let vm = MapViewModel(
+            locationService: LocationService(),
+            experienceService: service,
+            aiService: AIService(),
+            preferences: prefs
+        )
+        vm.selectedCity = "cmi"
+        vm.isNowFilter = true
+        return vm
+    }
+
+    /// Given a fixed `now` that is before the experience's start hour,
+    /// `nextBestExperience(now:)` returns the correct experience and a
+    /// positive `minutesUntil`. A second call with `now + 1 min` returns
+    /// a value that is 1 minute smaller (the countdown decrements).
+    func testMinutesUntilDecrementsWithInjectableNow() throws {
+        let cal = Calendar.current
+
+        // Pin `now` to 07:30 local so startHour 9 is reliably in the future.
+        var components = cal.dateComponents([.year, .month, .day], from: Date())
+        components.hour = 7
+        components.minute = 30
+        components.second = 0
+        let baseNow = try XCTUnwrap(cal.date(from: components))
+
+        let exp = makeExperience(id: "sunrise_walk", startHour: 9, endHour: 11)
+        let vm = makeViewModel(seed: [exp])
+
+        let result1 = try XCTUnwrap(vm.nextBestExperience(now: baseNow))
+        XCTAssertEqual(result1.experience.id, "sunrise_walk")
+        XCTAssert(result1.minutesUntil > 0, "minutesUntil must be positive when start is in the future")
+        XCTAssert(result1.minutesUntil <= 180, "must be within the 180-minute window")
+
+        // Advance by 1 minute — the countdown must be exactly 1 less.
+        let oneMinuteLater = baseNow.addingTimeInterval(60)
+        let result2 = try XCTUnwrap(vm.nextBestExperience(now: oneMinuteLater))
+        XCTAssertEqual(result2.minutesUntil, result1.minutesUntil - 1,
+                       "each successive minute must decrement minutesUntil by 1")
+
+        // Advance by 10 more minutes.
+        let tenMinutesLater = baseNow.addingTimeInterval(600)
+        let result3 = try XCTUnwrap(vm.nextBestExperience(now: tenMinutesLater))
+        XCTAssertEqual(result3.minutesUntil, result1.minutesUntil - 10,
+                       "10-minute advance must decrement minutesUntil by 10")
+    }
+
+    /// When `now` is inside the best window (experience is already at its best),
+    /// `nextBestExperience(now:)` must not return that experience.
+    func testReturnsNilWhenExperienceIsCurrentlyAtBest() throws {
+        let cal = Calendar.current
+        var components = cal.dateComponents([.year, .month, .day], from: Date())
+        // Pin to 10:00 — inside the 9..11 window.
+        components.hour = 10
+        components.minute = 0
+        components.second = 0
+        let insideWindow = try XCTUnwrap(cal.date(from: components))
+
+        let exp = makeExperience(id: "peak_now", startHour: 9, endHour: 11)
+        let vm = makeViewModel(seed: [exp])
+
+        // The experience is isBestNow at this time, so it should be filtered out.
+        XCTAssertNil(vm.nextBestExperience(now: insideWindow),
+                     "nextBestExperience must return nil when the only candidate is already at its best")
+    }
+}

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -3806,7 +3806,7 @@ final class SoloCompassTests: XCTestCase {
             preferences: UserPreferences()
         )
         // At hour ≤ 20 the window is at least 3 h away, beyond the 180-min cap.
-        XCTAssertNil(vm.nextBestExperience)
+        XCTAssertNil(vm.nextBestExperience())
     }
 
     /// `nextBestExperience` returns the soonest experience within 180 min.
@@ -3844,7 +3844,7 @@ final class SoloCompassTests: XCTestCase {
             aiService: AIService(),
             preferences: UserPreferences()
         )
-        let next = vm.nextBestExperience
+        let next = vm.nextBestExperience()
         XCTAssertNotNil(next)
         XCTAssertEqual(next?.experience.id, "soon", "must pick the soonest, not the first in array")
         XCTAssertLessThanOrEqual(next?.minutesUntil ?? Int.max, 180)

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -935,8 +935,9 @@ public final class MapViewModel {
     /// The soonest experience (across all loaded experiences in the current city)
     /// that is not yet at its best but starts within 180 minutes.
     /// Used by the "Now" filter empty state to offer a one-tap next action.
-    public var nextBestExperience: (experience: Experience, minutesUntil: Int)? {
-        let now = Date()
+    /// `now` is injectable so callers (e.g. a `TimelineView`) can drive the
+    /// recompute from a clock tick and so unit tests can pin a deterministic instant.
+    public func nextBestExperience(now: Date = Date()) -> (experience: Experience, minutesUntil: Int)? {
         let cityCode = selectedCity
         let candidates = experienceService.allExperiences.filter { exp in
             guard !exp.isBestNow(at: now) else { return false }

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -1208,54 +1208,62 @@ private struct MapOverlayView: View {
         }()
 
         if count == 0 {
-            if viewModel.isNowFilter, let next = viewModel.nextBestExperience {
+            if viewModel.isNowFilter, let next = viewModel.nextBestExperience() {
                 // "Now" filter is active, nothing is at its best, but something
-                // is coming up soon — offer a one-tap jump to it.
-                let idleText = NSLocalizedString("filter.now.empty.idle", comment: "Nothing's at its best now")
-                let upcomingText = String(
-                    format: NSLocalizedString("filter.now.empty.upcoming", comment: "%@ in %dm"),
-                    next.experience.title, next.minutesUntil
-                )
-                let a11yText = String(
-                    format: NSLocalizedString("filter.now.empty.a11y", comment: ""),
-                    next.experience.title, next.minutesUntil
-                )
+                // is coming up soon — offer a one-tap jump to it. Wrap in a
+                // TimelineView so the countdown decrements every minute without
+                // user interaction, matching every other BestNow surface.
+                TimelineView(.periodic(from: .now, by: 60)) { context in
+                    let tickedNext = viewModel.nextBestExperience(now: context.date) ?? next
+                    let minutesUntil = tickedNext.minutesUntil
+                    let idleText = NSLocalizedString("filter.now.empty.idle", comment: "Nothing's at its best now")
+                    let upcomingText = String(
+                        format: NSLocalizedString("filter.now.empty.upcoming", comment: "%@ in %dm"),
+                        tickedNext.experience.title, minutesUntil
+                    )
+                    let a11yText = String(
+                        format: NSLocalizedString("filter.now.empty.a11y", comment: ""),
+                        tickedNext.experience.title, minutesUntil
+                    )
 
-                GlassmorphismCapsule(
-                    horizontalPadding: 12,
-                    verticalPadding: 6,
-                    shadowRadius: 6,
-                    shadowY: 3
-                ) {
-                    HStack(spacing: 6) {
-                        Circle()
-                            .fill(accentGold)
-                            .frame(width: 8, height: 8)
-                        Text(idleText)
-                            .font(.caption.weight(.medium))
-                            .foregroundStyle(.primary)
-                        Text("·")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Text(upcomingText)
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(accentGold)
+                    GlassmorphismCapsule(
+                        horizontalPadding: 12,
+                        verticalPadding: 6,
+                        shadowRadius: 6,
+                        shadowY: 3
+                    ) {
+                        HStack(spacing: 6) {
+                            Circle()
+                                .fill(accentGold)
+                                .frame(width: 8, height: 8)
+                            Text(idleText)
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(.primary)
+                            Text("·")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(upcomingText)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(accentGold)
+                                .contentTransition(.numericText())
+                                .animation(reduceMotion ? nil : .easeInOut, value: minutesUntil)
+                        }
                     }
-                }
-                .contentTransition(.opacity)
-                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: count)
-                .accessibilityElement(children: .ignore)
-                .accessibilityLabel(Text(a11yText))
-                .accessibilityAddTraits(.isButton)
-                .accessibilityAction {
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                    viewModel.focusOnExperience(next.experience)
-                    viewModel.selectExperience(next.experience)
-                }
-                .onTapGesture {
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                    viewModel.focusOnExperience(next.experience)
-                    viewModel.selectExperience(next.experience)
+                    .contentTransition(.opacity)
+                    .animation(.spring(response: 0.3, dampingFraction: 0.8), value: count)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(Text(a11yText))
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityAction {
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        viewModel.focusOnExperience(tickedNext.experience)
+                        viewModel.selectExperience(tickedNext.experience)
+                    }
+                    .onTapGesture {
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        viewModel.focusOnExperience(tickedNext.experience)
+                        viewModel.selectExperience(tickedNext.experience)
+                    }
                 }
             } else {
                 let noMatchText = NSLocalizedString("filter.matches.none", comment: "No matches")


### PR DESCRIPTION
## Live-tick the "Now" filter empty-state countdown on the map home screen

When the "Now" filter is active but nothing is currently at its best, the map shows a prominent glass capsule reading e.g. "Nothing's at its best now · Riverside walk in 12m" with a one-tap jump. But minutesUntil is computed once from Date() and only recomputes when the result count changes, so the countdown freezes — a user watching the map sees a stale "in 12m" indefinitely. This directly undermines the product's signature right-place-right-time promise. Every other BestNow surface in the app already ticks live via the shared BestNowClock; this top-level home-screen capsule is the one that doesn't.

### Acceptance
With the "Now" filter active and no experience currently at its best (but one starting within 180m), the capsule's "in Nm" value decrements every minute without any user interaction, animating with a numeric roll. Tapping it still focuses+selects the upcoming experience. When the upcoming window finally opens (minutesUntil hits 0), the badge updates to reflect the new state on the next tick. reduceMotion disables the roll animation. A new MapViewModel unit test passing a fixed `now` confirms `nextBestExperience(now:)` returns the correct experience and a decreasing minutesUntil for successive timestamps; `xcodebuild build` and the SoloCompassTests suite pass.