### PR TITLE
auto: Category breakdown bar in the Journey stats section

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -281,6 +281,12 @@
 "journey.progress.milestone.a11y" = "Completed %d of %d experiences. Milestone reached!";
 "journey.progress.a11y" = "Completed %d of %d experiences";
 
+/* Journey category breakdown bar */
+/* Single item in the VoiceOver summary, e.g. "3 coffee" — arg 1 is count, arg 2 is category name */
+"journey.breakdown.a11y.item" = "%1$d %2$@";
+/* Full VoiceOver label for the breakdown bar, arg is a comma-joined list of items */
+"journey.breakdown.a11y.label" = "Category breakdown: %@";
+
 /* Settings */
 "settings.title" = "Preferences";
 "settings.done" = "Done";

--- a/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
@@ -425,9 +425,26 @@ public struct SettingsView: View {
         }
     }
 
+    /// Groups completed experience IDs by category, sorted descending by count.
+    private var categoryCounts: [(ExperienceCategory, Int)] {
+        var counts: [ExperienceCategory: Int] = [:]
+        for id in preferences.completedExperiences {
+            guard let exp = experienceService.getExperience(id: id) else { continue }
+            counts[exp.category, default: 0] += 1
+        }
+        return counts
+            .filter { $0.value > 0 }
+            .sorted { $0.value > $1.value }
+            .map { ($0.key, $0.value) }
+    }
+
     private var statsSection: some View {
         Section {
             journeyProgressCard
+
+            if !categoryCounts.isEmpty {
+                CategoryBreakdownBar(categoryCounts: categoryCounts)
+            }
 
             Button {
                 onShowFavorites?()
@@ -994,6 +1011,106 @@ extension UserPreferences.SoloTravelStyle {
     }
 }
 
+// MARK: - Category Breakdown Bar
+
+private struct CategoryBreakdownBar: View {
+    let categoryCounts: [(ExperienceCategory, Int)]
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var appeared = false
+
+    private var total: Int { categoryCounts.reduce(0) { $0 + $1.1 } }
+
+    private var a11yLabel: String {
+        let parts = categoryCounts.map { cat, count in
+            String(format: NSLocalizedString(
+                "journey.breakdown.a11y.item",
+                comment: "Category count accessibility item, e.g. '3 coffee'"
+            ), count, cat.localizedTitle)
+        }
+        return String(
+            format: NSLocalizedString(
+                "journey.breakdown.a11y.label",
+                comment: "Category breakdown accessibility label"
+            ),
+            parts.joined(separator: ", ")
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Proportional segmented bar
+            GeometryReader { geo in
+                HStack(spacing: 2) {
+                    ForEach(categoryCounts, id: \.0) { category, count in
+                        let fraction = total > 0 ? Double(count) / Double(total) : 0
+                        let width = geo.size.width * (appeared ? fraction : 0)
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(category.color)
+                            .frame(width: max(width, appeared ? 2 : 0), height: 12)
+                            .animation(
+                                reduceMotion ? nil : .easeInOut(duration: 0.45).delay(0.05),
+                                value: appeared
+                            )
+                    }
+                }
+                .clipShape(Capsule())
+            }
+            .frame(height: 12)
+
+            // Legend chips — top categories
+            let topCounts = Array(categoryCounts.prefix(5))
+            FlexibleLegend(items: topCounts)
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(a11yLabel)
+        .onAppear {
+            if reduceMotion {
+                appeared = true
+            } else {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    appeared = true
+                }
+            }
+        }
+        .onChange(of: categoryCounts.map { $0.1 }) { _, _ in
+            appeared = false
+            if reduceMotion {
+                appeared = true
+            } else {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    appeared = true
+                }
+            }
+        }
+    }
+}
+
+private struct FlexibleLegend: View {
+    let items: [(ExperienceCategory, Int)]
+
+    var body: some View {
+        // Wrapping row via a simple flow approach using fixed-size chips
+        HStack(alignment: .center, spacing: 6) {
+            ForEach(items, id: \.0) { category, count in
+                HStack(spacing: 3) {
+                    Image(systemName: category.symbol)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(category.color)
+                    Text("\(count)")
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(category.color)
+                }
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+                .background(category.color.opacity(0.12), in: Capsule())
+            }
+            Spacer(minLength: 0)
+        }
+    }
+}
+
 // MARK: - Journey Progress Card
 
 private struct JourneyProgressCard: View {
@@ -1146,6 +1263,26 @@ private extension Color {
         JourneyProgressCard(completed: 5, milestone: 10, caption: "You're on a roll!")
         JourneyProgressCard(completed: 0, milestone: 3, caption: "Every journey starts here.")
         JourneyProgressCard(completed: 25, milestone: 50, caption: "A seasoned solo traveler.")
+    }
+    .listStyle(.insetGrouped)
+}
+
+#Preview("Category Breakdown Bar — populated") {
+    List {
+        CategoryBreakdownBar(categoryCounts: [
+            (.coffee, 5),
+            (.culture, 3),
+            (.food, 2),
+            (.nature, 1),
+        ])
+    }
+    .listStyle(.insetGrouped)
+}
+
+#Preview("Category Breakdown Bar — empty (not shown)") {
+    List {
+        Text("Bar is hidden when categoryCounts is empty.")
+            .foregroundStyle(.secondary)
     }
     .listStyle(.insetGrouped)
 }


### PR DESCRIPTION
## Category breakdown bar in the Journey stats section

The Settings 'Your Journey' section shows total completions toward the next milestone but no breakdown of what kinds of experiences the traveler has actually done. Add a compact, horizontal category-distribution bar beneath the JourneyProgressCard that segments completed experiences by ExperienceCategory using each category's existing color and symbol, giving solo travelers an at-a-glance sense of their travel personality (e.g. 'mostly coffee & culture'). It reuses ExperienceCategory colors/symbols and the existing completedExperiences set, with no schema changes.

### Acceptance
When the user has ≥1 completed experience, the Journey section shows a proportional color-segmented bar plus a category legend with per-category symbol and count, matching ExperienceCategory colors; segments animate when a new completion lands and freeze under Reduce Motion. With zero completions the bar is absent and only the existing JourneyProgressCard shows. VoiceOver reads a single summarized breakdown label. `xcodebuild build` succeeds, `SoloCompassTests` pass, and all new user-facing strings resolve via NSLocalizedString (no raw literals).