### PR TITLE
auto: OfflineBanner retry-failure feedback (shake + warning haptic + VoiceOver)

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -682,6 +682,7 @@
 "offline.banner" = "Offline mode · showing cached data";
 "offline.banner.retry" = "Tap to retry";
 "offline.banner.retry.hint" = "Double tap to retry connection";
+"offline.banner.retry.failed" = "Retry failed — still offline";
 
 /* Theme picker (US-039) */
 "settings.appearance" = "Appearance";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1222,6 +1222,7 @@
 /* Offline banner */
 "offline.banner.retry" = "点击重试";
 "offline.banner.retry.hint" = "双击重试连接";
+"offline.banner.retry.failed" = "重试失败 — 仍处于离线状态";
 
 /* Profile walked routes */
 "profile.walkedRoutes.empty.cta" = "发现路线";

--- a/apps/ios/SoloCompass/Views/Shared/OfflineBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/OfflineBanner.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 /// Amber pill banner shown in CompassMapView when the app is offline and showing cached data (US-041).
 /// When `onRetry` is non-nil the banner becomes a tappable button that re-runs the experience load.
@@ -8,6 +11,8 @@ struct OfflineBanner: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isPulsing = false
     @State private var isRetrying = false
+    @State private var shakeOffset: CGFloat = 0
+    @State private var retryFailed = false
 
     var body: some View {
         pillContent
@@ -40,10 +45,15 @@ struct OfflineBanner: View {
                 isRetrying = true
                 Task {
                     await onRetry()
+                    let stillOffline = await MainActor.run { !NetworkMonitor.shared.isConnected }
+                    if stillOffline {
+                        await handleRetryFailure()
+                    }
                     isRetrying = false
                 }
             } label: {
                 capsuleView
+                    .offset(x: shakeOffset)
             }
             .buttonStyle(.plain)
             .accessibilityAddTraits(.isButton)
@@ -52,6 +62,33 @@ struct OfflineBanner: View {
             capsuleView
         }
     }
+
+    @MainActor
+    private func handleRetryFailure() async {
+        Haptics.notify(.warning)
+
+        UIAccessibility.post(
+            notification: .announcement,
+            argument: NSLocalizedString("offline.banner.retry.failed", comment: "Retry failed — still offline")
+        )
+
+        retryFailed = true
+
+        if !reduceMotion {
+            let steps: [(CGFloat, Double)] = [(-6, 0.07), (6, 0.07), (-4, 0.07), (4, 0.07), (0, 0.07)]
+            for (offset, duration) in steps {
+                withAnimation(.easeInOut(duration: duration)) {
+                    shakeOffset = offset
+                }
+                try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+            }
+        }
+
+        try? await Task.sleep(nanoseconds: 600_000_000)
+        retryFailed = false
+    }
+
+    private var failureColor: Color { retryFailed ? .red : .orange }
 
     @ViewBuilder
     private var capsuleView: some View {
@@ -66,7 +103,7 @@ struct OfflineBanner: View {
                     } else {
                         Image(systemName: "wifi.slash")
                             .font(.caption.weight(.semibold))
-                            .foregroundStyle(Color.orange)
+                            .foregroundStyle(failureColor)
                             .scaleEffect(isPulsing ? 1.12 : 0.96)
                             .opacity(isPulsing ? 1.0 : 0.65)
                     }
@@ -76,14 +113,14 @@ struct OfflineBanner: View {
                 HStack(spacing: 4) {
                     Text(NSLocalizedString("offline.banner", comment: "Offline mode banner"))
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(Color.orange)
+                        .foregroundStyle(failureColor)
                     if onRetry != nil && !isRetrying {
                         Text("·")
                             .font(.caption)
-                            .foregroundStyle(Color.orange.opacity(0.7))
+                            .foregroundStyle(failureColor.opacity(0.7))
                         Text(NSLocalizedString("offline.banner.retry", comment: "Tap to retry connection"))
                             .font(.caption.weight(.semibold))
-                            .foregroundStyle(Color.orange.opacity(0.85))
+                            .foregroundStyle(failureColor.opacity(0.85))
                     }
                 }
             }


### PR DESCRIPTION
## OfflineBanner retry-failure feedback (shake + warning haptic + VoiceOver)

The offline banner's retry button shows a spinner but gives no signal when the retry fails to restore connectivity — the user can't tell whether their tap did anything. Add a brief shake, a red-tint flash, a warning haptic, and a VoiceOver announcement when a retry completes while still offline, all self-contained in OfflineBanner.swift with no change to the call site.

### Acceptance
With Network Link Conditioner / airplane mode on, tapping the offline banner's retry triggers a warning haptic, a brief shake, and a momentary red flash, then the banner settles back to its amber idle state (it stays mounted because the app is still offline). VoiceOver announces the failure via offline.banner.retry.failed. Under Reduce Motion the shake and flash are suppressed but the haptic and announcement still fire. `xcodebuild build -scheme SoloCompass` succeeds and StringsParityTests passes with the new key present across all lproj files.