### PR TITLE
auto: Add proximity color dots to CityPickerSheet distance labels

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -641,6 +641,7 @@
 "city.distanceAway" = "%.1f km away";
 "city.distanceAway.mi" = "%.1f mi away";
 "city.distanceUnknown" = "Distance unknown";
+"city.distanceAway.a11y" = "%@ away";
 
 
 /* AgentRouter fallback replies (US-034) */

--- a/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
@@ -58,6 +58,9 @@ public struct CityPickerSheet: View {
 
                             // US-019: Sort by distance ascending, then alphabetical
                             ForEach(filtered, id: \.code) { city in
+                                let prox = proximity(for: city.center)
+                                let expCount = viewModel.experienceCount(for: city.code)
+                                let distLabel = distanceLabel(for: city.center)
                                 Button {
                                     selectCity(city.code)
                                 } label: {
@@ -68,7 +71,7 @@ public struct CityPickerSheet: View {
                                                 .foregroundStyle(.primary)
                                             Text(String(
                                                 format: NSLocalizedString("city.experienceCount", comment: "Experience count in city"),
-                                                viewModel.experienceCount(for: city.code)
+                                                expCount
                                             ))
                                             .font(.subheadline)
                                             .foregroundStyle(.secondary)
@@ -82,13 +85,31 @@ public struct CityPickerSheet: View {
                                                     .scaleEffect(justSelectedCode == city.code ? 1.3 : 1.0)
                                                     .symbolEffect(.bounce, value: justSelectedCode)
                                             }
-                                            Text(distanceLabel(for: city.center))
-                                                .font(.caption)
-                                                .foregroundStyle(.tertiary)
-                                                .monospacedDigit()
+                                            HStack(spacing: 3) {
+                                                if let prox {
+                                                    Circle()
+                                                        .fill(prox.color)
+                                                        .frame(width: 7, height: 7)
+                                                        .accessibilityHidden(true)
+                                                }
+                                                Text(distLabel)
+                                                    .font(.caption)
+                                                    .monospacedDigit()
+                                            }
+                                            .foregroundStyle(.tertiary)
                                         }
                                     }
                                 }
+                                .accessibilityElement(children: .combine)
+                                .accessibilityLabel({
+                                    let countStr = String(format: NSLocalizedString("city.experienceCount", comment: "Experience count in city"), expCount)
+                                    let awayFmt = NSLocalizedString("city.distanceAway.a11y", comment: "Distance away accessibility label")
+                                    let distA11y = String(format: awayFmt, distLabel)
+                                    if let prox {
+                                        return Text("\(city.name), \(countStr), \(distA11y), \(prox.a11yWord)")
+                                    }
+                                    return Text("\(city.name), \(countStr), \(distA11y)")
+                                }())
                             }
                         }
                     }
@@ -136,6 +157,38 @@ public struct CityPickerSheet: View {
             if abs(dA - dB) < 1_000 { return a.name < b.name }
             return dA < dB
         }
+    }
+
+    private enum CityProximity {
+        case near, mid, far
+
+        static func from(meters: CLLocationDistance) -> CityProximity {
+            if meters <= 25_000 { return .near }
+            if meters <= 150_000 { return .mid }
+            return .far
+        }
+
+        var color: Color {
+            switch self {
+            case .near: return .green
+            case .mid: return .orange
+            case .far: return Color(.tertiaryLabel)
+            }
+        }
+
+        var a11yWord: String {
+            switch self {
+            case .near: return NSLocalizedString("favorites.proximity.near", comment: "Proximity: walkable")
+            case .mid: return NSLocalizedString("favorites.proximity.mid", comment: "Proximity: short ride")
+            case .far: return NSLocalizedString("favorites.proximity.far", comment: "Proximity: far away")
+            }
+        }
+    }
+
+    private func proximity(for coord: CLLocationCoordinate2D) -> CityProximity? {
+        guard let userLoc = userLocation else { return nil }
+        let cityLoc = CLLocation(latitude: coord.latitude, longitude: coord.longitude)
+        return CityProximity.from(meters: userLoc.distance(from: cityLoc))
     }
 
     private func distanceLabel(for coord: CLLocationCoordinate2D) -> String {


### PR DESCRIPTION
## Add proximity color dots to CityPickerSheet distance labels

CityPickerSheet rows show a distance from the user but no at-a-glance proximity cue, unlike FavoritesListView which pairs each distance with a colored dot (green=walkable, orange=short ride, gray=far). Add the same dot to each city's distance label so users can scan the list and instantly judge which cities are nearby, creating visual consistency with the existing favorites pattern.

### Acceptance
City picker rows with a known user location show a green/orange/gray dot beside the distance matching the same thresholds-style cue used in Favorites; rows render the bare distance unchanged when location is unavailable; VoiceOver reads the proximity word; the iOS target builds (xcodebuild build) and existing tests pass.