### PR TITLE
auto: Animate Discover companion list with staggered fade-in rows + tappable send-button press feedback

### DIFF
--- a/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
@@ -161,13 +161,16 @@ public struct DiscoverListView: View {
     }
 
     private var postList: some View {
-        List(service.discoverPosts) { post in
-            DiscoverPostRow(
-                post: post,
-                hasSentRequest: sentRequestIds.contains(post.id),
-                onSendRequest: { selectedPost = post },
-                onReport: { reportTarget = post }
-            )
+        List {
+            ForEach(Array(service.discoverPosts.enumerated()), id: \.element.id) { index, post in
+                DiscoverPostRow(
+                    post: post,
+                    index: index,
+                    hasSentRequest: sentRequestIds.contains(post.id),
+                    onSendRequest: { selectedPost = post },
+                    onReport: { reportTarget = post }
+                )
+            }
         }
         .listStyle(.insetGrouped)
         .refreshable { await loadPosts() }
@@ -240,9 +243,14 @@ public struct DiscoverListView: View {
 
 private struct DiscoverPostRow: View {
     let post: DiscoverPost
+    let index: Int
     let hasSentRequest: Bool
     let onSendRequest: () -> Void
     let onReport: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var appeared = false
+    @State private var pressed = false
 
     private static let dateFormatter: DateFormatter = {
         let f = DateFormatter()
@@ -279,6 +287,17 @@ private struct DiscoverPostRow: View {
             sendButton
         }
         .padding(.vertical, 4)
+        .opacity(appeared ? 1 : 0)
+        .offset(y: appeared ? 0 : 12)
+        .onAppear {
+            if reduceMotion {
+                appeared = true
+            } else {
+                withAnimation(.easeOut(duration: 0.3).delay(min(Double(index) * 0.05, 0.4))) {
+                    appeared = true
+                }
+            }
+        }
         .contextMenu {
             Button(role: .destructive) {
                 onReport()
@@ -310,6 +329,7 @@ private struct DiscoverPostRow: View {
 
     private var sendButton: some View {
         Button {
+            Haptics.selection()
             onSendRequest()
         } label: {
             Label(
@@ -324,6 +344,18 @@ private struct DiscoverPostRow: View {
         .buttonStyle(.bordered)
         .tint(hasSentRequest ? .green : .accentColor)
         .disabled(hasSentRequest)
+        .scaleEffect(pressed ? 0.96 : 1)
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in
+                    guard !reduceMotion, !pressed else { return }
+                    withAnimation(.easeOut(duration: 0.12)) { pressed = true }
+                }
+                .onEnded { _ in
+                    guard !reduceMotion else { return }
+                    withAnimation(.easeOut(duration: 0.12)) { pressed = false }
+                }
+        )
     }
 
     private func formattedDateRange(from: String, to: String) -> String {


### PR DESCRIPTION
## Animate Discover companion list with staggered fade-in rows + tappable send-button press feedback

The companion DiscoverListView pops its rows in abruptly with no entrance motion, and DiscoverPostRow is the only major interactive control in the app missing tap haptics/press feedback. Add a staggered slide+fade reveal as posts load and a subtle press-scale + selection haptic on each row's send button, matching the polish standard set by FavoritesListView and OfflineBanner (respecting Reduce Motion).

### Acceptance
On opening Discover with posts, rows fade and slide up in sequence (capped stagger ~0.4s total); with Reduce Motion enabled rows appear instantly with no offset. Tapping a row's Send request button produces a selection haptic and a brief 0.96 press-scale (no scale under Reduce Motion). `xcodebuild build` succeeds and existing previews ('With posts', 'Empty state', 'Loading skeleton') still compile.