### PR TITLE
auto: Make the favorites Completion Ring tappable to filter 'still to do'

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -418,6 +418,9 @@
 "favorites.completed.count.a11y" = "%1$d of %2$d favorites completed";
 "favorites.completed.allDone.a11y" = "All saved experiences completed";
 "favorites.row.done.a11y" = "completed";
+"favorites.remaining.show.a11y" = "Show remaining experiences";
+"favorites.remaining.active.a11y" = "Showing remaining, tap to show all";
+"favorites.remaining.hint" = "Filters the list to not-yet-completed favorites";
 
 /* Generic actions */
 "action.undo" = "Undo";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -26,6 +26,7 @@ public struct FavoritesListView: View {
     @State private var hintDismissTask: Task<Void, Never>?
     @AppStorage("favorites.swipeHintSeen") private var swipeHintSeen = false
     @State private var ringDidCelebrate = false
+    @State private var showRemainingOnly = false
 
     private var undoDismissSeconds: Double { voiceOverOn ? 12 : 4 }
 
@@ -118,11 +119,17 @@ public struct FavoritesListView: View {
 
     private var filteredFavorites: [Experience] {
         let query = searchText.trimmingCharacters(in: .whitespaces)
-        guard !query.isEmpty else { return sortedFavorites }
-        return sortedFavorites.filter {
-            $0.title.localizedCaseInsensitiveContains(query) ||
-            $0.oneLiner.localizedCaseInsensitiveContains(query)
+        let afterSearch: [Experience]
+        if query.isEmpty {
+            afterSearch = sortedFavorites
+        } else {
+            afterSearch = sortedFavorites.filter {
+                $0.title.localizedCaseInsensitiveContains(query) ||
+                $0.oneLiner.localizedCaseInsensitiveContains(query)
+            }
         }
+        guard showRemainingOnly else { return afterSearch }
+        return afterSearch.filter { !preferences.completedExperiences.contains($0.id) }
     }
 
     private var nearbyCount: Int {
@@ -167,12 +174,43 @@ public struct FavoritesListView: View {
                                     .contentTransition(.numericText())
                                 Spacer()
                                 if showCompletedChip {
-                                    CompletionRing(
+                                    let isAllDone = completedCount == sortedFavorites.count
+                                    let ringView = CompletionRing(
                                         done: completedCount,
                                         total: sortedFavorites.count,
                                         didCelebrate: $ringDidCelebrate
                                     )
-                                    .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
+                                    if isAllDone {
+                                        ringView
+                                            .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
+                                    } else {
+                                        Button {
+                                            Haptics.selection()
+                                            withAnimation(reduceMotion ? nil : .easeInOut) {
+                                                showRemainingOnly.toggle()
+                                            }
+                                        } label: {
+                                            ringView
+                                                .padding(.horizontal, showRemainingOnly ? 6 : 0)
+                                                .padding(.vertical, showRemainingOnly ? 4 : 0)
+                                                .background(
+                                                    showRemainingOnly
+                                                        ? Color.green.opacity(0.12)
+                                                        : Color.clear,
+                                                    in: Capsule()
+                                                )
+                                                .animation(reduceMotion ? nil : .easeInOut, value: showRemainingOnly)
+                                        }
+                                        .buttonStyle(.plain)
+                                        .accessibilityLabel(
+                                            showRemainingOnly
+                                                ? NSLocalizedString("favorites.remaining.active.a11y", comment: "Completion ring active filter accessibility label")
+                                                : NSLocalizedString("favorites.remaining.show.a11y", comment: "Completion ring show remaining accessibility label")
+                                        )
+                                        .accessibilityHint(NSLocalizedString("favorites.remaining.hint", comment: "Completion ring accessibility hint"))
+                                        .accessibilityAddTraits(.isButton)
+                                        .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
+                                    }
                                 }
                                 if showNearbyChip {
                                     Button {
@@ -278,6 +316,13 @@ public struct FavoritesListView: View {
         .animation(.easeInOut, value: lastUnfavorited != nil)
         .onChange(of: lastUnfavorited == nil) { _, isNil in
             if isNil { undoDragOffset = 0 }
+        }
+        .onChange(of: completedCount) { _, _ in
+            let allDone = completedCount == sortedFavorites.count
+            let remainingCount = sortedFavorites.filter { !preferences.completedExperiences.contains($0.id) }.count
+            if showRemainingOnly && (allDone || remainingCount == 0) {
+                withAnimation(reduceMotion ? nil : .easeInOut) { showRemainingOnly = false }
+            }
         }
     }
 }


### PR DESCRIPTION
## Make the favorites Completion Ring tappable to filter 'still to do'

The CompletionRing chip in FavoritesListView already shows how many saved experiences are done and celebrates at 100%, but it's purely decorative — unlike the adjacent 'nearby' chip, which is tappable to re-sort. This adds a 'remaining' filter mode so tapping the ring shows only not-yet-completed favorites, turning a passive stat into the actionable 'what's left to do' loop that fits a solo traveler working through saved spots.

### Acceptance
Tapping the completion ring filters the list to only not-yet-completed favorites and the ring shows an active (highlighted) state; tapping again restores all. The chip is not interactive when 0 are done or all are done. Selection haptic fires on toggle; VoiceOver reads it as a button with the new label/hint. No regression to the existing ring progress animation or 100% success-haptic celebration. iOS target builds and the existing FavoritesListView previews/tests pass (`xcodebuild build` + `xcodebuild test` on iPhone 17 Pro sim).