### PR TITLE
auto: Show walk-time ETA in the Favorites list rows (match the experience card)

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -88,13 +88,6 @@ public struct FavoritesListView: View {
         }
     }
 
-    private static let metersFormatter: MeasurementFormatter = {
-        let f = MeasurementFormatter()
-        f.unitOptions = .providedUnit
-        f.numberFormatter.maximumFractionDigits = 0
-        return f
-    }()
-
     private static let kilometersFormatter: MeasurementFormatter = {
         let f = MeasurementFormatter()
         f.unitOptions = .providedUnit
@@ -103,17 +96,25 @@ public struct FavoritesListView: View {
         return f
     }()
 
-    private func distanceString(for experience: Experience) -> String? {
+    private static let walkThresholdMeters = 1500.0
+    private static let walkMetersPerMin = 80.0
+
+    private func distanceInfo(for experience: Experience) -> (text: String, symbol: String)? {
         guard let userLocation = LocationService.shared.currentLocation,
               let coord = experience.coordinate else { return nil }
         let meters = userLocation.distance(from: CLLocation(latitude: coord.latitude, longitude: coord.longitude))
-        if meters < 1000 {
-            let rounded = (meters / 50).rounded() * 50
-            let measurement = Measurement(value: max(50, rounded), unit: UnitLength.meters)
-            return Self.metersFormatter.string(from: measurement)
+        if meters < Self.walkThresholdMeters {
+            let minutes = Int((meters / Self.walkMetersPerMin).rounded(.up))
+            let label: String
+            if minutes < 1 {
+                label = NSLocalizedString("card.distance.walkSub1", comment: "Distance less than 1 min walk")
+            } else {
+                label = String(format: NSLocalizedString("card.distance.walk", comment: "Distance in walk minutes"), minutes)
+            }
+            return (label, "figure.walk")
         } else {
             let measurement = Measurement(value: meters / 1000, unit: UnitLength.kilometers)
-            return Self.kilometersFormatter.string(from: measurement)
+            return (Self.kilometersFormatter.string(from: measurement), "location.fill")
         }
     }
 
@@ -622,7 +623,7 @@ private extension FavoritesListView {
 
     @ViewBuilder
     func favoriteRow(_ exp: Experience) -> some View {
-        let distStr = distanceString(for: exp)
+        let distInfo = distanceInfo(for: exp)
         let prox = proximity(for: exp)
         let isDone = preferences.completedExperiences.contains(exp.id)
         Button {
@@ -655,7 +656,7 @@ private extension FavoritesListView {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(2)
-                    if let distStr {
+                    if let distInfo {
                         HStack(spacing: 3) {
                             if let prox {
                                 Circle()
@@ -663,7 +664,7 @@ private extension FavoritesListView {
                                     .frame(width: 7, height: 7)
                                     .accessibilityHidden(true)
                             }
-                            Text(distStr)
+                            Label(distInfo.text, systemImage: distInfo.symbol)
                                 .font(.caption2)
                                 .monospacedDigit()
                         }
@@ -683,9 +684,9 @@ private extension FavoritesListView {
         .buttonStyle(.plain)
         .accessibilityLabel({
             let doneWord = isDone ? ", \(NSLocalizedString("favorites.row.done.a11y", comment: "Completed row suffix"))" : ""
-            if let distStr {
+            if let distInfo {
                 let awayFmt = NSLocalizedString("favorites.row.distance.a11y", comment: "Distance away accessibility label")
-                let distLabel = String(format: awayFmt, distStr)
+                let distLabel = String(format: awayFmt, distInfo.text)
                 if let prox {
                     return Text("\(exp.title), \(exp.oneLiner), \(distLabel), \(prox.a11yWord)\(doneWord)")
                 }


### PR DESCRIPTION
## Show walk-time ETA in the Favorites list rows (match the experience card)

The polished ExperienceCardView already converts any distance under 1.5 km into a friendly walk-time ETA (e.g. '12 min walk') with a figure.walk icon, but FavoritesListView rows still show raw meters/kilometers ('350 m', '2.3 km') — an inconsistency that buries the one number solo travelers actually plan around. This aligns the favorites row to the same walk-time formatting so nearby saved spots read as 'how far is it to walk there' instead of an abstract distance, keeping the metric/kilometer fallback for anything beyond walking range.

### Acceptance
Favorites rows for spots within 1.5 km read as 'N min walk' with a figure.walk icon (and '<1 min walk' for very close spots); spots beyond 1.5 km still show formatted kilometers with a location.fill icon. The proximity color dot and monospaced digits remain. VoiceOver announces the walk-time phrasing via the existing distance.a11y format. Reduce Motion is unaffected. xcodebuild build + SoloCompassTests pass, and the FavoritesListView #Preview renders the walk-time pill in the row.