### PR TITLE
auto: Wire RouteCard's dead press-scale animation to a real touch gesture

### DIFF
--- a/apps/ios/SoloCompass/Views/Companion/Components/RouteCard.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Components/RouteCard.swift
@@ -83,8 +83,21 @@ public struct RouteCard: View {
                 .strokeBorder(CT.borderSubtle, lineWidth: 0.5)
         )
         .shadow(color: .black.opacity(0.04), radius: 1, x: 0, y: 1)
-        .scaleEffect(pressed ? 0.985 : 1)
-        .animation(.easeOut(duration: 0.18), value: pressed)
+        .scaleEffect(reduceMotion ? 1 : (pressed ? 0.985 : 1))
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.18), value: pressed)
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in
+                    guard !pressed else { return }
+                    pressed = true
+                    #if canImport(UIKit)
+                    if !reduceMotion { Haptics.impact(.soft) }
+                    #endif
+                }
+                .onEnded { _ in
+                    pressed = false
+                }
+        )
         .contentShape(Rectangle())
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(route.title + ", " + monoBaseline))


### PR DESCRIPTION
## Wire RouteCard's dead press-scale animation to a real touch gesture

RouteCard declares a `pressed` @State that drives a `scaleEffect(pressed ? 0.985 : 1)` with an ease-out animation, but no gesture ever mutates it, so the press feedback never fires — the card looks tappable (chevron, combined a11y element) yet feels inert on touch. This wires a long-press/drag gesture that sets `pressed` on touch-down and clears it on release, making the scale-down feedback actually animate across all ~7 call sites (BottomInfoSheet route list, ChatView, Discover, MyRequests, etc.). Also gate the haptic and respect reduce-motion.

### Acceptance
Card visibly scales to 0.985 on touch-down and springs back on release in the Simulator (verify in BottomInfoSheet route list); a single soft haptic fires per press; existing tap/navigation at all call sites still triggers; under Reduce Motion the scale is suppressed and no haptic fires; `xcodebuild build` and the existing RouteCard* tests pass unchanged; #Previews still render.