### PR TITLE
auto: Show total walking budget for nearby favorites in the Favorites footer

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -421,6 +421,8 @@
 "favorites.remaining.show.a11y" = "Show remaining experiences";
 "favorites.remaining.active.a11y" = "Showing remaining, tap to show all";
 "favorites.remaining.hint" = "Filters the list to not-yet-completed favorites";
+"favorites.nearby.walkBudget" = "~%dm on foot";
+"favorites.nearby.walkBudget.a11y" = "About %d minutes of walking across nearby favorites";
 
 /* Generic actions */
 "action.undo" = "Undo";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -137,6 +137,15 @@ public struct FavoritesListView: View {
         sortedFavorites.filter { proximity(for: $0) == .near }.count
     }
 
+    private var nearbyWalkMinutesTotal: Int? {
+        guard locationService.currentLocation != nil else { return nil }
+        let total = sortedFavorites
+            .filter { proximity(for: $0) == .near }
+            .compactMap { distanceMeters(for: $0) }
+            .reduce(0) { $0 + Int(($1 / Self.walkMetersPerMin).rounded(.up)) }
+        return total > 0 ? total : nil
+    }
+
     private var completedCount: Int {
         sortedFavorites.filter { preferences.completedExperiences.contains($0.id) }.count
     }
@@ -238,6 +247,22 @@ public struct FavoritesListView: View {
                                     .accessibilityHint(NSLocalizedString("favorites.nearby.hint", comment: "Nearby chip sorts by distance"))
                                     .accessibilityAddTraits(.isButton)
                                     .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
+
+                                    if let mins = nearbyWalkMinutesTotal {
+                                        HStack(spacing: 4) {
+                                            Image(systemName: "figure.walk")
+                                                .accessibilityHidden(true)
+                                            Text(String(format: NSLocalizedString("favorites.nearby.walkBudget", comment: "Walk budget chip: ~Xm on foot"), mins))
+                                        }
+                                        .font(.caption2)
+                                        .foregroundStyle(Color.green)
+                                        .padding(.horizontal, 10)
+                                        .padding(.vertical, 5)
+                                        .background(Color.green.opacity(0.12), in: Capsule())
+                                        .accessibilityLabel(String(format: NSLocalizedString("favorites.nearby.walkBudget.a11y", comment: "Walk budget chip accessibility label"), mins))
+                                        .animation(.easeInOut, value: nearbyWalkMinutesTotal)
+                                        .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
+                                    }
                                 }
                             }
                             .padding(.horizontal, 16)


### PR DESCRIPTION
## Show total walking budget for nearby favorites in the Favorites footer

When the user has location and is viewing favorites sorted by nearest, the footer shows a 'N nearby' chip but no sense of the overall effort to clear them. Add a compact 'walkable in ~Xm total' summary that sums the walk-time ETAs of the nearby (≤1km) favorites, giving solo travelers an at-a-glance answer to 'can I knock these out on foot today?' — reinforcing the map-first, experience-as-unit framing.

### Acceptance
With location available and ≥1 favorite within 1km, the Favorites footer shows a green '~Xm on foot' chip beside the 'N nearby' chip whose minutes equal the sum of the per-row walk ETAs; the chip disappears when searching, when no favorites are within 1km, or when location is unavailable; VoiceOver reads the descriptive label; reduce-motion suppresses the scale transition; the build passes `xcodebuild build` and existing FavoritesListView previews render.