### PR TITLE
auto: Make the check-in banner's 'Yes!' button earn the tap with a breathing pulse + VoiceOver announcement

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -363,6 +363,7 @@
 "checkin.banner.title" = "Did you visit?";
 "checkin.banner.yes" = "Yes!";
 "checkin.banner.a11y" = "Did you visit %@?";
+"checkin.banner.a11yAnnouncement" = "You just passed %@ — did you visit?";
 
 /* Experience detail overflow */
 "detail.report" = "Report an issue";

--- a/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
@@ -8,8 +8,10 @@ public struct PendingCheckInBanner: View {
     var onConfirm: () -> Void
     var onDismiss: () -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var dragOffset: CGFloat = 0
     @State private var crossedThreshold = false
+    @State private var pulse = false
     private let dismissThreshold: CGFloat = 80
 
     public var body: some View {
@@ -42,6 +44,8 @@ public struct PendingCheckInBanner: View {
                         .padding(.vertical, 6)
                         .background(Capsule().fill(.blue))
                         .foregroundStyle(.white)
+                        .scaleEffect(reduceMotion ? 1.0 : (pulse ? 1.04 : 1.0))
+                        .animation(reduceMotion ? nil : .easeInOut(duration: 1.3).repeatForever(autoreverses: true), value: pulse)
                 }
                 .buttonStyle(.plain)
 
@@ -92,6 +96,19 @@ public struct PendingCheckInBanner: View {
                     }
                 }
         )
+        .onAppear {
+            #if canImport(UIKit)
+            UIAccessibility.post(
+                notification: .announcement,
+                argument: String(
+                    format: NSLocalizedString("checkin.banner.a11yAnnouncement", comment: "VoiceOver announcement when check-in banner appears"),
+                    experienceTitle
+                )
+            )
+            #endif
+            guard !reduceMotion else { return }
+            pulse = true
+        }
         .transition(.move(edge: .bottom).combined(with: .opacity))
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(String(


### PR DESCRIPTION
## Make the check-in banner's "Yes!" button earn the tap with a breathing pulse + VoiceOver announcement

PendingCheckInBanner is the app's single most important conversion moment — confirming you completed an experience — yet its "Yes!" button is a flat static capsule while every sibling surface (VoiceButton, POILoadingBanner, EmptyFavoritesView) has a living animation, and the banner posts no VoiceOver announcement when it slides in. This adds a gentle, reduce-motion-aware breathing pulse to the confirm button to draw the eye, plus an on-appear .announcement so VoiceOver users know the geofence prompt arrived.

### Acceptance
Banner builds (`xcodebuild build`). When it appears, the "Yes!" capsule gently pulses ~1.04x and stops respecting Reduce Motion (no pulse, scale stays 1.0). On appear with VoiceOver on, an announcement naming the experience is posted. Existing drag-to-dismiss, confirm, and dismiss behavior plus the #Preview are unchanged. No new force-unwraps; all strings via NSLocalizedString.