### PR TITLE
auto: Make the Favorites walk-budget chip tappable to start directions to the nearest favorite

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -423,6 +423,7 @@
 "favorites.remaining.hint" = "Filters the list to not-yet-completed favorites";
 "favorites.nearby.walkBudget" = "~%dm on foot";
 "favorites.nearby.walkBudget.a11y" = "About %d minutes of walking across nearby favorites";
+"favorites.nearby.walkBudget.start.a11y" = "Walk to nearest favorite, %@, about %d minutes";
 
 /* Generic actions */
 "action.undo" = "Undo";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -137,6 +137,12 @@ public struct FavoritesListView: View {
         sortedFavorites.filter { proximity(for: $0) == .near }.count
     }
 
+    private var nearestFavorite: Experience? {
+        sortedFavorites
+            .filter { proximity(for: $0) == .near }
+            .min { (distanceMeters(for: $0) ?? .greatestFiniteMagnitude) < (distanceMeters(for: $1) ?? .greatestFiniteMagnitude) }
+    }
+
     private var nearbyWalkMinutesTotal: Int? {
         guard locationService.currentLocation != nil else { return nil }
         let total = sortedFavorites
@@ -249,7 +255,7 @@ public struct FavoritesListView: View {
                                     .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
 
                                     if let mins = nearbyWalkMinutesTotal {
-                                        HStack(spacing: 4) {
+                                        let chipContent = HStack(spacing: 4) {
                                             Image(systemName: "figure.walk")
                                                 .accessibilityHidden(true)
                                             Text(String(format: NSLocalizedString("favorites.nearby.walkBudget", comment: "Walk budget chip: ~Xm on foot"), mins))
@@ -259,9 +265,25 @@ public struct FavoritesListView: View {
                                         .padding(.horizontal, 10)
                                         .padding(.vertical, 5)
                                         .background(Color.green.opacity(0.12), in: Capsule())
-                                        .accessibilityLabel(String(format: NSLocalizedString("favorites.nearby.walkBudget.a11y", comment: "Walk budget chip accessibility label"), mins))
                                         .animation(.easeInOut, value: nearbyWalkMinutesTotal)
                                         .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
+
+                                        if let nearest = nearestFavorite,
+                                           let coord = nearest.coordinate,
+                                           let app = NavigationLauncher.availableApps().first {
+                                            Button {
+                                                Haptics.impact(.light)
+                                                NavigationLauncher.open(app: app, coordinate: coord, name: nearest.title)
+                                            } label: {
+                                                chipContent
+                                            }
+                                            .buttonStyle(.plain)
+                                            .accessibilityLabel(String(format: NSLocalizedString("favorites.nearby.walkBudget.start.a11y", comment: "Walk to nearest favorite button accessibility label"), nearest.title, mins))
+                                            .accessibilityAddTraits(.isButton)
+                                        } else {
+                                            chipContent
+                                                .accessibilityLabel(String(format: NSLocalizedString("favorites.nearby.walkBudget.a11y", comment: "Walk budget chip accessibility label"), mins))
+                                        }
                                     }
                                 }
                             }

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -143,6 +143,22 @@ public struct FavoritesListView: View {
             .min { (distanceMeters(for: $0) ?? .greatestFiniteMagnitude) < (distanceMeters(for: $1) ?? .greatestFiniteMagnitude) }
     }
 
+    @ViewBuilder
+    private func walkBudgetChipContent(mins: Int) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "figure.walk")
+                .accessibilityHidden(true)
+            Text(String(format: NSLocalizedString("favorites.nearby.walkBudget", comment: "Walk budget chip: ~Xm on foot"), mins))
+        }
+        .font(.caption2)
+        .foregroundStyle(Color.green)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(Color.green.opacity(0.12), in: Capsule())
+        .animation(.easeInOut, value: nearbyWalkMinutesTotal)
+        .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
+    }
+
     private var nearbyWalkMinutesTotal: Int? {
         guard locationService.currentLocation != nil else { return nil }
         let total = sortedFavorites
@@ -255,19 +271,6 @@ public struct FavoritesListView: View {
                                     .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
 
                                     if let mins = nearbyWalkMinutesTotal {
-                                        let chipContent = HStack(spacing: 4) {
-                                            Image(systemName: "figure.walk")
-                                                .accessibilityHidden(true)
-                                            Text(String(format: NSLocalizedString("favorites.nearby.walkBudget", comment: "Walk budget chip: ~Xm on foot"), mins))
-                                        }
-                                        .font(.caption2)
-                                        .foregroundStyle(Color.green)
-                                        .padding(.horizontal, 10)
-                                        .padding(.vertical, 5)
-                                        .background(Color.green.opacity(0.12), in: Capsule())
-                                        .animation(.easeInOut, value: nearbyWalkMinutesTotal)
-                                        .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
-
                                         if let nearest = nearestFavorite,
                                            let coord = nearest.coordinate,
                                            let app = NavigationLauncher.availableApps().first {
@@ -275,13 +278,13 @@ public struct FavoritesListView: View {
                                                 Haptics.impact(.light)
                                                 NavigationLauncher.open(app: app, coordinate: coord, name: nearest.title)
                                             } label: {
-                                                chipContent
+                                                walkBudgetChipContent(mins: mins)
                                             }
                                             .buttonStyle(.plain)
                                             .accessibilityLabel(String(format: NSLocalizedString("favorites.nearby.walkBudget.start.a11y", comment: "Walk to nearest favorite button accessibility label"), nearest.title, mins))
                                             .accessibilityAddTraits(.isButton)
                                         } else {
-                                            chipContent
+                                            walkBudgetChipContent(mins: mins)
                                                 .accessibilityLabel(String(format: NSLocalizedString("favorites.nearby.walkBudget.a11y", comment: "Walk budget chip accessibility label"), mins))
                                         }
                                     }


### PR DESCRIPTION
## Make the Favorites walk-budget chip tappable to start directions to the nearest favorite

The Favorites footer shows a passive '~Xm on foot' walk-budget chip summarizing nearby favorites, but unlike the adjacent 'N nearby' chip it isn't interactive. Convert it into a button that launches turn-by-turn directions (via the existing NavigationLauncher) to the single closest favorite, turning a read-only stat into the natural 'start walking' action with haptic feedback and full VoiceOver support.

### Acceptance
Building with `xcodebuild build` succeeds and `pnpm` string-parity tests (StringsParityTests) pass. In the Simulator with a location set and ≥1 nearby favorite, the '~Xm on foot' chip is tappable, fires a light haptic, and opens the device's maps app routing to the nearest favorite; with no nearby favorite or no maps app the chip renders as a passive label as before; VoiceOver reads it as a button naming the destination and walk time.