### PR TITLE
auto: Fix broken empty state when the 'remaining only' favorites filter yields zero results

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -421,6 +421,9 @@
 "favorites.remaining.show.a11y" = "Show remaining experiences";
 "favorites.remaining.active.a11y" = "Showing remaining, tap to show all";
 "favorites.remaining.hint" = "Filters the list to not-yet-completed favorites";
+"favorites.remaining.allDone.title" = "You've done them all";
+"favorites.remaining.allDone.hint" = "Every favorite here is checked off. Nice work.";
+"favorites.remaining.allDone.cta" = "Show all favorites";
 "favorites.nearby.walkBudget" = "~%dm on foot";
 "favorites.nearby.walkBudget.a11y" = "About %d minutes of walking across nearby favorites";
 

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -156,6 +156,12 @@ public struct FavoritesListView: View {
                 if sortedFavorites.isEmpty && lastUnfavorited == nil {
                     EmptyFavoritesView(onExplore: onExplore)
                         .transition(.scale(scale: 0.85).combined(with: .opacity))
+                } else if filteredFavorites.isEmpty && showRemainingOnly && searchText.trimmingCharacters(in: .whitespaces).isEmpty {
+                    AllRemainingDoneView(onShowAll: {
+                        Haptics.selection()
+                        withAnimation(reduceMotion ? nil : .easeInOut) { showRemainingOnly = false }
+                    })
+                    .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
                 } else if filteredFavorites.isEmpty {
                     NoSearchResultsView(query: searchText, onClear: { searchText = "" })
                         .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
@@ -471,6 +477,49 @@ private struct EmptyFavoritesView: View {
         .onAppear {
             guard !isBreathing, !reduceMotion else { return }
             isBreathing = true
+        }
+    }
+}
+
+private struct AllRemainingDoneView: View {
+    let onShowAll: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var appeared = false
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(Color.green)
+                .accessibilityHidden(true)
+            Text(NSLocalizedString("favorites.remaining.allDone.title", comment: "All remaining favorites done title"))
+                .font(.headline)
+                .multilineTextAlignment(.center)
+            Text(NSLocalizedString("favorites.remaining.allDone.hint", comment: "All remaining favorites done caption"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Button {
+                onShowAll()
+            } label: {
+                Label(NSLocalizedString("favorites.remaining.allDone.cta", comment: "Show all favorites button in all-done state"), systemImage: "heart.fill")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.regular)
+            .padding(.top, 4)
+        }
+        .padding(32)
+        .scaleEffect(appeared ? 1 : 0.85)
+        .opacity(appeared ? 1 : 0)
+        .onAppear {
+            guard !reduceMotion else {
+                appeared = true
+                return
+            }
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
+                appeared = true
+            }
         }
     }
 }


### PR DESCRIPTION
## Fix broken empty state when the 'remaining only' favorites filter yields zero results

In FavoritesListView, when the user taps the completion ring to filter to not-yet-completed favorites and the search field is empty, an empty result currently falls through to NoSearchResultsView, rendering a confusing 'No matches for ""' message with an irrelevant 'clear search' button. This adds a dedicated, on-brand empty state that correctly explains everything is done and offers a 'Show all' action to clear the filter.

### Acceptance
With ≥1 favorite, all favorites completed: tapping the completion ring to enable 'remaining only' shows the new 'You've done them all' state (not 'No matches for ""'), and tapping 'Show all favorites' clears the filter and restores the full list. Existing search-no-results behavior is unchanged when a non-empty query yields no matches. `xcodebuild build` and `xcodebuild test` for the SoloCompass scheme pass; #Preview renders the new state.