### PR TITLE
auto: Tap the Favorites 'nearby' chip to launch directions to the closest saved spot

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -428,6 +428,9 @@
 "favorites.nearby.walkBudget" = "~%dm on foot";
 "favorites.nearby.walkBudget.a11y" = "About %d minutes of walking across nearby favorites";
 "favorites.nearby.walkBudget.start.a11y" = "Walk to nearest favorite, %@, about %d minutes";
+"favorites.nearby.go" = "Go";
+"favorites.nearby.go.a11y" = "Directions to nearest favorite, %@";
+"favorites.nearby.go.hint" = "Opens turn-by-turn directions in Maps";
 
 /* Generic actions */
 "action.undo" = "Undo";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -139,8 +139,8 @@ public struct FavoritesListView: View {
 
     private var nearestFavorite: Experience? {
         sortedFavorites
-            .filter { proximity(for: $0) == .near }
-            .min { (distanceMeters(for: $0) ?? .greatestFiniteMagnitude) < (distanceMeters(for: $1) ?? .greatestFiniteMagnitude) }
+            .filter { distanceMeters(for: $0) != nil }
+            .min(by: { (distanceMeters(for: $0) ?? .greatestFiniteMagnitude) < (distanceMeters(for: $1) ?? .greatestFiniteMagnitude) })
     }
 
     @ViewBuilder
@@ -293,6 +293,32 @@ public struct FavoritesListView: View {
                                             walkBudgetChipContent(mins: mins)
                                                 .accessibilityLabel(String(format: NSLocalizedString("favorites.nearby.walkBudget.a11y", comment: "Walk budget chip accessibility label"), mins))
                                         }
+                                    }
+
+                                    let availableApps = NavigationLauncher.availableApps()
+                                    if let nearest = nearestFavorite,
+                                       let app = availableApps.first {
+                                        Button {
+                                            Haptics.impact(.light)
+                                            guard let coord = nearest.coordinate else { return }
+                                            NavigationLauncher.open(app: app, coordinate: coord, name: nearest.title)
+                                        } label: {
+                                            HStack(spacing: 4) {
+                                                Image(systemName: "arrow.triangle.turn.up.right.diamond.fill")
+                                                    .accessibilityHidden(true)
+                                                Text(NSLocalizedString("favorites.nearby.go", comment: "Go button: launch directions to nearest favorite"))
+                                            }
+                                            .font(.caption2)
+                                            .foregroundStyle(Color.green)
+                                            .padding(.horizontal, 10)
+                                            .padding(.vertical, 5)
+                                            .background(Color.green.opacity(0.12), in: Capsule())
+                                        }
+                                        .buttonStyle(.plain)
+                                        .accessibilityLabel(String(format: NSLocalizedString("favorites.nearby.go.a11y", comment: "Directions to nearest favorite accessibility label"), nearest.title))
+                                        .accessibilityHint(NSLocalizedString("favorites.nearby.go.hint", comment: "Go button accessibility hint"))
+                                        .accessibilityAddTraits(.isButton)
+                                        .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
                                     }
                                 }
                             }


### PR DESCRIPTION
## Tap the Favorites "nearby" chip to launch directions to the closest saved spot

When a solo traveler has favorites near them, the Favorites footer already shows a green 'N nearby' chip and a '~Xm on foot' walk-budget chip — but both only re-sort the list. This adds a one-tap 'Go' affordance that launches turn-by-turn directions straight to the single closest favorite via the existing NavigationLauncher, turning a passive count into the most actionable thing a traveler on foot wants. The directions plumbing is already used by the row swipe actions, so this is purely a new entry point.

### Acceptance
With ≥1 nearby favorite and a location fix, a 'Go' capsule appears beside the walk-budget chip; tapping it opens the device's maps app routed to the closest favorite. The button is hidden when no maps app is available or no favorite is nearby. VoiceOver reads the nearest favorite's name and that it opens directions. Reduce Motion shows a fade instead of scale transition. `xcodebuild build` and the existing SoloCompassTests pass; no @Model/schema files touched; change stays under 100 lines across the two files.