### PR TITLE
auto: Add tap feedback and pressed-state animation to favorite rows

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -752,6 +752,7 @@ private extension FavoritesListView {
         let prox = proximity(for: exp)
         let isDone = preferences.completedExperiences.contains(exp.id)
         Button {
+            Haptics.selection()
             onSelectExperience(exp)
         } label: {
             HStack(spacing: 12) {
@@ -806,7 +807,7 @@ private extension FavoritesListView {
             }
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(PressableRowStyle(reduceMotion: reduceMotion))
         .accessibilityLabel({
             let doneWord = isDone ? ", \(NSLocalizedString("favorites.row.done.a11y", comment: "Completed row suffix"))" : ""
             if let distInfo {
@@ -857,6 +858,20 @@ private extension FavoritesListView {
             Haptics.impact(.light)
             NavigationLauncher.open(app: app, coordinate: coord, name: exp.title)
         }
+    }
+}
+
+private struct PressableRowStyle: ButtonStyle {
+    let reduceMotion: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect((!reduceMotion && configuration.isPressed) ? 0.97 : 1)
+            .opacity(configuration.isPressed ? 0.7 : 1)
+            .animation(
+                reduceMotion ? nil : .easeOut(duration: 0.12),
+                value: configuration.isPressed
+            )
     }
 }
 


### PR DESCRIPTION
## Add tap feedback and pressed-state animation to favorite rows

Tapping a favorite row in FavoritesListView navigates instantly with no tactile or visual confirmation, unlike the swipe actions and chips which all fire haptics. Add a light selection haptic plus a subtle scale/opacity pressed state to each row so selection feels responsive and consistent with the rest of the screen's polish.

### Acceptance
Tapping a favorite row produces a selection haptic and a brief press-in scale/opacity dip before the detail opens; with Reduce Motion enabled the scale is suppressed but the haptic still fires (respecting HapticService's own reduce-motion gate); swipe actions and existing chips are unchanged; `xcodebuild build` and the SoloCompassTests suite both pass.