### PR TITLE
auto: Animated value count-up for SoloScoreRadarChart numbers

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
@@ -26,6 +26,10 @@ public struct SoloScoreRadarChart: View {
         Self.axes.map { score.breakdown[keyPath: $0.keyPath] }
     }
 
+    private func animatedValue(_ raw: Double) -> Int {
+        Int((raw * drawProgress).rounded())
+    }
+
     private var variance: Double {
         let vals = values
         let mean = vals.reduce(0, +) / Double(vals.count)
@@ -162,10 +166,12 @@ public struct SoloScoreRadarChart: View {
                         Image(systemName: axis.symbol)
                             .font(.system(size: size * 0.065))
                             .foregroundStyle(iconColor)
-                        // Always display final values — animation only affects opacity
-                        Text(String(format: "%.0f", values[i]))
+                        Text(String(animatedValue(values[i])))
                             .font(.system(size: size * 0.055, weight: fontWeight, design: .rounded))
                             .foregroundStyle(textColor)
+                            .monospacedDigit()
+                            .contentTransition(.numericText())
+                            .animation(reduceMotion ? nil : .spring(response: Self.springDuration, dampingFraction: 0.75), value: animatedValue(values[i]))
                     }
                     .opacity(labelOpacity)
                     .position(pos)
@@ -343,10 +349,12 @@ public struct SoloScoreRadarChart: View {
                         }
                     }
                     .frame(height: 6)
-                    Text(String(format: "%.0f", val))
+                    Text(String(animatedValue(val)))
                         .font(.caption.monospacedDigit())
                         .foregroundStyle(textColor)
                         .fontWeight((isWeakest || isStrongest) ? .bold : .regular)
+                        .contentTransition(.numericText())
+                        .animation(reduceMotion ? nil : .spring(response: Self.springDuration, dampingFraction: 0.75), value: animatedValue(val))
                         .frame(width: 24, alignment: .trailing)
                         .accessibilityHidden(true)
                 }


### PR DESCRIPTION
## Animated value count-up for SoloScoreRadarChart numbers

The radar chart's per-axis numeric labels (and fallback-bar values) snap to their final value instantly while the polygon/bars animate in, creating a visual mismatch. This adds a synchronized count-up so each dimension's number ticks from 0 to its value in lockstep with the draw-in/replay animation, matching the numericText content-transition polish already used elsewhere (e.g. FavoritesListView completion ring).

### Acceptance
On opening an experience detail, each SoloScore number visibly counts up from 0 to its final value in sync with the polygon/bar fill; tapping the radar replays both the shape and the count-up. With Reduce Motion on, numbers appear at final values with no animation. VoiceOver still announces true dimension values. iOS build + existing SoloScoreRadarChart tests pass; #Previews render correctly.