### PR TITLE
fix(ios): keep map overlays clear of the bottom sheet at any Dynamic Type

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		000540BEF14A8F061B20E2DC /* CompanionProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112365ED9467BFB0994BC0A0 /* CompanionProfile.swift */; };
 		01EEEE1B470DED9075038A93 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28A851F789C7482CD44DCAE /* Theme.swift */; };
 		03FDD2032C0B0D8B59A1EE8E /* POILoadingBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C23113554E651AA08FD2430 /* POILoadingBanner.swift */; };
+		045740DB5060EBE8D6D2EEA0 /* PendingCheckInBannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26F2087E12E63A73B812D7E /* PendingCheckInBannerTests.swift */; };
 		066FE809A43C937B7EFA7609 /* VoiceToastA11yTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A3AF5B9538F583142315C2 /* VoiceToastA11yTests.swift */; };
 		0A830B26D4A18948D16F3A42 /* Experience.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C97F8159A6FA7953D28DAB /* Experience.swift */; };
 		0B7CC2BD1359B8AB3E4A590D /* HapticServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4609B3C2E77F98A59871C26E /* HapticServiceTests.swift */; };
@@ -66,6 +67,7 @@
 		3B2C16B114CAAADE0862AF7B /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AF76F1B505EF8AF6EF2470 /* ShareSheet.swift */; };
 		3C5AB28556912D115AEC4AEC /* LocationPickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 052B6F076F405C203184CB88 /* LocationPickerState.swift */; };
 		3CB7E26BCF3339F2CE297528 /* ItineraryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D60D55727FB72C1C202C90 /* ItineraryListView.swift */; };
+		3CBA775B8C215CBAE3A73EA0 /* CardBottomInsetClearanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0674DC5D526883C657A63C38 /* CardBottomInsetClearanceTest.swift */; };
 		3D393CD7ACFD865D7297FA5D /* AIProviderSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7295DF9392F0361C0B2E313D /* AIProviderSettingsView.swift */; };
 		3E24606FB907D7BB18E3C496 /* Itinerary.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F5D58C93D87AC9205148CC /* Itinerary.swift */; };
 		3EF7E97963960C09B7A5575D /* StringsParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14FE2118ED82DD0593F5C3C /* StringsParityTests.swift */; };
@@ -266,6 +268,7 @@
 		FA8584E1511404B374B57E66 /* ExploreProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0997D8150E77F70A4B8C64 /* ExploreProgressBar.swift */; };
 		FBE9F5951D501A611EB19EEC /* SecretsRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA8C8BF234F3C74D0D8A9BD /* SecretsRuntime.swift */; };
 		FBF29A9700B10AEF682A36AF /* Geohash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9504D49E879C4D2BB34F99E9 /* Geohash.swift */; };
+		FC1E25FED02B767FBFB5EFE2 /* NextBestExperienceClockTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08AFC181DB143A21E97A2ED /* NextBestExperienceClockTest.swift */; };
 		FC5971A3C5E9DDB7F88E58E8 /* BestNowClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4617984392FDCCA6F2F9FAD7 /* BestNowClock.swift */; };
 		FD3636FCB777A292C57B7B06 /* GuideAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187534C119545F7D61CE693B /* GuideAgent.swift */; };
 		FD8F94BFC5C298D62943FFF3 /* MarkerStatePerformanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658C2890F90C08A686F501BA /* MarkerStatePerformanceTest.swift */; };
@@ -290,6 +293,7 @@
 		052B6F076F405C203184CB88 /* LocationPickerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationPickerState.swift; sourceTree = "<group>"; };
 		0535B15C19B134898D9880BE /* CompassMapViewLayerToggleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompassMapViewLayerToggleTests.swift; sourceTree = "<group>"; };
 		06086F5F9463C18F486E5694 /* QueryAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryAgent.swift; sourceTree = "<group>"; };
+		0674DC5D526883C657A63C38 /* CardBottomInsetClearanceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBottomInsetClearanceTest.swift; sourceTree = "<group>"; };
 		06B7D586552E9F1EA44F5657 /* MapKitPOIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapKitPOIService.swift; sourceTree = "<group>"; };
 		0709110B381DEDA32C3292AE /* ChatUIState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatUIState.swift; sourceTree = "<group>"; };
 		086B3C207483BA0EBD27451F /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
@@ -501,7 +505,9 @@
 		CF90C42465B4E989A6DB9D05 /* CompanionSafetyConsentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionSafetyConsentSheet.swift; sourceTree = "<group>"; };
 		CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIdentityService.swift; sourceTree = "<group>"; };
 		D07ACA7C1A1574A244E73796 /* NavigationLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLauncher.swift; sourceTree = "<group>"; };
+		D08AFC181DB143A21E97A2ED /* NextBestExperienceClockTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextBestExperienceClockTest.swift; sourceTree = "<group>"; };
 		D22A9156A8CA2E798375C5C9 /* HitTargetMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitTargetMetrics.swift; sourceTree = "<group>"; };
+		D26F2087E12E63A73B812D7E /* PendingCheckInBannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingCheckInBannerTests.swift; sourceTree = "<group>"; };
 		D30D09E054C6CE013359301E /* TopOverlayLayoutTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopOverlayLayoutTest.swift; sourceTree = "<group>"; };
 		D3DBD8BED52DB4E9DD339BFD /* MapPinPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapPinPickerView.swift; sourceTree = "<group>"; };
 		D4C10384834D53FE83113D51 /* Configuration.storekit */ = {isa = PBXFileReference; path = Configuration.storekit; sourceTree = "<group>"; };
@@ -660,6 +666,7 @@
 				56F91067B8A0FACD9369243B /* BottomInfoSheetTests.swift */,
 				C63BC4737C3134075574125E /* BottomSheetDetentDynamicTypeTest.swift */,
 				999E8DA69CB660A94E71D02A /* BottomSheetSectionSeparationTest.swift */,
+				0674DC5D526883C657A63C38 /* CardBottomInsetClearanceTest.swift */,
 				308B7A34171C74B1CF2DE3F9 /* CityPillHitTargetTests.swift */,
 				907EA19EC9B84B93AB110C70 /* ColdStartExperienceLoadTests.swift */,
 				A00295FF044E4D732D1EB2EA /* ColorExtensionScopeTest.swift */,
@@ -693,11 +700,13 @@
 				774D16A741A01ECD6F878025 /* MapViewModelEagerInitTest.swift */,
 				658C2890F90C08A686F501BA /* MarkerStatePerformanceTest.swift */,
 				F7FB43528F45882868CCC203 /* NavigationLauncherTests.swift */,
+				D08AFC181DB143A21E97A2ED /* NextBestExperienceClockTest.swift */,
 				CE95C3399C8616CBDE8B44BE /* NoProductionPrintTests.swift */,
 				F1D68F42114231582501CB90 /* NowCountCacheTests.swift */,
 				FF7D0A1F8E3B8909F465194C /* ObsidianThemeContrastTest.swift */,
 				61D000D2E41CDD0DBF2B54C1 /* OnboardingA11yOrderTest.swift */,
 				C7BCDB936C9D0BE9138C617B /* OnboardingSkipTest.swift */,
+				D26F2087E12E63A73B812D7E /* PendingCheckInBannerTests.swift */,
 				70AF2705AB2F24B69DE8CB4F /* PerformanceTests.swift */,
 				A267CD0DA0A8053B0AB072BC /* PrivacyAcknowledgementSheetSnapshotTest.swift */,
 				EBCD0D2CE7423C29CD668866 /* PublicAPIDocCommentTests.swift */,
@@ -1201,6 +1210,7 @@
 				C2AE6B28BA196E2EDEE89012 /* BottomInfoSheetTests.swift in Sources */,
 				AB8E6644540AE90657471002 /* BottomSheetDetentDynamicTypeTest.swift in Sources */,
 				BF7D61FAEF133A0E77C585C9 /* BottomSheetSectionSeparationTest.swift in Sources */,
+				3CBA775B8C215CBAE3A73EA0 /* CardBottomInsetClearanceTest.swift in Sources */,
 				D2BCD302B16BBC174B71F84A /* CityPillHitTargetTests.swift in Sources */,
 				81470D06CD0593B278B110CC /* ColdStartExperienceLoadTests.swift in Sources */,
 				53C4F7B11856CF3D1313A228 /* ColorExtensionScopeTest.swift in Sources */,
@@ -1234,11 +1244,13 @@
 				C68E48A7B9D9E45647898D4C /* MapViewModelEagerInitTest.swift in Sources */,
 				FD8F94BFC5C298D62943FFF3 /* MarkerStatePerformanceTest.swift in Sources */,
 				D4193263CDA544D0995749B0 /* NavigationLauncherTests.swift in Sources */,
+				FC1E25FED02B767FBFB5EFE2 /* NextBestExperienceClockTest.swift in Sources */,
 				B42207A02271655D3498B723 /* NoProductionPrintTests.swift in Sources */,
 				C3A87993F509B921A9F7FE06 /* NowCountCacheTests.swift in Sources */,
 				546A552C93C3537B9A070220 /* ObsidianThemeContrastTest.swift in Sources */,
 				1DAB805A68DF18F2AC776160 /* OnboardingA11yOrderTest.swift in Sources */,
 				E7454BEAD925FCC11C83D83E /* OnboardingSkipTest.swift in Sources */,
+				045740DB5060EBE8D6D2EEA0 /* PendingCheckInBannerTests.swift in Sources */,
 				D7ABC99B7839B64FF014D344 /* PerformanceTests.swift in Sources */,
 				A5D3EF6A05AD9B93FA5ACD8A /* PrivacyAcknowledgementSheetSnapshotTest.swift in Sources */,
 				79E4FD6C7F9522BDB1106F56 /* PublicAPIDocCommentTests.swift in Sources */,

--- a/apps/ios/SoloCompass/Tests/CardBottomInsetClearanceTest.swift
+++ b/apps/ios/SoloCompass/Tests/CardBottomInsetClearanceTest.swift
@@ -1,0 +1,178 @@
+import XCTest
+import SwiftUI
+@testable import SoloCompass
+
+/// Regression guard for the "selected-experience floating card hidden behind the
+/// bottom sheet" bug.
+///
+/// **The bug:** `ExperienceCardView` (the popup preview card in
+/// `CompassMapView`) used a hard-coded `.padding(.bottom, 80)`. The
+/// `BottomInfoSheet` rests at its `peek` detent at **170pt** (the
+/// `basePeekHeight`) and grows further with Dynamic Type. An 80pt inset is far
+/// shorter than the 170pt peek, so the card's lower edge — including its
+/// Solo-Score rating row — was occluded by the sheet.
+///
+/// **The fix:** `CompassMapView.cardBottomInset` now computes
+/// `BottomSheetDetent.peekHeight(for: traits) + cardSheetGap` where
+/// `cardSheetGap == 12`, so the card always floats clear of the sheet's resting
+/// height at any text size.
+///
+/// These are pure geometric assertions (no pixel rendering) so they are fast and
+/// deterministic. The `cardBottomInset` formula is reproduced below as the unit
+/// under test.
+///
+/// ⚠️ If `CompassMapView.cardBottomInset` ever changes its formula or the
+/// `cardSheetGap` constant, update `Self.cardSheetGap` and `inset(for:)` here to
+/// match, or this regression guard will silently drift from production.
+@MainActor
+final class CardBottomInsetClearanceTest: XCTestCase {
+
+    // MARK: - Reproduced production constants
+
+    /// Mirror of `CompassMapView.cardBottomInset`'s `cardSheetGap` (the breathing
+    /// room between the card's lower edge and the sheet's top). Keep in sync with
+    /// production.
+    private static let cardSheetGap: CGFloat = 12
+
+    /// The old hard-coded inset that caused the bug: 80pt < 170pt peek height, so
+    /// the card's Solo-Score row was hidden behind the sheet. This is the root
+    /// cause being regressed against.
+    private static let legacyBrokenInset: CGFloat = 80
+
+    /// The unscaled base `peek` detent height (`basePeekHeight` in
+    /// `BottomInfoSheet.swift`).
+    private static let basePeekHeight: CGFloat = 170
+
+    /// Mirror of `CompassMapView.controlBarBottomInset`'s `controlSheetGap` — the
+    /// gap between the floating map control bar (filter / explore / `+` FAB) and
+    /// the sheet top. Slightly smaller than `cardSheetGap` so the controls hug the
+    /// sheet. Keep in sync with production.
+    private static let controlSheetGap: CGFloat = 8
+
+    /// Reproduces `CompassMapView.cardBottomInset` for the given traits.
+    private func inset(for traits: UITraitCollection?) -> CGFloat {
+        BottomSheetDetent.peekHeight(for: traits) + Self.cardSheetGap
+    }
+
+    /// Reproduces `CompassMapView.controlBarBottomInset` for the given traits.
+    private func controlInset(for traits: UITraitCollection?) -> CGFloat {
+        BottomSheetDetent.peekHeight(for: traits) + Self.controlSheetGap
+    }
+
+    // MARK: - Trait collections
+
+    private var ax5Traits: UITraitCollection {
+        UITraitCollection(preferredContentSizeCategory: .accessibilityExtraExtraExtraLarge)
+    }
+
+    // MARK: - 1. Core clearance assertion
+
+    /// The default peek height must be ≥ the 170pt base, and the card inset
+    /// (peek + gap) must be strictly greater than the peek height — i.e. the
+    /// card's bottom edge sits above the sheet's top edge with a positive gap.
+    func testCardInsetClearsPeekHeightWithPositiveGap() {
+        let peekHeight = BottomSheetDetent.peekHeight(for: nil)
+        XCTAssertGreaterThanOrEqual(
+            peekHeight, Self.basePeekHeight,
+            "Default peek height must be at least the \(Self.basePeekHeight)pt base; got \(peekHeight)"
+        )
+
+        let inset = inset(for: nil)
+        XCTAssertGreaterThan(
+            inset, peekHeight,
+            "Card inset (\(inset)) must exceed the peek height (\(peekHeight)) so the card floats clear of the sheet"
+        )
+
+        let gap = inset - peekHeight
+        XCTAssertGreaterThan(gap, 0, "Gap between card and sheet must be positive; got \(gap)")
+        XCTAssertEqual(
+            gap, Self.cardSheetGap, accuracy: 0.0001,
+            "Gap must equal cardSheetGap (\(Self.cardSheetGap)); if this fails the formula drifted from CompassMapView"
+        )
+    }
+
+    // MARK: - 2. Dynamic Type does not regress
+
+    /// At the largest text size (AX5) the peek height — and therefore the card
+    /// inset — must grow beyond the default, so the card still clears the
+    /// (now taller) sheet rather than falling back behind it.
+    func testCardInsetGrowsAtAX5SoCardStillClears() {
+        let defaultPeek = BottomSheetDetent.peekHeight(for: nil)
+        let ax5Peek = BottomSheetDetent.peekHeight(for: ax5Traits)
+        XCTAssertGreaterThan(
+            ax5Peek, defaultPeek,
+            "At AX5 the peek height (\(ax5Peek)) must exceed the default (\(defaultPeek))"
+        )
+
+        let defaultInset = inset(for: nil)
+        let ax5Inset = inset(for: ax5Traits)
+        XCTAssertGreaterThan(
+            ax5Inset, defaultInset,
+            "At AX5 the card inset (\(ax5Inset)) must grow beyond the default (\(defaultInset))"
+        )
+
+        // The clearance gap is preserved at AX5 too — card still floats clear.
+        XCTAssertGreaterThan(
+            ax5Inset, ax5Peek,
+            "At AX5 the card inset (\(ax5Inset)) must still exceed the peek height (\(ax5Peek))"
+        )
+    }
+
+    // MARK: - 3. Regression against the old broken value
+
+    /// The fixed default inset (≈182pt) must be strictly greater than the old
+    /// hard-coded 80pt. The 80pt inset is precisely the bug's root cause: it sat
+    /// far below the 170pt peek, hiding the card's Solo-Score row behind the
+    /// sheet.
+    func testDefaultInsetExceedsLegacyBrokenValue() {
+        let defaultInset = inset(for: nil)
+        XCTAssertGreaterThan(
+            defaultInset, Self.legacyBrokenInset,
+            "Fixed inset (\(defaultInset)) must exceed the legacy broken 80pt that caused the occlusion bug"
+        )
+        // Sanity: the legacy value was itself below the peek height — that is *why*
+        // it broke.
+        XCTAssertLessThan(
+            Self.legacyBrokenInset, BottomSheetDetent.peekHeight(for: nil),
+            "The legacy 80pt inset was below the peek height, confirming the documented root cause"
+        )
+    }
+
+    // MARK: - 4. Map control bar clears the sheet too
+
+    /// The floating control bar (filter / explore / `+` FAB) shared the exact same
+    /// bug: a hard-coded `.padding(.bottom, 80)` left the lower half of all three
+    /// buttons occluded by the peek sheet. `controlBarBottomInset` now tracks the
+    /// peek height, so the controls clear the sheet at every Dynamic Type size.
+    func testControlBarInsetClearsPeekHeightAtDefaultAndAX5() {
+        // Default size: inset clears peek with the documented gap.
+        let defaultPeek = BottomSheetDetent.peekHeight(for: nil)
+        let defaultControlInset = controlInset(for: nil)
+        XCTAssertGreaterThan(
+            defaultControlInset, defaultPeek,
+            "Control-bar inset (\(defaultControlInset)) must exceed the peek height (\(defaultPeek))"
+        )
+        XCTAssertEqual(
+            defaultControlInset - defaultPeek, Self.controlSheetGap, accuracy: 0.0001,
+            "Control-bar gap must equal controlSheetGap (\(Self.controlSheetGap)); if this fails the formula drifted from CompassMapView"
+        )
+
+        // Regression against the shared legacy 80pt root cause.
+        XCTAssertGreaterThan(
+            defaultControlInset, Self.legacyBrokenInset,
+            "Fixed control inset (\(defaultControlInset)) must exceed the legacy broken 80pt that occluded the buttons"
+        )
+
+        // AX5: inset grows with the taller peek so the controls still clear.
+        let ax5Peek = BottomSheetDetent.peekHeight(for: ax5Traits)
+        let ax5ControlInset = controlInset(for: ax5Traits)
+        XCTAssertGreaterThan(
+            ax5ControlInset, defaultControlInset,
+            "At AX5 the control inset (\(ax5ControlInset)) must grow beyond the default (\(defaultControlInset))"
+        )
+        XCTAssertGreaterThan(
+            ax5ControlInset, ax5Peek,
+            "At AX5 the control inset (\(ax5ControlInset)) must still exceed the peek height (\(ax5Peek))"
+        )
+    }
+}

--- a/apps/ios/SoloCompass/Tests/EmptyStateAnnouncementTest.swift
+++ b/apps/ios/SoloCompass/Tests/EmptyStateAnnouncementTest.swift
@@ -13,13 +13,23 @@ final class EmptyStateAnnouncementTest: XCTestCase {
     /// StringsParityTests does, so we assert against the shipped keys rather
     /// than relying on the test host's main-bundle lookup.
     private func englishStrings() -> [String: String]? {
-        guard let url = Bundle(for: type(of: self)).url(
-            forResource: "Localizable",
-            withExtension: "strings",
-            subdirectory: nil,
-            localization: "en"
-        ) else { return nil }
-        return NSDictionary(contentsOf: url) as? [String: String]
+        // The .strings files ship in the app bundle (the test host), not the
+        // test bundle — so search both, the same way StringsParityTests does.
+        // Looking up only `Bundle(for: self)` returns nil under the test host
+        // (the resource isn't in the test bundle), which previously tripped the
+        // XCTFail in testEmptyAnnouncementKeysExistInEnglish.
+        let searchBundles = [Bundle.main, Bundle(for: type(of: self))]
+        for bundle in searchBundles {
+            if let url = bundle.url(
+                forResource: "Localizable",
+                withExtension: "strings",
+                subdirectory: nil,
+                localization: "en"
+            ), let dict = NSDictionary(contentsOf: url) as? [String: String] {
+                return dict
+            }
+        }
+        return nil
     }
 
     // MARK: - Keys exist and resolve
@@ -109,15 +119,44 @@ final class EmptyStateAnnouncementTest: XCTestCase {
 
     // MARK: - Reflection helper
 
+    /// The "base name" of a metatype: module prefix and generic parameters
+    /// stripped. `SoloCompass.NearbyExperienceRow` → `NearbyExperienceRow`;
+    /// `_ConditionalContent<EmptySheetListView, ScrollView<…>>` →
+    /// `_ConditionalContent`.
+    ///
+    /// This is the crux of the fix. A SwiftUI `if/else` compiles to
+    /// `_ConditionalContent<TrueBranch, FalseBranch>`, so the *unselected*
+    /// branch's type name (e.g. `…NearbyExperienceRow…`) is baked into the
+    /// container's full type-name string even when only the other branch is
+    /// rendered. A `contains(typeName)` substring match therefore reports the
+    /// else-branch view as "present" in an empty list — a false positive. By
+    /// matching against the generic-parameter-free base name we only ever match
+    /// a node that is *actually that view instance* (its base name == typeName),
+    /// never an ancestor whose static type signature merely mentions it.
+    private static func typeBaseName(_ type: Any.Type) -> String {
+        var name = String(describing: type)
+        if let angle = name.firstIndex(of: "<") {
+            name = String(name[..<angle])
+        }
+        if let dot = name.lastIndex(of: ".") {
+            name = String(name[name.index(after: dot)...])
+        }
+        return name
+    }
+
     /// Recursive Mirror walk that returns true if any node in the reflected
-    /// structure has a type whose name contains `typeName`. This only inspects
-    /// Mirror children — it never evaluates a SwiftUI `body` — so it is safe to
-    /// run against trees containing primitive views (Text/Image) whose body is
-    /// `Never` and would trap if accessed.
+    /// structure is itself an instance of a view whose base type name equals
+    /// `typeName`. This only inspects Mirror children — it never evaluates a
+    /// SwiftUI `body` — so it is safe to run against trees containing primitive
+    /// views (Text/Image) whose body is `Never` and would trap if accessed.
+    ///
+    /// Crucially it matches the *base name* (see `typeBaseName`), not a substring
+    /// of the full generic type signature, so the unselected branch of a
+    /// `_ConditionalContent` is never mistaken for a rendered view.
     private static func viewTreeContains(_ root: Any, typeName: String, depth: Int = 0) -> Bool {
         if depth > 60 { return false }
         let mirror = Mirror(reflecting: root)
-        if String(describing: mirror.subjectType).contains(typeName) {
+        if typeBaseName(mirror.subjectType) == typeName {
             return true
         }
         for child in mirror.children {

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -280,7 +280,11 @@ public struct ExperienceCardView: View {
                     .accessibilityHidden(true)
                 RoundedRectangle(cornerRadius: 20)
                     .fill(.regularMaterial)
-                    .shadow(color: .black.opacity(0.1), radius: 12, y: -2)
+                    // Card now floats ABOVE the BottomInfoSheet, so it casts a
+                    // soft downward shadow onto the sheet to read as "lifted",
+                    // instead of the former upward (y:-2) shadow that suited a
+                    // card pinned to the screen bottom.
+                    .shadow(color: .black.opacity(0.16), radius: 16, y: 6)
             }
         )
         .offset(y: totalOffset)

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -139,6 +139,14 @@ public enum BottomSheetDetent: CaseIterable {
         baseHeight * BottomSheetDetentScale.factor(for: traits)
     }
 
+    /// Effective `peek` detent height for the supplied Dynamic Type traits.
+    /// Exposed so floating overlays (e.g. the selected-experience card) can sit
+    /// clear of the sheet's resting height at any text size instead of relying
+    /// on a hard-coded inset that clips at large Dynamic Type.
+    static func peekHeight(for traits: UITraitCollection? = nil) -> CGFloat {
+        BottomSheetDetent.peek.scaledHeight(for: traits)
+    }
+
     static func nearest(
         to height: CGFloat,
         traits: UITraitCollection? = nil

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -75,6 +75,8 @@ struct CompassMapContentView: View {
     private let companionService: CompanionService
     private let presenceService: PresenceService
 
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     @State private var viewModel: MapViewModel
     @State private var voiceService = VoiceService()
     @State private var dismissedAIError: String? = nil
@@ -174,6 +176,21 @@ struct CompassMapContentView: View {
         )
         vm.attachSubscriptionService(subscriptionService)
         _viewModel = State(initialValue: vm)
+    }
+
+    /// Bottom inset for the floating selected-experience card so it rests
+    /// clear of the `BottomInfoSheet` at its `peek` height — at any Dynamic
+    /// Type size, since the peek height itself scales with `UIFontMetrics`.
+    /// The old hard-coded `80pt` clipped the card's Solo-Score row behind the
+    /// sheet (the peek height is ≥170pt). `cardSheetGap` is the breathing room
+    /// between the card's lower edge and the sheet's top, so the layering reads
+    /// as "card floating above sheet" rather than "card jammed against it".
+    private var cardBottomInset: CGFloat {
+        let traits = UITraitCollection(
+            preferredContentSizeCategory: dynamicTypeSize.uiContentSizeCategory
+        )
+        let cardSheetGap: CGFloat = 12
+        return BottomSheetDetent.peekHeight(for: traits) + cardSheetGap
     }
 
     @ViewBuilder
@@ -381,19 +398,6 @@ struct CompassMapContentView: View {
                     }
                 }
 
-                if let selected = viewModel.selectedExperience, !viewModel.isShowingDetail {
-                    VStack {
-                        Spacer()
-                        ExperienceCardView(
-                            experience: selected,
-                            onExpand: { viewModel.isShowingDetail = true },
-                            onDismiss: { viewModel.selectedExperience = nil }
-                        )
-                        .padding(.bottom, 80)
-                    }
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-                }
-
                 if viewModel.visibleExperiences.isEmpty && !isFilterActive {
                     EmptyStateOverlay(
                         viewModel: viewModel,
@@ -494,6 +498,24 @@ struct CompassMapContentView: View {
                             .environment(experienceService)
                         }
                     }
+                }
+
+                // Selected-experience card floats ABOVE the BottomInfoSheet
+                // (declared after it → higher z-order) and rests on a Dynamic-
+                // Type-aware inset so its Solo-Score row is never clipped by the
+                // sheet's peek height. Previously declared before the sheet with
+                // a fixed 80pt inset, which let the sheet occlude its lower edge.
+                if let selected = viewModel.selectedExperience, !viewModel.isShowingDetail {
+                    VStack {
+                        Spacer()
+                        ExperienceCardView(
+                            experience: selected,
+                            onExpand: { viewModel.isShowingDetail = true },
+                            onDismiss: { viewModel.selectedExperience = nil }
+                        )
+                        .padding(.bottom, cardBottomInset)
+                    }
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
                 }
         }
     }

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -186,11 +186,27 @@ struct CompassMapContentView: View {
     /// between the card's lower edge and the sheet's top, so the layering reads
     /// as "card floating above sheet" rather than "card jammed against it".
     private var cardBottomInset: CGFloat {
+        let cardSheetGap: CGFloat = 12
+        return sheetPeekClearance + cardSheetGap
+    }
+
+    /// Bottom inset for the map's floating control bar (filter, explore, and the
+    /// `+` FAB) so they rest clear of the `BottomInfoSheet` peek instead of being
+    /// half-occluded by it. Same root cause as the card: a fixed `80pt` inset sat
+    /// below the ≥170pt peek height. Slightly smaller gap than the card so the
+    /// controls hug the sheet without crowding it.
+    private var controlBarBottomInset: CGFloat {
+        let controlSheetGap: CGFloat = 8
+        return sheetPeekClearance + controlSheetGap
+    }
+
+    /// The `BottomInfoSheet` peek height at the current Dynamic Type size — the
+    /// vertical space any bottom-anchored floating overlay must clear.
+    private var sheetPeekClearance: CGFloat {
         let traits = UITraitCollection(
             preferredContentSizeCategory: dynamicTypeSize.uiContentSizeCategory
         )
-        let cardSheetGap: CGFloat = 12
-        return BottomSheetDetent.peekHeight(for: traits) + cardSheetGap
+        return BottomSheetDetent.peekHeight(for: traits)
     }
 
     @ViewBuilder
@@ -387,7 +403,8 @@ struct CompassMapContentView: View {
                             // correct when the sheet content is first evaluated.
                             chatStartMode = mode
                             ensureOrchestrator(viewModel: viewModel)
-                        }
+                        },
+                        bottomInset: controlBarBottomInset
                     )
                 }
                 .onChange(of: isCompanionLayerOn) { _, on in
@@ -1495,6 +1512,10 @@ private struct MapControlBar: View {
     let preferences: UserPreferences
     @Binding var voiceOrchestrator: VoiceAgentOrchestrator?
     let onOpenChat: (CompassMapContentView.ChatStartMode) -> Void
+    /// Bottom inset that keeps the controls clear of the BottomInfoSheet peek.
+    /// Dynamic-Type-aware (peek height + gap), replacing a fixed 80pt that let
+    /// the sheet occlude the lower half of these buttons.
+    let bottomInset: CGFloat
 
     var body: some View {
         HStack(alignment: .bottom) {
@@ -1509,7 +1530,7 @@ private struct MapControlBar: View {
             }
             .buttonStyle(FABButtonStyle())
             .padding(.leading, 20)
-            .padding(.bottom, 80)
+            .padding(.bottom, bottomInset)
             .accessibilityLabel(Text(NSLocalizedString("settings.title", comment: "Settings")))
 
             Button {
@@ -1535,7 +1556,7 @@ private struct MapControlBar: View {
             }
             .buttonStyle(FABButtonStyle())
             .padding(.leading, 12)
-            .padding(.bottom, 80)
+            .padding(.bottom, bottomInset)
             .disabled(viewModel.isExploring || viewModel.isExploringFreeMode)
 
             Spacer()
@@ -1548,7 +1569,7 @@ private struct MapControlBar: View {
                 onLongPress: { onOpenChat(.voice) }
             )
             .padding(.trailing, 20)
-            .padding(.bottom, 80)
+            .padding(.bottom, bottomInset)
         }
     }
 }

--- a/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
@@ -231,6 +231,11 @@ public struct PendingCheckInBanner: View {
             onDismiss: {}
         )
         .padding(.bottom, 40)
-        .environment(\.accessibilityReduceMotion, true)
+        // NOTE: `accessibilityReduceMotion` is a READ-ONLY EnvironmentValue —
+        // SwiftUI exposes no writable setter, so it cannot be injected here.
+        // To preview the reduce-motion path, toggle the Simulator's
+        // Settings → Accessibility → Motion → Reduce Motion. The previous
+        // `.environment(\.accessibilityReduceMotion, true)` broke the build
+        // (KeyPath is not a WritableKeyPath).
     }
 }


### PR DESCRIPTION
## What & why

Two bottom-anchored floating overlays on the map home screen were being **occluded by the `BottomInfoSheet`** in its resting (`peek`) state. Both used a hard-coded `.padding(.bottom, 80)`, but the sheet's peek height is **≥170pt** and scales further with Dynamic Type — so ~90pt of each overlay was hidden behind the sheet.

### 1. Selected-experience card (`ExperienceCardView`)
The popup preview card's lower edge — including its **Solo-Score rating row** — sat behind the sheet.

**Fix:** `cardBottomInset = BottomSheetDetent.peekHeight(for: traits) + 12pt gap`, declared *after* the sheet so it floats above it. Shadow flipped from upward (`y:-2`) to a soft downward cast so it reads as "lifted".

### 2. Map control bar (`MapControlBar`)
The filter (`slider.horizontal.3`), explore (`sparkle.magnifyingglass`), and the black `+` FAB — the lower half of all three was clipped by the sheet.

**Fix:** `controlBarBottomInset = peek height + 8pt gap`, threaded into `MapControlBar`. The shared peek-clearance is factored out as `sheetPeekClearance` so both overlays track the sheet at every text size.

### 3. Pre-existing flaky test (`EmptyStateAnnouncementTest`)
`viewTreeContains` substring-matched the full generic type signature, so a SwiftUI `if/else` (`_ConditionalContent<TrueBranch, FalseBranch>`) reported the **unselected** else-branch view (`NearbyExperienceRow`) as present in an empty list — a false positive that failed on `main` independently of this change. Now matches the generic-parameter-free **base name**, so only an actually-rendered instance counts.

## Tests
- New `CardBottomInsetClearanceTest` — geometric regression guard for **both** the card and control-bar insets (default + AX5), asserting each clears the peek height and exceeds the legacy broken 80pt.
- **29 affected tests pass** (card/control/detent/Dynamic-Type/empty-state/overlay-render).
- Build succeeds; simulator screenshots confirm both the card and all three control buttons rest fully visible above the sheet peek.

## Notes
- Also carries `db4d59d` (a small `#Preview` build fix: removing an illegal write to the read-only `accessibilityReduceMotion` environment value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)