### PR TITLE
fix(ios): green the iOS CI — build regression + 4 pre-existing test failures

### DIFF
--- a/apps/ios/SoloCompass/Tests/NowCountCacheTests.swift
+++ b/apps/ios/SoloCompass/Tests/NowCountCacheTests.swift
@@ -84,12 +84,25 @@ final class NowCountCacheTests: XCTestCase {
         return (vm, service)
     }
 
-    /// Before any load the cache is its initial value (0).
-    func testInitialCountIsZero() {
+    /// With no visible best-now experiences the cache is 0. The view model's
+    /// `init` runs the documented `loadNearbyExperiences` checkpoint (V-004: a
+    /// cold start must anchor on the selected city, not the simulator's default
+    /// GPS), so we can't observe a "before any load" state. Instead we anchor on
+    /// a city with no seeded experiences nearby (San Francisco, while the only
+    /// fixture sits in Chiang Mai), so the load filters everything out and the
+    /// now-best subset — hence the cached count — is genuinely 0.
+    func testCountIsZeroWhenNoVisibleBestNow() {
         let (vm, _) = makeViewModel(seed: [
             makeExperience(id: "cmi_1", cityCode: "cmi", lon: 98.99, lat: 18.79, bestNow: true),
         ])
-        XCTAssertEqual(vm.nowCount, 0, "nowCount must be 0 before the first load")
+        vm.selectedCity = "san-francisco"
+        vm.loadNearbyExperiences()
+
+        XCTAssertTrue(
+            vm.visibleExperiences.isEmpty,
+            "the lone Chiang Mai fixture must be filtered out when anchored on San Francisco"
+        )
+        XCTAssertEqual(vm.nowCount, 0, "nowCount must be 0 when no visible experience is best now")
     }
 
     /// `loadNearbyExperiences` is a documented checkpoint: it recomputes the

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -310,19 +310,28 @@ public final class MapViewModel {
     }
 
     /// Center coordinate for the selected city, or the default if none selected.
-    /// Resolution order: live `availableCities` (seed + discovered) → the static
-    /// `knownCityCenters` slug catalog → the global default (Chiang Mai).
+    /// Resolution order: the static `knownCityCenters` catalog (a city's stable
+    /// authoritative center, by slug or seed-code alias) → live `availableCities`
+    /// (seed + discovered) centroid → the global default (Chiang Mai).
+    ///
+    /// V-002: `knownCityCenters` is consulted FIRST for cities it covers because
+    /// the seed centroid is just the mean of however many sample pins exist
+    /// (the 5 Chiang Mai seeds average ~2.6 km off the city center) and drifts
+    /// as seeds are added/removed — an unstable camera anchor. The authoritative
+    /// center keeps a cold start landing on the city proper; the centroid only
+    /// anchors cities the catalog doesn't cover (discovered / Explore-added).
     public var defaultCenterForSelectedCity: CLLocationCoordinate2D {
         guard let code = selectedCity else { return Self.defaultCenter }
-        // V-004: match alias-aware so a header slug (`chiang-mai`, `vientiane`)
-        // resolves to the seed-coded city's centroid — exact `==` left slug
-        // selections falling through to the global default (Chiang Mai), which
-        // mis-anchored both the camera and the nearby query origin.
+        // Try the slug directly, then the alias-resolved seed code, so both a
+        // header slug (`chiang-mai`) and a seed code (`cmi`) hit the catalog.
+        if let known = Self.knownCityCenters[code]
+            ?? Self.cityCodeAliases[code.lowercased()].flatMap({ Self.knownCityCenters[$0] }) {
+            return known
+        }
+        // V-004: match alias-aware so a header slug resolves to the seed-coded
+        // city's centroid for cities the catalog doesn't cover.
         if let city = availableCities.first(where: { Self.cityCodeMatches($0.code, selected: code) }) {
             return city.center
-        }
-        if let known = Self.knownCityCenters[code] {
-            return known
         }
         return Self.defaultCenter
     }


### PR DESCRIPTION
## 背景

接续设计落地工作后发现 `main` 当前 **iOS 构建是红的**，且测试套件有若干预存失败。本 PR 把构建修绿、并修复了 4 个预存测试失败。

## 改动（4 个 commit）

### 1. `db4d59d` 修构建回归 🔴
`PendingCheckInBanner` 的 `#Preview` 写入只读环境值 `.environment(\.accessibilityReduceMotion, true)`（`KeyPath` 非 `WritableKeyPath`），阻断整个 iOS target 编译。SwiftUI 不提供该值的 setter——移除该行并加注释说明（预览 reduce-motion 路径请用模拟器辅助功能开关）。

### 2. `9cc6cbe` Dynamic Type 卡片避让
选中体验卡用硬编码 `80pt` 底部 inset，在大号 Dynamic Type 下被 `BottomInfoSheet`（peek 高度 ≥170pt，随 `UIFontMetrics` 缩放）遮住 Solo-Score 行。
- `BottomInfoSheet`：暴露 `BottomSheetDetent.peekHeight(for:)`
- `CompassMapView`：卡片改在 sheet 之后声明（提高 z-order）+ 用 Dynamic-Type-aware `cardBottomInset`
- `ExperienceCardView`：卡片浮于 sheet 上，阴影改为向下投射（y:6）

### 3. `ddc703b` 控制栏避让 + EmptyState 反射测试修复
（并行协作提交）map control bar 同根因避让 sheet（复用 `peekHeight`）；`EmptyStateAnnouncementTest` 反射改用 `typeBaseName` 避免 `_ConditionalContent` 未选分支假阳性；新增 `CardBottomInsetClearanceTest` 覆盖卡片 inset；`englishStrings()` 改双 bundle 搜索（`[Bundle.main, Bundle(for:)]`）——资源在 test host bundle 而非 test bundle，单 bundle 查找返回 nil 触发 XCTFail。

### 4. `5658fb6` 冷启动相机 + nowCount 测试
- **CityRegion（生产修复）**：`defaultCenterForSelectedCity` 此前对已知城市返回种子坐标质心（清迈 5 个种子均值偏城市中心 ~2.6km > 测试 1km 容差）。改为优先查 `knownCityCenters`（按 slug 或 alias 解析的 seed code），种子质心仅兜底未在目录中的城市——质心会随种子增删漂移，是不稳定的相机锚点。
- **NowCount（测试修复）**：`testInitialCountIsZero` 错误假设 init 不 load，但 `init` 有意运行 `loadNearbyExperiences` 检查点（V-004：冷启动须锚定选定城市而非模拟器默认 GPS）。重命名为 `testCountIsZeroWhenNoVisibleBestNow`，锚定无附近种子的城市使可见集为空、缓存计数真为 0。

## 验证

- `xcodebuild build` → **BUILD SUCCEEDED**（0 error）
- 原 4 个失败用例全部转绿：EmptyStateAnnouncementTest(6/6)、MapViewModelCityRegionSyncTests(2/2)、NowCountCacheTests(4/4)
- 相机/城市相关回归套件 17/17 通过（ColdStartExperienceLoad、MapViewModelCityCache、NextBestExperienceClock、FilterNowMapSync）——确认 `defaultCenterForSelectedCity` 改动无回归
- 完整测试套件 exit 0