### PR TITLE
auto: Heart-burst particle animation when favoriting an experience

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -32,7 +32,7 @@ public struct ExperienceDetailView: View {
     @State private var isShowingReport: Bool = false
     @State private var showingRadarTooltip: Bool = false
     @State private var exportMarkdown: String? = nil
-    @State private var heartPop = false
+    @State private var heartBurstTrigger = 0
     @State private var celebrationTrigger = 0
     @State private var celebrationMilestone: Int? = nil
     @State private var isShowingNavPicker = false
@@ -1086,9 +1086,9 @@ public struct ExperienceDetailView: View {
                 let willFavorite = !viewModel.isFavorited
                 withAnimation(.spring(response: 0.3, dampingFraction: 0.45)) {
                     viewModel.toggleFavorite()
-                    heartPop.toggle()
                 }
                 if willFavorite {
+                    heartBurstTrigger += 1
                     Haptics.notify(.success)
                 } else {
                     Haptics.impact(.light)
@@ -1102,6 +1102,9 @@ public struct ExperienceDetailView: View {
                     .animation(.spring(response: 0.3, dampingFraction: 0.45), value: viewModel.isFavorited)
                     .frame(width: 50, height: 50)
                     .background(Circle().fill(.regularMaterial))
+                    .overlay {
+                        HeartBurstView(trigger: heartBurstTrigger)
+                    }
             }
             .accessibilityLabel(Text(viewModel.isFavorited
                 ? NSLocalizedString("action.unfavorite", comment: "Remove favorite")

--- a/apps/ios/SoloCompass/Views/Shared/HeartBurstView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/HeartBurstView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+/// Lightweight radial heart-particle burst fired when the user favorites an
+/// experience. Driven by `trigger` (Int): each increment spawns a new burst.
+/// Respects Reduce Motion — renders nothing when reduced motion is enabled.
+public struct HeartBurstView: View {
+    /// Increment to fire a burst. No burst on initial value (0).
+    let trigger: Int
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private struct Particle: Identifiable {
+        let id: Int
+        let angle: Double   // radians, deterministic from index
+        let color: Color
+        let size: CGFloat
+        let distance: CGFloat
+        let delay: Double
+    }
+
+    @State private var animated = false
+
+    // 8 particles at fixed 45° increments — no randomness needed.
+    private static let particleCount = 8
+    private static let colors: [Color] = [
+        .red, .pink, .red, Color(red: 1, green: 0.4, blue: 0.6),
+        .red, .pink, .red, Color(red: 1, green: 0.4, blue: 0.6),
+    ]
+    private static let sizes: [CGFloat] = [9, 7, 10, 7, 9, 8, 7, 10]
+    private static let distances: [CGFloat] = [38, 32, 42, 30, 38, 34, 42, 30]
+    private static let delays: [Double] = [0, 0.04, 0.02, 0.06, 0.01, 0.05, 0.03, 0.07]
+
+    private var particles: [Particle] {
+        (0..<Self.particleCount).map { i in
+            Particle(
+                id: i,
+                angle: Double(i) / Double(Self.particleCount) * .pi * 2,
+                color: Self.colors[i],
+                size: Self.sizes[i],
+                distance: Self.distances[i],
+                delay: Self.delays[i]
+            )
+        }
+    }
+
+    public var body: some View {
+        ZStack {
+            if !reduceMotion {
+                ForEach(particles) { p in
+                    Image(systemName: "heart.fill")
+                        .font(.system(size: p.size))
+                        .foregroundStyle(p.color)
+                        .opacity(animated ? 0 : 0.9)
+                        .scaleEffect(animated ? 0.2 : 1.0)
+                        .offset(
+                            x: animated ? cos(p.angle) * p.distance : 0,
+                            y: animated ? sin(p.angle) * p.distance : 0
+                        )
+                        .animation(
+                            .spring(response: 0.45, dampingFraction: 0.65).delay(p.delay),
+                            value: animated
+                        )
+                        .accessibilityHidden(true)
+                }
+            }
+        }
+        .allowsHitTesting(false)
+        .onChange(of: trigger) { _, _ in
+            guard trigger > 0, !reduceMotion else { return }
+            fire()
+        }
+    }
+
+    private func fire() {
+        animated = false
+        withAnimation(.spring(response: 0.45, dampingFraction: 0.65)) {
+            animated = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.65) {
+            animated = false
+        }
+    }
+}
+
+#Preview("HeartBurst") {
+    struct Demo: View {
+        @State private var trigger = 0
+        var body: some View {
+            ZStack {
+                Color(.systemBackground).ignoresSafeArea()
+                VStack(spacing: 48) {
+                    ZStack {
+                        Image(systemName: "heart.fill")
+                            .font(.title)
+                            .foregroundStyle(.red)
+                        HeartBurstView(trigger: trigger)
+                    }
+                    Button("Tap to favorite") { trigger += 1 }
+                        .buttonStyle(.borderedProminent)
+                }
+            }
+        }
+    }
+    return Demo()
+}


### PR DESCRIPTION
## Heart-burst particle animation when favoriting an experience

The favorite button in ExperienceDetailView declares @State private var heartPop and toggles it on tap, but the value is never consumed anywhere — it's dead state that produces no visual effect. Favoriting currently only gives a subtle SF Symbol bounce, while the parallel 'Mark Done' button gets a full CompletionCelebrationView burst. This adds a lightweight radial heart-particle burst (a new HeartBurstView in Views/Shared) that fires when a user favorites, wiring up the existing heartPop state and giving the heart action the same delightful, on-brand feedback as completion.

### Acceptance
Tapping the heart to favorite an experience triggers a radial burst of small heart particles emanating from the button, then fading; un-favoriting produces NO burst (only the existing bounce). With Reduce Motion enabled, no particles render. The previously-dead `heartPop` state is removed. App builds via `xcodebuild build -scheme SoloCompass` and the existing SoloCompassTests pass; the burst is verified visually in the iPhone 17 Pro simulator (heart action shows particles, mark-done still shows its own celebration independently).