### PR TITLE
auto: Personalized greeting + journey-progress header in Favorites list

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -435,6 +435,14 @@
 "favorites.nearby.go.a11y" = "Directions to nearest favorite, %@";
 "favorites.nearby.go.hint" = "Opens turn-by-turn directions in Maps";
 
+/* Favorites journey header */
+"favorites.greeting.morning" = "Good morning";
+"favorites.greeting.afternoon" = "Good afternoon";
+"favorites.greeting.evening" = "Good evening";
+"favorites.journey.allDone" = "You've explored them all";
+"favorites.journey.progress" = "%1$d of %2$d explored";
+"favorites.journey.awaiting" = "%d place(s) waiting for you";
+
 /* Generic actions */
 "action.undo" = "Undo";
 "favorites.undo.swipeHint" = "Swipe down to dismiss";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -190,6 +190,14 @@ public struct FavoritesListView: View {
                 } else {
                     VStack(spacing: 0) {
                         if sortedFavorites.count > 0 {
+                            FavoritesJourneyHeader(
+                                total: sortedFavorites.count,
+                                completed: completedCount,
+                                nearbyCount: nearbyCount
+                            )
+                            .padding(.horizontal, 16)
+                            .padding(.top, 12)
+
                             // Footer reflects the active search filter when one is present.
                             let countLabel: String = {
                                 let query = searchText.trimmingCharacters(in: .whitespaces)
@@ -405,6 +413,61 @@ public struct FavoritesListView: View {
             let remainingCount = sortedFavorites.filter { !preferences.completedExperiences.contains($0.id) }.count
             if showRemainingOnly && (allDone || remainingCount == 0) {
                 withAnimation(reduceMotion ? nil : .easeInOut) { showRemainingOnly = false }
+            }
+        }
+    }
+}
+
+private struct FavoritesJourneyHeader: View {
+    let total: Int
+    let completed: Int
+    let nearbyCount: Int
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var appeared = false
+
+    private var greeting: String {
+        let hour = Calendar.current.component(.hour, from: Date())
+        if hour < 12 {
+            return NSLocalizedString("favorites.greeting.morning", comment: "Morning greeting in favorites header")
+        } else if hour < 17 {
+            return NSLocalizedString("favorites.greeting.afternoon", comment: "Afternoon greeting in favorites header")
+        } else {
+            return NSLocalizedString("favorites.greeting.evening", comment: "Evening greeting in favorites header")
+        }
+    }
+
+    private var journeySummary: String {
+        if completed == total {
+            return NSLocalizedString("favorites.journey.allDone", comment: "All favorites explored")
+        } else if completed > 0 {
+            return String(format: NSLocalizedString("favorites.journey.progress", comment: "N of M explored"), completed, total)
+        } else {
+            return String(format: NSLocalizedString("favorites.journey.awaiting", comment: "N places waiting"), total)
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(greeting)
+                .font(.headline)
+                .foregroundStyle(.primary)
+            Text(journeySummary)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .contentTransition(.numericText())
+                .animation(.easeInOut, value: completed)
+                .animation(.easeInOut, value: total)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .opacity(appeared ? 1 : 0)
+        .offset(y: appeared ? 0 : (reduceMotion ? 0 : 6))
+        .accessibilityElement(children: .combine)
+        .onAppear {
+            if reduceMotion {
+                appeared = true
+            } else {
+                withAnimation(.easeOut(duration: 0.3)) { appeared = true }
             }
         }
     }


### PR DESCRIPTION
## Personalized greeting + journey-progress header in Favorites list

Add a time-of-day aware greeting header to the top of the FavoritesListView that frames the user's saved experiences as an emotional journey ('Good evening — 3 places await you' / 'You've completed 5 of 8'). This turns the dry count footer into a warm, motivating moment-of-arrival that matches Solo Compass's story-rich, companion ethos, with a subtle fade-in and Reduce Motion support.

### Acceptance
Opening Favorites with ≥1 saved experience shows a greeting matching the current local hour and a progress/awaiting line reflecting completed vs total counts; the line updates with a numeric transition when an experience is completed or removed; numbers read correctly under VoiceOver as one combined element; with Reduce Motion enabled the header appears with no fade/offset animation; empty-favorites and no-search-results states are unchanged; `xcodebuild build` and the SoloCompassTests suite pass.