### PR TITLE
fix(ios): map companion nearby cells from geohash6 (drop nil placeholder)

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -752,14 +752,13 @@ struct CompassMapContentView: View {
         await companionService.fetchDiscovery(
             params: CompanionDiscoverParams(cityCode: cityCode, mode: .nearby)
         )
-        // DiscoverPost doesn't expose geohash6 yet — build NearbyCell from
-        // city centroid as a placeholder until the Edge Function returns geohash6.
-        // When the backend returns geohash6, map post.geohash6 → NearbyCell(geohash:).
+        // Map each nearby-mode discovery hit to its blurred geohash-6 cell centre.
+        // `DiscoverPost.geohash6` exists, so resolve it directly; posts without a
+        // geohash6 (itinerary mode, or a backend that doesn't yet return the
+        // field) are dropped rather than rendered at a bogus location.
         nearbyCells = companionService.discoverPosts.compactMap { post in
-            // Use the post id as a synthetic geohash placeholder when geohash6
-            // is not yet in the DiscoverPost model. This keeps the layer compilable
-            // while the full geohash6 field lands in a follow-up backend deploy.
-            nil // placeholder — real mapping done once DiscoverPost.geohash6 is added
+            guard let gh = post.geohash6 else { return nil }
+            return NearbyCell(geohash: gh)
         }
     }
 


### PR DESCRIPTION
## What

`fetchNearbyCells` 把每个 discovery post 映射成 `nil`(`compactMap { nil }`),注释声称 `DiscoverPost` 还没有 geohash6 字段。但**那个字段早就存在了**,所以约伴 nearby 图层即使后端返回数据也永远渲染不出任何 cell。

改成真实映射:`NearbyCell(geohash: post.geohash6)`,没有 geohash6 的 post 丢弃而非放在错误位置。

## Why

这个占位是**伪装成 TODO 的死代码**——它等的字段已经落地了,所以这个"临时" nil 实际上永久保证图层为空。

## Scope

- 单文件单处改动:`apps/ios/SoloCompass/Views/Map/CompassMapView.swift`(+6/-7)
- 用户当前**无行为变化**(图层仍由 `FF_COMPANION` / `FF_COMPANION_LAYER_ENABLED` 关闭),但后端一返回 geohash6 图层就正确,无需再改代码。

## Verification

- ✅ `xcodebuild build` → BUILD SUCCEEDED

## Context

从一批更大的 companion 改动里拆出来的**唯一真 bug 修复**。其余(Supabase route-companion remote 实现、详情页入口、DEBUG mock)依赖未定的后端 schema(`0005_route_companion.sql.draft`,标注 "Do not apply until P3"),已主动丢弃,等 P3 结合真实 schema 重做。后端缺口见 #387。