### PR TITLE
fix(ios): stop companion-enable consent sheet crashing on accept

### DIFF
--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -96,6 +96,31 @@ final class SoloCompassTests: XCTestCase {
         XCTAssertTrue(reloaded.companionEnabled, "companionEnabled=true must persist across instantiation")
     }
 
+    /// US-020: reproduces exactly what the safety-consent "Accept & Continue"
+    /// button does (`acceptCompanionConsent()` + `companionEnabled = true`) and
+    /// asserts BOTH survive a reload. Guards the "enable failed" symptom: the
+    /// feature must actually stick on after the consent flow, not silently
+    /// revert to off.
+    func testAcceptingCompanionConsentEnablesAndPersists() throws {
+        let suite = "us020.companionConsentAccept.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let prefs = UserPreferences(defaults: defaults)
+        XCTAssertFalse(prefs.hasAcceptedCompanionConsent)
+        XCTAssertFalse(prefs.companionEnabled)
+
+        // Mirror CompanionSafetyConsentSheet.consentButton + the SettingsView
+        // onAccepted handler.
+        prefs.acceptCompanionConsent()
+        prefs.companionEnabled = true
+
+        let reloaded = UserPreferences(defaults: defaults)
+        XCTAssertTrue(reloaded.hasAcceptedCompanionConsent, "consent must persist")
+        XCTAssertNotNil(reloaded.companionConsentGivenAt, "consent timestamp must persist")
+        XCTAssertTrue(reloaded.companionEnabled, "companion must stay enabled after accept")
+    }
+
     /// `UserPreferences.customTags` defaults to empty and survives a
     /// UserDefaults reload.
     func testUserPreferencesCustomTagsPersistsAcrossReload() throws {

--- a/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
@@ -90,6 +90,24 @@ public struct SettingsView: View {
             .task {
                 isAnonymous = await SupabaseClient.shared.isAnonymous
             }
+            // US-020: Companion safety consent. Anchored to the stable List —
+            // NOT to `companionSection` — so List row recycling can't tear
+            // down the presentation source mid-transition. Accepting flips
+            // `companionEnabled`, which grows that Section from 1 row to 6;
+            // when the sheet was anchored to the Section, that row churn
+            // destroyed its own presentation anchor and crashed on device,
+            // leaving the flag unwritten ("enable failed").
+            .sheet(isPresented: $showingCompanionConsent) {
+                // Cancel path: companionEnabled stays false (only accept
+                // writes it). The Toggle re-reads from preferences and
+                // auto-rolls-back. The sheet dismisses itself via the
+                // environment `dismiss`, which resets this binding — so we
+                // only flip the persisted flag here (no double dismissal).
+                CompanionSafetyConsentSheet(onAccepted: {
+                    preferences.companionEnabled = true
+                })
+                .environment(preferences)
+            }
         }
     }
 
@@ -891,15 +909,6 @@ public struct SettingsView: View {
             )
         } footer: {
             Text(NSLocalizedString("settings.companion.footer", comment: "Companion section footer"))
-        }
-        .sheet(isPresented: $showingCompanionConsent) {
-            // Cancel path: companionEnabled stays false (only accept writes
-            // it). The Toggle re-reads from preferences and auto-rollbacks.
-            CompanionSafetyConsentSheet(onAccepted: {
-                preferences.companionEnabled = true
-                showingCompanionConsent = false
-            })
-            .environment(preferences)
         }
     }
 }


### PR DESCRIPTION
## Problem

Enabling **Companion** from Settings crashes when the user taps "接受并继续 / Accept & Continue" on the safety consent sheet, and the feature is left **off** afterwards ("开启失败" / enable failed). Reported from TestFlight (on-device); does not reproduce in the Simulator.

## Root cause

In `SettingsView`, the consent sheet was presented with `.sheet(isPresented:)` attached to **`companionSection` — a `Section` inside the settings `List`**.

Tapping accept ran:

```swift
preferences.companionEnabled = true   // grows companionSection 1 row → 6 rows
showingCompanionConsent = false        // dismiss via binding
// …and CompanionSafetyConsentSheet ALSO called dismiss() → double dismissal
```

Setting `companionEnabled = true` makes `companionSection` insert 5 new `NavigationLink` rows (profile / requests / conversations / discover / hosted). Because the sheet was anchored to that *same* recyclable Section, mutating the observed value re-rendered the Section and tore down the sheet's own presentation source mid-transition — a classic SwiftUI presentation crash that surfaces on device but not in Debug/Simulator. The crash interrupted the flag write, so `companionEnabled` never stuck.

## Fix

- **Anchor the consent `.sheet` to the stable `List`** in `body` instead of the recyclable `companionSection`, so row churn can't destroy its presentation anchor.
- **Remove the double dismissal**: the sheet now closes solely via its own environment `dismiss()` (which resets the `isPresented` binding); `onAccepted` only flips the persisted `companionEnabled` flag.

## Tests

Adds `testAcceptingCompanionConsentEnablesAndPersists`, which mirrors the accept handler (`acceptCompanionConsent()` + `companionEnabled = true`) and asserts consent, timestamp, and the enabled flag all survive a reload — guarding the "enable failed" symptom.

## Verification note

This runner is Linux (no Xcode toolchain), so the iOS build/test runs in CI (`ios-ci.yml`, `macos-latest`). The change is a SwiftUI presentation race fix that **should be verified on a device** (enable Companion → check both checkboxes → Accept → confirm no crash and the toggle stays on after relaunch), since the bug is device-specific by nature.

https://claude.ai/code/session_01NBMAhrdRSCG7egDMvgBYVg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBMAhrdRSCG7egDMvgBYVg)_