### PR TITLE
auto: Add late-night greeting bucket + 'nearby now' nudge to Favorites journey header

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -440,12 +440,14 @@
 "favorites.nearby.go.hint" = "Opens turn-by-turn directions in Maps";
 
 /* Favorites journey header */
+"favorites.greeting.night" = "Still up?";
 "favorites.greeting.morning" = "Good morning";
 "favorites.greeting.afternoon" = "Good afternoon";
 "favorites.greeting.evening" = "Good evening";
 "favorites.journey.allDone" = "You've explored them all";
 "favorites.journey.progress" = "%1$d of %2$d explored";
 "favorites.journey.awaiting" = "%d place(s) waiting for you";
+"favorites.journey.nearbyNow" = "%d within walking distance";
 
 /* Generic actions */
 "action.undo" = "Undo";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -428,7 +428,9 @@ private struct FavoritesJourneyHeader: View {
 
     private var greeting: String {
         let hour = Calendar.current.component(.hour, from: Date())
-        if hour < 12 {
+        if hour < 5 {
+            return NSLocalizedString("favorites.greeting.night", comment: "Late-night greeting in favorites header")
+        } else if hour < 12 {
             return NSLocalizedString("favorites.greeting.morning", comment: "Morning greeting in favorites header")
         } else if hour < 17 {
             return NSLocalizedString("favorites.greeting.afternoon", comment: "Afternoon greeting in favorites header")
@@ -447,6 +449,16 @@ private struct FavoritesJourneyHeader: View {
         }
     }
 
+    @ViewBuilder
+    private var nearbyNudge: some View {
+        if nearbyCount > 0 {
+            Text(String(format: NSLocalizedString("favorites.journey.nearbyNow", comment: "N favorites within walking distance nudge"), nearbyCount))
+                .font(.caption2)
+                .foregroundStyle(Color.green)
+                .transition(reduceMotion ? .opacity : .scale(scale: 0.9).combined(with: .opacity))
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(greeting)
@@ -458,6 +470,8 @@ private struct FavoritesJourneyHeader: View {
                 .contentTransition(.numericText())
                 .animation(.easeInOut, value: completed)
                 .animation(.easeInOut, value: total)
+            nearbyNudge
+                .animation(reduceMotion ? nil : .easeInOut, value: nearbyCount)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .opacity(appeared ? 1 : 0)


### PR DESCRIPTION
## Add late-night greeting bucket + 'nearby now' nudge to Favorites journey header

The FavoritesJourneyHeader greeting only has 3 time buckets, so it wrongly says 'Good morning' from midnight to noon (e.g. 2am). It also never tells a solo traveler the one actionable fact when they open the list at night: whether any saved spot is walkable right now. This adds a 'Good evening/night' refinement plus a subtle, time-aware nudge line when nearby favorites exist, reinforcing the map-first 'best now' ethos.

### Acceptance
Build succeeds (xcodebuild build, iPhone 17 Pro sim). Opening Favorites between midnight and 5am shows the night greeting, not 'Good morning'. When at least one favorite is within ~1km and location is available, a green 'N within walking distance' line appears under the journey summary and animates in respecting Reduce Motion. VoiceOver reads the header as a single combined element. All strings resolve via NSLocalizedString (no raw literals); existing FavoritesListView tests still pass.