### PR TITLE
auto: Route SoloScoreRadarChart haptics through HapticService so the user's haptics opt-out is respected

### DIFF
--- a/apps/ios/SoloCompass/Tests/HapticServiceTests.swift
+++ b/apps/ios/SoloCompass/Tests/HapticServiceTests.swift
@@ -72,4 +72,16 @@ final class HapticServiceTests: XCTestCase {
         XCTAssertTrue(HapticService.shared.isEnabled)
         HapticService.shared.selectionChanged()
     }
+
+    /// SoloScoreRadarChart routes its draw-in and replay haptics through
+    /// Haptics.impact(.soft) / HapticService, so disabling hapticsEnabled
+    /// silences the radar chart without any additional wiring in the view.
+    func testRadarChartHapticsRespectOptOut() {
+        HapticService.shared.isEnabled = false
+        // Simulates what SoloScoreRadarChart does on draw-in and replay.
+        HapticService.shared.prepare(style: .soft)
+        HapticService.shared.impact(style: .soft)
+        // No crash and no haptic fired — shouldFire() returns false when disabled.
+        XCTAssertFalse(HapticService.shared.isEnabled)
+    }
 }

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
@@ -10,7 +10,6 @@ public struct SoloScoreRadarChart: View {
     @State private var isReplaying: Bool = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    private let haptic = UIImpactFeedbackGenerator(style: .soft)
     private static let springDuration: Double = 0.7
 
     private static let axes: [(label: String, symbol: String, keyPath: KeyPath<SoloScore.Breakdown, Double>)] = [
@@ -78,9 +77,10 @@ public struct SoloScoreRadarChart: View {
                 withAnimation(.spring(response: Self.springDuration, dampingFraction: 0.75)) {
                     drawProgress = 1
                 }
-                haptic.prepare()
+                // Route through HapticService so the user's haptics opt-out is respected.
+                HapticService.shared.prepare(style: .soft)
                 DispatchQueue.main.asyncAfter(deadline: .now() + Self.springDuration) {
-                    haptic.impactOccurred()
+                    Haptics.impact(.soft)
                 }
             }
         }
@@ -268,9 +268,9 @@ public struct SoloScoreRadarChart: View {
         withAnimation(.spring(response: Self.springDuration, dampingFraction: 0.75)) {
             drawProgress = 1
         }
-        haptic.prepare()
+        HapticService.shared.prepare(style: .soft)
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.springDuration) {
-            haptic.impactOccurred()
+            Haptics.impact(.soft)
             isReplaying = false
         }
     }


### PR DESCRIPTION
## Route SoloScoreRadarChart haptics through HapticService so the user's haptics opt-out is respected

SoloScoreRadarChart creates a raw UIImpactFeedbackGenerator and fires it directly on draw-in and tap-to-replay, bypassing the centralized Haptics/HapticService wrapper. As a result its haptics fire even when the user has turned off 'hapticsEnabled' in Settings (the wrapper checks that flag, Reduce Motion, and preview suppression). Replace the direct generator with Haptics.impact(.soft) to honor the opt-out, drop a redundant ad-hoc generator, and keep behavior identical when haptics are enabled.

### Acceptance
1) No raw UIImpactFeedbackGenerator remains in SoloScoreRadarChart.swift — all haptics go through Haptics/HapticService. 2) With 'hapticsEnabled' set to false in UserDefaults, tapping the radar to replay and the draw-in completion fire NO haptic; with it true (and Reduce Motion off) they fire a .soft impact exactly as before. 3) The draw-in and replay animations are visually unchanged. 4) `xcodebuild build -scheme SoloCompass` succeeds and `xcodebuild test` passes (including HapticServiceTests). 5) The #Preview blocks still render with no haptics (preview suppression already handled by HapticService).