### PR TITLE
auto: Add a slow-fetch reassurance state to POILoadingBanner

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -215,6 +215,8 @@
 "map.loading" = "Loading map";
 "map.loadingPOIs" = "Finding nearby places…";
 "map.loadingPOIs.a11yAnnouncement" = "Finding nearby places";
+/* Shown after ~6 s when the Overpass fetch is still running — reassures the user the app is not stuck */
+"map.loadingPOIs.slow" = "Still searching nearby…";
 
 /* City picker */
 "city.all" = "All Cities";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1216,6 +1216,8 @@
 
 /* Map loading */
 "map.loadingPOIs.a11yAnnouncement" = "正在查找附近地点";
+/* Shown after ~6 s when the Overpass fetch is still running — reassures the user the app is not stuck */
+"map.loadingPOIs.slow" = "仍在搜索附近…";
 
 /* My requests */
 "my.requests.empty.cta" = "找一条路线加入";

--- a/apps/ios/SoloCompass/Views/Map/POILoadingBanner.swift
+++ b/apps/ios/SoloCompass/Views/Map/POILoadingBanner.swift
@@ -7,6 +7,13 @@ import SwiftUI
 struct POILoadingBanner: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isPulsing = false
+    @State private var isSlow: Bool
+    @State private var slowTask: Task<Void, Never>?
+
+    // `previewSlow` is only used in #Preview blocks to skip the 6-second wait.
+    init(previewSlow: Bool = false) {
+        _isSlow = State(initialValue: previewSlow)
+    }
 
     var body: some View {
         GlassmorphismCapsule(
@@ -18,14 +25,20 @@ struct POILoadingBanner: View {
                     .opacity(isPulsing ? 1.0 : 0.6)
             },
             content: {
-                Text(NSLocalizedString("map.loadingPOIs", comment: "Loading nearby places banner"))
+                Text(isSlow
+                     ? NSLocalizedString("map.loadingPOIs.slow", comment: "Reassurance shown when POI fetch exceeds ~6 s")
+                     : NSLocalizedString("map.loadingPOIs", comment: "Loading nearby places banner"))
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
+                    .contentTransition(.opacity)
+                    .animation(reduceMotion ? nil : .easeInOut, value: isSlow)
             }
         )
         .transition(.move(edge: .top).combined(with: .opacity))
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(Text(NSLocalizedString("map.loadingPOIs", comment: "Loading nearby places banner")))
+        .accessibilityLabel(Text(isSlow
+            ? NSLocalizedString("map.loadingPOIs.slow", comment: "Reassurance shown when POI fetch exceeds ~6 s")
+            : NSLocalizedString("map.loadingPOIs", comment: "Loading nearby places banner")))
         .onAppear {
             UIAccessibility.post(
                 notification: .announcement,
@@ -35,6 +48,22 @@ struct POILoadingBanner: View {
             withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
                 isPulsing = true
             }
+            guard !isSlow else { return }
+            slowTask = Task {
+                try? await Task.sleep(for: .seconds(6))
+                guard !Task.isCancelled else { return }
+                withAnimation(reduceMotion ? nil : .easeInOut) {
+                    isSlow = true
+                }
+                UIAccessibility.post(
+                    notification: .announcement,
+                    argument: NSLocalizedString("map.loadingPOIs.slow", comment: "Reassurance shown when POI fetch exceeds ~6 s")
+                )
+            }
+        }
+        .onDisappear {
+            slowTask?.cancel()
+            slowTask = nil
         }
         .onChange(of: reduceMotion) { _, reduced in
             if reduced {
@@ -52,6 +81,14 @@ struct POILoadingBanner: View {
     ZStack {
         Color(.systemBackground).ignoresSafeArea()
         POILoadingBanner()
+            .padding(.top, 60)
+    }
+}
+
+#Preview("Slow") {
+    ZStack {
+        Color(.systemBackground).ignoresSafeArea()
+        POILoadingBanner(previewSlow: true)
             .padding(.top, 60)
     }
 }


### PR DESCRIPTION
## Add a slow-fetch reassurance state to POILoadingBanner

POILoadingBanner shows an indefinite spinner with no feedback when an Overpass POI fetch runs long, leaving users unsure whether the app is stuck. Add a graceful 'still working' state that, after ~6 seconds, swaps the caption to a reassuring message and a subtle SF Symbol, mirroring the existing OfflineBanner failure-state pattern. This is a visible, self-contained UX polish with no schema impact.

### Acceptance
Build succeeds (xcodebuild build, iPhone 17 Pro sim). When a POI fetch exceeds ~6s the banner caption animates from the default loading text to the reassurance text and a VoiceOver announcement fires; under Reduce Motion the swap is instant with no repeating pulse changes. New localization key is present in every .lproj and StringsParityTests passes. The banner still dismisses normally when the fetch completes and the slow-timer Task is cancelled on disappear (no leaked tasks).