### PR TITLE
auto: Fix stale Solo Score in compact badge when score updates live

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -59,14 +59,8 @@ public struct SoloScoreBadge: View {
         .scaleEffect(appeared ? 1 : 0.7)
         .opacity(appeared ? 1 : 0)
         .onAppear {
-            if reduceMotion {
-                appeared = true
-                animatedScore = score.overall
-            } else {
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.6)) {
-                    appeared = true
-                }
-            }
+            appeared = true
+            updateAnimatedScore()
         }
         .accessibilityLabel(Text(
             isExcellent
@@ -77,13 +71,8 @@ public struct SoloScoreBadge: View {
         .accessibilityHint(Text(NSLocalizedString("solo.compact.a11y.hint", comment: "Double tap to see score breakdown")))
         .accessibilityAddTraits(.isButton)
         .onChange(of: score.overall) { _, _ in
-            if reduceMotion {
-                animatedScore = score.overall
-            } else {
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.6)) {
-                    appeared = true
-                }
-            }
+            appeared = true
+            updateAnimatedScore()
         }
     }
 
@@ -123,6 +112,16 @@ public struct SoloScoreBadge: View {
             }
         }
         .onChange(of: score.overall) { triggerAnimation() }
+    }
+
+    private func updateAnimatedScore() {
+        if reduceMotion {
+            animatedScore = score.overall
+        } else {
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.6)) {
+                animatedScore = score.overall
+            }
+        }
     }
 
     private func triggerAnimation() {


### PR DESCRIPTION
## Fix stale Solo Score in compact badge when score updates live

The compact SoloScoreBadge's onChange(of: score.overall) handler sets `appeared = true` but never updates `animatedScore`, so the pill keeps showing the old number when an experience's score changes (e.g. after a community vote shifts overall/basedOnCount). The full-style badge handles this correctly via triggerAnimation(). This fixes the divergence so the compact pill animates to the new value with its already-wired .numericText transition.

### Acceptance
When an experience's soloScore.overall changes while a compact SoloScoreBadge is on screen, the pill animates from the previous number to the new number (numericText count-up), and renders the exact new value when Reduce Motion is enabled. The full-style badge behavior is unchanged. `xcodebuild build` and the SoloScoreBadge unit tests pass; a #Preview demonstrates the compact pill updating to a new score.