### PR TITLE
auto: Celebrate the all-favorites-explored moment with a heart-burst flourish

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -495,6 +495,7 @@ private struct CompletionRing: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var animatedFraction: CGFloat = 0
     @State private var bloomScale: CGFloat = 1
+    @State private var celebrationBurst = 0
 
     private var isAllDone: Bool { total > 0 && done == total }
     private var fraction: CGFloat { total > 0 ? CGFloat(done) / CGFloat(total) : 0 }
@@ -507,6 +508,7 @@ private struct CompletionRing: View {
 
     var body: some View {
         ZStack {
+            HeartBurstView(trigger: celebrationBurst)
             Circle()
                 .stroke(Color.green.opacity(0.15), lineWidth: 2.5)
             Circle()
@@ -556,6 +558,7 @@ private struct CompletionRing: View {
     private func triggerCelebration() {
         didCelebrate = true
         Haptics.notify(.success)
+        celebrationBurst += 1
         guard !reduceMotion else { return }
         withAnimation(.easeOut(duration: 0.15)) { bloomScale = 1.15 }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {


### PR DESCRIPTION
## Celebrate the all-favorites-explored moment with a heart-burst flourish

When a solo traveler completes the last of their saved favorites, the CompletionRing in FavoritesListView currently swaps to a tiny static checkmark with only a 0.15s scale bloom — an anticlimactic payoff for a meaningful milestone. This reuses the existing reduce-motion-aware HeartBurstView to fire a radial heart particle burst behind the ring at the exact moment done reaches total, turning a quiet state change into a delightful, emotionally-resonant reward consistent with the app's 'story-rich' ethos.

### Acceptance
Completing the final favorite (done == total) fires a single radial heart-particle burst behind the CompletionRing checkmark with a success haptic; the burst does not re-fire on subsequent list re-renders or scrolls (didCelebrate gate); under Reduce Motion no particles render and only the haptic + static checkmark remain; xcodebuild build and SoloCompassTests pass, including the existing FavoritesBounceAvailabilityTest.