### PR TITLE
auto: Make the Favorites journey-header nearby nudge a tappable shortcut to nearest-sort

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -450,6 +450,8 @@
 "favorites.journey.progress" = "%1$d of %2$d explored";
 "favorites.journey.awaiting" = "%d place(s) waiting for you";
 "favorites.journey.nearbyNow" = "%d within walking distance";
+"favorites.journey.nearbyNow.a11y" = "%d favorites within walking distance";
+"favorites.journey.nearbyNow.hint" = "Sorts favorites by distance";
 
 /* Generic actions */
 "action.undo" = "Undo";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -476,7 +476,6 @@ private struct FavoritesJourneyHeader: View {
 
             if let onTap = onTapNearby {
                 Button {
-                    Haptics.selection()
                     onTap()
                 } label: {
                     nudgeContent
@@ -484,7 +483,6 @@ private struct FavoritesJourneyHeader: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel(String(format: NSLocalizedString("favorites.journey.nearbyNow.a11y", comment: "Nearby nudge button accessibility label"), nearbyCount))
                 .accessibilityHint(NSLocalizedString("favorites.journey.nearbyNow.hint", comment: "Nearby nudge button sorts by distance hint"))
-                .accessibilityAddTraits(.isButton)
             } else {
                 nudgeContent
                     .accessibilityLabel(label)

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -193,7 +193,11 @@ public struct FavoritesListView: View {
                             FavoritesJourneyHeader(
                                 total: sortedFavorites.count,
                                 completed: completedCount,
-                                nearbyCount: nearbyCount
+                                nearbyCount: nearbyCount,
+                                onTapNearby: locationService.currentLocation != nil && nearbyCount > 0 ? {
+                                    Haptics.selection()
+                                    withAnimation(reduceMotion ? nil : .easeInOut) { sortMode = .nearest }
+                                } : nil
                             )
                             .padding(.horizontal, 16)
                             .padding(.top, 12)
@@ -422,6 +426,7 @@ private struct FavoritesJourneyHeader: View {
     let total: Int
     let completed: Int
     let nearbyCount: Int
+    var onTapNearby: (() -> Void)? = nil
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var appeared = false
@@ -452,10 +457,38 @@ private struct FavoritesJourneyHeader: View {
     @ViewBuilder
     private var nearbyNudge: some View {
         if nearbyCount > 0 {
-            Text(String(format: NSLocalizedString("favorites.journey.nearbyNow", comment: "N favorites within walking distance nudge"), nearbyCount))
-                .font(.caption2)
-                .foregroundStyle(Color.green)
-                .transition(reduceMotion ? .opacity : .scale(scale: 0.9).combined(with: .opacity))
+            let label = String(format: NSLocalizedString("favorites.journey.nearbyNow", comment: "N favorites within walking distance nudge"), nearbyCount)
+            let nudgeContent = HStack(spacing: 4) {
+                Text(label)
+                    .font(.caption2)
+                    .foregroundStyle(Color.green)
+                if onTapNearby != nil {
+                    Image(systemName: "chevron.right.circle.fill")
+                        .font(.caption2)
+                        .foregroundStyle(Color.green)
+                        .accessibilityHidden(true)
+                }
+            }
+            .padding(.horizontal, onTapNearby != nil ? 8 : 0)
+            .padding(.vertical, onTapNearby != nil ? 4 : 0)
+            .background(onTapNearby != nil ? Color.green.opacity(0.12) : Color.clear, in: Capsule())
+            .transition(reduceMotion ? .opacity : .scale(scale: 0.9).combined(with: .opacity))
+
+            if let onTap = onTapNearby {
+                Button {
+                    Haptics.selection()
+                    onTap()
+                } label: {
+                    nudgeContent
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(format: NSLocalizedString("favorites.journey.nearbyNow.a11y", comment: "Nearby nudge button accessibility label"), nearbyCount))
+                .accessibilityHint(NSLocalizedString("favorites.journey.nearbyNow.hint", comment: "Nearby nudge button sorts by distance hint"))
+                .accessibilityAddTraits(.isButton)
+            } else {
+                nudgeContent
+                    .accessibilityLabel(label)
+            }
         }
     }
 


### PR DESCRIPTION
## Make the Favorites journey-header nearby nudge a tappable shortcut to nearest-sort

In FavoritesListView the prominent journey header shows a 'N favorites within walking distance' nudge as static, non-interactive text, even though the same action (switch to nearest-sort) already exists as a small footer chip below it. Promoting this top-of-screen nudge to a tappable button that switches sortMode to .nearest with a haptic gives travelers a one-tap path from 'something's close' to 'show me the closest one' right where their eye lands first.

### Acceptance
With location available and ≥1 nearby favorite, the header nudge renders inside a subtle green capsule with a trailing chevron and is tappable; tapping it fires a selection haptic and animates the sort picker to 'Nearest', reordering the list. When onTapNearby is nil (or no nearby favorites) the header renders exactly as before with no button affordance. VoiceOver announces it as a button with the nearby-count label and a 'sorts by distance' hint. xcodebuild build succeeds and existing FavoritesListView tests still pass.