### PR TITLE
auto: Proximity-band crossing feedback on the experience card distance pill

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -264,6 +264,9 @@
 /* Proximity cue appended to bearing arrow a11y label when user is ≤300 m away */
 "card.distance.proximity.near" = "getting close";
 
+/* VoiceOver announcement posted once when the user enters the near proximity band (≤300 m) */
+"card.proximity.closer" = "Getting closer";
+
 /* On-course cue appended to bearing arrow a11y label when user faces the experience within ±15° */
 "card.distance.onCourse.a11y" = "On course";
 

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -22,6 +22,8 @@ public struct ExperienceCardView: View {
     @State private var arrivalGlow = false
     @State private var didFireOnCourse = false
     @State private var onCourseSnap = false
+    @State private var lastProximityBand: ProximityTint?
+    @State private var proximityPop = false
 
     private static let arrivedThresholdMeters = 75.0
 
@@ -84,8 +86,20 @@ public struct ExperienceCardView: View {
         return directions[index]
     }
 
-    private enum ProximityTint {
-        case near, mid, far
+    private enum ProximityTint: Comparable {
+        case far, mid, near
+
+        private var rank: Int {
+            switch self {
+            case .far: return 0
+            case .mid: return 1
+            case .near: return 2
+            }
+        }
+
+        static func < (lhs: ProximityTint, rhs: ProximityTint) -> Bool {
+            lhs.rank < rhs.rank
+        }
 
         static func from(meters: Double) -> ProximityTint {
             if meters <= 300 { return .near }
@@ -407,6 +421,29 @@ public struct ExperienceCardView: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(Capsule().fill(Color.secondary.opacity(0.12)))
+        .scaleEffect(proximityPop && !reduceMotion ? 1.18 : 1.0)
+        .animation(.spring(response: 0.25, dampingFraction: 0.5), value: proximityPop)
+        .onChange(of: distanceMeters) { _, meters in
+            guard let meters else { return }
+            let current = ProximityTint.from(meters: meters)
+            defer { lastProximityBand = current }
+            guard let last = lastProximityBand, current > last else { return }
+            let style: UIImpactFeedbackGenerator.FeedbackStyle = current == .near ? .medium : .light
+            Haptics.impact(style)
+            if current == .near {
+                UIAccessibility.post(
+                    notification: .announcement,
+                    argument: NSLocalizedString("card.proximity.closer", comment: "VoiceOver announcement when user enters the near proximity band")
+                )
+            }
+            if !reduceMotion {
+                proximityPop = true
+                Task {
+                    try? await Task.sleep(nanoseconds: 300_000_000)
+                    proximityPop = false
+                }
+            }
+        }
         .onChange(of: isOnCourse) { _, onCourse in
             if onCourse {
                 guard !didFireOnCourse else { return }


### PR DESCRIPTION
## Proximity-band crossing feedback on the experience card distance pill

The card's distance pill already tints by proximity band (near/mid/far) and snaps green when on-course, but gives no feedback the moment the walking user actually crosses a band boundary (far→mid→near) — the single most important 'you're getting warmer' signal in a compass app. This adds a one-shot haptic plus a brief scale-pop on the distance pill each time the user enters a closer band, mirroring the existing on-course and arrival feedback patterns already in the file.

### Acceptance
Building apps/ios with xcodebuild succeeds. Walking toward an experience in the Simulator (Features > Location > Custom, stepping coordinates closer) fires one light/medium haptic and a brief pill scale-pop exactly once per band entered (far→mid at 1000m, mid→near at 300m), never repeats within a band, never fires on the first location fix, and stays silent under Reduce Motion for the visual while VoiceOver announces 'Getting closer' on entering the near band. No regression to the existing on-course snap or arrival glow.