### PR TITLE
auto: Add a gentle attention pulse to the low-Solo-Score caution glyph

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -11,6 +11,7 @@ public struct SoloScoreBadge: View {
     @State private var appeared = false
     @State private var showBreakdown = false
     @State private var twinkle = false
+    @State private var cautionPulse = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     public init(score: SoloScore, style: Style = .compact) {
@@ -46,6 +47,10 @@ public struct SoloScoreBadge: View {
                     Image(systemName: "person.fill.questionmark")
                         .font(.caption2)
                         .foregroundStyle(.white.opacity(0.95))
+                        .scaleEffect(cautionPulse && !reduceMotion ? 1.12 : 1.0)
+                        .opacity(cautionPulse && !reduceMotion ? 1.0 : 0.78)
+                        .animation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true), value: cautionPulse)
+                        .accessibilityHidden(true)
                 }
                 Text(NSLocalizedString("solo.label", comment: "Solo"))
                     .font(.caption2)
@@ -74,6 +79,9 @@ public struct SoloScoreBadge: View {
             if isExcellent && !reduceMotion {
                 twinkle = true
             }
+            if isCaution && !reduceMotion {
+                cautionPulse = true
+            }
         }
         .accessibilityLabel(Text(
             isExcellent
@@ -95,6 +103,13 @@ public struct SoloScoreBadge: View {
                 twinkle = true
             } else if !nowExcellent {
                 twinkle = false
+            }
+            let nowCaution = newValue < 4.0
+            if nowCaution && !reduceMotion {
+                cautionPulse = false
+                cautionPulse = true
+            } else if !nowCaution {
+                cautionPulse = false
             }
         }
     }


### PR DESCRIPTION
## Add a gentle attention pulse to the low-Solo-Score caution glyph

In SoloScoreBadge's compact view, the 'excellent' state (≥8.5) gets a twinkling, scaling star, but the safety-critical 'caution' state (<4.0) shows a static person.fill.questionmark glyph with no animation — even though a low Solo Score is the signal a solo traveler most needs to notice (a place that 'may feel exposed'). This adds a subtle, reduce-motion-gated pulse/opacity breath to the caution glyph so the warning draws the eye as deliberately as the celebration does, without being alarming.

### Acceptance
xcodebuild build succeeds for the SoloCompass scheme. In the Simulator, a card with Solo Score < 4.0 shows the person.fill.questionmark glyph gently pulsing/breathing; a score ≥ 8.5 still twinkles its star; mid scores show no glyph. Enabling Settings → Accessibility → Reduce Motion freezes the caution glyph static (no pulse). VoiceOver still reads the existing 'Solo Score X of 10, may feel exposed for solo travelers' label unchanged. Live-updating a score across the 4.0 threshold starts/stops the pulse correctly.