### PR TITLE
auto: Highlight the weakest dimension in the Solo Score breakdown popover

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -197,6 +197,8 @@
 "solo.dim.portioning" = "Solo Portioning";
 "solo.dim.ambiance" = "Ambiance Fit";
 "solo.dim.safety" = "Safety";
+"solo.weakest" = "Watch: %@";
+"solo.weakest.a11y" = "Watch out: %@ is the weakest dimension for this place.";
 
 /* Empty filter banner (below FilterBarView) */
 "filter.empty.title" = "No matches";

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -168,6 +168,8 @@ private struct SoloScorePopoverContent: View {
     @State private var barsFilled = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    private let weakestThreshold: Double = 5.0
+
     private struct DimensionRow {
         let labelKey: String
         let value: Double
@@ -182,6 +184,18 @@ private struct SoloScorePopoverContent: View {
             DimensionRow(labelKey: "solo.dim.ambiance",   value: score.breakdown.ambianceFit),
             DimensionRow(labelKey: "solo.dim.safety",     value: score.breakdown.safety),
         ]
+    }
+
+    private var weakestIndex: Int {
+        dimensions.enumerated().min(by: { $0.element.value < $1.element.value })?.offset ?? 0
+    }
+
+    private var weakestLabel: String {
+        NSLocalizedString(dimensions[weakestIndex].labelKey, comment: "")
+    }
+
+    private var showWeakestCaption: Bool {
+        dimensions[weakestIndex].value < weakestThreshold
     }
 
     var body: some View {
@@ -202,10 +216,29 @@ private struct SoloScorePopoverContent: View {
                     .foregroundStyle(.secondary)
             }
 
+            if showWeakestCaption {
+                HStack(spacing: 4) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                        .accessibilityHidden(true)
+                    Text(String(format: NSLocalizedString("solo.weakest", comment: ""), weakestLabel))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(Text(String(format: NSLocalizedString("solo.weakest.a11y", comment: ""), weakestLabel)))
+            }
+
             Divider()
 
             ForEach(Array(dimensions.enumerated()), id: \.offset) { index, row in
-                dimensionRow(label: NSLocalizedString(row.labelKey, comment: ""), value: row.value, index: index)
+                dimensionRow(
+                    label: NSLocalizedString(row.labelKey, comment: ""),
+                    value: row.value,
+                    index: index,
+                    isWeakest: index == weakestIndex && showWeakestCaption
+                )
             }
 
             if score.basedOnCount > 0 {
@@ -239,13 +272,20 @@ private struct SoloScorePopoverContent: View {
         }
     }
 
-    private func dimensionRow(label: String, value: Double, index: Int) -> some View {
+    private func dimensionRow(label: String, value: Double, index: Int, isWeakest: Bool) -> some View {
         let clamped = max(0, min(10, value))
+        let barColor: Color = isWeakest ? .orange.opacity(0.8) : score.scoreColor.opacity(0.8)
         return VStack(alignment: .leading, spacing: 3) {
             HStack {
+                if isWeakest {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.orange)
+                        .accessibilityHidden(true)
+                }
                 Text(label)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(isWeakest ? .caption.bold() : .caption)
+                    .foregroundStyle(isWeakest ? .primary : .secondary)
                 Spacer()
                 Text(String(format: "%.1f", value))
                     .font(.caption.weight(.medium))
@@ -256,7 +296,7 @@ private struct SoloScorePopoverContent: View {
                     .fill(Color.secondary.opacity(0.2))
                     .overlay(alignment: .leading) {
                         Capsule()
-                            .fill(score.scoreColor.opacity(0.8))
+                            .fill(barColor)
                             .frame(width: barsFilled ? geo.size.width * CGFloat(clamped / 10) : 0)
                             .animation(
                                 reduceMotion ? nil : .spring(response: 0.5, dampingFraction: 0.8)
@@ -267,6 +307,9 @@ private struct SoloScorePopoverContent: View {
             }
             .frame(height: 4)
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(label))
+        .accessibilityValue(Text(String(format: "%.1f", value)))
     }
 }
 
@@ -333,8 +376,19 @@ private struct SoloScorePopoverContent: View {
         hint: "Corner seats by the window are ideal.",
         basedOnCount: 11
     )
-    SoloScorePopoverContent(score: score)
-        .padding()
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
-        .padding()
+    let cautionScore = SoloScore(
+        overall: 3.1,
+        breakdown: .init(seatingFriendly: 2, soloPatronRatio: 3, staffPressure: 4, soloPortioning: 3, ambianceFit: 3, safety: 4),
+        hint: "Can feel exposed as a solo diner.",
+        basedOnCount: 7
+    )
+    VStack(spacing: 24) {
+        SoloScorePopoverContent(score: score)
+            .padding()
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+        SoloScorePopoverContent(score: cautionScore)
+            .padding()
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+    }
+    .padding()
 }


### PR DESCRIPTION
## Highlight the weakest dimension in the Solo Score breakdown popover

The Solo Score breakdown popover lists all six dimension bars in one uniform color with no signal for which dimension drags the score down — yet for a solo traveler the lowest dimension (often safety or staff pressure) is the single most decision-relevant fact. This mirrors the existing ConfidenceBadge popover, which already bolds and stars its strongest signal. Add a one-line 'Watch: <dimension>' caption under the title and visually emphasize the lowest-scoring dimension row (bolded label + a small caution glyph + amber-tinted bar when that dimension is notably low), so the risk is legible at a glance.

### Acceptance
Opening the Solo Score breakdown on a place whose lowest dimension is below 5.0 shows a 'Watch: <dimension>' caption under the header and visually emphasizes that dimension's row (bold label, caution glyph, amber bar); places with all dimensions >= 5.0 show no caption and uniform styling. VoiceOver announces the weakest dimension. `xcodebuild build` and `xcodebuild test` pass (including StringsParityTests), and the three SoloScoreBadge previews still render.