### PR TITLE
auto: Make Solo Score radar chart's tap-to-replay discoverable and VoiceOver-accessible

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -62,6 +62,8 @@
 "solo.basedOn" = "Based on %d solo travelers";
 "solo.radar.a11y" = "Solo Score radar";
 "solo.radar.replayHint" = "Tap to replay the draw-in animation";
+"solo.radar.replay.hint" = "Tap to replay";
+"solo.radar.replay.a11y" = "Replay score animation";
 "solo.radar.weakest" = "Weakest: %@ — expect it to be a tradeoff";
 "solo.radar.weakest.a11y" = "Note: %@ is the weakest dimension — expect it to be a tradeoff.";
 "solo.radar.strongest" = "Great for solo %@";

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
@@ -11,6 +11,8 @@ public struct SoloScoreRadarChart: View {
     @State private var isReplaying: Bool = false
     @State private var selectedAxis: Int? = nil
     @State private var tooltipDismissTask: Task<Void, Never>? = nil
+    @State private var showReplayHint: Bool = false
+    @AppStorage("radar.replayHintSeen") private var replayHintSeen: Bool = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private static let springDuration: Double = 0.7
@@ -71,8 +73,20 @@ public struct SoloScoreRadarChart: View {
                     fallbackBars
                 }
             }
+            .accessibilityAction(named: Text(NSLocalizedString("solo.radar.replay.a11y", comment: ""))) {
+                guard !reduceMotion else { return }
+                replay()
+            }
 
             weakestCaption
+
+            if showReplayHint {
+                Label(NSLocalizedString("solo.radar.replay.hint", comment: ""), systemImage: "arrow.clockwise")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .transition(reduceMotion ? .opacity : .scale(scale: 0.92).combined(with: .opacity))
+                    .accessibilityHidden(true)
+            }
 
             if let idx = selectedAxis {
                 axisDimensionTooltip(for: idx)
@@ -85,6 +99,7 @@ public struct SoloScoreRadarChart: View {
             }
         }
         .animation(reduceMotion ? .easeInOut(duration: 0.2) : .spring(response: 0.3, dampingFraction: 0.75), value: selectedAxis)
+        .animation(reduceMotion ? .easeInOut(duration: 0.2) : .spring(response: 0.3, dampingFraction: 0.75), value: showReplayHint)
         .onAppear {
             if reduceMotion {
                 drawProgress = 1
@@ -96,6 +111,14 @@ public struct SoloScoreRadarChart: View {
                 HapticService.shared.prepare(style: .soft)
                 DispatchQueue.main.asyncAfter(deadline: .now() + Self.springDuration) {
                     Haptics.impact(.soft)
+                    if !replayHintSeen && !isReplaying {
+                        showReplayHint = true
+                        replayHintSeen = true
+                        Task { @MainActor in
+                            try? await Task.sleep(nanoseconds: 3_000_000_000)
+                            withAnimation { showReplayHint = false }
+                        }
+                    }
                 }
             }
         }
@@ -278,6 +301,7 @@ public struct SoloScoreRadarChart: View {
     // MARK: - Replay
 
     private func replay() {
+        showReplayHint = false
         isReplaying = true
         drawProgress = 0
         withAnimation(.spring(response: Self.springDuration, dampingFraction: 0.75)) {


### PR DESCRIPTION
## Make Solo Score radar chart's tap-to-replay discoverable and VoiceOver-accessible

The SoloScoreRadarChart replays its draw-in animation when tapped, but there is no visual affordance hinting at this and no VoiceOver action exposing it — so the interaction is effectively invisible to most users and entirely unreachable for VoiceOver users. Add a subtle, one-time 'Tap to replay' caption that fades in after the initial draw completes (auto-hides after a few seconds, respects Reduce Motion) and attach a named accessibilityAction so assistive-tech users can trigger the replay too.

### Acceptance
On first view of an experience detail with a radar chart (Reduce Motion off), a 'Tap to replay' hint fades in after the draw-in finishes and auto-dismisses within ~3s, appearing only once (persisted via AppStorage). Tapping the chart still replays and immediately hides any visible hint. With VoiceOver on, a 'Replay score animation' custom action is available on the chart and triggers a replay. With Reduce Motion on, no hint shows and no replay haptic/animation fires. xcodebuild build and the SoloCompassTests suite both pass; new user-facing strings resolve via NSLocalizedString with entries in en.lproj/Localizable.strings.