### PR TITLE
auto: Momentum line in the Favorites journey header

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -464,6 +464,10 @@
 "favorites.journey.nearbyNow.a11y" = "%d favorites within walking distance";
 "favorites.journey.nearbyNow.hint" = "Sorts favorites by distance";
 
+/* Favorites momentum line in journey header */
+"favorites.momentum.justDid" = "Nice — you just did %@";
+"favorites.momentum.closest" = "%@ is closest — go?";
+
 /* Generic actions */
 "action.undo" = "Undo";
 "favorites.undo.swipeHint" = "Swipe down to dismiss";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -172,6 +172,35 @@ public struct FavoritesListView: View {
         sortedFavorites.filter { preferences.completedExperiences.contains($0.id) }.count
     }
 
+    private var momentumLine: String? {
+        let favIds = preferences.favoritedExperiences
+        let completedFavIds = favIds.filter { preferences.completedExperiences.contains($0) }
+        let cutoff = Date().addingTimeInterval(-86_400)
+        let recentlyDone = completedFavIds
+            .compactMap { id -> (id: String, date: Date)? in
+                guard let date = preferences.visitHistory[id], date >= cutoff else { return nil }
+                return (id: id, date: date)
+            }
+            .max(by: { $0.date < $1.date })
+
+        if let done = recentlyDone,
+           let exp = experienceService.getExperience(id: done.id) {
+            return String(
+                format: NSLocalizedString("favorites.momentum.justDid", comment: "Momentum: recently completed favorite"),
+                exp.title
+            )
+        }
+
+        if let nearest = nearestFavorite {
+            return String(
+                format: NSLocalizedString("favorites.momentum.closest", comment: "Momentum: nearest favorite nudge"),
+                nearest.title
+            )
+        }
+
+        return nil
+    }
+
     public var body: some View {
         NavigationStack {
             Group {
@@ -197,7 +226,8 @@ public struct FavoritesListView: View {
                                 onTapNearby: locationService.currentLocation != nil && nearbyCount > 0 ? {
                                     Haptics.selection()
                                     withAnimation(reduceMotion ? nil : .easeInOut) { sortMode = .nearest }
-                                } : nil
+                                } : nil,
+                                momentumLine: momentumLine
                             )
                             .padding(.horizontal, 16)
                             .padding(.top, 12)
@@ -427,6 +457,7 @@ private struct FavoritesJourneyHeader: View {
     let completed: Int
     let nearbyCount: Int
     var onTapNearby: (() -> Void)? = nil
+    var momentumLine: String? = nil
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var appeared = false
@@ -503,6 +534,15 @@ private struct FavoritesJourneyHeader: View {
                 .animation(.easeInOut, value: total)
             nearbyNudge
                 .animation(reduceMotion ? nil : .easeInOut, value: nearbyCount)
+            if let line = momentumLine {
+                Text(line)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .contentTransition(.opacity)
+                    .animation(.easeInOut, value: line)
+                    .opacity(appeared ? 1 : 0)
+                    .offset(y: appeared ? 0 : (reduceMotion ? 0 : 6))
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .opacity(appeared ? 1 : 0)


### PR DESCRIPTION
## Momentum line in the Favorites journey header

The FavoritesJourneyHeader greets by time-of-day and shows a static count, but never reflects recent progress momentum. Add a contextual momentum subtitle that celebrates a recently-completed favorite (within the last 24h) or, when none, nudges the single closest favorite by name — turning a passive header into a 'what next' prompt.

### Acceptance
Build passes (xcodebuild build, iPhone 17 Pro). With a favorite completed in-session, the header shows a 'you just did <title>' momentum line; with none completed but location available, it shows the closest favorite's name; with neither, no third line renders. reduceMotion shows the line with no entrance animation. VoiceOver reads greeting + summary + momentum as a single combined element. All new strings resolved via NSLocalizedString (no hardcoded user text).