### PR TITLE
auto: Respect Reduce Motion & add VoiceOver labels in CompletionMoment celebration

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1250,6 +1250,7 @@
 "completion.stat.walked" = "走过";
 "completion.stat.travelers" = "旅人";
 "completion.tagline" = "这条路线现在为下一批旅人发光";
+"completion.a11y" = "Route complete — walked by %d travelers, %d companions joined";
 
 /* US-039 — OpenForCompanionsSheet */
 "openForCompanions.button" = "开为招募路线 ->";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -934,6 +934,7 @@
 "completion.stat.walked" = "走过";
 "completion.stat.travelers" = "旅人";
 "completion.tagline" = "这条路线现在为下一批旅人发光";
+"completion.a11y" = "路线完成 — 已有 %d 位旅人走过，%d 位同伴加入";
 
 /* Confidence */
 "confidence.lastVerified" = "验证于 %@";

--- a/apps/ios/SoloCompass/Views/Companion/CompletionMoment.swift
+++ b/apps/ios/SoloCompass/Views/Companion/CompletionMoment.swift
@@ -12,6 +12,7 @@ public struct CompletionMoment: View {
     private let remoteProvider: @MainActor () -> any RouteCompanionRemote
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var pulse: Bool = false
     @State private var appeared: Bool = false
@@ -42,17 +43,28 @@ public struct CompletionMoment: View {
                 Spacer()
             }
             .padding(.horizontal, 28)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(String(
+                format: NSLocalizedString("completion.a11y", comment: ""),
+                route.verification.walkedByCount,
+                route.companion?.confirmedMembers.count ?? 0
+            ))
 
             closeButton
         }
         .ignoresSafeArea()
         .onAppear {
-            withAnimation(.easeIn(duration: 0.4)) { appeared = true }
-            withAnimation(
-                .easeInOut(duration: 1.2)
-                .repeatForever(autoreverses: true)
-            ) {
-                pulse = true
+            if reduceMotion {
+                appeared = true
+                pulse = false
+            } else {
+                withAnimation(.easeIn(duration: 0.4)) { appeared = true }
+                withAnimation(
+                    .easeInOut(duration: 1.2)
+                    .repeatForever(autoreverses: true)
+                ) {
+                    pulse = true
+                }
             }
             markCompleted()
         }


### PR DESCRIPTION
## Respect Reduce Motion & add VoiceOver labels in CompletionMoment celebration

CompletionMoment is the only animated view in the iOS app that ignores @Environment(\.accessibilityReduceMotion) — it unconditionally runs an infinite repeating pulse and a fade-in, contradicting the reduce-motion pattern used by every other celebratory view (HeartBurstView, CompletionRing, SoloScoreBadge, etc.). It also exposes no consolidated VoiceOver label, so the seal/stats/tagline read as disjointed fragments. This fix gates the pulse and fade-in behind reduceMotion and adds a combined accessibility element, matching house conventions.

### Acceptance
With Reduce Motion ON (Simulator > Accessibility > Motion), CompletionMoment appears with no fade-in and no pulsing — the seal is static at full scale. With Reduce Motion OFF, the existing fade-in and gentle pulse still play. VoiceOver reads the celebration as a single coherent sentence including walked/companion counts. xcodebuild build succeeds and the existing SoloCompassTests pass; #Preview still renders.