### PR TITLE
auto: Live walk-ETA pill that ticks down as you approach

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -265,6 +265,10 @@
 "card.distance.arrived.a11y" = "You're here";
 "card.distance.bearing.a11y" = "toward the %@";
 
+/* ETA pill shown while walking toward an experience (<1500 m, not yet arrived) */
+"card.eta" = "arriving ~%@";
+"card.eta.a11y" = "Estimated arrival at %@";
+
 /* Proximity cue appended to bearing arrow a11y label when user is ≤300 m away */
 "card.distance.proximity.near" = "getting close";
 

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1166,6 +1166,8 @@
 
 /* Card / compass */
 "card.distance.proximity.near" = "即将到达";
+"card.eta" = "预计 ~%@ 到达";
+"card.eta.a11y" = "预计到达时间 %@";
 "compass.direction.a11y" = "距离 %1$@，朝向 %2$@";
 "compass.pointing.title" = "正指向";
 "nearby.direction.suffix" = "在%@方向";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -30,6 +30,7 @@ public struct ExperienceCardView: View {
     @Environment(UserPreferences.self) private var preferences
     @Environment(LocationService.self) private var locationService
     @Environment(AIService.self) private var aiService
+    @Environment(BestNowClock.self) private var clock
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// True when the most recent synthesis degraded to skeleton placeholders.
@@ -130,6 +131,13 @@ public struct ExperienceCardView: View {
 
     private static let walkThresholdMeters = 1500.0
     private static let walkMetersPerMin = 80.0
+
+    private static let etaFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.timeStyle = .short
+        f.dateStyle = .none
+        return f
+    }()
 
     /// Returns a (text, SF Symbol name) pair for the distance pill.
     /// Under 1 500 m → walk-minutes + figure.walk; otherwise → formatted distance + location.fill.
@@ -267,6 +275,9 @@ public struct ExperienceCardView: View {
                 }
                 .contentTransition(.numericText())
                 .animation(.spring(response: 0.4), value: distanceMeters)
+                if let meters = distanceMeters, !isArrived, meters < Self.walkThresholdMeters {
+                    etaPill(meters: meters)
+                }
                 if !experience.realInconveniences.isEmpty {
                     inconveniencePill
                 } else if experience.isBestNow() {
@@ -474,6 +485,23 @@ public struct ExperienceCardView: View {
             }
             return text
         }())
+    }
+
+    @ViewBuilder
+    private func etaPill(meters: Double) -> some View {
+        let minutes = Int((meters / Self.walkMetersPerMin).rounded(.up))
+        let arrival = clock.tick.addingTimeInterval(Double(minutes) * 60)
+        let timeString = Self.etaFormatter.string(from: arrival)
+        let label = String(format: NSLocalizedString("card.eta", comment: "ETA pill"), timeString)
+        let a11y = String(format: NSLocalizedString("card.eta.a11y", comment: "ETA pill accessibility"), timeString)
+        Label(label, systemImage: "figure.walk.arrival")
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .foregroundStyle(Color.green)
+            .background(Capsule().fill(Color.green.opacity(0.12)))
+            .contentTransition(reduceMotion ? .identity : .numericText())
+            .accessibilityLabel(a11y)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Live walk-ETA pill that ticks down as you approach

The ExperienceCardView distance pill shows static walk-minutes derived from raw distance, but offers no sense of motion or progress while a solo traveler is actually walking toward a place. Add an 'arriving ~HH:MM' ETA pill that derives an arrival clock-time from current walk-distance and refreshes once a minute via the existing shared BestNowClock, giving live, glanceable feedback that updates as the user closes the gap.

### Acceptance
When location is known and the experience is <1500 m away but not yet within 75 m, the card shows a green 'arriving ~<clock time>' pill alongside the distance/bearing pill; the time updates each minute as distance changes and animates via numericText; the pill disappears at arrival (replaced by the existing arrived pill) and when distance ≥1500 m. The new strings exist in both en and zh-Hans and pass `StringsParityTests`; VoiceOver reads a descriptive ETA label; reduce-motion users see no animation. `xcodebuild build` and the existing test suite pass.