### PR TITLE
auto: Make the entire Favorites undo bar tappable to restore, with a clearer countdown affordance

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -475,6 +475,7 @@
 /* Generic actions */
 "action.undo" = "Undo";
 "favorites.undo.swipeHint" = "Swipe down to dismiss";
+"favorites.undo.tapHint" = "Double tap to restore";
 "favorites.undo.announcement" = "Removed %@. Undo available.";
 
 /* Notifications */

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -808,28 +808,31 @@ private extension FavoritesListView {
 
     var undoBar: some View {
         ZStack(alignment: .bottom) {
-            HStack {
-                Text(String(format: NSLocalizedString("favorites.undo.named", comment: "Removed named experience undo banner"), lastUnfavorited?.title ?? ""))
-                    .font(.subheadline)
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                Spacer()
-                Button {
-                    performUndo()
-                } label: {
+            Button {
+                performUndo()
+            } label: {
+                HStack {
+                    Text(String(format: NSLocalizedString("favorites.undo.named", comment: "Removed named experience undo banner"), lastUnfavorited?.title ?? ""))
+                        .font(.subheadline)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Spacer()
                     Text(NSLocalizedString("action.undo", comment: "Undo action"))
                         .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.accentColor)
                 }
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
+                .padding(.bottom, 14)
+                .contentShape(Rectangle())
             }
-            .padding(.horizontal, 16)
-            .padding(.top, 12)
-            .padding(.bottom, 14)
+            .buttonStyle(.plain)
 
             if !reduceMotion {
                 GeometryReader { geo in
                     Capsule()
-                        .fill(Color.accentColor)
+                        .fill(countdownLineColor)
                         .frame(width: geo.size.width * undoProgress, height: 2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -870,7 +873,7 @@ private extension FavoritesListView {
         )
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(String(format: NSLocalizedString("favorites.undo.named", comment: "Removed named experience undo banner"), lastUnfavorited?.title ?? "")))
-        .accessibilityHint(Text(NSLocalizedString("favorites.undo.swipeHint", comment: "Swipe down to dismiss undo bar")))
+        .accessibilityHint(Text(NSLocalizedString("favorites.undo.tapHint", comment: "Double tap to restore removed favorite")))
         .accessibilityAction(named: Text(NSLocalizedString("action.undo", comment: "Undo action"))) {
             performUndo()
         }
@@ -882,6 +885,15 @@ private extension FavoritesListView {
                     undoProgress = 0
                 }
             }
+        }
+    }
+
+    private var countdownLineColor: Color {
+        guard !reduceMotion else { return .accentColor }
+        if #available(iOS 18, *) {
+            return Color.accentColor.mix(with: .orange, by: 1 - undoProgress)
+        } else {
+            return .accentColor
         }
     }
 


### PR DESCRIPTION
## Make the entire Favorites undo bar tappable to restore, with a clearer countdown affordance

Currently the undo bar in FavoritesListView only restores a removed favorite when the user taps the small 'Undo' text button; the large bar surface itself is dead space, and the thin 2pt countdown line gives little sense of remaining time. This expands the tap target to the whole bar (a common iOS pattern, easier for one-handed use) and gives the countdown line a subtle color shift as time runs out, making the recovery window feel more forgiving and discoverable.

### Acceptance
Tapping anywhere on the undo bar restores the removed favorite and fires Haptics.impact(.light), identical to tapping the 'Undo' button. Swipe-down to dismiss still works and does not trigger a restore. The countdown line shifts toward orange as it nears expiry on iOS 18+, and renders as a static accent line under Reduce Motion or on iOS 17. The new 'favorites.undo.tapHint' key exists in Localizable.strings and StringsParityTests passes. `xcodebuild build` and `xcodebuild test` (SoloCompassTests, iPhone 17 Pro) both succeed.