### PR TITLE
auto: Low-sample 'early estimate' treatment in the Solo Score breakdown popover

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -185,6 +185,10 @@
 /* Bottom info accessibility */
 "info.nearbySolo.a11y" = "%d solo travelers passed nearby today";
 
+/* Early estimate badge — shown in breakdown popover when basedOnCount is 1–3 */
+"solo.earlyEstimate" = "Early estimate";
+"solo.earlyEstimate.a11y" = "Early estimate, based on few solo travelers — score may shift";
+
 /* Solo score accessibility */
 "solo.a11y" = "Solo Score %@ of 10";
 "solo.excellent.a11y" = "Excellent for solo travelers";

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -185,6 +185,8 @@ private struct SoloScorePopoverContent: View {
 
     private let weakestThreshold: Double = 5.0
 
+    private var isEarlyEstimate: Bool { score.basedOnCount > 0 && score.basedOnCount <= 3 }
+
     private struct DimensionRow {
         let labelKey: String
         let value: Double
@@ -261,13 +263,33 @@ private struct SoloScorePopoverContent: View {
                 HStack(spacing: 6) {
                     Image(systemName: "person.2.fill")
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(isEarlyEstimate ? Color.orange.opacity(0.9) : .secondary)
                     Text(String(format: NSLocalizedString("solo.basedOn", comment: "Based on N solo travelers"), score.basedOnCount))
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(isEarlyEstimate ? Color.orange.opacity(0.9) : .secondary)
+                    if isEarlyEstimate {
+                        HStack(spacing: 3) {
+                            Image(systemName: "hourglass")
+                                .font(.system(size: 9, weight: .medium))
+                                .accessibilityHidden(true)
+                            Text(NSLocalizedString("solo.earlyEstimate", comment: "Early estimate"))
+                                .font(.caption2.weight(.medium))
+                        }
+                        .foregroundStyle(Color.orange.opacity(0.9))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.orange.opacity(0.12), in: Capsule())
+                        .scaleEffect(appeared && !reduceMotion ? 1 : (reduceMotion ? 1 : 0.85))
+                        .opacity(appeared ? 1 : 0)
+                    }
                 }
                 .accessibilityElement(children: .combine)
-                .accessibilityLabel(Text(String(format: NSLocalizedString("solo.basedOn", comment: "Based on N solo travelers"), score.basedOnCount)))
+                .accessibilityLabel(Text(
+                    isEarlyEstimate
+                        ? String(format: NSLocalizedString("solo.basedOn", comment: "Based on N solo travelers"), score.basedOnCount)
+                            + ", " + NSLocalizedString("solo.earlyEstimate.a11y", comment: "Early estimate, based on few solo travelers — score may shift")
+                        : String(format: NSLocalizedString("solo.basedOn", comment: "Based on N solo travelers"), score.basedOnCount)
+                ))
             }
         }
         .padding()
@@ -406,4 +428,17 @@ private struct SoloScorePopoverContent: View {
             .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
     }
     .padding()
+}
+
+#Preview("Early Estimate (basedOnCount: 2)") {
+    let earlyScore = SoloScore(
+        overall: 6.4,
+        breakdown: .init(seatingFriendly: 7, soloPatronRatio: 6, staffPressure: 7, soloPortioning: 6, ambianceFit: 6, safety: 7),
+        hint: "Score based on very few reports — may shift.",
+        basedOnCount: 2
+    )
+    SoloScorePopoverContent(score: earlyScore)
+        .padding()
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .padding()
 }


### PR DESCRIPTION
## Low-sample 'early estimate' treatment in the Solo Score breakdown popover

The Solo Score breakdown popover shows 'Based on N solo travelers' but a score from 1-2 travelers carries identical visual authority as one from 20, overstating trust on thin data. This adds a subtle 'Early estimate' badge and softened sample-count line when basedOnCount is low (1-3), so users instinctively weight provisional scores correctly — reinforcing the app's core confidence/trust signal without adding a new screen.

### Acceptance
Breakdown popover for a score with basedOnCount 1-3 shows an amber 'Early estimate' badge beside the sample-count line; scores with basedOnCount >=4 are visually unchanged; VoiceOver reads the early-estimate caveat; the new #Preview renders; reduceMotion path has no animation; xcodebuild build and SoloCompassTests pass.