### PR TITLE
auto: VoiceOver labels for the inconvenience warning pill on experience cards

### DIFF
--- a/apps/ios/SoloCompass/Models/Experience.swift
+++ b/apps/ios/SoloCompass/Models/Experience.swift
@@ -180,6 +180,18 @@ public struct RealInconvenience: Codable, Hashable, Identifiable {
             case .other:                               return .low
             }
         }
+
+        public var label: String {
+            switch self {
+            case .safety:    return NSLocalizedString("inconvenience.category.safety", comment: "Inconvenience category: safety")
+            case .scam:      return NSLocalizedString("inconvenience.category.scam", comment: "Inconvenience category: scam")
+            case .crowds:    return NSLocalizedString("inconvenience.category.crowds", comment: "Inconvenience category: crowds")
+            case .logistics: return NSLocalizedString("inconvenience.category.logistics", comment: "Inconvenience category: logistics")
+            case .weather:   return NSLocalizedString("inconvenience.category.weather", comment: "Inconvenience category: weather")
+            case .etiquette: return NSLocalizedString("inconvenience.category.etiquette", comment: "Inconvenience category: etiquette")
+            case .other:     return NSLocalizedString("inconvenience.category.other", comment: "Inconvenience category: note/other")
+            }
+        }
     }
 
     public let category: Category

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -92,14 +92,19 @@
 "inconvenience.category.logistics" = "Logistics";
 "inconvenience.category.weather" = "Weather";
 "inconvenience.category.etiquette" = "Etiquette";
-"inconvenience.category.safety" = "Safety";
-"inconvenience.category.other" = "Heads up";
+"inconvenience.category.safety" = "Safety concern";
+"inconvenience.category.other" = "Note";
 /* Accessibility label for each inconvenience row: "Heads up: <category> — <text>" */
 "inconvenience.a11y.prefix" = "Heads up: %@ — %@";
 /* Inconvenience pill on floating card: visible count label */
 "inconvenience.card.count" = "%d";
 /* VoiceOver suffix appended to the card's accessibilityLabel when inconveniences exist */
 "inconvenience.card.a11y" = "Heads up: %d things to know";
+/* VoiceOver label for the inconvenience pill itself — arg 1: count, arg 2: category label */
+/* High severity (safety / scam): "Important: 2 safety concerns to know before you go" */
+"inconvenience.card.count.a11y.high" = "Important: %1$d %2$@ to know before you go";
+/* Normal severity: "1 crowds heads-up" */
+"inconvenience.card.count.a11y.normal" = "%1$d %2$@ heads-up";
 
 /* Sections */
 "section.whyItMatters" = "Why it matters";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -597,6 +597,9 @@ public struct ExperienceCardView: View {
             let isHighSeverity = category == .safety || category == .scam
             let tint = isHighSeverity ? Color.red : Color(red: 0xF5/255, green: 0x9E/255, blue: 0x0B/255)
             let count = experience.realInconveniences.count
+            let a11yFormat = isHighSeverity
+                ? NSLocalizedString("inconvenience.card.count.a11y.high", comment: "High-severity inconvenience pill accessibility label")
+                : NSLocalizedString("inconvenience.card.count.a11y.normal", comment: "Normal inconvenience pill accessibility label")
             Label(
                 String(format: NSLocalizedString("inconvenience.card.count", comment: "Inconvenience count on card"), count),
                 systemImage: category.symbol
@@ -606,6 +609,8 @@ public struct ExperienceCardView: View {
             .padding(.vertical, 4)
             .foregroundStyle(tint)
             .background(Capsule().fill(tint.opacity(0.12)))
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(String(format: a11yFormat, count, category.label))
         }
     }
 }


### PR DESCRIPTION
## VoiceOver labels for the inconvenience warning pill on experience cards

The inconvenience pill (safety/scam/crowds heads-up) on each experience card is purely visual — it renders an SF Symbol plus a bare count, so VoiceOver announces only a number like "2" with no indication that it's a warning or which category. This adds a descriptive accessibility label that names the most-severe category and conveys it's a traveler heads-up, matching the a11y treatment BestNowBadge already has, with high-vs-normal severity reflected in the spoken text.

### Acceptance
With VoiceOver on, focusing the warning pill on a card that has a safety/scam inconvenience announces something like 'Important: 2 safety concerns to know before you go' (high severity) or '1 crowds heads-up' (normal), instead of a bare number. Visible UI is unchanged; `xcodebuild build` and existing SoloCompassTests pass; all new user-facing strings go through NSLocalizedString.