### PR TITLE
auto: Cap filter pill count badges at '99+' to protect the single-line pill bar layout

### DIFF
--- a/apps/ios/SoloCompass/Tests/FilterBarViewTests.swift
+++ b/apps/ios/SoloCompass/Tests/FilterBarViewTests.swift
@@ -45,6 +45,24 @@ final class FilterBarViewTests: XCTestCase {
         XCTAssertFalse(reloaded.visibleCategories.contains(.nightlife))
     }
 
+    // MARK: - compactCount badge formatter
+
+    func testCompactCountZero() {
+        XCTAssertEqual(FilterBarView.compactCount(0), "0")
+    }
+
+    func testCompactCountAtLimit() {
+        XCTAssertEqual(FilterBarView.compactCount(99), "99")
+    }
+
+    func testCompactCountJustOverLimit() {
+        XCTAssertEqual(FilterBarView.compactCount(100), "99+")
+    }
+
+    func testCompactCountLargeNumber() {
+        XCTAssertEqual(FilterBarView.compactCount(1234), "99+")
+    }
+
     // MARK: - Toggle-off routing (pill clear behaviour)
 
     func testResolvesToClearWhenPillIsSelected() {

--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -109,6 +109,10 @@ public struct FilterBarView: View {
     /// equal — sub-pixel layout rounding shouldn't trigger a spurious fade.
     static let overflowTolerance: CGFloat = 1.0
 
+    /// Clamps a count for display in a pill badge to prevent 3-digit values from
+    /// overflowing the single-line pill bar layout.
+    static func compactCount(_ n: Int) -> String { n > 99 ? "99+" : "\(n)" }
+
     /// Pure, testable overflow predicate driving the right-edge scroll fade.
     /// Returns true only when the pill content is meaningfully wider than the
     /// visible viewport (i.e. some chips are off-screen to the right). A zero
@@ -270,7 +274,7 @@ public struct FilterBarView: View {
                     .font(.subheadline.weight(.medium))
 
                 if nowCount > 0 {
-                    Text("\(nowCount)")
+                    Text(Self.compactCount(nowCount))
                         .font(.caption2.monospacedDigit().weight(.semibold))
                         .padding(.horizontal, 5)
                         .padding(.vertical, 2)
@@ -436,7 +440,7 @@ public struct FilterBarView: View {
 
     @ViewBuilder
     private func countBadge(count: Int, tint: Color) -> some View {
-        Text("\(count)")
+        Text(Self.compactCount(count))
             .font(.caption2.weight(.semibold).monospacedDigit())
             .foregroundStyle(.white)
             .padding(.horizontal, 5)


### PR DESCRIPTION
## Cap filter pill count badges at "99+" to protect the single-line pill bar layout

The 'Now' and selected-category count badges in FilterBarView render the raw visible-experience integer, so once Explore loads a dense city (100+ POIs) a 3-digit count widens the pills and can break the carefully-tuned single-line, horizontally-scrolling pill bar. Add a pure, testable `compactCount` formatter that clamps display to "99+" (keeping the monospacedDigit alignment) and route all count badges plus the 'Now' badge through it. This mirrors the existing `static func` + unit-test convention already used for `visiblePills` / `shouldShowScrollAffordance`.

### Acceptance
Selecting a category/Now in a dense city (≥100 visible) shows a '99+' badge instead of a 3-digit number; the pill bar stays single-line and pills keep their width budget. VoiceOver still reads the exact result count. New unit tests for `compactCount` pass via `xcodebuild test`, and `xcodebuild build` succeeds.