### PR TITLE
auto: Bring the Itinerary undo bar to parity with Favorites: animated countdown line + swipe-to-dismiss

### DIFF
--- a/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
@@ -80,6 +80,9 @@ public struct ItineraryListView: View {
             }
         }
         .animation(reduceMotion ? nil : .easeInOut, value: lastDeleted != nil)
+        .onChange(of: lastDeleted == nil) { _, isNil in
+            if isNil { undoDragOffset = 0 }
+        }
     }
 
     private func loadItineraries() {
@@ -122,27 +125,71 @@ public struct ItineraryListView: View {
     }
 
     private var undoBar: some View {
-        HStack {
-            Text(String(
-                format: NSLocalizedString("itinerary.undo.named", comment: "Removed named itinerary undo banner"),
-                lastDeleted?.title ?? ""
-            ))
-            .font(.subheadline)
-            .foregroundStyle(.primary)
-            .lineLimit(1)
-            .truncationMode(.tail)
-            Spacer()
-            Button {
-                performUndo()
-            } label: {
-                Text(NSLocalizedString("action.undo", comment: "Undo action"))
-                    .font(.subheadline.weight(.semibold))
+        ZStack(alignment: .bottom) {
+            HStack {
+                Text(String(
+                    format: NSLocalizedString("itinerary.undo.named", comment: "Removed named itinerary undo banner"),
+                    lastDeleted?.title ?? ""
+                ))
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                Spacer()
+                Button {
+                    performUndo()
+                } label: {
+                    Text(NSLocalizedString("action.undo", comment: "Undo action"))
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.accentColor)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            .padding(.bottom, 14)
+
+            if !reduceMotion {
+                GeometryReader { geo in
+                    Capsule()
+                        .fill(Color.accentColor)
+                        .frame(width: geo.size.width * undoProgress, height: 2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(height: 2)
+                .padding(.horizontal, 2)
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
         .padding(.horizontal, 16)
+        .offset(y: undoDragOffset)
+        .gesture(
+            DragGesture()
+                .onChanged { gesture in
+                    undoDragOffset = max(0, gesture.translation.height * 0.85)
+                    let overThreshold = gesture.translation.height > 80
+                    if overThreshold && !undoDragCrossedThreshold {
+                        undoDragCrossedThreshold = true
+                        Haptics.selection()
+                    } else if !overThreshold && undoDragCrossedThreshold {
+                        undoDragCrossedThreshold = false
+                    }
+                }
+                .onEnded { gesture in
+                    undoDragCrossedThreshold = false
+                    if gesture.translation.height > 80 {
+                        Haptics.impact(.soft)
+                        withAnimation(.easeOut(duration: 0.2)) { undoDragOffset = 300 }
+                        undoDismissTask?.cancel()
+                        undoDismissTask = nil
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                            withAnimation(.easeInOut) { lastDeleted = nil }
+                            undoDragOffset = 0
+                        }
+                    } else {
+                        withAnimation(.spring(response: 0.3)) { undoDragOffset = 0 }
+                    }
+                }
+        )
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(String(
             format: NSLocalizedString("itinerary.undo.named.a11y", comment: "Accessibility label for itinerary undo banner"),
@@ -150,6 +197,15 @@ public struct ItineraryListView: View {
         )))
         .accessibilityAction(named: Text(NSLocalizedString("action.undo", comment: "Undo action"))) {
             performUndo()
+        }
+        .onAppear {
+            undoProgress = 1
+            undoDragOffset = 0
+            if !reduceMotion {
+                withAnimation(.linear(duration: 4)) {
+                    undoProgress = 0
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Bring the Itinerary undo bar to parity with Favorites: animated countdown line + swipe-to-dismiss

The itinerary-delete undo bar in ItineraryListView is a plain static banner that vanishes abruptly after 4 seconds, while the sibling FavoritesListView undo bar has an animated countdown progress line and a swipe-down-to-dismiss gesture. This brings the itinerary undo bar to visual and interaction parity — a draining countdown capsule so users can see how long they have to undo, plus a drag-down gesture to dismiss it early — closing a jarring inconsistency between two near-identical flows.

### Acceptance
Deleting an itinerary shows the undo bar with a thin accent-colored line that visibly drains left-to-right over 4 seconds (static bar with no line under Reduce Motion). Dragging the bar downward past ~80pt dismisses it early with a soft haptic and a selection haptic at the threshold; a short drag springs the bar back. Undo via the button still restores the itinerary. xcodebuild build succeeds for the SoloCompass scheme and the existing #Preview blocks still render.