### PR TITLE
auto: Bring the Itinerary undo bar to tap-anywhere parity with Favorites (full-bar tap target + warm countdown line)

### DIFF
--- a/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
@@ -124,34 +124,45 @@ public struct ItineraryListView: View {
         loadItineraries()
     }
 
+    private var countdownLineColor: Color {
+        guard !reduceMotion else { return .accentColor }
+        if #available(iOS 18, *) {
+            return Color.accentColor.mix(with: .orange, by: 1 - undoProgress)
+        } else {
+            return .accentColor
+        }
+    }
+
     private var undoBar: some View {
         ZStack(alignment: .bottom) {
-            HStack {
-                Text(String(
-                    format: NSLocalizedString("itinerary.undo.named", comment: "Removed named itinerary undo banner"),
-                    lastDeleted?.title ?? ""
-                ))
-                .font(.subheadline)
-                .foregroundStyle(.primary)
-                .lineLimit(1)
-                .truncationMode(.tail)
-                Spacer()
-                Button {
-                    performUndo()
-                } label: {
+            Button {
+                performUndo()
+            } label: {
+                HStack {
+                    Text(String(
+                        format: NSLocalizedString("itinerary.undo.named", comment: "Removed named itinerary undo banner"),
+                        lastDeleted?.title ?? ""
+                    ))
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    Spacer()
                     Text(NSLocalizedString("action.undo", comment: "Undo action"))
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(.accentColor)
                 }
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
+                .padding(.bottom, 14)
+                .contentShape(Rectangle())
             }
-            .padding(.horizontal, 16)
-            .padding(.top, 12)
-            .padding(.bottom, 14)
+            .buttonStyle(.plain)
 
             if !reduceMotion {
                 GeometryReader { geo in
                     Capsule()
-                        .fill(Color.accentColor)
+                        .fill(countdownLineColor)
                         .frame(width: geo.size.width * undoProgress, height: 2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }


### PR DESCRIPTION
## Bring the Itinerary undo bar to tap-anywhere parity with Favorites (full-bar tap target + warm countdown line)

The Favorites undo bar wraps its entire surface in a Button so tapping anywhere restores the item, and its countdown line warms from accent toward orange as time runs out. The Itinerary undo bar only makes the tiny 'Undo' label tappable and uses a flat accent line, so it feels less responsive and harder to hit one-handed. This change closes the remaining gap so both undo bars behave identically.

### Acceptance
Tapping anywhere on the itinerary undo bar (not just the word 'Undo') restores the deleted itinerary and fires a light haptic; the countdown line shifts from accent toward orange as the 4s timer elapses on iOS 18+; reduce-motion and iOS 17 keep the flat accent line and skip the animated fill; swipe-down-to-dismiss and the VoiceOver 'Undo' action still work; `xcodebuild build` and the SoloCompassTests suite pass.