### PR TITLE
auto: Wire the SoloScore radar chart's summary VoiceOver label into the actual view

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
@@ -134,6 +134,17 @@ public struct SoloScoreRadarChart: View {
             let radius = size * 0.38
 
             ZStack {
+                // Summary accessibility element — VoiceOver lands here first
+                Rectangle().fill(.clear).frame(height: 0)
+                    .accessibilityElement()
+                    .accessibilityLabel(radarAccessibilityLabel)
+                    .accessibilityValue(radarAccessibilityValue)
+                    .accessibilityAddTraits(.isImage)
+                    .accessibilityAction(named: Text(NSLocalizedString("solo.radar.replay.a11y", comment: ""))) {
+                        guard !reduceMotion else { return }
+                        replay()
+                    }
+
                 // Grid rings (static scaffold)
                 ForEach([0.25, 0.5, 0.75, 1.0], id: \.self) { fraction in
                     radarPolygon(
@@ -221,7 +232,6 @@ public struct SoloScoreRadarChart: View {
             }
         }
         .aspectRatio(1, contentMode: .fit)
-        .accessibilityElement(children: .contain)
         .onTapGesture {
             guard !reduceMotion, !isReplaying else { return }
             replay()
@@ -357,6 +367,17 @@ public struct SoloScoreRadarChart: View {
 
     private var fallbackBars: some View {
         VStack(spacing: 8) {
+            // Summary accessibility element — VoiceOver lands here first
+            Rectangle().fill(.clear).frame(height: 0)
+                .accessibilityElement()
+                .accessibilityLabel(radarAccessibilityLabel)
+                .accessibilityValue(radarAccessibilityValue)
+                .accessibilityAddTraits(.isImage)
+                .accessibilityAction(named: Text(NSLocalizedString("solo.radar.replay.a11y", comment: ""))) {
+                    guard !reduceMotion else { return }
+                    replay()
+                }
+
             ForEach(0..<Self.axes.count, id: \.self) { i in
                 let axis = Self.axes[i]
                 let val = values[i]
@@ -403,7 +424,6 @@ public struct SoloScoreRadarChart: View {
                 .accessibilityLabel(Text(axis.label))
             }
         }
-        .accessibilityElement(children: .contain)
     }
 }
 


### PR DESCRIPTION
## Wire the SoloScore radar chart's summary VoiceOver label into the actual view

SoloScoreRadarChart computes radarAccessibilityLabel (names all six dimensions with values, sorted strongest-first, plus strongest/weakest callouts) and radarAccessibilityValue (the overall Solo Score), and both are unit-tested in SoloScoreRadarA11yTest.swift — but neither is ever applied to the view. Both the radar (line 224) and fallback-bars (line 406) paths use .accessibilityElement(children: .contain), so VoiceOver users hear only six fragmented per-axis labels and never the overall score. Add a summary accessibility element so swiping the chart announces, e.g., 'Safety 9 of 10, Seating 8 of 10, … Solo Score 7.8 of 10' while keeping the per-axis tap actions reachable.

### Acceptance
Building with `xcodebuild build -scheme SoloCompass` succeeds. Existing SoloScoreRadarA11yTest still passes. With VoiceOver on in the Simulator on an ExperienceDetail showing a SoloScore, swiping onto the chart announces a single summary that names all six dimensions with their values AND the overall Solo Score (e.g. 'Solo Score 7.8 of 10'), in both the high-variance radar path and the low-variance fallback-bars path; the per-axis tap-for-tooltip behavior and the replay accessibility action remain reachable.