### PR TITLE
auto: Locale-aware distance on the map's Nearby sheet (mi/ft for non-metric travelers)

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -526,6 +526,14 @@ struct NearbyExperienceRow: View {
 
     private static let sunGold = Color(red: 1.0, green: 0.80, blue: 0.2)
 
+    private static let distanceFormatter: MeasurementFormatter = {
+        let f = MeasurementFormatter()
+        f.unitOptions = .naturalScale
+        f.unitStyle = .short
+        f.numberFormatter.maximumFractionDigits = 1
+        return f
+    }()
+
     // MARK: Proximity helpers (mirrors FavoritesListView.Proximity)
 
     private enum Proximity {
@@ -716,11 +724,7 @@ struct NearbyExperienceRow: View {
     }
 
     private func formattedDistance(_ meters: Double) -> String {
-        if meters < 1000 {
-            return String(format: "%dm", Int(meters))
-        } else {
-            return String(format: "%.1fkm", meters / 1000)
-        }
+        Self.distanceFormatter.string(from: Measurement(value: meters, unit: UnitLength.meters))
     }
 }
 


### PR DESCRIPTION
## Locale-aware distance on the map's Nearby sheet (mi/ft for non-metric travelers)

BottomInfoSheet — the map home screen — hardcodes metric distances ("850m", "2.3km") while ExperienceCardView and FavoritesListView already render locale-correct units via MeasurementFormatter (.naturalScale). A US/UK solo traveler sees kilometers on the primary surface but miles on the card, an inconsistency on the most-visited screen of a global travel app. This replaces the hardcoded formatter with the same locale-aware pattern used elsewhere.

### Acceptance
On a device/sim set to US (imperial) locale, distances in the map's Nearby sheet render as miles/feet (e.g. "0.5 mi", "260 ft") and match the units shown on the experience card and in Favorites for the same experience; on a metric locale they still render as km/m. xcodebuild build succeeds, SoloCompassTests pass, and the Nearby sheet visually shows locale-correct units in the Simulator.