### PR TITLE
auto: Make Report Issue reason rows VoiceOver-accessible (button trait + selection state)

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -395,6 +395,7 @@
 "report.reason.vibe_different" = "Vibe is very different";
 "report.reason.factually_wrong" = "Factually incorrect";
 "report.reason.other" = "Something else";
+"report.reason.hint" = "Selects this reason and reveals an optional details field.";
 
 /* Pending check-in banner */
 "checkin.banner.title" = "Did you visit?";

--- a/apps/ios/SoloCompass/Views/Experience/ReportIssueSheet.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ReportIssueSheet.swift
@@ -94,10 +94,12 @@ public struct ReportIssueSheet: View {
                     Image(systemName: reason.symbol)
                         .frame(width: 24)
                         .foregroundStyle(reason == selectedReason ? .red : .secondary)
+                        .accessibilityHidden(true)
                     Text(reason.label)
                     Spacer()
                     if reason == selectedReason {
                         Image(systemName: "checkmark").foregroundStyle(.red).fontWeight(.semibold)
+                            .accessibilityHidden(true)
                     }
                 }
                 .contentShape(Rectangle())
@@ -105,6 +107,9 @@ public struct ReportIssueSheet: View {
                     selectedReason = reason
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 }
+                .accessibilityElement(children: .combine)
+                .accessibilityAddTraits(reason == selectedReason ? [.isButton, .isSelected] : .isButton)
+                .accessibilityHint(NSLocalizedString("report.reason.hint", comment: "Describes that selecting a reason reveals an optional details field"))
                 .listRowBackground(reason == selectedReason
                     ? Color.red.opacity(0.06)
                     : Color(.secondarySystemGroupedBackground))


### PR DESCRIPTION
## Make Report Issue reason rows VoiceOver-accessible (button trait + selection state)

In ReportIssueSheet, the report-reason rows use a bare .onTapGesture, so VoiceOver doesn't announce them as buttons and never speaks which reason is selected (the red checkmark is purely visual). Wrap each row in proper accessibility traits (.isButton + .isSelected), combine children into one element, and add a hint — bringing this US-034 flow in line with the codebase's day-1 a11y standard used elsewhere (FavoritesListView, OfflineBanner).

### Acceptance
Build succeeds (xcodebuild build, iPhone 17 Pro sim). With VoiceOver on, each reason row is announced as a button, the currently selected reason is announced as 'selected', the decorative symbol/checkmark are not separately spoken, and tapping still selects the reason with the existing light-impact haptic and reveals the details section. No new force-unwraps; #Preview still compiles; no @Model/schema files touched.