### PR TITLE
auto: Locale-aware distance in the Favorites list (mi for non-metric travelers)

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -113,6 +113,11 @@ public struct FavoritesListView: View {
             }
             return (label, "figure.walk")
         } else {
+            if Locale.current.measurementSystem == .us {
+                let mi = (meters / 1000) * 0.621371
+                let text = String(format: NSLocalizedString("favorites.distance.mi", comment: "Distance in miles"), mi)
+                return (text, "location.fill")
+            }
             let measurement = Measurement(value: meters / 1000, unit: UnitLength.kilometers)
             return (Self.kilometersFormatter.string(from: measurement), "location.fill")
         }


### PR DESCRIPTION
## Locale-aware distance in the Favorites list (mi for non-metric travelers)

FavoritesListView's distance label hardcodes kilometers via a `.providedUnit` MeasurementFormatter, so a US/imperial solo traveler in Chiang Mai sees '1.2 km' in their saved list while the map's experience card and the city picker already render locale-correct units. This makes the Favorites distance pill respect `Locale.current.measurementSystem`, matching the recently-shipped Nearby-sheet fix and the existing `city.distanceAway.mi` pattern.

### Acceptance
With device region set to United States, a saved favorite >1.5 km away shows e.g. '0.8 mi' in the Favorites list row instead of '1.2 km'; metric regions are unchanged. Walk-minute labels under 1.5 km are unaffected. Row VoiceOver label reads the mi value. `xcodebuild build` succeeds and existing FavoritesList tests pass; `#Preview` renders. Under 100 lines changed across 2 files.