### PR TITLE
auto: Live 'X min left' countdown in the Experience Detail best-time pill

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -83,6 +83,8 @@
 "timeline.a11y" = "Best between %@. %@";
 "timeline.now.tick" = "now";
 "bestTimes.now.pill" = "Good time now";
+"bestTimes.now.pill.left" = "Good now · %d min left";
+"bestTimes.now.pill.left.a11y" = "Good time now, %d minutes left in this window";
 "bestTimes.next.pill" = "Better at %@";
 "bestTimes.window.active.a11y" = "happening now";
 

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -60,6 +60,7 @@ public struct ExperienceDetailView: View {
     }
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(BestNowClock.self) private var bestNowClock
 
     public var body: some View {
         ScrollView {
@@ -535,13 +536,22 @@ public struct ExperienceDetailView: View {
     }
 
     private var bestTimeStatusPill: some View {
-        let isNow = viewModel.experience.isBestNow()
-        let hint = viewModel.experience.bestTimeHint()
+        let now = bestNowClock.tick
+        let isNow = viewModel.experience.isBestNow(at: now)
+        let hint = viewModel.experience.bestTimeHint(at: now)
+        let minutesLeft = viewModel.experience.minutesLeftInBestWindow(at: now)
         let label: String
         let symbol: String
         let background: Color
         if isNow {
-            label = NSLocalizedString("bestTimes.now.pill", comment: "Good time now pill")
+            if let minutesLeft {
+                label = String(
+                    format: NSLocalizedString("bestTimes.now.pill.left", comment: "Good now with minutes left pill"),
+                    minutesLeft
+                )
+            } else {
+                label = NSLocalizedString("bestTimes.now.pill", comment: "Good time now pill")
+            }
             symbol = "clock.badge.checkmark"
             background = Color.green.opacity(0.15)
         } else if let hint {
@@ -551,9 +561,17 @@ public struct ExperienceDetailView: View {
         } else {
             return AnyView(EmptyView())
         }
-        let a11yLabel = isNow
-            ? NSLocalizedString("timeline.now.good", comment: "")
-            : NSLocalizedString("timeline.now.off", comment: "")
+        let a11yLabel: String
+        if isNow, let minutesLeft {
+            a11yLabel = String(
+                format: NSLocalizedString("bestTimes.now.pill.left.a11y", comment: "Good now accessibility with minutes left"),
+                minutesLeft
+            )
+        } else {
+            a11yLabel = isNow
+                ? NSLocalizedString("timeline.now.good", comment: "")
+                : NSLocalizedString("timeline.now.off", comment: "")
+        }
         return AnyView(
             HStack(spacing: 4) {
                 Image(systemName: symbol)
@@ -561,6 +579,8 @@ public struct ExperienceDetailView: View {
                     .symbolEffect(.pulse, isActive: isNow && !reduceMotion)
                 Text(label)
                     .font(.caption.weight(.semibold))
+                    .contentTransition(.numericText())
+                    .animation(reduceMotion ? nil : .easeInOut, value: minutesLeft)
             }
             .foregroundStyle(isNow ? Color.green : Color.secondary)
             .padding(.horizontal, 8)


### PR DESCRIPTION
## Live 'X min left' countdown in the Experience Detail best-time pill

The map pin card already surfaces a live 'good now · X min left' countdown via Experience.minutesLeftInBestWindow + the shared BestNowClock, but the full-screen ExperienceDetailView pill shows only a static 'Good time now' that never updates — even as the window closes while the user reads. This adds the remaining-minutes countdown to the detail pill and drives it off the existing BestNowClock so it ticks every minute, directly reinforcing the product's core 'is this good right now' pillar and matching the card's behavior.

### Acceptance
Opening an experience whose bestTimes window is currently active shows a green pill reading 'Good now · X min left' where X equals minutesLeftInBestWindow, and the value decrements once per minute without re-opening the sheet (driven by BestNowClock). When the active window closes, the pill switches to the existing 'Better at <time>' state on the next tick. When minutesLeft is unavailable the pill falls back to 'Good time now'. With Reduce Motion on, no pulse/animation runs but the text still updates. VoiceOver reads the remaining minutes. `xcodebuild build` and the SoloCompassTests suite pass; no @Model/schema files are modified.