### PR TITLE
auto: Nearest-city hero header in the City Picker sheet

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -713,6 +713,11 @@
 "city.distanceUnknown" = "Distance unknown";
 "city.distanceAway.a11y" = "%@ away";
 
+/* City picker hero header */
+"city.header.nearest" = "Nearest: %@";
+"city.header.nearest.a11y" = "Nearest city %@, %@ away, %d experiences. Tap to select.";
+"city.header.nearest.hint" = "Selects the closest discovered city";
+
 
 /* AgentRouter fallback replies (US-034) */
 "router.fallback.find" = "I found some nearby spots — check the map!";

--- a/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
@@ -23,6 +23,11 @@ public struct CityPickerSheet: View {
         }
     }
 
+    private var nearestCity: (code: String, name: String, center: CLLocationCoordinate2D)? {
+        guard userLocation != nil else { return nil }
+        return sortedCities.first
+    }
+
     public var body: some View {
         NavigationStack {
             Group {
@@ -34,6 +39,20 @@ public struct CityPickerSheet: View {
                     if filtered.isEmpty {
                         ContentUnavailableView.search(text: citySearchText)
                     } else {
+                        VStack(spacing: 0) {
+                            if citySearchText.trimmingCharacters(in: .whitespaces).isEmpty,
+                               !viewModel.availableCities.isEmpty,
+                               let nearest = nearestCity {
+                                CityPickerHeader(
+                                    cityName: nearest.name,
+                                    distanceLabel: distanceLabel(for: nearest.center),
+                                    proximityColor: proximity(for: nearest.center)?.color ?? Color(.tertiaryLabel),
+                                    experienceCount: viewModel.experienceCount(for: nearest.code),
+                                    onTapNearest: { selectCity(nearest.code) }
+                                )
+                                .padding(.horizontal, 16)
+                                .padding(.top, 12)
+                            }
                         List {
                             // "All Cities" option — hidden while a search query is active
                             if citySearchText.trimmingCharacters(in: .whitespaces).isEmpty {
@@ -112,6 +131,7 @@ public struct CityPickerSheet: View {
                                 }())
                             }
                         }
+                        } // VStack
                     }
                 }
             }
@@ -202,6 +222,101 @@ public struct CityPickerSheet: View {
             return String(format: NSLocalizedString("city.distanceAway.mi", comment: ""), mi)
         }
         return String(format: NSLocalizedString("city.distanceAway", comment: ""), km)
+    }
+}
+
+private struct CityPickerHeader: View {
+    let cityName: String
+    let distanceLabel: String
+    let proximityColor: Color
+    let experienceCount: Int
+    var onTapNearest: (() -> Void)? = nil
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var appeared = false
+
+    private var greeting: String {
+        let hour = Calendar.current.component(.hour, from: Date())
+        if hour < 5 {
+            return NSLocalizedString("favorites.greeting.night", comment: "Late-night greeting in favorites header")
+        } else if hour < 12 {
+            return NSLocalizedString("favorites.greeting.morning", comment: "Morning greeting in favorites header")
+        } else if hour < 17 {
+            return NSLocalizedString("favorites.greeting.afternoon", comment: "Afternoon greeting in favorites header")
+        } else {
+            return NSLocalizedString("favorites.greeting.evening", comment: "Evening greeting in favorites header")
+        }
+    }
+
+    private var nudgeLabel: String {
+        String(
+            format: NSLocalizedString("city.header.nearest", comment: "Nearest city nudge"),
+            cityName
+        ) + " · \(distanceLabel) · " + String(
+            format: NSLocalizedString("city.experienceCount", comment: "Experience count in city"),
+            experienceCount
+        )
+    }
+
+    @ViewBuilder
+    private var nudgeCapsule: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(proximityColor)
+                .frame(width: 7, height: 7)
+                .accessibilityHidden(true)
+            Text(nudgeLabel)
+                .font(.caption2)
+                .foregroundStyle(Color.green)
+            Image(systemName: "chevron.right.circle.fill")
+                .font(.caption2)
+                .foregroundStyle(Color.green)
+                .accessibilityHidden(true)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Color.green.opacity(0.12), in: Capsule())
+        .transition(reduceMotion ? .opacity : .scale(scale: 0.9).combined(with: .opacity))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(greeting)
+                .font(.headline)
+                .foregroundStyle(.primary)
+
+            if let onTap = onTapNearest {
+                Button {
+                    onTap()
+                } label: {
+                    nudgeCapsule
+                }
+                .buttonStyle(.plain)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(
+                    String(
+                        format: NSLocalizedString("city.header.nearest.a11y", comment: "Nearest city capsule accessibility label"),
+                        cityName, distanceLabel, experienceCount
+                    )
+                )
+                .accessibilityHint(NSLocalizedString("city.header.nearest.hint", comment: "Selects the closest discovered city"))
+                .accessibilityAddTraits(.isButton)
+            } else {
+                nudgeCapsule
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(nudgeLabel)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .opacity(appeared ? 1 : 0)
+        .offset(y: appeared ? 0 : (reduceMotion ? 0 : 6))
+        .onAppear {
+            if reduceMotion {
+                appeared = true
+            } else {
+                withAnimation(.easeOut(duration: 0.3)) { appeared = true }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Nearest-city hero header in the City Picker sheet

The City Picker sheet lists discovered cities sorted by distance but, unlike the Favorites sheet's rich journey header, gives the solo traveler no orientation about where they are or which city is closest. Add a compact hero header above the list that surfaces the nearest discovered city with its distance and experience count, and a one-tap 'Jump to nearest' action — mirroring the established FavoritesJourneyHeader pattern (greeting + nudge + appear animation).

### Acceptance
Build succeeds via xcodebuild for the SoloCompass scheme. When the City Picker opens with ≥1 discovered city and a known user location, a header appears above the list showing a greeting and a tappable 'Nearest: <City>' capsule; tapping it selects that city and dismisses the sheet with a light haptic. The header is hidden while a search query is active, when no cities exist, or when location is unavailable (falling back to current alphabetical behavior). With Reduce Motion on, the entrance animation is skipped and the header renders statically. VoiceOver reads the header as a single element with the city name, distance, and experience count. All three existing #Preview variants still compile and render.