### PR TITLE
auto: Animate the 'best time' hint pill with a subtle clock-glow and entrance, matching the card's other pills

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -24,6 +24,8 @@ public struct ExperienceCardView: View {
     @State private var onCourseSnap = false
     @State private var lastProximityBand: ProximityTint?
     @State private var proximityPop = false
+    @State private var bestTimeAppeared = false
+    @State private var clockNudge = false
 
     private static let arrivedThresholdMeters = 75.0
 
@@ -579,6 +581,19 @@ public struct ExperienceCardView: View {
         .padding(.vertical, 4)
         .foregroundStyle(Color.secondary)
         .background(Capsule().fill(Color.secondary.opacity(0.12)))
+        .symbolEffect(.bounce, value: clockNudge)
+        .scaleEffect(bestTimeAppeared ? 1 : 0.85)
+        .opacity(bestTimeAppeared ? 1 : 0)
+        .onAppear {
+            if reduceMotion {
+                bestTimeAppeared = true
+            } else {
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                    bestTimeAppeared = true
+                }
+                clockNudge.toggle()
+            }
+        }
     }
 
     // Severity order: safety > scam > weather > crowds > logistics > etiquette > other


### PR DESCRIPTION
## Animate the 'best time' hint pill with a subtle clock-glow and entrance, matching the card's other pills

The `bestTimeHintPill` in `ExperienceCardView` is the only status pill that renders completely flat — no entrance transition, no motion, no emphasis — while every sibling pill (arrived, distance, ETA, best-now, inconvenience) has a spring/pop/pulse. This adds a gentle one-time clock-icon pulse and a scale-in entrance (gated behind `reduceMotion`) so the timing hint reads as a live, actionable cue rather than dead text, closing a visible polish gap.

### Acceptance
Card shows the best-time hint pill scaling/fading in on appear with a single clock-icon bounce; with Reduce Motion on, the pill appears instantly with no animation; accessibility label is unchanged; `xcodebuild build` succeeds and existing SoloCompassTests pass. Verified visually in the iPhone 17 Pro Simulator on an experience that has a bestTimeHint but no inconveniences and is not best-now.