### PR TITLE
auto: Add a confirmation micro-moment to the geofence check-in banner's 'Yes' button

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -402,6 +402,7 @@
 /* Pending check-in banner */
 "checkin.banner.title" = "Did you visit?";
 "checkin.banner.yes" = "Yes!";
+"checkin.banner.confirmed.a11y" = "Visit confirmed";
 "checkin.banner.a11y" = "Did you visit %@?";
 "checkin.banner.a11yAnnouncement" = "You just passed %@ — did you visit?";
 

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 /* Pending check-in banner */
 "checkin.banner.title" = "你来过了吗？";
 "checkin.banner.yes" = "来过！";
+"checkin.banner.confirmed.a11y" = "已确认到访";
 "checkin.banner.a11y" = "你来过 %@ 吗？";
 
 /* Experience detail overflow */

--- a/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
@@ -11,6 +11,7 @@ public struct PendingCheckInBanner: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.accessibilityVoiceOverEnabled) private var voiceOverOn
+    @State private var confirmed = false
     @State private var dragOffset: CGFloat = 0
     @State private var crossedThreshold = false
     @State private var pulse = false
@@ -50,23 +51,39 @@ public struct PendingCheckInBanner: View {
 
                 HStack(spacing: 8) {
                     Button {
-                        #if canImport(UIKit)
-                        Haptics.notify(.success)
-                        #endif
+                        guard !confirmed else { return }
+                        confirmed = true
                         autoDismissTask?.cancel()
                         autoDismissTask = nil
-                        onConfirm()
+                        #if canImport(UIKit)
+                        Haptics.notify(.success)
+                        UIAccessibility.post(
+                            notification: .announcement,
+                            argument: NSLocalizedString("checkin.banner.confirmed.a11y", comment: "Visit confirmed")
+                        )
+                        #endif
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.28) { onConfirm() }
                     } label: {
-                        Text(NSLocalizedString("checkin.banner.yes", comment: "Yes!"))
-                            .font(.caption.weight(.semibold))
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 6)
-                            .background(Capsule().fill(isExpiringSoon ? Color.orange : Color.blue))
-                            .foregroundStyle(.white)
-                            .scaleEffect(reduceMotion ? 1.0 : (pulse ? 1.04 : 1.0))
-                            .animation(reduceMotion ? nil : .easeInOut(duration: 1.3).repeatForever(autoreverses: true), value: pulse)
+                        Group {
+                            if confirmed {
+                                Image(systemName: "checkmark")
+                                    .font(.caption.weight(.semibold))
+                                    .contentTransition(.symbolEffect(.replace))
+                            } else {
+                                Text(NSLocalizedString("checkin.banner.yes", comment: "Yes!"))
+                                    .font(.caption.weight(.semibold))
+                            }
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Capsule().fill(confirmed ? Color.green : (isExpiringSoon ? Color.orange : Color.blue)))
+                        .foregroundStyle(.white)
+                        .scaleEffect(reduceMotion ? 1.0 : (confirmed ? 1.0 : (pulse ? 1.04 : 1.0)))
+                        .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.6), value: confirmed)
+                        .animation(reduceMotion ? nil : .easeInOut(duration: 1.3).repeatForever(autoreverses: true), value: pulse)
                     }
                     .buttonStyle(.plain)
+                    .disabled(confirmed)
 
                     Button {
                         autoDismissTask?.cancel()
@@ -80,6 +97,7 @@ public struct PendingCheckInBanner: View {
                             .background(Circle().fill(Color(.secondarySystemFill)))
                     }
                     .buttonStyle(.plain)
+                    .disabled(confirmed)
                     .accessibilityLabel(Text(NSLocalizedString("common.dismiss", comment: "Dismiss")))
                 }
             }
@@ -106,6 +124,7 @@ public struct PendingCheckInBanner: View {
         .gesture(
             DragGesture()
                 .onChanged { gesture in
+                    guard !confirmed else { return }
                     dragOffset = min(0, gesture.translation.height * 0.85)
                     let overThreshold = -gesture.translation.height > dismissThreshold
                     if overThreshold && !crossedThreshold {
@@ -124,6 +143,7 @@ public struct PendingCheckInBanner: View {
                     }
                 }
                 .onEnded { gesture in
+                    guard !confirmed else { return }
                     if gesture.translation.height < -dismissThreshold {
                         #if canImport(UIKit)
                         Haptics.impact(.soft)


### PR DESCRIPTION
## Add a confirmation micro-moment to the geofence check-in banner's "Yes" button

When the user taps "Yes!" on the PendingCheckInBanner (the floating prompt shown when they walk into an experience's geofence), the banner vanishes instantly with no acknowledgment that the tap registered — a missed emotional beat for the app's core 'I was there' moment. This adds a brief inline success state: the Yes button morphs to a checkmark with a spring scale-bounce and success haptic, then calls onConfirm after ~280ms so the celebration that follows feels earned. Fully self-contained in PendingCheckInBanner.swift; onConfirm is simply deferred, so no call sites change.

### Acceptance
Tapping "Yes!" shows a green checkmark with a spring bounce and success haptic, then the celebration flow proceeds after ~280ms (onConfirm still fires exactly once). With Reduce Motion on, the checkmark appears without the bounce and onConfirm still fires once. The dismiss button and swipe-up gesture are inert during the confirm animation. VoiceOver announces "Visit confirmed". `xcodebuild build` succeeds and the existing PendingCheckInBanner tests still pass.