### PR TITLE
auto: Tappable best-time status pill that scrolls to the live timeline

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -87,6 +87,7 @@
 "bestTimes.now.pill.left.a11y" = "Good time now, %d minutes left in this window";
 "bestTimes.next.pill" = "Better at %@";
 "bestTimes.window.active.a11y" = "happening now";
+"bestTimes.pill.scrollHint" = "Scrolls to the time-of-day timeline";
 
 /* Inconvenience categories */
 "inconvenience.category.scam" = "Scam risk";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -49,6 +49,7 @@
 "timeline.now.tick" = "现在";
 "bestTimes.now.pill" = "此刻最佳";
 "bestTimes.next.pill" = "%@ 更好";
+"bestTimes.pill.scrollHint" = "滚动至时段时间轴";
 
 /* Sections */
 "section.whyItMatters" = "为什么值得";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -62,7 +62,10 @@ public struct ExperienceDetailView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(BestNowClock.self) private var bestNowClock
 
+    @State private var scrollProxy: ScrollViewProxy? = nil
+
     public var body: some View {
+        ScrollViewReader { proxy in
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 heroSection
@@ -113,6 +116,8 @@ public struct ExperienceDetailView: View {
             // with a home indicator).
         }
         .coordinateSpace(name: "detailScroll")
+        .onAppear { scrollProxy = proxy }
+        } // ScrollViewReader
         .onPreferenceChange(HeroTitleOffsetKey.self) { offset in
             let visible = offset > 0
             guard visible != heroTitleVisible else { return }
@@ -572,22 +577,34 @@ public struct ExperienceDetailView: View {
                 ? NSLocalizedString("timeline.now.good", comment: "")
                 : NSLocalizedString("timeline.now.off", comment: "")
         }
+        let scrollHint = NSLocalizedString("bestTimes.pill.scrollHint", comment: "Scrolls to the time-of-day timeline")
         return AnyView(
-            HStack(spacing: 4) {
-                Image(systemName: symbol)
-                    .font(.caption2.weight(.semibold))
-                    .symbolEffect(.pulse, isActive: isNow && !reduceMotion)
-                Text(label)
-                    .font(.caption.weight(.semibold))
-                    .contentTransition(.numericText())
-                    .animation(reduceMotion ? nil : .easeInOut, value: minutesLeft)
+            Button {
+                Haptics.selection()
+                if let proxy = scrollProxy {
+                    withAnimation(reduceMotion ? nil : .easeInOut) {
+                        proxy.scrollTo("bestTimesTimeline", anchor: .center)
+                    }
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: symbol)
+                        .font(.caption2.weight(.semibold))
+                        .symbolEffect(.pulse, isActive: isNow && !reduceMotion)
+                    Text(label)
+                        .font(.caption.weight(.semibold))
+                        .contentTransition(.numericText())
+                        .animation(reduceMotion ? nil : .easeInOut, value: minutesLeft)
+                }
+                .foregroundStyle(isNow ? Color.green : Color.secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Capsule().fill(background))
             }
-            .foregroundStyle(isNow ? Color.green : Color.secondary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(Capsule().fill(background))
+            .buttonStyle(.plain)
             .accessibilityElement(children: .combine)
             .accessibilityLabel(Text(a11yLabel))
+            .accessibilityHint(Text(scrollHint))
         )
     }
 
@@ -626,6 +643,7 @@ public struct ExperienceDetailView: View {
                 if !viewModel.experience.bestTimes.isEmpty {
                     HStack { Spacer(); bestTimeStatusPill }
                     BestTimesTimeline(experience: viewModel.experience)
+                        .id("bestTimesTimeline")
                         .padding(.bottom, 4)
                     TimelineView(.periodic(from: .now, by: 60)) { context in
                         let currentHour = Calendar.current.component(.hour, from: context.date)


### PR DESCRIPTION
## Tappable best-time status pill that scrolls to the live timeline

The best-times status pill in ExperienceDetailView ('Good time now' / 'Better at 18:00') is currently static text, while the rich live BestTimesTimeline sits just below it. Make the pill a button that smoothly scrolls the detail ScrollView to the timeline and fires a selection haptic, so a traveler glancing at the pill is drawn directly to the visual proof of when to go.

### Acceptance
Tapping the best-time status pill in the experience detail sheet smoothly scrolls the timeline into view and plays a selection haptic; with Reduce Motion enabled the scroll is instant (no animation). VoiceOver reads the pill's value plus the new scroll hint. Existing pill text/colors and the live-updating timeline are unchanged. `xcodebuild build` succeeds and SoloCompassTests pass; no @Model/schema files are touched.