### PR TITLE
auto: Show a 'best time to go now' glow on favorite rows that are in their ideal hour

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -472,6 +472,8 @@
 "favorites.nearby.go" = "Go";
 "favorites.nearby.go.a11y" = "Directions to nearest favorite, %@";
 "favorites.nearby.go.hint" = "Opens turn-by-turn directions in Maps";
+"favorites.row.goodNow" = "Good time now";
+"favorites.row.goodNow.a11y" = "good time to visit now";
 
 /* Favorites journey header */
 "favorites.greeting.night" = "Still up?";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -984,11 +984,17 @@ private extension FavoritesListView {
         }
     }
 
+    private func isGoodNow(_ exp: Experience) -> Bool {
+        guard !exp.bestTimes.isEmpty else { return false }
+        return exp.isBestNow()
+    }
+
     @ViewBuilder
     func favoriteRow(_ exp: Experience) -> some View {
         let distInfo = distanceInfo(for: exp)
         let prox = proximity(for: exp)
         let isDone = preferences.completedExperiences.contains(exp.id)
+        let goodNow = !isDone && isGoodNow(exp)
         Button {
             Haptics.selection()
             onSelectExperience(exp)
@@ -1035,6 +1041,21 @@ private extension FavoritesListView {
                         .foregroundStyle(.tertiary)
                         .padding(.top, 1)
                     }
+                    if goodNow {
+                        HStack(spacing: 4) {
+                            Image(systemName: "clock.badge.checkmark")
+                                .accessibilityHidden(true)
+                            Text(NSLocalizedString("favorites.row.goodNow", comment: "Good time now pill in favorites row"))
+                        }
+                        .font(.caption2)
+                        .foregroundStyle(exp.category.color)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(exp.category.color.opacity(0.12), in: Capsule())
+                        .padding(.top, 2)
+                        .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
+                        .accessibilityHidden(true)
+                    }
                 }
 
                 Spacer()
@@ -1048,15 +1069,16 @@ private extension FavoritesListView {
         .buttonStyle(PressableRowStyle(reduceMotion: reduceMotion))
         .accessibilityLabel({
             let doneWord = isDone ? ", \(NSLocalizedString("favorites.row.done.a11y", comment: "Completed row suffix"))" : ""
+            let goodNowWord = goodNow ? ", \(NSLocalizedString("favorites.row.goodNow.a11y", comment: "Good time now accessibility suffix"))" : ""
             if let distInfo {
                 let awayFmt = NSLocalizedString("favorites.row.distance.a11y", comment: "Distance away accessibility label")
                 let distLabel = String(format: awayFmt, distInfo.text)
                 if let prox {
-                    return Text("\(exp.title), \(exp.oneLiner), \(distLabel), \(prox.a11yWord)\(doneWord)")
+                    return Text("\(exp.title), \(exp.oneLiner), \(distLabel), \(prox.a11yWord)\(doneWord)\(goodNowWord)")
                 }
-                return Text("\(exp.title), \(exp.oneLiner), \(distLabel)\(doneWord)")
+                return Text("\(exp.title), \(exp.oneLiner), \(distLabel)\(doneWord)\(goodNowWord)")
             }
-            return Text("\(exp.title), \(exp.oneLiner)\(doneWord)")
+            return Text("\(exp.title), \(exp.oneLiner)\(doneWord)\(goodNowWord)")
         }())
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             Button(role: .destructive) {


### PR DESCRIPTION
## Show a 'best time to go now' glow on favorite rows that are in their ideal hour

Each Experience has bestTimes (0–23 local hour ints), but the favorites list never surfaces whether a saved place is good to visit right now. Add a subtle, accessible 'good now' indicator to favoriteRow when the current local hour falls within an experience's bestTimes, turning the list into a live, time-aware planning surface instead of a static archive.

### Acceptance
Opening Favorites during an experience's bestTimes hour shows a 'Good time now' pill on that row in the category color; completed rows never show it; rows with empty bestTimes never show it; the pill matches existing chip styling (caption2, Capsule, 0.12 bg); VoiceOver reads the 'good now' status as part of the row label; with Reduce Motion on there is no entrance animation; xcodebuild build and SoloCompassTests pass.