### PR TITLE
auto: Show 'best at <time>' hint on favorite rows that aren't ideal right now

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -475,6 +475,8 @@
 "favorites.nearby.go.hint" = "Opens turn-by-turn directions in Maps";
 "favorites.row.goodNow" = "Good time now";
 "favorites.row.goodNow.a11y" = "good time to visit now";
+"favorites.row.bestAt" = "Best ~%@";
+"favorites.row.bestAt.a11y" = "best around %@";
 
 /* Favorites journey header */
 "favorites.greeting.night" = "Still up?";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1203,6 +1203,8 @@
 "favorites.nearby.hint" = "按距离排序收藏";
 "favorites.row.directions" = "导航";
 "favorites.row.done.a11y" = "已完成";
+"favorites.row.bestAt" = "%@ 最佳";
+"favorites.row.bestAt.a11y" = "约 %@ 最佳";
 "favorites.undo.announcement" = "已移除 %@。可撤销。";
 
 /* Filter empty */

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -995,6 +995,7 @@ private extension FavoritesListView {
         let prox = proximity(for: exp)
         let isDone = preferences.completedExperiences.contains(exp.id)
         let goodNow = !isDone && isGoodNow(exp)
+        let bestHint = (!isDone && !goodNow) ? exp.bestTimeHint() : nil
         Button {
             Haptics.selection()
             onSelectExperience(exp)
@@ -1055,6 +1056,20 @@ private extension FavoritesListView {
                         .padding(.top, 2)
                         .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
                         .accessibilityHidden(true)
+                    } else if let hint = bestHint {
+                        HStack(spacing: 4) {
+                            Image(systemName: "clock")
+                                .accessibilityHidden(true)
+                            Text(String(format: NSLocalizedString("favorites.row.bestAt", comment: "Best at time pill in favorites row"), hint))
+                        }
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(Color.secondary.opacity(0.1), in: Capsule())
+                        .padding(.top, 2)
+                        .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
+                        .accessibilityHidden(true)
                     }
                 }
 
@@ -1070,15 +1085,19 @@ private extension FavoritesListView {
         .accessibilityLabel({
             let doneWord = isDone ? ", \(NSLocalizedString("favorites.row.done.a11y", comment: "Completed row suffix"))" : ""
             let goodNowWord = goodNow ? ", \(NSLocalizedString("favorites.row.goodNow.a11y", comment: "Good time now accessibility suffix"))" : ""
+            let bestAtWord: String = {
+                guard let hint = bestHint else { return "" }
+                return ", \(String(format: NSLocalizedString("favorites.row.bestAt.a11y", comment: "Best at time accessibility suffix"), hint))"
+            }()
             if let distInfo {
                 let awayFmt = NSLocalizedString("favorites.row.distance.a11y", comment: "Distance away accessibility label")
                 let distLabel = String(format: awayFmt, distInfo.text)
                 if let prox {
-                    return Text("\(exp.title), \(exp.oneLiner), \(distLabel), \(prox.a11yWord)\(doneWord)\(goodNowWord)")
+                    return Text("\(exp.title), \(exp.oneLiner), \(distLabel), \(prox.a11yWord)\(doneWord)\(goodNowWord)\(bestAtWord)")
                 }
-                return Text("\(exp.title), \(exp.oneLiner), \(distLabel)\(doneWord)\(goodNowWord)")
+                return Text("\(exp.title), \(exp.oneLiner), \(distLabel)\(doneWord)\(goodNowWord)\(bestAtWord)")
             }
-            return Text("\(exp.title), \(exp.oneLiner)\(doneWord)\(goodNowWord)")
+            return Text("\(exp.title), \(exp.oneLiner)\(doneWord)\(goodNowWord)\(bestAtWord)")
         }())
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             Button(role: .destructive) {


### PR DESCRIPTION
## Show 'best at <time>' hint on favorite rows that aren't ideal right now

The favorites list already glows a 'Good now' pill on rows in their ideal hour, but rows that AREN'T currently ideal show nothing time-related — the traveler has to open the detail view to learn a favorite is better later. This adds a subtle 'Best ~5pm' hint pill to each favorite row using the existing Experience.bestTimeHint(at:) model method, turning the list into a glanceable 'what should I do now vs. later' planner without any new model or schema changes.

### Acceptance
Build succeeds (xcodebuild build, iPhone 17 Pro sim). In the favorites list: a favorite currently in its ideal hour still shows the colored 'Good now' pill; a favorite NOT currently ideal but with bestTimes shows a muted 'Best ~5pm' pill with the next applicable window; a completed favorite or one with empty bestTimes shows neither. The 12/24-hour format follows locale (reusing bestTimeHint formatting). VoiceOver reads the best-time hint as part of the row label. No new model/schema changes; both en and zh-Hans strings resolve (no raw keys visible).