### PR TITLE
auto: Show a 'closing soon' countdown on favorites rows whose ideal window is about to end

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -475,6 +475,8 @@
 "favorites.nearby.go.hint" = "Opens turn-by-turn directions in Maps";
 "favorites.row.goodNow" = "Good time now";
 "favorites.row.goodNow.a11y" = "good time to visit now";
+"favorites.row.closingSoon" = "Closing soon · %dm left";
+"favorites.row.closingSoon.a11y" = "closing soon, %d minutes left";
 "favorites.row.bestAt" = "Best ~%@";
 "favorites.row.bestAt.a11y" = "best around %@";
 

--- a/apps/ios/SoloCompass/Tests/FavoritesClosingSoonThresholdTest.swift
+++ b/apps/ios/SoloCompass/Tests/FavoritesClosingSoonThresholdTest.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import SoloCompass
+
+/// Verifies that the ≤45-minute threshold driving the "Closing soon" pill in
+/// FavoritesListView is consistent with `minutesLeftInBestWindow(at:)`.
+///
+/// The pill logic:
+///   let minutesLeft = goodNow ? exp.minutesLeftInBestWindow(at: now) : nil
+///   let closingSoon = (minutesLeft ?? .max) <= 45
+///
+/// Tests here exercise the model method that feeds that computation directly,
+/// confirming the boundary at 45 minutes.
+final class FavoritesClosingSoonThresholdTest: XCTestCase {
+
+    // MARK: - Fixture
+
+    private static func makeExp(startHour: Int, endHour: Int) -> Experience {
+        let now = Date()
+        return Experience(
+            id: "closing_soon_fixture",
+            title: "Closing Soon Fixture",
+            oneLiner: "Test",
+            whyItMatters: "Test",
+            category: .coffee,
+            location: ExperienceLocation(coordinates: [100.0, 13.0], cityCode: "bkk"),
+            bestTimes: [TimeWindow(startHour: startHour, endHour: endHour)],
+            durationMinutes: .init(min: 30, max: 60),
+            howTo: [],
+            realInconveniences: [],
+            soloScore: SoloScore(
+                overall: 7.0,
+                breakdown: .init(
+                    seatingFriendly: 7, soloPatronRatio: 7, staffPressure: 7,
+                    soloPortioning: 7, ambianceFit: 7, safety: 7
+                ),
+                basedOnCount: 1
+            ),
+            sources: [InformationSource(type: .user, attribution: "fixture", verifiedAt: now)],
+            confidence: Confidence(
+                level: 3,
+                lastVerifiedAt: now,
+                reason: "Fixture",
+                signals: .init(aiScrapeAgeDays: 1, passiveGpsHits30d: 0,
+                               activeReports30d: 0, trustedVerifications: 0)
+            ),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .active,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    // MARK: - Tests
+
+    /// When 46 minutes remain, closingSoon must be false.
+    func testAboveThresholdIsNotClosingSoon() {
+        let cal = Calendar.current
+        // Build a window that ends exactly 46 minutes from now.
+        let endDate = Date().addingTimeInterval(46 * 60)
+        let endHour = cal.component(.hour, from: endDate)
+        // Start well before now so the window is currently open.
+        let startHour = (endHour + 23) % 24
+        let exp = Self.makeExp(startHour: startHour, endHour: endHour)
+
+        let minutesLeft = exp.minutesLeftInBestWindow(at: Date())
+        guard let mins = minutesLeft else {
+            XCTFail("Expected window to be active")
+            return
+        }
+        let closingSoon = mins <= 45
+        XCTAssertFalse(closingSoon, "46 min left — should not be closing soon (got \(mins))")
+    }
+
+    /// When 45 minutes remain, closingSoon must be true.
+    func testAtThresholdIsClosingSoon() {
+        let cal = Calendar.current
+        let endDate = Date().addingTimeInterval(45 * 60)
+        let endHour = cal.component(.hour, from: endDate)
+        let startHour = (endHour + 23) % 24
+        let exp = Self.makeExp(startHour: startHour, endHour: endHour)
+
+        let minutesLeft = exp.minutesLeftInBestWindow(at: Date())
+        guard let mins = minutesLeft else {
+            XCTFail("Expected window to be active")
+            return
+        }
+        let closingSoon = mins <= 45
+        XCTAssertTrue(closingSoon, "45 min left — should be closing soon (got \(mins))")
+    }
+
+    /// When the experience is not currently in its best window, minutesLeft is
+    /// nil and closingSoon must be false (nil ?? .max is greater than 45).
+    func testNotGoodNowIsNeverClosingSoon() {
+        // Window 3–4 am — almost certainly not open right now during a test run.
+        let exp = Self.makeExp(startHour: 3, endHour: 4)
+        let now = Date()
+        guard !exp.isBestNow(at: now) else {
+            // If test is somehow run between 3–4am, skip rather than fail.
+            return
+        }
+        let minutesLeft = exp.minutesLeftInBestWindow(at: now)
+        XCTAssertNil(minutesLeft, "Window not active — minutesLeftInBestWindow should be nil")
+        let closingSoon = (minutesLeft ?? .max) <= 45
+        XCTAssertFalse(closingSoon, "Not in best window — closingSoon must be false")
+    }
+}

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -9,6 +9,7 @@ public struct FavoritesListView: View {
     @Environment(ExperienceService.self) private var experienceService
     @Environment(UserPreferences.self) private var preferences
     @Environment(LocationService.self) private var locationService
+    @Environment(BestNowClock.self) private var bestNowClock
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.accessibilityVoiceOverEnabled) private var voiceOverOn
     let onSelectExperience: (Experience) -> Void
@@ -984,17 +985,20 @@ private extension FavoritesListView {
         }
     }
 
-    private func isGoodNow(_ exp: Experience) -> Bool {
+    private func isGoodNow(_ exp: Experience, at date: Date) -> Bool {
         guard !exp.bestTimes.isEmpty else { return false }
-        return exp.isBestNow()
+        return exp.isBestNow(at: date)
     }
 
     @ViewBuilder
     func favoriteRow(_ exp: Experience) -> some View {
+        let now = bestNowClock.tick
         let distInfo = distanceInfo(for: exp)
         let prox = proximity(for: exp)
         let isDone = preferences.completedExperiences.contains(exp.id)
-        let goodNow = !isDone && isGoodNow(exp)
+        let goodNow = !isDone && isGoodNow(exp, at: now)
+        let minutesLeft = goodNow ? exp.minutesLeftInBestWindow(at: now) : nil
+        let closingSoon = (minutesLeft ?? .max) <= 45
         let bestHint = (!isDone && !goodNow) ? exp.bestTimeHint() : nil
         Button {
             Haptics.selection()
@@ -1043,19 +1047,35 @@ private extension FavoritesListView {
                         .padding(.top, 1)
                     }
                     if goodNow {
-                        HStack(spacing: 4) {
-                            Image(systemName: "clock.badge.checkmark")
-                                .accessibilityHidden(true)
-                            Text(NSLocalizedString("favorites.row.goodNow", comment: "Good time now pill in favorites row"))
+                        if closingSoon, let mins = minutesLeft {
+                            HStack(spacing: 4) {
+                                Image(systemName: "clock.badge.exclamationmark")
+                                    .accessibilityHidden(true)
+                                Text(String(format: NSLocalizedString("favorites.row.closingSoon", comment: "Closing soon pill in favorites row"), mins))
+                            }
+                            .font(.caption2)
+                            .foregroundStyle(Color.orange)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(Color.orange.opacity(0.12), in: Capsule())
+                            .padding(.top, 2)
+                            .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
+                            .accessibilityHidden(true)
+                        } else {
+                            HStack(spacing: 4) {
+                                Image(systemName: "clock.badge.checkmark")
+                                    .accessibilityHidden(true)
+                                Text(NSLocalizedString("favorites.row.goodNow", comment: "Good time now pill in favorites row"))
+                            }
+                            .font(.caption2)
+                            .foregroundStyle(exp.category.color)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(exp.category.color.opacity(0.12), in: Capsule())
+                            .padding(.top, 2)
+                            .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
+                            .accessibilityHidden(true)
                         }
-                        .font(.caption2)
-                        .foregroundStyle(exp.category.color)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 5)
-                        .background(exp.category.color.opacity(0.12), in: Capsule())
-                        .padding(.top, 2)
-                        .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
-                        .accessibilityHidden(true)
                     } else if let hint = bestHint {
                         HStack(spacing: 4) {
                             Image(systemName: "clock")
@@ -1084,7 +1104,15 @@ private extension FavoritesListView {
         .buttonStyle(PressableRowStyle(reduceMotion: reduceMotion))
         .accessibilityLabel({
             let doneWord = isDone ? ", \(NSLocalizedString("favorites.row.done.a11y", comment: "Completed row suffix"))" : ""
-            let goodNowWord = goodNow ? ", \(NSLocalizedString("favorites.row.goodNow.a11y", comment: "Good time now accessibility suffix"))" : ""
+            let timingWord: String = {
+                if goodNow {
+                    if closingSoon, let mins = minutesLeft {
+                        return ", \(String(format: NSLocalizedString("favorites.row.closingSoon.a11y", comment: "Closing soon accessibility suffix"), mins))"
+                    }
+                    return ", \(NSLocalizedString("favorites.row.goodNow.a11y", comment: "Good time now accessibility suffix"))"
+                }
+                return ""
+            }()
             let bestAtWord: String = {
                 guard let hint = bestHint else { return "" }
                 return ", \(String(format: NSLocalizedString("favorites.row.bestAt.a11y", comment: "Best at time accessibility suffix"), hint))"
@@ -1093,11 +1121,11 @@ private extension FavoritesListView {
                 let awayFmt = NSLocalizedString("favorites.row.distance.a11y", comment: "Distance away accessibility label")
                 let distLabel = String(format: awayFmt, distInfo.text)
                 if let prox {
-                    return Text("\(exp.title), \(exp.oneLiner), \(distLabel), \(prox.a11yWord)\(doneWord)\(goodNowWord)\(bestAtWord)")
+                    return Text("\(exp.title), \(exp.oneLiner), \(distLabel), \(prox.a11yWord)\(doneWord)\(timingWord)\(bestAtWord)")
                 }
-                return Text("\(exp.title), \(exp.oneLiner), \(distLabel)\(doneWord)\(goodNowWord)\(bestAtWord)")
+                return Text("\(exp.title), \(exp.oneLiner), \(distLabel)\(doneWord)\(timingWord)\(bestAtWord)")
             }
-            return Text("\(exp.title), \(exp.oneLiner)\(doneWord)\(goodNowWord)\(bestAtWord)")
+            return Text("\(exp.title), \(exp.oneLiner)\(doneWord)\(timingWord)\(bestAtWord)")
         }())
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             Button(role: .destructive) {
@@ -1184,4 +1212,5 @@ private struct DirectionsSwipeModifier: ViewModifier {
         .environment(ExperienceService())
         .environment(UserPreferences())
         .environment(LocationService.shared)
+        .environment(BestNowClock.shared)
 }


### PR DESCRIPTION
## Show a 'closing soon' countdown on favorites rows whose ideal window is about to end

The favorites list already shows a static 'Good time now' pill, but it can't tell a solo traveler that the window is about to close — the exact signal that converts a passive favorite into an act-now decision. The Experience model already computes minutesLeftInBestWindow() (used in the detail/card views) and BestNowClock.shared already broadcasts a shared minute-cadence tick, so this surfaces existing data with no new model or schema work. When a 'good now' favorite has ≤45 minutes left, the green pill switches to an orange 'Closing soon · Nm left' urgency pill that recomputes every minute.

### Acceptance
A favorited experience currently in its ideal window with >45 minutes remaining shows the existing green 'Good time now' pill; the same row, when ≤45 minutes remain, shows an orange 'Closing soon · Nm left' pill that decrements once a minute via BestNowClock without manual refresh. VoiceOver reads the closing-soon suffix with the remaining minutes. Reduce Motion shows no scale transition. `xcodebuild build` and `xcodebuild test` pass for the SoloCompass scheme.