### PR TITLE
auto: Surface a 'closing soon' urgency state in the experience detail Best Times pill

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -85,6 +85,8 @@
 "bestTimes.now.pill" = "Good time now";
 "bestTimes.now.pill.left" = "Good now · %d min left";
 "bestTimes.now.pill.left.a11y" = "Good time now, %d minutes left in this window";
+"bestTimes.now.pill.closing" = "Closing in %dm — go now";
+"bestTimes.now.pill.closing.a11y" = "Closing soon, %d minutes left in this window — go now";
 "bestTimes.next.pill" = "Better at %@";
 "bestTimes.window.active.a11y" = "happening now";
 "bestTimes.pill.scrollHint" = "Scrolls to the time-of-day timeline";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -545,37 +545,59 @@ public struct ExperienceDetailView: View {
         let isNow = viewModel.experience.isBestNow(at: now)
         let hint = viewModel.experience.bestTimeHint(at: now)
         let minutesLeft = viewModel.experience.minutesLeftInBestWindow(at: now)
+        let closingSoon = isNow && (minutesLeft ?? .max) <= 45
         let label: String
         let symbol: String
         let background: Color
+        let tint: Color
         if isNow {
-            if let minutesLeft {
+            if closingSoon, let mins = minutesLeft {
+                label = String(
+                    format: NSLocalizedString("bestTimes.now.pill.closing", comment: "Closing soon pill in best times detail"),
+                    mins
+                )
+                symbol = "clock.badge.exclamationmark"
+                background = Color.orange.opacity(0.15)
+                tint = Color.orange
+            } else if let minutesLeft {
                 label = String(
                     format: NSLocalizedString("bestTimes.now.pill.left", comment: "Good now with minutes left pill"),
                     minutesLeft
                 )
+                symbol = "clock.badge.checkmark"
+                background = Color.green.opacity(0.15)
+                tint = Color.green
             } else {
                 label = NSLocalizedString("bestTimes.now.pill", comment: "Good time now pill")
+                symbol = "clock.badge.checkmark"
+                background = Color.green.opacity(0.15)
+                tint = Color.green
             }
-            symbol = "clock.badge.checkmark"
-            background = Color.green.opacity(0.15)
         } else if let hint {
             label = String(format: NSLocalizedString("bestTimes.next.pill", comment: "Better at time pill"), hint)
             symbol = "clock"
             background = Color(.tertiarySystemFill)
+            tint = Color.secondary
         } else {
             return AnyView(EmptyView())
         }
         let a11yLabel: String
-        if isNow, let minutesLeft {
-            a11yLabel = String(
-                format: NSLocalizedString("bestTimes.now.pill.left.a11y", comment: "Good now accessibility with minutes left"),
-                minutesLeft
-            )
+        if isNow {
+            if closingSoon, let mins = minutesLeft {
+                a11yLabel = String(
+                    format: NSLocalizedString("bestTimes.now.pill.closing.a11y", comment: "Closing soon accessibility label in best times detail"),
+                    mins
+                )
+            } else if let minutesLeft {
+                a11yLabel = String(
+                    format: NSLocalizedString("bestTimes.now.pill.left.a11y", comment: "Good now accessibility with minutes left"),
+                    minutesLeft
+                )
+            } else {
+                a11yLabel = NSLocalizedString("timeline.now.good", comment: "")
+            }
         } else {
-            a11yLabel = isNow
-                ? NSLocalizedString("timeline.now.good", comment: "")
-                : NSLocalizedString("timeline.now.off", comment: "")
+            a11yLabel = NSLocalizedString("timeline.now.off", comment: "")
         }
         let scrollHint = NSLocalizedString("bestTimes.pill.scrollHint", comment: "Scrolls to the time-of-day timeline")
         return AnyView(
@@ -596,7 +618,7 @@ public struct ExperienceDetailView: View {
                         .contentTransition(.numericText())
                         .animation(reduceMotion ? nil : .easeInOut, value: minutesLeft)
                 }
-                .foregroundStyle(isNow ? Color.green : Color.secondary)
+                .foregroundStyle(tint)
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
                 .background(Capsule().fill(background))


### PR DESCRIPTION
## Surface a 'closing soon' urgency state in the experience detail Best Times pill

The detail view's Best Times status pill shows a calm green 'Good now · N min left' right up until the window closes, while the Favorites row already escalates to an orange 'closing soon' cue when under 45 minutes remain. This adds the same closing-soon escalation to the detail pill so the higher-intent decision screen gives travelers the same urgency signal — turning the pill orange with a warning icon and 'Closing in Nm — go now' copy when the active window is about to end. It reuses the existing minutesLeftInBestWindow helper and the 45-minute threshold already established in FavoritesListView, so behavior stays consistent across screens.

### Acceptance
Build succeeds (xcodebuild build, iPhone 17 Pro sim). When an experience is best-now with >45 min left, the pill renders green 'Good now · N min left' unchanged. When ≤45 min remain in the active window, the pill renders orange with the warning clock icon and 'Closing in Nm — go now' copy, matching the Favorites row's closing-soon cue. The pill still scrolls to the timeline on tap, the minutes count animates via contentTransition(.numericText()), VoiceOver reads the closing-soon label, and reduce-motion disables the pulse. New strings exist in en.lproj/Localizable.strings.