### PR TITLE
auto: Add an animated journey progress bar to the Favorites header

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -672,6 +672,11 @@ private struct FavoritesJourneyHeader: View {
                 .contentTransition(.numericText())
                 .animation(.easeInOut, value: completed)
                 .animation(.easeInOut, value: total)
+            if total > 0 {
+                JourneyProgressBar(completed: completed, total: total)
+                    .padding(.top, 4)
+                    .accessibilityHidden(true)
+            }
             goodNowNudge
                 .animation(reduceMotion ? nil : .easeInOut, value: goodNowCount)
             nearbyNudge
@@ -697,6 +702,56 @@ private struct FavoritesJourneyHeader: View {
                 appeared = true
             } else {
                 withAnimation(.easeOut(duration: 0.3)) { appeared = true }
+            }
+        }
+    }
+}
+
+private struct JourneyProgressBar: View {
+    let completed: Int
+    let total: Int
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var animatedFraction: CGFloat = 0
+
+    private var targetFraction: CGFloat {
+        total > 0 ? CGFloat(completed) / CGFloat(total) : 0
+    }
+
+    private var isAllDone: Bool { total > 0 && completed == total }
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.green.opacity(0.15))
+                    .frame(height: 4)
+                Capsule()
+                    .fill(isAllDone ? Color.green : Color.green.opacity(0.75))
+                    .frame(width: geo.size.width * animatedFraction, height: 4)
+                    .shadow(
+                        color: isAllDone ? Color.green.opacity(0.4) : Color.clear,
+                        radius: 3
+                    )
+            }
+        }
+        .frame(height: 4)
+        .onAppear {
+            if reduceMotion {
+                animatedFraction = targetFraction
+            } else {
+                withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
+                    animatedFraction = targetFraction
+                }
+            }
+        }
+        .onChange(of: completed) { _, _ in
+            if reduceMotion {
+                animatedFraction = targetFraction
+            } else {
+                withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
+                    animatedFraction = targetFraction
+                }
             }
         }
     }


### PR DESCRIPTION
## Add an animated journey progress bar to the Favorites header

The FavoritesJourneyHeader shows a text-only 'N of M explored' line, but the only visual progress indicator (CompletionRing) is a tiny 22pt ring buried in the count footer. Add a slim, animated horizontal progress bar directly beneath the journey summary so a traveler can feel their completion momentum at a glance — it fills with a spring as favorites get checked off and shows a subtle full-width green glow when all are explored.

### Acceptance
Build succeeds via xcodebuild for the SoloCompass scheme. In the Favorites sheet with some-but-not-all favorites completed, a slim green progress bar appears under the 'N of M explored' line and its fill width matches completed/total. Completing a favorite (or toggling completion) animates the bar's fill with a spring; with Reduce Motion enabled the bar jumps to its final width without animation. When all favorites are completed the bar is full-width with a subtle green glow. VoiceOver does not announce the bar separately (it stays accessibilityHidden). The #Preview for FavoritesListView still renders.