### PR TITLE
auto: Escalate the map card's 'Best now' badge to an urgent 'closing soon' state when the window is about to end

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -134,6 +134,8 @@
 "experience.bestNow" = "Best now";
 "experience.bestNow.countdown" = "Best now · %dm left";
 "experience.bestNow.countdown.a11y" = "Best now, %d minutes left";
+"experience.bestNow.closingSoon" = "Closing soon · %dm left";
+"experience.bestNow.closingSoon.a11y" = "Closing soon, %d minutes left";
 "experience.viewDetails" = "View details →";
 "experience.bestTime.hint" = "Best %@";
 "experience.bestTime.hint.a11y" = "Best %@";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -638,6 +638,8 @@ private struct BestNowBadge: View {
     var experience: Experience
 
     private static let gold = Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)
+    private static let amber = Color(red: 0xF5/255, green: 0x9E/255, blue: 0x0B/255)
+    private static let closingSoonThresholdMinutes = 45
 
     @State private var pulse = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -646,8 +648,15 @@ private struct BestNowBadge: View {
     /// up 20+ concurrent timelines.
     @Environment(BestNowClock.self) private var clock
 
+    private func isClosingSoon(at date: Date) -> Bool {
+        (experience.minutesLeftInBestWindow(at: date) ?? .max) <= Self.closingSoonThresholdMinutes
+    }
+
     private func labelText(at date: Date) -> String {
         if let minutes = experience.minutesLeftInBestWindow(at: date) {
+            if isClosingSoon(at: date) {
+                return String(format: NSLocalizedString("experience.bestNow.closingSoon", comment: "Closing soon with countdown"), minutes)
+            }
             return String(format: NSLocalizedString("experience.bestNow.countdown", comment: "Best now with countdown"), minutes)
         }
         return NSLocalizedString("experience.bestNow", comment: "Best now label")
@@ -655,12 +664,17 @@ private struct BestNowBadge: View {
 
     private func a11yText(at date: Date) -> String {
         if let minutes = experience.minutesLeftInBestWindow(at: date) {
+            if isClosingSoon(at: date) {
+                return String(format: NSLocalizedString("experience.bestNow.closingSoon.a11y", comment: "Closing soon accessibility with countdown"), minutes)
+            }
             return String(format: NSLocalizedString("experience.bestNow.countdown.a11y", comment: "Best now accessibility with countdown"), minutes)
         }
         return NSLocalizedString("experience.bestNow", comment: "Best now label")
     }
 
     var body: some View {
+        let closingSoon = isClosingSoon(at: clock.tick)
+        let pulseDuration = closingSoon ? 0.7 : 1.1
         Group {
             if reduceMotion {
                 badgeLabel(at: clock.tick)
@@ -673,7 +687,13 @@ private struct BestNowBadge: View {
                 badgeLabel(at: clock.tick)
                     .accessibilityLabel(a11yText(at: clock.tick))
                     .onAppear {
-                        withAnimation(.easeInOut(duration: 1.1).repeatForever(autoreverses: true)) {
+                        withAnimation(.easeInOut(duration: pulseDuration).repeatForever(autoreverses: true)) {
+                            pulse = true
+                        }
+                    }
+                    .onChange(of: closingSoon) { _, _ in
+                        pulse = false
+                        withAnimation(.easeInOut(duration: pulseDuration).repeatForever(autoreverses: true)) {
                             pulse = true
                         }
                     }
@@ -682,14 +702,17 @@ private struct BestNowBadge: View {
     }
 
     private func badgeLabel(at date: Date) -> some View {
-        Label(labelText(at: date), systemImage: "sparkle")
+        let closingSoon = isClosingSoon(at: date)
+        let tint = closingSoon ? Self.amber : Self.gold
+        let symbol = closingSoon ? "clock.badge.exclamationmark" : "sparkle"
+        return Label(labelText(at: date), systemImage: symbol)
             .font(.caption)
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
-            .background(Capsule().fill(Self.gold.opacity(0.2)))
-            .foregroundStyle(Self.gold)
+            .background(Capsule().fill(tint.opacity(0.2)))
+            .foregroundStyle(tint)
             .scaleEffect(pulse ? 1.06 : 1.0)
-            .shadow(color: Self.gold.opacity(pulse ? 0.55 : 0.0), radius: pulse ? 8 : 0)
+            .shadow(color: tint.opacity(pulse ? 0.55 : 0.0), radius: pulse ? 8 : 0)
             .contentTransition(.numericText())
     }
 }


### PR DESCRIPTION
## Escalate the map card's 'Best now' badge to an urgent 'closing soon' state when the window is about to end

The BestNowBadge on ExperienceCardView (the primary surface shown when a map marker is tapped) currently shows only a gold countdown with no urgency signal as the ideal window runs out. FavoritesListView rows already distinguish a ≤45-minute 'closing soon' state (amber tint, clock.badge.exclamationmark icon), but that escalation is absent from the map card where most go/no-go decisions happen. This adds the same closing-soon treatment to BestNowBadge — amber color, an exclamation clock symbol, and a tighter/faster pulse — so a traveler standing on the map gets a clear 'go now or miss it' cue, reusing the existing minutesLeftInBestWindow API, the 45-minute threshold, and the established visual language.

### Acceptance
When a tapped experience's best window has >45 minutes left, the card badge is unchanged (gold, sparkle, 'Best now · Nm left', 1.1s pulse). When ≤45 minutes remain, the badge turns amber with a clock.badge.exclamationmark icon, reads 'Closing soon · Nm left', and pulses faster; VoiceOver announces 'Closing soon, N minutes left'. Under Reduce Motion the badge is static in both states. The 45-minute threshold matches FavoritesListView so the map card and favorites row agree. `xcodebuild build` and the existing SoloCompassTests suite pass, and StringsParityTests still passes with the two new keys added.