### PR TITLE
auto: Add a swipe-to-complete (mark visited) leading action to favorite rows

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -483,6 +483,10 @@
 "favorites.row.closingSoon.a11y" = "closing soon, %d minutes left";
 "favorites.row.bestAt" = "Best ~%@";
 "favorites.row.bestAt.a11y" = "best around %@";
+"favorites.row.markVisited" = "Mark visited";
+"favorites.row.markNotVisited" = "Mark not visited";
+"favorites.row.markVisited.announcement" = "Marked %@ as visited";
+"favorites.row.markNotVisited.announcement" = "Marked as not visited";
 
 /* Favorites journey header — good now nudge */
 "favorites.journey.goodNow" = "%d great to do right now";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -1281,7 +1281,60 @@ private extension FavoritesListView {
                       systemImage: "heart.slash")
             }
         }
+        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+            Button {
+                if isDone {
+                    Haptics.selection()
+                    withAnimation(.easeInOut) {
+                        preferences.completedExperiences.remove(exp.id)
+                        preferences.visitHistory.removeValue(forKey: exp.id)
+                    }
+                    UIAccessibility.post(
+                        notification: .announcement,
+                        argument: NSLocalizedString("favorites.row.markNotVisited.announcement", comment: "VoiceOver announcement after marking as not visited")
+                    )
+                } else {
+                    Haptics.notify(.success)
+                    withAnimation(.easeInOut) {
+                        preferences.markCompleted(exp.id)
+                    }
+                    UIAccessibility.post(
+                        notification: .announcement,
+                        argument: String(format: NSLocalizedString("favorites.row.markVisited.announcement", comment: "VoiceOver announcement after marking as visited"), exp.title)
+                    )
+                }
+            } label: {
+                Label(
+                    isDone
+                        ? NSLocalizedString("favorites.row.markNotVisited", comment: "Swipe action to un-complete a favorite")
+                        : NSLocalizedString("favorites.row.markVisited", comment: "Swipe action to mark a favorite as visited"),
+                    systemImage: isDone ? "arrow.uturn.backward" : "checkmark.circle"
+                )
+            }
+            .tint(.green)
+        }
         .modifier(DirectionsSwipeModifier(exp: exp))
+        .accessibilityAction(named: Text(isDone
+            ? NSLocalizedString("favorites.row.markNotVisited", comment: "Swipe action to un-complete a favorite")
+            : NSLocalizedString("favorites.row.markVisited", comment: "Swipe action to mark a favorite as visited")
+        )) {
+            if isDone {
+                Haptics.selection()
+                preferences.completedExperiences.remove(exp.id)
+                preferences.visitHistory.removeValue(forKey: exp.id)
+                UIAccessibility.post(
+                    notification: .announcement,
+                    argument: NSLocalizedString("favorites.row.markNotVisited.announcement", comment: "VoiceOver announcement after marking as not visited")
+                )
+            } else {
+                Haptics.notify(.success)
+                preferences.markCompleted(exp.id)
+                UIAccessibility.post(
+                    notification: .announcement,
+                    argument: String(format: NSLocalizedString("favorites.row.markVisited.announcement", comment: "VoiceOver announcement after marking as visited"), exp.title)
+                )
+            }
+        }
         .accessibilityAction(named: Text(NSLocalizedString("favorites.row.directions", comment: "Directions accessibility action"))) {
             guard let coord = exp.coordinate,
                   let app = NavigationLauncher.availableApps().first else { return }


### PR DESCRIPTION
## Add a swipe-to-complete (mark visited) leading action to favorite rows

Favorite rows already support swipe-to-remove (trailing) and swipe-for-directions (leading), but there is no fast way to mark a favorite as completed — users must open the detail view. Adding a leading swipe action that toggles completion gives one-gesture progress on the journey ring and 'remaining only' filter, reinforcing the journey-completion loop the header already celebrates.

### Acceptance
Swiping a favorite row left-to-right reveals a green 'Mark visited' action; tapping it adds the completion checkmark badge, advances the journey progress bar and completion ring (with success haptic), and updates the 'remaining only' filter. Swiping a completed row offers 'Mark not visited' which reverses it. VoiceOver exposes the same action and announces the change. xcodebuild build and existing SoloCompassTests pass; new strings present in Localizable.strings.