### PR TITLE
auto: Fix proximity-color inconsistency in CityPicker nearest-city nudge

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
@@ -260,6 +260,7 @@ private struct CityPickerHeader: View {
 
     @ViewBuilder
     private var nudgeCapsule: some View {
+        // Capsule color derives from proximity so dot, text, chevron, and tint read as one honest signal.
         HStack(spacing: 4) {
             Circle()
                 .fill(proximityColor)
@@ -267,15 +268,15 @@ private struct CityPickerHeader: View {
                 .accessibilityHidden(true)
             Text(nudgeLabel)
                 .font(.caption2)
-                .foregroundStyle(Color.green)
+                .foregroundStyle(proximityColor)
             Image(systemName: "chevron.right.circle.fill")
                 .font(.caption2)
-                .foregroundStyle(Color.green)
+                .foregroundStyle(proximityColor)
                 .accessibilityHidden(true)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
-        .background(Color.green.opacity(0.12), in: Capsule())
+        .background(proximityColor.opacity(0.12), in: Capsule())
         .transition(reduceMotion ? .opacity : .scale(scale: 0.9).combined(with: .opacity))
     }
 


### PR DESCRIPTION
## Fix proximity-color inconsistency in CityPicker nearest-city nudge

The 'Nearest city' nudge capsule in CityPickerSheet draws its proximity dot with the real proximity color (green/orange/gray) but hardcodes the text and chevron to green — so a far-away nearest city shows a green label beside an orange or gray dot, contradicting the proximity signal. This change threads the proximity color through the whole capsule (text, chevron, and tint) so the nudge reads as a single honest color, matching the proximity-color pattern already established in FavoritesListView's closest-favorite nudge.

### Acceptance
Build succeeds (`xcodebuild build -project SoloCompass.xcodeproj -scheme SoloCompass`). In the CityPickerSheet, a nearest city that is far away (gray) or mid-distance (orange) renders the dot, text, chevron, and capsule tint in that same proximity color — no more green text beside a non-green dot. A near city still renders fully green. Reduce Motion and VoiceOver behavior are unchanged; accessibility label/hint untouched. All existing previews render without errors.