### PR TITLE
auto: Rotating motivational tips in the Favorites empty state

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -435,6 +435,10 @@
 "favorites.empty.title" = "No favorites yet";
 "favorites.empty.hint" = "Tap the heart on any experience to save it here.";
 "favorites.empty.cta" = "Explore the map";
+"favorites.empty.tip1" = "Tap the heart on any experience to save it here.";
+"favorites.empty.tip2" = "Saved spots show a green dot when they're walkable right now.";
+"favorites.empty.tip3" = "Favorites sort by what's good to do at this hour.";
+"favorites.empty.tip4" = "Swipe left on a saved spot to remove it — tap Undo to bring it back.";
 "favorites.undo" = "Removed — Undo";
 "favorites.undo.named" = "Removed \"%@\"";
 /* Plural forms handled by Localizable.stringsdict */

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -842,6 +842,17 @@ private struct EmptyFavoritesView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isBreathing = false
+    @State private var tipIndex = 0
+    @State private var rotateTask: Task<Void, Never>?
+
+    private var tips: [String] {
+        [
+            NSLocalizedString("favorites.empty.tip1", comment: "Empty favorites tip 1"),
+            NSLocalizedString("favorites.empty.tip2", comment: "Empty favorites tip 2"),
+            NSLocalizedString("favorites.empty.tip3", comment: "Empty favorites tip 3"),
+            NSLocalizedString("favorites.empty.tip4", comment: "Empty favorites tip 4"),
+        ]
+    }
 
     var body: some View {
         VStack(spacing: 12) {
@@ -858,10 +869,14 @@ private struct EmptyFavoritesView: View {
             }
             Text(NSLocalizedString("favorites.empty.title", comment: "No favorites yet"))
                 .font(.headline)
-            Text(NSLocalizedString("favorites.empty.hint", comment: "Tap the heart on any experience"))
+            Text(tips[tipIndex])
+                .id(tipIndex)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
+                .frame(minHeight: 36)
+                .transition(.opacity)
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.4), value: tipIndex)
             if let onExplore {
                 Button {
                     Haptics.selection()
@@ -875,9 +890,22 @@ private struct EmptyFavoritesView: View {
             }
         }
         .padding(32)
+        .accessibilityElement(children: .combine)
         .onAppear {
             guard !isBreathing, !reduceMotion else { return }
             isBreathing = true
+            rotateTask = Task {
+                while !Task.isCancelled {
+                    try? await Task.sleep(for: .seconds(4))
+                    guard !Task.isCancelled else { return }
+                    await MainActor.run {
+                        withAnimation { tipIndex = (tipIndex + 1) % tips.count }
+                    }
+                }
+            }
+        }
+        .onDisappear {
+            rotateTask?.cancel()
         }
     }
 }


### PR DESCRIPTION
## Rotating motivational tips in the Favorites empty state

The Favorites empty state (EmptyFavoritesView) currently shows a single static breathing-heart icon plus one fixed hint line, which feels dead and gives the user no reason to return. Add a gently cross-fading carousel of 3–4 localized tips (e.g. 'Tap the heart on any experience to save it for later', 'Saved spots show a green dot when they're walkable right now', 'Favorites sort by what's good to do at this hour') that auto-rotates every few seconds, respecting Reduce Motion by showing a single static tip. This turns an empty screen into a lightweight onboarding moment that teaches the app's core favorites mechanics.

### Acceptance
Open Favorites with zero saved experiences: the hint line cross-fades between 3–4 distinct tips roughly every 4 seconds while the heart keeps breathing. With Reduce Motion enabled (Simulator → Accessibility → Motion), a single static tip shows and no rotation occurs. VoiceOver reads the combined title and current tip as one element. Adding a favorite dismisses the empty state and cancels the rotation task (no leaked Task). xcodebuild build and the existing SoloCompassTests pass; #Preview for the empty state renders. No new force-unwraps; all strings via NSLocalizedString.