### PR TITLE
feat(ios): 此刻適合 routes section header + 此刻理由 banner

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -43,12 +43,14 @@
 		259F1E0030F914782D632794 /* CompiledPlaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AF27F0567AACEA9E6D916E /* CompiledPlaceTests.swift */; };
 		26BDD8E9011EE16C9FB5931C /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F336099C48E0B04CD7612E4C /* Haptics.swift */; };
 		2734D573E867497B18878D84 /* CompanionProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69068DE8A2F71601627AE3E8 /* CompanionProfileView.swift */; };
+		28B8736A9740C11F9E343040 /* RouteIsBestNowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79DAF94BA8A4DD5FF569EF3 /* RouteIsBestNowTests.swift */; };
 		28E3EB1BFFB0A73A1C56FD54 /* MarkerIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E0157D30FF53B21FF31D519 /* MarkerIconView.swift */; };
 		297541149234668D12EAF272 /* FilterBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9A1F22AAE512199548C269 /* FilterBarView.swift */; };
 		2A4A75FDB09E99452C161048 /* seed_users.json in Resources */ = {isa = PBXBuildFile; fileRef = 8C8D88BCFAC97E436BE97274 /* seed_users.json */; };
 		2ADAF284E5182CF955D9641E /* LocationPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323B1BAB8D4A2BE116D8A789 /* LocationPickerSheet.swift */; };
 		2C5A15DE0FCF30A3BCF1EB20 /* RouteItineraryBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8670B08F2AB2779C31E0870 /* RouteItineraryBridgeTests.swift */; };
 		2D379EAE0BCD339DB670EB5C /* CompanionPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431DC31A80132F719AFEE471 /* CompanionPost.swift */; };
+		2EC741296992D9D0A4F3077D /* RouteCardNowReasonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D31F422914779D9228B0278 /* RouteCardNowReasonTests.swift */; };
 		2F532734CA53A554106DC739 /* SeedRoutesParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A644911E7B2824A7ABBA4D6F /* SeedRoutesParityTests.swift */; };
 		2FFDD120FE87D1EE121EAB40 /* SkeletonBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659B2C7C4B36A086968A28EF /* SkeletonBadgeView.swift */; };
 		30293CB7BCCE6B600A82C292 /* EmptyStateAnnouncementTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763DF01F638C99097DD5FE20 /* EmptyStateAnnouncementTest.swift */; };
@@ -405,6 +407,7 @@
 		67DAE302128E657E150C4B0D /* FoursquareService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoursquareService.swift; sourceTree = "<group>"; };
 		69068DE8A2F71601627AE3E8 /* CompanionProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionProfileView.swift; sourceTree = "<group>"; };
 		6C5CA5533D846B39EF16CDFA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		6D31F422914779D9228B0278 /* RouteCardNowReasonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCardNowReasonTests.swift; sourceTree = "<group>"; };
 		6DFBC1C003B8745713588A23 /* City.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = City.swift; sourceTree = "<group>"; };
 		7022B4362225428DCEB74D59 /* SettingsAdminUnlockTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAdminUnlockTest.swift; sourceTree = "<group>"; };
 		70AF2705AB2F24B69DE8CB4F /* PerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
@@ -529,6 +532,7 @@
 		E575898B14533C58035EFC79 /* ConversationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStore.swift; sourceTree = "<group>"; };
 		E5DB59261DB471FD587F4134 /* AgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTests.swift; sourceTree = "<group>"; };
 		E71DE291BE5569E719413B74 /* SoloCompassApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassApp.swift; sourceTree = "<group>"; };
+		E79DAF94BA8A4DD5FF569EF3 /* RouteIsBestNowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteIsBestNowTests.swift; sourceTree = "<group>"; };
 		E7E69F3EF6F0100CFA47DAFE /* AISynthesisCacheRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISynthesisCacheRecord.swift; sourceTree = "<group>"; };
 		E893D776B3D5A647320EDDB0 /* LocationSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchService.swift; sourceTree = "<group>"; };
 		E9A3AF5B9538F583142315C2 /* VoiceToastA11yTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceToastA11yTests.swift; sourceTree = "<group>"; };
@@ -718,12 +722,14 @@
 				A267CD0DA0A8053B0AB072BC /* PrivacyAcknowledgementSheetSnapshotTest.swift */,
 				EBCD0D2CE7423C29CD668866 /* PublicAPIDocCommentTests.swift */,
 				7A6F9AAA8749FA23B91F7C93 /* ReviewsServiceTests.swift */,
+				6D31F422914779D9228B0278 /* RouteCardNowReasonTests.swift */,
 				4EAB2E028C69B7C63DCAF860 /* RouteCardRecruitMiniTest.swift */,
 				EAFD5561863516F6E60AEDE3 /* RouteCardStopStripTest.swift */,
 				1A9FE3BB447D84732CCE0B07 /* RouteCardWalkedByTest.swift */,
 				5BF2CEF9FE62124F51460453 /* RouteCompanionForceUnwrapTests.swift */,
 				10F48D7FA14E29D606FD11EA /* RouteCompanionStateMachineTests.swift */,
 				7BA9EA4E29955D78499E3AAC /* RouteCompanionTests.swift */,
+				E79DAF94BA8A4DD5FF569EF3 /* RouteIsBestNowTests.swift */,
 				A8670B08F2AB2779C31E0870 /* RouteItineraryBridgeTests.swift */,
 				B6BAB6EA03E81F52D00CCD59 /* RouteRecordTests.swift */,
 				3AF871B84DDAAD8453B8258D /* RouteStoreTests.swift */,
@@ -1264,12 +1270,14 @@
 				A5D3EF6A05AD9B93FA5ACD8A /* PrivacyAcknowledgementSheetSnapshotTest.swift in Sources */,
 				79E4FD6C7F9522BDB1106F56 /* PublicAPIDocCommentTests.swift in Sources */,
 				49C48BE7027B3D172A0BD9B1 /* ReviewsServiceTests.swift in Sources */,
+				2EC741296992D9D0A4F3077D /* RouteCardNowReasonTests.swift in Sources */,
 				3253E70A5F98389A985CA7B9 /* RouteCardRecruitMiniTest.swift in Sources */,
 				4A32BD98962770BAAB48B504 /* RouteCardStopStripTest.swift in Sources */,
 				9B906CA9BF24104FB2BF7773 /* RouteCardWalkedByTest.swift in Sources */,
 				A12DF78B6B05519D2177A519 /* RouteCompanionForceUnwrapTests.swift in Sources */,
 				8BF4070A63A8B52C58F0E93E /* RouteCompanionStateMachineTests.swift in Sources */,
 				85B238721EB01B78DDC078F0 /* RouteCompanionTests.swift in Sources */,
+				28B8736A9740C11F9E343040 /* RouteIsBestNowTests.swift in Sources */,
 				2C5A15DE0FCF30A3BCF1EB20 /* RouteItineraryBridgeTests.swift in Sources */,
 				58EC3C9838462DCD66F11975 /* RouteRecordTests.swift in Sources */,
 				71B9FD2F300F42A5197FFA15 /* RouteStoreTests.swift in Sources */,

--- a/apps/ios/SoloCompass/Models/Route.swift
+++ b/apps/ios/SoloCompass/Models/Route.swift
@@ -6,6 +6,8 @@
 /// arrive in later stories. Mirrors the route shape planned for
 /// `packages/core/src/route.ts` — keep field names in sync when that lands.
 
+import Foundation
+
 // MARK: - RouteId
 
 /// Strongly-typed identifier for a Route, preventing raw-string ID mix-ups.
@@ -225,6 +227,9 @@ public struct Route: Identifiable, Codable, Sendable {
     public var bestStartHour: Double?
     /// Whether the route is currently inside its preferred window.
     public var bestNow: Bool
+    /// Short human reason explaining why this route is surfaced right now,
+    /// shown as the "此刻理由" banner in now-context (e.g. "日落將至 · 30 分鐘後是最佳光線").
+    public var reasonNow: String?
     public var verification: RouteVerification
     public var companion: RouteCompanion?
 
@@ -243,6 +248,7 @@ public struct Route: Identifiable, Codable, Sendable {
         authorId: String? = nil,
         bestStartHour: Double? = nil,
         bestNow: Bool = false,
+        reasonNow: String? = nil,
         verification: RouteVerification = RouteVerification(),
         companion: RouteCompanion? = nil
     ) {
@@ -260,7 +266,31 @@ public struct Route: Identifiable, Codable, Sendable {
         self.authorId = authorId
         self.bestStartHour = bestStartHour
         self.bestNow = bestNow
+        self.reasonNow = reasonNow
         self.verification = verification
         self.companion = companion
+    }
+
+    // MARK: - Runtime now-window check
+
+    /// How many hours after `bestStartHour` the route still counts as "best now".
+    /// Sunset/golden-hour style windows read as ~3h; tune here if needed.
+    private static let nowWindowHours: Double = 3
+
+    /// Runtime "best right now" check derived from `bestStartHour`, mirroring the
+    /// intent of `Experience.isBestNow(at:)`. When a `bestStartHour` is set, the
+    /// route is best-now while the current hour falls inside
+    /// `[bestStartHour, bestStartHour + nowWindowHours)` (wrapping past midnight).
+    /// Falls back to the static `bestNow` field when no `bestStartHour` is present
+    /// — so seed data that only carries the boolean still behaves as before.
+    public func isBestNow(at date: Date = Date()) -> Bool {
+        guard let start = bestStartHour else { return bestNow }
+        let hour = Double(Calendar.current.component(.hour, from: date))
+        let end = start + Self.nowWindowHours
+        if end <= 24 {
+            return hour >= start && hour < end
+        }
+        // Window wraps past midnight (e.g. start 22 → end 25 ⇒ 22..24 or 0..1).
+        return hour >= start || hour < (end - 24)
     }
 }

--- a/apps/ios/SoloCompass/Persistence/Models/RouteRecord.swift
+++ b/apps/ios/SoloCompass/Persistence/Models/RouteRecord.swift
@@ -27,6 +27,8 @@ public final class RouteRecord {
     public var authorId: String?
     public var bestStartHour: Double?
     public var bestNow: Bool
+    /// Short human reason shown as the "此刻理由" banner in now-context.
+    public var reasonNow: String?
     /// Raw value of `VerificationStatus`.
     public var verificationStatus: String
     public var walkedByCount: Int
@@ -53,6 +55,7 @@ public final class RouteRecord {
         authorId: String?,
         bestStartHour: Double?,
         bestNow: Bool,
+        reasonNow: String?,
         verificationStatus: String,
         walkedByCount: Int,
         experienceIdsBlob: Data,
@@ -72,6 +75,7 @@ public final class RouteRecord {
         self.authorId = authorId
         self.bestStartHour = bestStartHour
         self.bestNow = bestNow
+        self.reasonNow = reasonNow
         self.verificationStatus = verificationStatus
         self.walkedByCount = walkedByCount
         self.experienceIdsBlob = experienceIdsBlob
@@ -115,6 +119,7 @@ extension RouteRecord {
             authorId: route.authorId,
             bestStartHour: route.bestStartHour,
             bestNow: route.bestNow,
+            reasonNow: route.reasonNow,
             verificationStatus: route.verification.status.rawValue,
             walkedByCount: route.verification.walkedByCount,
             experienceIdsBlob: experienceIdsBlob,
@@ -160,6 +165,7 @@ extension RouteRecord {
             authorId: authorId,
             bestStartHour: bestStartHour,
             bestNow: bestNow,
+            reasonNow: reasonNow,
             verification: RouteVerification(
                 status: statusValue,
                 walkedByCount: walkedByCount,

--- a/apps/ios/SoloCompass/Resources/JSON/seed_routes.json
+++ b/apps/ios/SoloCompass/Resources/JSON/seed_routes.json
@@ -14,6 +14,7 @@
     "authorId": "editorial-team",
     "bestStartHour": 17.0,
     "bestNow": false,
+    "reasonNow": "日落將至 · 30 分鐘後是最佳光線",
     "verification": {
       "status": "walkedBy",
       "walkedByCount": 12,
@@ -66,6 +67,7 @@
     "authorId": "editorial-team",
     "bestStartHour": 8.0,
     "bestNow": false,
+    "reasonNow": "上午正好 · 咖啡館人少、光線柔和",
     "verification": {
       "status": "proposed",
       "walkedByCount": 5,
@@ -103,6 +105,7 @@
     "authorId": "editorial-team",
     "bestStartHour": 6.0,
     "bestNow": false,
+    "reasonNow": "清晨時段 · 市場剛開、空氣最清爽",
     "verification": {
       "status": "proposed",
       "walkedByCount": 0,
@@ -129,6 +132,7 @@
     "authorId": "editorial-team",
     "bestStartHour": 8.0,
     "bestNow": false,
+    "reasonNow": "上午涼爽 · 適合慢走看古蹟，避開正午曝曬",
     "verification": {
       "status": "verified",
       "walkedByCount": 28,

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1080,6 +1080,8 @@
 
 /* US-036 — BottomInfoSheet section separation (Routes / Nearby headers) */
 "sheet.section.routes" = "Routes";
+/* Now-context (此刻適合) header for the routes section */
+"sheet.section.routes.now" = "Routes · Best Right Now";
 "sheet.section.nearby" = "Nearby";
 
 /* US-020 — Sort mode sheet */

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1106,6 +1106,8 @@
 
 /* US-036 — BottomInfoSheet section separation (Routes / Nearby headers) */
 "sheet.section.routes" = "路线";
+/* Now-context (此刻适合) header for the routes section */
+"sheet.section.routes.now" = "路线 · 此刻适合";
 "sheet.section.nearby" = "附近";
 
 /* Solo breakdown */

--- a/apps/ios/SoloCompass/Tests/RouteCardNowReasonTests.swift
+++ b/apps/ios/SoloCompass/Tests/RouteCardNowReasonTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+import SwiftUI
+@testable import SoloCompass
+
+/// Coverage for the 此刻理由 (now-reason) banner on `RouteCard`.
+///
+/// The banner only surfaces when the card is in now-context AND the route carries
+/// a non-empty `reasonNow`. We assert the model-level `showsNowReason` invariant
+/// across the four combinations, then render the banner state to confirm it
+/// produces a valid image (no snapshot library is shipped).
+@MainActor
+final class RouteCardNowReasonTests: XCTestCase {
+
+    private func makeRoute(reasonNow: String?) -> Route {
+        Route(
+            id: RouteId(rawValue: "r-now"),
+            title: "Mekong Sunset Walk",
+            summary: "Promenade along the river.",
+            experienceIds: ["e1", "e2", "e3"],
+            cityCode: "VTE",
+            region: "Riverfront",
+            estimatedDuration: 90,
+            distanceMeters: 1200,
+            pace: .relaxed,
+            tags: ["nature"],
+            source: .editorial,
+            bestStartHour: 17.0,
+            bestNow: true,
+            reasonNow: reasonNow,
+            verification: RouteVerification(status: .verified, walkedByCount: 12, walkedBy: [])
+        )
+    }
+
+    private func render(_ card: RouteCard) -> UIImage? {
+        let view = card
+            .frame(width: 390) // iPhone 17 Pro logical width
+            .fixedSize(horizontal: false, vertical: true)
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 2
+        return renderer.uiImage
+    }
+
+    // MARK: - showsNowReason invariant
+
+    func testBannerShownInNowContextWithReason() {
+        let card = RouteCard(route: makeRoute(reasonNow: "日落將至 · 30 分鐘後是最佳光線"), nowContext: true)
+        XCTAssertTrue(card.showsNowReason)
+    }
+
+    func testBannerHiddenWithoutNowContext() {
+        let card = RouteCard(route: makeRoute(reasonNow: "日落將至 · 30 分鐘後是最佳光線"), nowContext: false)
+        XCTAssertFalse(card.showsNowReason)
+    }
+
+    func testBannerHiddenWhenReasonNil() {
+        let card = RouteCard(route: makeRoute(reasonNow: nil), nowContext: true)
+        XCTAssertFalse(card.showsNowReason)
+    }
+
+    func testBannerHiddenWhenReasonEmpty() {
+        let card = RouteCard(route: makeRoute(reasonNow: ""), nowContext: true)
+        XCTAssertFalse(card.showsNowReason)
+    }
+
+    // MARK: - Render
+
+    func testRendersWithBanner() throws {
+        let card = RouteCard(route: makeRoute(reasonNow: "日落將至 · 30 分鐘後是最佳光線"), nowContext: true)
+        let image = try XCTUnwrap(render(card))
+        XCTAssertGreaterThan(image.size.width, 0)
+        XCTAssertGreaterThan(image.size.height, 0)
+    }
+}

--- a/apps/ios/SoloCompass/Tests/RouteIsBestNowTests.swift
+++ b/apps/ios/SoloCompass/Tests/RouteIsBestNowTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import SoloCompass
+
+/// Coverage for `Route.isBestNow(at:)` — the runtime now-window check that powers
+/// the 此刻適合 routes section. Because the static seed `bestNow` flag is all-false
+/// today, the section relies on this method deriving the window from `bestStartHour`.
+final class RouteIsBestNowTests: XCTestCase {
+
+    /// Build a Date at a fixed local hour today (minute 0) for deterministic checks.
+    private func date(hour: Int) -> Date {
+        let cal = Calendar.current
+        var comps = cal.dateComponents([.year, .month, .day], from: Date())
+        comps.hour = hour
+        comps.minute = 0
+        return cal.date(from: comps)!
+    }
+
+    private func makeRoute(bestStartHour: Double?, bestNow: Bool = false) -> Route {
+        Route(
+            id: RouteId(rawValue: "r-now"),
+            title: "Mekong Sunset",
+            summary: "Riverside walk.",
+            experienceIds: ["e1"],
+            cityCode: "VTE",
+            region: "Riverfront",
+            estimatedDuration: 90,
+            distanceMeters: 1200,
+            pace: .relaxed,
+            tags: ["nature"],
+            source: .editorial,
+            bestStartHour: bestStartHour,
+            bestNow: bestNow
+        )
+    }
+
+    // MARK: - bestStartHour drives the window
+
+    func testInsideWindowAtStartHour() {
+        let route = makeRoute(bestStartHour: 17.0)
+        XCTAssertTrue(route.isBestNow(at: date(hour: 17)))
+    }
+
+    func testInsideWindowMidway() {
+        let route = makeRoute(bestStartHour: 17.0)
+        // Window is [17, 20); hour 19 is still inside.
+        XCTAssertTrue(route.isBestNow(at: date(hour: 19)))
+    }
+
+    func testOutsideWindowBeforeStart() {
+        let route = makeRoute(bestStartHour: 17.0)
+        XCTAssertFalse(route.isBestNow(at: date(hour: 16)))
+    }
+
+    func testOutsideWindowAtEndBoundary() {
+        let route = makeRoute(bestStartHour: 17.0)
+        // End boundary is exclusive: 17 + 3 = 20 is no longer best-now.
+        XCTAssertFalse(route.isBestNow(at: date(hour: 20)))
+    }
+
+    func testWindowWrapsPastMidnight() {
+        let route = makeRoute(bestStartHour: 23.0)
+        // [23, 26) ⇒ 23, 0, 1 are inside; 2 is outside.
+        XCTAssertTrue(route.isBestNow(at: date(hour: 23)))
+        XCTAssertTrue(route.isBestNow(at: date(hour: 0)))
+        XCTAssertTrue(route.isBestNow(at: date(hour: 1)))
+        XCTAssertFalse(route.isBestNow(at: date(hour: 2)))
+    }
+
+    // MARK: - Fallback to static bestNow when no bestStartHour
+
+    func testFallsBackToStaticBestNowTrue() {
+        let route = makeRoute(bestStartHour: nil, bestNow: true)
+        XCTAssertTrue(route.isBestNow(at: date(hour: 3)))
+    }
+
+    func testFallsBackToStaticBestNowFalse() {
+        let route = makeRoute(bestStartHour: nil, bestNow: false)
+        XCTAssertFalse(route.isBestNow(at: date(hour: 3)))
+    }
+}

--- a/apps/ios/SoloCompass/Views/Companion/Components/RouteCard.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Components/RouteCard.swift
@@ -13,14 +13,19 @@ public struct RouteCard: View {
     /// companion slot), the card surfaces a social-proof walked-by row instead
     /// of the recruit-mini strip.
     var companionOn: Bool = false
+    /// Whether the card is rendered in the 此刻適合 (now) context. When true and
+    /// the route carries a `reasonNow`, a golden "此刻理由" banner is shown on top
+    /// and the card border shifts to the warm accent tone (`.sc-route-card.is-now`).
+    var nowContext: Bool = false
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var pulse = false
     @State private var pressed = false
 
-    public init(route: Route, companionOn: Bool = false) {
+    public init(route: Route, companionOn: Bool = false, nowContext: Bool = false) {
         self.route = route
         self.companionOn = companionOn
+        self.nowContext = nowContext
     }
 
     private var monoBaseline: String {
@@ -50,8 +55,18 @@ public struct RouteCard: View {
         route.verification.status == .verified
     }
 
+    /// Whether the golden "此刻理由" banner should surface: only in now-context
+    /// and when the route carries a non-empty `reasonNow`.
+    var showsNowReason: Bool {
+        nowContext && !(route.reasonNow ?? "").isEmpty
+    }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: 0) {
+            if showsNowReason, let reason = route.reasonNow {
+                nowReasonBanner(reason)
+            }
+
             headRow
 
             Text(route.title)
@@ -80,7 +95,8 @@ public struct RouteCard: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .strokeBorder(CT.borderSubtle, lineWidth: 0.5)
+                // `.sc-route-card.is-now` warms the border to the accent tone.
+                .strokeBorder(nowContext ? CT.accentBorder : CT.borderSubtle, lineWidth: 0.5)
         )
         .shadow(color: .black.opacity(0.04), radius: 1, x: 0, y: 1)
         .scaleEffect(reduceMotion ? 1 : (pressed ? 0.985 : 1))
@@ -105,6 +121,32 @@ public struct RouteCard: View {
             guard !reduceMotion else { return }
             pulse = true
         }
+    }
+
+    // MARK: - Now-reason banner (此刻理由)
+
+    /// Golden banner explaining *why* the route is surfaced right now, e.g.
+    /// "日落將至 · 30 分鐘後是最佳光線". Mirrors styles.css `.sc-route-card .now-reason`:
+    /// sun-gold-soft fill, sun-gold-deep text, 9pt radius, 11pt bottom gap.
+    private func nowReasonBanner(_ reason: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 11, weight: .semibold))
+            Text(reason)
+                .font(CT.body(11.5, .semibold))
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .foregroundStyle(CT.sunGoldDeep)
+        .padding(.horizontal, 11)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 9, style: .continuous).fill(CT.sunGoldSoft)
+        )
+        .padding(.bottom, 11)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(reason))
     }
 
     // MARK: - Head row (category dot + tag + verified-mini / now-pill)
@@ -396,6 +438,29 @@ public struct RouteCard: View {
         verification: RouteVerification(status: .verified, walkedByCount: 12, walkedBy: [])
     )
     RouteCard(route: route)
+        .padding()
+        .background(CT.bgWarm)
+}
+
+#Preview("RouteCard — now-context (此刻理由)") {
+    let route = Route(
+        id: RouteId(rawValue: "r-now"),
+        title: "Mekong Sunset Walk",
+        summary: "Promenade along the river.",
+        experienceIds: ["e1", "e2", "e3"],
+        cityCode: "VTE",
+        region: "Riverfront",
+        estimatedDuration: 90,
+        distanceMeters: 1200,
+        pace: .relaxed,
+        tags: ["nature"],
+        source: .editorial,
+        bestStartHour: 17.0,
+        bestNow: true,
+        reasonNow: "日落將至 · 30 分鐘後是最佳光線",
+        verification: RouteVerification(status: .verified, walkedByCount: 12, walkedBy: [])
+    )
+    return RouteCard(route: route, nowContext: true)
         .padding()
         .background(CT.bgWarm)
 }

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -776,7 +776,10 @@ struct RoutesSection: View {
     let onSelectRoute: (Route) -> Void
 
     private var displayed: [Route] {
-        isNowFilter ? routes.filter(\.bestNow) : routes
+        // Now-context uses the runtime check (derived from bestStartHour) so the
+        // 此刻適合 section surfaces routes inside their window — the static
+        // `bestNow` seed flag is all-false today, which would empty the section.
+        isNowFilter ? routes.filter { $0.isBestNow() } : routes
     }
 
     var body: some View {
@@ -789,10 +792,18 @@ struct RoutesSection: View {
                     // RouteCard now carries its own card chrome (.sc-route-card:
                     // white fill, border, shadow), so rows are separated by 10pt
                     // spacing rather than full-bleed dividers.
-                    SheetSectionSeparator(titleKey: "sheet.section.routes", showsDivider: false)
+                    //
+                    // In now-context the section gets a dedicated golden header
+                    // (sparkles + 「路線 · 此刻適合」+ AI · NOW), mirroring the
+                    // 此刻精選 AI region — see styles.css `.sc-section-label .lhs.now`.
+                    if isNowFilter {
+                        RouteNowSectionHeader()
+                    } else {
+                        SheetSectionSeparator(titleKey: "sheet.section.routes", showsDivider: false)
+                    }
                     ForEach(items) { route in
                         Button { onSelectRoute(route) } label: {
-                            RouteCard(route: route)
+                            RouteCard(route: route, nowContext: isNowFilter)
                         }
                         .buttonStyle(.plain)
                     }
@@ -801,6 +812,40 @@ struct RoutesSection: View {
                 .padding(.top, 8)
             }
         }
+    }
+}
+
+// MARK: - RouteNowSectionHeader
+
+/// Dedicated golden header for the 路线 section in now-context.
+///
+/// Mirrors styles.css `.sc-section-label` with the `.lhs.now` treatment and the
+/// 此刻精選 AI region: left → sparkles + 「路線 · 此刻適合」(uppercase display,
+/// sun-gold-deep), right → mono `AI · NOW` badge in fg-subtle.
+struct RouteNowSectionHeader: View {
+    var body: some View {
+        HStack(alignment: .center) {
+            HStack(spacing: 7) {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(CT.sunGoldDeep)
+                Text(NSLocalizedString("sheet.section.routes.now", comment: "路線 · 此刻適合 section header"))
+                    .font(CT.display(11, .bold))
+                    .tracking(1.3)
+                    .textCase(.uppercase)
+                    .foregroundStyle(CT.sunGoldDeep)
+            }
+            Spacer(minLength: 8)
+            Text(verbatim: "AI · NOW")
+                .font(CT.mono(11, .regular))
+                .tracking(0.4)
+                .foregroundStyle(CT.fgSubtle)
+        }
+        .padding(.horizontal, 4)
+        .padding(.top, 6)
+        .padding(.bottom, 2)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isHeader)
     }
 }
 

--- a/packages/core/src/route.ts
+++ b/packages/core/src/route.ts
@@ -41,6 +41,11 @@ export interface Route {
   readonly bestStartHour?: number;
   /** Whether the route is currently inside its preferred window. */
   readonly bestNow: boolean;
+  /**
+   * Short human reason explaining why this route is surfaced right now,
+   * shown as the "此刻理由" banner in now-context (e.g. "日落將至 · 30 分鐘後是最佳光線").
+   */
+  readonly reasonNow?: string;
   readonly verification: RouteVerification;
   readonly companion?: RouteCompanion;
 }


### PR DESCRIPTION
## What

Implements the **「路線 · 此刻適合」** iteration from the Claude Design handoff (`SoloCompass.html`) to lift information density on the map home screen's routes section.

## Changes
- **`Route.reasonNow`** — new optional field (TS `route.ts` + Swift `Route.swift` + `RouteRecord` round-trip mapping), kept in **TS↔Swift schema parity** (`pnpm parity:check` green).
- **`Route.isBestNow(at:)`** — runtime now-window check derived from `bestStartHour` (mirrors `Experience.isBestNow`). The static `bestNow` seed flag is all-false today, so without this the 此刻適合 section would be empty. `RoutesSection` now filters on it in now-context.
- **`RouteNowSectionHeader`** — dedicated golden header (sparkles + 「路線 · 此刻適合」+ `AI · NOW`), shown only in now-context, mirroring the 此刻精選 AI region.
- **`RouteCard`** — golden 此刻理由 banner (`sunGoldSoft`/`sunGoldDeep`) + warm accent border in now-context, surfacing *why* a route is best right now (e.g. 「日落將至 · 30 分鐘後是最佳光線」).
- **seed** — `reasonNow` copy for all four Vientiane routes.
- **l10n** — `sheet.section.routes.now` (en + zh-Hans).

## Tests
- `RouteIsBestNowTests` (7) — window / midnight-wrap / static fallback.
- `RouteCardNowReasonTests` (5) — banner show/hide invariants + real SwiftUI render.
- Regression green: `RouteRecordTests` (round-trip incl. reasonNow), `SeedRoutesParityTests`, `BottomSheetSectionSeparationTest`, `RouteTests`.

## Verification
- ✅ `pnpm parity:check`
- ✅ `xcodebuild build` (BUILD SUCCEEDED)
- ✅ 18 relevant tests pass (incl. new suites + round-trip)
- ⚠️ Scripted simulator gestures unavailable on this host (no idb/cliclick), so the now-context UI was verified through the real SwiftUI `ImageRenderer` test (`testRendersWithBanner`) + show/hide invariants rather than an on-device screenshot.

## Out of scope (design's later iterations)
- Drawing route polylines on the map.
- Companion 攻略 / onboarding page.
- RouteComposer create-and-publish flow.