### PR TITLE
feat(ios): 路线/列表卡片化 + 创建路线入口 + AI 生成路线

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		3CBA775B8C215CBAE3A73EA0 /* CardBottomInsetClearanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0674DC5D526883C657A63C38 /* CardBottomInsetClearanceTest.swift */; };
 		3D393CD7ACFD865D7297FA5D /* AIProviderSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7295DF9392F0361C0B2E313D /* AIProviderSettingsView.swift */; };
 		3E24606FB907D7BB18E3C496 /* Itinerary.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F5D58C93D87AC9205148CC /* Itinerary.swift */; };
+		3E92704051F386C38C3A5533 /* RouteBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C8EE9D6C64872261609DEF /* RouteBuilderTests.swift */; };
 		3EF7E97963960C09B7A5575D /* StringsParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14FE2118ED82DD0593F5C3C /* StringsParityTests.swift */; };
 		42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */; };
 		436C2BF0D0723B2B07428F07 /* CompanionBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBBF77E10D341C38C093D22D /* CompanionBlock.swift */; };
@@ -115,6 +116,7 @@
 		63DCAC4B5E83B26B9B175344 /* AIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4515228D70D8804596299D /* AIProvider.swift */; };
 		641D80BD116D6F255A9ED26A /* PendingSyncRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A92E0AE1868C3A165F3E95 /* PendingSyncRecord.swift */; };
 		65E57E8B02E7889BD8EE8DD4 /* ContextManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1F5F43F42E03BA5F10FA2F /* ContextManager.swift */; };
+		680774109C2AD675E26ADA18 /* CreateRouteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0782F4AA0496B97DDAAA380 /* CreateRouteView.swift */; };
 		690ED25AA3EDA8529E915850 /* MyWalkedRoutesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F48906724062C4636DE947 /* MyWalkedRoutesListView.swift */; };
 		6AA87132BC6ACDDDC6D98735 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF007DB5F72E30021CADA555 /* NetworkMonitor.swift */; };
 		6BC4542A9B952BA2AFA9332C /* FilterNowMapSyncTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C75D64D462A03DBEFFC4EB /* FilterNowMapSyncTest.swift */; };
@@ -154,6 +156,7 @@
 		8E347182E133BD35C712AADB /* FilterChipContrastTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E8F519A353F18BDE4C3307 /* FilterChipContrastTest.swift */; };
 		8F8ED2236A149DAE2B3923CF /* ShareCardComponentsL10nTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7324256A8D7E93FBA67F91 /* ShareCardComponentsL10nTest.swift */; };
 		90C2EC1E98DDE7C3D3A5B4E9 /* GroupConversationAutoCreateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48ADAE2497800574C4E8819B /* GroupConversationAutoCreateTests.swift */; };
+		95389B7D23017957CB6C69E0 /* RouteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66273C940FD90B51EBCD97BC /* RouteBuilder.swift */; };
 		953C7BD48AF4AF55608145A6 /* LanguageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87002BB6D344B384A3FDFBFD /* LanguageService.swift */; };
 		963BC062494BCC3B655AFDC0 /* RouteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3FB0F0B974CA1C89BA5201 /* RouteStore.swift */; };
 		96A79D8DD36F5B67B3146998 /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F32B7DE32405561C4159843 /* ChatMessage.swift */; };
@@ -302,6 +305,7 @@
 		0674DC5D526883C657A63C38 /* CardBottomInsetClearanceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBottomInsetClearanceTest.swift; sourceTree = "<group>"; };
 		06B7D586552E9F1EA44F5657 /* MapKitPOIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapKitPOIService.swift; sourceTree = "<group>"; };
 		0709110B381DEDA32C3292AE /* ChatUIState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatUIState.swift; sourceTree = "<group>"; };
+		07C8EE9D6C64872261609DEF /* RouteBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteBuilderTests.swift; sourceTree = "<group>"; };
 		086B3C207483BA0EBD27451F /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
 		099B762F3026466B64C18015 /* JoinRouteRequestSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinRouteRequestSheet.swift; sourceTree = "<group>"; };
 		0A0997D8150E77F70A4B8C64 /* ExploreProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreProgressBar.swift; sourceTree = "<group>"; };
@@ -405,6 +409,7 @@
 		6556C23BF1B228BF686C5500 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
 		658C2890F90C08A686F501BA /* MarkerStatePerformanceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerStatePerformanceTest.swift; sourceTree = "<group>"; };
 		659B2C7C4B36A086968A28EF /* SkeletonBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonBadgeView.swift; sourceTree = "<group>"; };
+		66273C940FD90B51EBCD97BC /* RouteBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteBuilder.swift; sourceTree = "<group>"; };
 		67173C74F1A76C3CE5C38C0A /* OverpassService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverpassService.swift; sourceTree = "<group>"; };
 		67DAE302128E657E150C4B0D /* FoursquareService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoursquareService.swift; sourceTree = "<group>"; };
 		69068DE8A2F71601627AE3E8 /* CompanionProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionProfileView.swift; sourceTree = "<group>"; };
@@ -547,6 +552,7 @@
 		ED3CB5045CE59A613B5CAAF5 /* SoloCompassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassTests.swift; sourceTree = "<group>"; };
 		EDE5D2141CB2B68B7F1C560E /* SentryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryService.swift; sourceTree = "<group>"; };
 		EF3FB0F0B974CA1C89BA5201 /* RouteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteStore.swift; sourceTree = "<group>"; };
+		F0782F4AA0496B97DDAAA380 /* CreateRouteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRouteView.swift; sourceTree = "<group>"; };
 		F1D68F42114231582501CB90 /* NowCountCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowCountCacheTests.swift; sourceTree = "<group>"; };
 		F336099C48E0B04CD7612E4C /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		F4814DBCEAB5975B6338558D /* AIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIService.swift; sourceTree = "<group>"; };
@@ -631,6 +637,7 @@
 				69068DE8A2F71601627AE3E8 /* CompanionProfileView.swift */,
 				CF90C42465B4E989A6DB9D05 /* CompanionSafetyConsentSheet.swift */,
 				387808A923EC7A99AD5390FD /* CompletionMoment.swift */,
+				F0782F4AA0496B97DDAAA380 /* CreateRouteView.swift */,
 				FADDD17473F138874328A33E /* DiscoverListView.swift */,
 				013CB7ADB0525E4F4E8EE959 /* DiscoverRecruitingRoutesView.swift */,
 				E0AA21CD490B436012818D9D /* ItineraryDetailView.swift */,
@@ -725,6 +732,7 @@
 				A267CD0DA0A8053B0AB072BC /* PrivacyAcknowledgementSheetSnapshotTest.swift */,
 				EBCD0D2CE7423C29CD668866 /* PublicAPIDocCommentTests.swift */,
 				7A6F9AAA8749FA23B91F7C93 /* ReviewsServiceTests.swift */,
+				07C8EE9D6C64872261609DEF /* RouteBuilderTests.swift */,
 				6D31F422914779D9228B0278 /* RouteCardNowReasonTests.swift */,
 				4EAB2E028C69B7C63DCAF860 /* RouteCardRecruitMiniTest.swift */,
 				EAFD5561863516F6E60AEDE3 /* RouteCardStopStripTest.swift */,
@@ -854,6 +862,7 @@
 				B3F5D58C93D87AC9205148CC /* Itinerary.swift */,
 				052B6F076F405C203184CB88 /* LocationPickerState.swift */,
 				038BEE46BF2DFAF762B605D5 /* Route.swift */,
+				66273C940FD90B51EBCD97BC /* RouteBuilder.swift */,
 				884AFD2A4ADF051FA9643166 /* RouteItineraryBridge.swift */,
 				0FCE40A39EEEDA3A22E17689 /* SavedCity.swift */,
 				23157DCAE693C4DE3CC5F7A6 /* SeedUser.swift */,
@@ -1274,6 +1283,7 @@
 				A5D3EF6A05AD9B93FA5ACD8A /* PrivacyAcknowledgementSheetSnapshotTest.swift in Sources */,
 				79E4FD6C7F9522BDB1106F56 /* PublicAPIDocCommentTests.swift in Sources */,
 				49C48BE7027B3D172A0BD9B1 /* ReviewsServiceTests.swift in Sources */,
+				3E92704051F386C38C3A5533 /* RouteBuilderTests.swift in Sources */,
 				2EC741296992D9D0A4F3077D /* RouteCardNowReasonTests.swift in Sources */,
 				3253E70A5F98389A985CA7B9 /* RouteCardRecruitMiniTest.swift in Sources */,
 				4A32BD98962770BAAB48B504 /* RouteCardStopStripTest.swift in Sources */,
@@ -1359,6 +1369,7 @@
 				C09361B1A5560755F3C5DD67 /* Conversation.swift in Sources */,
 				B9EDA827F7E00B19DF97512C /* ConversationRecord.swift in Sources */,
 				4C16F9056859D3AFA88B3355 /* ConversationStore.swift in Sources */,
+				680774109C2AD675E26ADA18 /* CreateRouteView.swift in Sources */,
 				48C924FB49F596D91D67A3B2 /* CustomCityStore.swift in Sources */,
 				42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */,
 				83328E4B13133FBCDA9E0A5D /* DiscoverListView.swift in Sources */,
@@ -1440,6 +1451,7 @@
 				62BB74EC16B92899A9A6A44C /* ReverseGeocodeService.swift in Sources */,
 				ADD51496532A0B763048AF5B /* ReviewsService.swift in Sources */,
 				7A5F7752DE91A7FEE6571C7A /* Route.swift in Sources */,
+				95389B7D23017957CB6C69E0 /* RouteBuilder.swift in Sources */,
 				A5F3AA050EDA3E3133A1612F /* RouteCard.swift in Sources */,
 				718A05DB2A42CB24354B8950 /* RouteCompanionRemote.swift in Sources */,
 				F189082793B447112F0BA5AB /* RouteCompanionStateMachine.swift in Sources */,

--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */; };
 		436C2BF0D0723B2B07428F07 /* CompanionBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBBF77E10D341C38C093D22D /* CompanionBlock.swift */; };
 		45A4E8EED0300F00253EC049 /* MarkdownExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F3FDE4BC9458E490AEA67A /* MarkdownExporter.swift */; };
+		4617863D79206886BE4A5586 /* FavoritesClosingSoonThresholdTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C94CC0395CC7FCC0A56D077 /* FavoritesClosingSoonThresholdTest.swift */; };
 		464746A44182622D4F617462 /* AIUsageRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */; };
 		47939336E63740302A83D121 /* AISynthesisQualityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CF57D3342E9C609CD56801 /* AISynthesisQualityTests.swift */; };
 		48C924FB49F596D91D67A3B2 /* CustomCityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2B85A119750C65697903E0 /* CustomCityStore.swift */; };
@@ -387,6 +388,7 @@
 		5BDE3513D89C9CD5FE893606 /* RouteCompanionStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCompanionStateMachine.swift; sourceTree = "<group>"; };
 		5BF2CEF9FE62124F51460453 /* RouteCompanionForceUnwrapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCompanionForceUnwrapTests.swift; sourceTree = "<group>"; };
 		5C62D0EFA5859698D9C70B7D /* OfflineBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBanner.swift; sourceTree = "<group>"; };
+		5C94CC0395CC7FCC0A56D077 /* FavoritesClosingSoonThresholdTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesClosingSoonThresholdTest.swift; sourceTree = "<group>"; };
 		5CA0BAEC05B72704552C0906 /* PendingCheckInRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingCheckInRecord.swift; sourceTree = "<group>"; };
 		5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailViewModel.swift; sourceTree = "<group>"; };
 		5D7324256A8D7E93FBA67F91 /* ShareCardComponentsL10nTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareCardComponentsL10nTest.swift; sourceTree = "<group>"; };
@@ -690,6 +692,7 @@
 				2CEFD2E522C2D9FFF8EF0B0B /* ConversationTests.swift */,
 				763DF01F638C99097DD5FE20 /* EmptyStateAnnouncementTest.swift */,
 				F8547EB44AE47A5D653D3994 /* FavoritesBounceAvailabilityTest.swift */,
+				5C94CC0395CC7FCC0A56D077 /* FavoritesClosingSoonThresholdTest.swift */,
 				FFED848E66BBE2A234AAA3CC /* FilterBarScrollAffordanceTest.swift */,
 				E1694A46513909CFE464D92E /* FilterBarViewTests.swift */,
 				35E8F519A353F18BDE4C3307 /* FilterChipContrastTest.swift */,
@@ -1238,6 +1241,7 @@
 				AA5C5AEBFB7B2266A4781877 /* ConversationTests.swift in Sources */,
 				30293CB7BCCE6B600A82C292 /* EmptyStateAnnouncementTest.swift in Sources */,
 				F721E7FE777AF2AFA0FA264D /* FavoritesBounceAvailabilityTest.swift in Sources */,
+				4617863D79206886BE4A5586 /* FavoritesClosingSoonThresholdTest.swift in Sources */,
 				63A45A90C2748A2729742C2F /* FilterBarScrollAffordanceTest.swift in Sources */,
 				8B118DFAAE23443EF7D90735 /* FilterBarViewTests.swift in Sources */,
 				8E347182E133BD35C712AADB /* FilterChipContrastTest.swift in Sources */,

--- a/apps/ios/SoloCompass/Models/RouteBuilder.swift
+++ b/apps/ios/SoloCompass/Models/RouteBuilder.swift
@@ -1,0 +1,120 @@
+import Foundation
+import CoreLocation
+
+/// Assembles a `Route` from an ordered list of experiences, deriving the
+/// distance and duration estimates that the raw `Route` initializer leaves to
+/// the caller. Shared by the manual "create your own route" flow and the AI
+/// route generator so both produce consistent, walkable estimates.
+///
+/// Pure value logic, no UI or persistence — unit-testable in isolation.
+public enum RouteBuilder {
+    /// Average solo walking speed in metres per minute (~4.8 km/h).
+    public static let walkMetersPerMinute: Double = 80
+    /// Dwell time added per stop (browsing, a coffee, a photo) in minutes.
+    public static let dwellMinutesPerStop: Int = 20
+
+    /// Straight-line (Haversine) distance in metres summed over consecutive
+    /// stops. Experiences without a coordinate are skipped for the leg they
+    /// would anchor, so a missing coordinate never inflates the total.
+    public static func totalDistanceMeters(_ experiences: [Experience]) -> Int {
+        let coords = experiences.compactMap(\.coordinate)
+        guard coords.count >= 2 else { return 0 }
+        var total: Double = 0
+        for i in 1..<coords.count {
+            let a = CLLocation(latitude: coords[i - 1].latitude, longitude: coords[i - 1].longitude)
+            let b = CLLocation(latitude: coords[i].latitude, longitude: coords[i].longitude)
+            total += a.distance(from: b)
+        }
+        return Int(total.rounded())
+    }
+
+    /// Estimated total minutes: walking time across the legs plus a dwell
+    /// buffer per stop. Always ≥ the dwell time of a single stop so a one-stop
+    /// route still reads as a real outing rather than "0 min".
+    public static func estimatedDurationMinutes(_ experiences: [Experience]) -> Int {
+        guard !experiences.isEmpty else { return 0 }
+        let walkMinutes = Double(totalDistanceMeters(experiences)) / walkMetersPerMinute
+        let dwell = dwellMinutesPerStop * experiences.count
+        return Int(walkMinutes.rounded()) + dwell
+    }
+
+    /// Greedy nearest-neighbour ordering starting from `origin` (or the first
+    /// experience when no origin is supplied). Used as the local fallback when
+    /// the AI generator is unavailable, so a route is still a sensible walk
+    /// rather than an arbitrary order.
+    public static func nearestNeighbourOrder(
+        _ experiences: [Experience],
+        from origin: CLLocationCoordinate2D? = nil
+    ) -> [Experience] {
+        var remaining = experiences
+        guard !remaining.isEmpty else { return [] }
+
+        var ordered: [Experience] = []
+        var cursor: CLLocationCoordinate2D
+        if let origin {
+            cursor = origin
+        } else {
+            let first = remaining.removeFirst()
+            ordered.append(first)
+            cursor = first.coordinate ?? origin ?? CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        }
+
+        while !remaining.isEmpty {
+            let cursorLoc = CLLocation(latitude: cursor.latitude, longitude: cursor.longitude)
+            // Pick the closest remaining experience; those without a coordinate
+            // sort last (infinite distance) so they don't anchor the walk.
+            let nextIndex = remaining.indices.min { lhs, rhs in
+                distance(from: cursorLoc, to: remaining[lhs]) < distance(from: cursorLoc, to: remaining[rhs])
+            }
+            guard let nextIndex else { break }
+            let next = remaining.remove(at: nextIndex)
+            ordered.append(next)
+            if let coord = next.coordinate { cursor = coord }
+        }
+        return ordered
+    }
+
+    /// Build a `Route` from an ordered list of experiences. Distance and
+    /// duration are derived; the caller supplies the editorial metadata
+    /// (title, summary, pace, source, tags, reasonNow).
+    public static func makeRoute(
+        id: RouteId,
+        title: String,
+        summary: String,
+        orderedExperiences: [Experience],
+        cityCode: String,
+        region: String = "",
+        pace: Pace = .relaxed,
+        tags: [String] = [],
+        source: RouteSource,
+        authorId: String? = nil,
+        bestStartHour: Double? = nil,
+        reasonNow: String? = nil
+    ) -> Route {
+        Route(
+            id: id,
+            title: title,
+            summary: summary,
+            experienceIds: orderedExperiences.map(\.id),
+            cityCode: cityCode,
+            region: region,
+            estimatedDuration: estimatedDurationMinutes(orderedExperiences),
+            distanceMeters: totalDistanceMeters(orderedExperiences),
+            pace: pace,
+            tags: tags,
+            source: source,
+            authorId: authorId,
+            bestStartHour: bestStartHour,
+            bestNow: false,
+            reasonNow: reasonNow,
+            verification: RouteVerification(status: .proposed, walkedByCount: 0, walkedBy: [])
+        )
+    }
+
+    // MARK: - Private
+
+    private static func distance(from loc: CLLocation, to experience: Experience) -> CLLocationDistance {
+        guard let coord = experience.coordinate else { return .greatestFiniteMagnitude }
+        return loc.distance(from: CLLocation(latitude: coord.latitude, longitude: coord.longitude))
+    }
+}

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1250,9 +1250,11 @@
 "recruiting.cta.requestJoinForming" = "申请加入(最后 %d 位)";
 
 /* US-057 — RouteCard recruit-mini inline state (CompareCanvas A-002) */
-"route.card.recruit.recruiting" = "%1$@ 招募 · %2$d/%3$d · %4$@";
+"route.card.recruit.recruiting" = "%1$@ 招募 · %2$d/%3$d 已確認 · %4$@";
 "route.card.recruit.closed" = "已成团 · %d 人 · 出发中";
 "route.card.recruit.completed" = "已完成 · 路线升级";
+/* Trailing affordance on a joinable recruit strip */
+"route.card.recruit.view" = "查看";
 
 /* US-058 — RouteCard walked-by row (CompareCanvas A-003) */
 "route.card.walkedBy" = "%d 位旅人走过";

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1256,6 +1256,23 @@
 /* Trailing affordance on a joinable recruit strip */
 "route.card.recruit.view" = "查看";
 
+/* AI route generation — fallback copy when the model is unavailable */
+"route.generate.fallback.summary" = "A short solo walk linking nearby spots.";
+"route.generate.fallback.title" = "Nearby Walk";
+"route.generate.fallback.titleFormat" = "%1$@ → %2$@";
+
+/* Create-route entry card + flow */
+"route.create.entry.title" = "創建你自己的路線";
+"route.create.entry.subtitle" = "串聯幾個地點 · 可選擇招募同伴一起走";
+"route.create.title" = "創建路線";
+"route.create.ai" = "✨ 讓 AI 幫我串成路線";
+"route.create.titleLabel" = "路線名稱";
+"route.create.titlePlaceholder" = "例如：湄公河日落散步";
+"route.create.paceLabel" = "節奏";
+"route.create.pickLabel" = "選擇地點（按點選順序串聯）";
+"route.create.selectedCount" = "已選 %d";
+"route.create.save" = "保存";
+
 /* US-058 — RouteCard walked-by row (CompareCanvas A-003) */
 "route.card.walkedBy" = "%d 位旅人走过";
 

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1165,6 +1165,14 @@
 "sheet.nearby.openNow" = "Open now";
 "sheet.nearby.openNow.a11y" = "Open now";
 
+/* NearbyExperienceRow card chips — walk-time, Solo score, 此刻最佳, proximity word */
+"nearby.chip.walkMin" = "%d min";
+"nearby.chip.solo" = "Solo %.1f";
+"nearby.chip.bestNow" = "Best now";
+"nearby.proximity.sparse" = "Quiet";
+"nearby.proximity.moderate" = "Moderate";
+"nearby.proximity.far" = "Far";
+
 /* US-036 — BottomInfoSheet section separation (Routes / Nearby headers) */
 "sheet.section.routes" = "Routes";
 /* Now-context (此刻適合) header for the routes section */

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1109,6 +1109,14 @@
 "sheet.nearby.openNow.a11y" = "此刻开放";
 "sheet.routes.section.title" = "路线";
 
+/* NearbyExperienceRow card chips — walk-time, Solo score, 此刻最佳, proximity word */
+"nearby.chip.walkMin" = "%d 分钟";
+"nearby.chip.solo" = "Solo %.1f";
+"nearby.chip.bestNow" = "此刻最佳";
+"nearby.proximity.sparse" = "稀疏";
+"nearby.proximity.moderate" = "中等";
+"nearby.proximity.far" = "较远";
+
 /* US-036 — BottomInfoSheet section separation (Routes / Nearby headers) */
 "sheet.section.routes" = "路线";
 /* Now-context (此刻适合) header for the routes section */

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1255,7 +1255,8 @@
 /* Route card recruit (mirrors en.lproj's Chinese values) */
 "route.card.recruit.closed" = "已成团 · %d 人 · 出发中";
 "route.card.recruit.completed" = "已完成 · 路线升级";
-"route.card.recruit.recruiting" = "%1$@ 招募 · %2$d/%3$d · %4$@";
+"route.card.recruit.recruiting" = "%1$@ 招募 · %2$d/%3$d 已确认 · %4$@";
+"route.card.recruit.view" = "查看";
 "route.card.walkedBy" = "%d 位旅人走过";
 
 /* Solo score breakdown */

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1259,6 +1259,23 @@
 "route.card.recruit.view" = "查看";
 "route.card.walkedBy" = "%d 位旅人走过";
 
+/* AI route generation — fallback copy when the model is unavailable */
+"route.generate.fallback.summary" = "串联附近地点的一段轻松独行散步。";
+"route.generate.fallback.title" = "附近散步";
+"route.generate.fallback.titleFormat" = "%1$@ → %2$@";
+
+/* Create-route entry card + flow */
+"route.create.entry.title" = "创建你自己的路线";
+"route.create.entry.subtitle" = "串联几个地点 · 可选择招募同伴一起走";
+"route.create.title" = "创建路线";
+"route.create.ai" = "✨ 让 AI 帮我串成路线";
+"route.create.titleLabel" = "路线名称";
+"route.create.titlePlaceholder" = "例如：湄公河日落散步";
+"route.create.paceLabel" = "节奏";
+"route.create.pickLabel" = "选择地点（按点选顺序串联）";
+"route.create.selectedCount" = "已选 %d";
+"route.create.save" = "保存";
+
 /* Solo score breakdown */
 "solo.breakdown.title" = "独行评分";
 "solo.compact.a11y.hint" = "双击查看评分明细";

--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -191,6 +191,88 @@ public final class AIService {
         }
     }
 
+    // MARK: - Generate a route (AI "discover / build a walk")
+
+    /// The model's route plan: an ordered subset of the candidate ids plus the
+    /// editorial copy. Decoded from a single JSON object the model returns.
+    private struct GeneratedRoutePlan: Codable {
+        let orderedIds: [String]
+        let title: String
+        let summary: String
+        let reasonNow: String?
+        let tags: [String]?
+    }
+
+    /// Generate a single walkable route from nearby experiences. The model
+    /// picks 3–5 stops, orders them into a sensible walk, and writes a title,
+    /// summary, and an optional "why now" line. Falls back — when no key is
+    /// configured or the response can't be parsed — to a local greedy
+    /// nearest-neighbour walk over the top Solo-scored candidates, so the
+    /// feature always produces a route.
+    ///
+    /// - Parameters:
+    ///   - candidates: nearby experiences to choose stops from.
+    ///   - cityCode: city the route belongs to (VTE/HAN/…).
+    ///   - userCoordinate: the traveler's location, used as the walk's origin
+    ///     in the local fallback ordering.
+    ///   - now: current time, used for the best-now boost in the fallback.
+    public func generateRoute(
+        from candidates: [Experience],
+        cityCode: String,
+        userCoordinate: CLLocationCoordinate2D?,
+        now: Date = Date()
+    ) async throws -> Route {
+        let routeId = RouteId(rawValue: "ai-\(UUID().uuidString.prefix(8))")
+        let validIds = Set(candidates.map(\.id))
+
+        do {
+            let prompt = Self.routeGenerationPrompt(candidates: candidates, cityCode: cityCode)
+            let raw = try await sendMessage(prompt: prompt, kind: .synthesis)
+            let plan = try Self.parseRoutePlan(raw)
+            // Keep only ids the model was actually given, in the order it chose,
+            // capped to a walkable 3–6 stops; drop dupes.
+            var seen = Set<String>()
+            let chosen = plan.orderedIds
+                .filter { validIds.contains($0) && seen.insert($0).inserted }
+                .prefix(6)
+            let ordered = chosen.compactMap { id in candidates.first { $0.id == id } }
+            guard ordered.count >= 2 else { throw AIError.decodingFailed("route plan too short") }
+            return RouteBuilder.makeRoute(
+                id: routeId,
+                title: plan.title.isEmpty ? Self.fallbackRouteTitle(ordered) : plan.title,
+                summary: plan.summary,
+                orderedExperiences: ordered,
+                cityCode: cityCode,
+                pace: .relaxed,
+                tags: plan.tags ?? Self.tags(from: ordered),
+                source: .aiGenerated,
+                reasonNow: plan.reasonNow?.isEmpty == false ? plan.reasonNow : nil
+            )
+        } catch {
+            // Local fallback: top Solo-scored candidates, walked nearest-first.
+            let top = candidates
+                .sorted { lhs, rhs in
+                    let l = lhs.soloScore.overall + (lhs.isBestNow(at: now) ? 2 : 0)
+                    let r = rhs.soloScore.overall + (rhs.isBestNow(at: now) ? 2 : 0)
+                    return l > r
+                }
+                .prefix(5)
+            let ordered = RouteBuilder.nearestNeighbourOrder(Array(top), from: userCoordinate)
+            guard !ordered.isEmpty else { throw AIError.decodingFailed("no candidates to build a route") }
+            return RouteBuilder.makeRoute(
+                id: routeId,
+                title: Self.fallbackRouteTitle(ordered),
+                summary: NSLocalizedString("route.generate.fallback.summary",
+                                           comment: "Local fallback route summary"),
+                orderedExperiences: ordered,
+                cityCode: cityCode,
+                pace: .relaxed,
+                tags: Self.tags(from: ordered),
+                source: .aiGenerated
+            )
+        }
+    }
+
     /// Generate one warm, grounded sentence on why a solo traveler would
     /// value visiting this specific place.
     public func explainRecommendation(for experience: Experience) async throws -> String {
@@ -701,6 +783,69 @@ public final class AIService {
         Candidates:
         \(candidateLines)
         """
+    }
+
+    /// Prompt for `generateRoute` — asks the model to choose and order 3–5
+    /// stops into a walkable loop and return a single JSON object.
+    private static func routeGenerationPrompt(candidates: [Experience], cityCode: String) -> String {
+        let candidateLines = candidates.prefix(40).map { exp in
+            let coord = exp.coordinate.map { String(format: "%.4f,%.4f", $0.latitude, $0.longitude) } ?? "?"
+            return "- \(exp.id): \(exp.title) [\(exp.category.rawValue), solo=\(String(format: "%.1f", exp.soloScore.overall)), @\(coord)]"
+        }.joined(separator: "\n")
+        return """
+        You are planning ONE walkable route for a solo traveler in city \(cityCode).
+        Choose 3 to 5 of the candidates below and order them into a sensible walk \
+        (short hops, varied categories, a satisfying arc — e.g. coffee → culture → sunset viewpoint).
+
+        Return ONLY a JSON object, no prose, with exactly these keys:
+        {
+          "orderedIds": ["id1","id2","id3"],   // 3–5 ids FROM the candidates, in walking order
+          "title": "短而具体的路线名",            // concise, evocative; the traveler's language is fine
+          "summary": "one sentence on the vibe of this walk",
+          "reasonNow": "optional: why it's good right now, or empty string",
+          "tags": ["culture","coffee"]          // 1–3 category tags
+        }
+
+        Candidates:
+        \(candidateLines)
+        """
+    }
+
+    /// Decode the single JSON object returned by `routeGenerationPrompt`.
+    private static func parseRoutePlan(_ raw: String) throws -> GeneratedRoutePlan {
+        guard
+            let start = raw.firstIndex(of: "{"),
+            let end = raw.lastIndex(of: "}"),
+            start <= end,
+            let data = String(raw[start...end]).data(using: .utf8)
+        else { throw AIError.decodingFailed("no JSON in route plan") }
+        return try JSONDecoder().decode(GeneratedRoutePlan.self, from: data)
+    }
+
+    /// A readable title when the model gives none — "<first> → <last> 散步".
+    private static func fallbackRouteTitle(_ ordered: [Experience]) -> String {
+        guard let first = ordered.first else {
+            return NSLocalizedString("route.generate.fallback.title", comment: "Default generated route title")
+        }
+        if ordered.count == 1 { return first.title }
+        let last = ordered[ordered.count - 1]
+        return String(
+            format: NSLocalizedString("route.generate.fallback.titleFormat",
+                                      comment: "Generated route title: '<first> → <last>'"),
+            first.title, last.title
+        )
+    }
+
+    /// Distinct category raw-values across the stops, capped at 3, for tags.
+    private static func tags(from ordered: [Experience]) -> [String] {
+        var seen = Set<String>()
+        var out: [String] = []
+        for exp in ordered {
+            let tag = exp.category.rawValue
+            if seen.insert(tag).inserted { out.append(tag) }
+            if out.count == 3 { break }
+        }
+        return out
     }
 
     private static func parseIDList(_ raw: String, validIDs: Set<String>) -> [String] {

--- a/apps/ios/SoloCompass/Tests/RouteBuilderTests.swift
+++ b/apps/ios/SoloCompass/Tests/RouteBuilderTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+import CoreLocation
+@testable import SoloCompass
+
+/// Unit coverage for `RouteBuilder` — the shared distance/duration estimator
+/// and greedy ordering behind both the manual create-route flow and the AI
+/// route generator.
+final class RouteBuilderTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Make an experience at a given coordinate ([lon, lat] GeoJSON order).
+    private func exp(_ id: String, lon: Double, lat: Double, solo: Double = 8.0) -> Experience {
+        let location = ExperienceLocation(coordinates: [lon, lat], cityCode: "vte")
+        let breakdown = SoloScore.Breakdown(
+            seatingFriendly: 8, soloPatronRatio: 8, staffPressure: 2,
+            soloPortioning: 8, ambianceFit: 8, safety: 8
+        )
+        let confidence = Confidence(
+            level: 2, lastVerifiedAt: Date(), reason: "test",
+            signals: Confidence.Signals(aiScrapeAgeDays: 1, passiveGpsHits30d: 1, activeReports30d: 1, trustedVerifications: 1)
+        )
+        return Experience(
+            id: id, title: id, oneLiner: "", whyItMatters: "",
+            category: .coffee, location: location, bestTimes: [],
+            durationMinutes: Experience.DurationRange(min: 30, max: 90),
+            howTo: [], realInconveniences: [],
+            soloScore: SoloScore(overall: solo, breakdown: breakdown, basedOnCount: 1),
+            sources: [], confidence: confidence, nearbyExperienceIds: [],
+            stats: Experience.Stats(completionCount: 0, averageRating: 0),
+            status: .active, createdAt: Date(), updatedAt: Date()
+        )
+    }
+
+    // MARK: - Distance
+
+    func testEmptyAndSingleStopHaveZeroDistance() {
+        XCTAssertEqual(RouteBuilder.totalDistanceMeters([]), 0)
+        XCTAssertEqual(RouteBuilder.totalDistanceMeters([exp("a", lon: 102.6, lat: 17.96)]), 0)
+    }
+
+    func testDistanceSumsConsecutiveLegs() {
+        let a = exp("a", lon: 102.6000, lat: 17.9600)
+        let b = exp("b", lon: 102.6030, lat: 17.9600) // ~318m east
+        let c = exp("c", lon: 102.6060, lat: 17.9600) // another ~318m east
+        let total = RouteBuilder.totalDistanceMeters([a, b, c])
+        let oneLeg = RouteBuilder.totalDistanceMeters([a, b])
+        XCTAssertGreaterThan(total, oneLeg)
+        XCTAssertGreaterThan(total, 500)
+        XCTAssertLessThan(total, 800)
+    }
+
+    // MARK: - Duration
+
+    func testDurationIncludesDwellPerStop() {
+        let a = exp("a", lon: 102.6000, lat: 17.9600)
+        let b = exp("b", lon: 102.6030, lat: 17.9600)
+        let duration = RouteBuilder.estimatedDurationMinutes([a, b])
+        XCTAssertGreaterThanOrEqual(duration, 2 * RouteBuilder.dwellMinutesPerStop)
+    }
+
+    func testSingleStopStillHasDwellTime() {
+        let a = exp("a", lon: 102.6, lat: 17.96)
+        XCTAssertEqual(RouteBuilder.estimatedDurationMinutes([a]), RouteBuilder.dwellMinutesPerStop)
+    }
+
+    // MARK: - Nearest-neighbour ordering
+
+    func testNearestNeighbourOrdersByProximityFromOrigin() {
+        let a = exp("a", lon: 102.6000, lat: 17.9600)
+        let b = exp("b", lon: 102.6030, lat: 17.9600)
+        let c = exp("c", lon: 102.6090, lat: 17.9600)
+        let origin = CLLocationCoordinate2D(latitude: 17.9600, longitude: 102.5990)
+        let ordered = RouteBuilder.nearestNeighbourOrder([c, b, a], from: origin)
+        XCTAssertEqual(ordered.map(\.id), ["a", "b", "c"], "Greedy walk should visit nearest-first from the origin")
+    }
+
+    func testNearestNeighbourEmptyIsEmpty() {
+        XCTAssertTrue(RouteBuilder.nearestNeighbourOrder([], from: nil).isEmpty)
+    }
+
+    // MARK: - makeRoute
+
+    func testMakeRouteDerivesDistanceDurationAndIds() {
+        let a = exp("a", lon: 102.6000, lat: 17.9600)
+        let b = exp("b", lon: 102.6030, lat: 17.9600)
+        let route = RouteBuilder.makeRoute(
+            id: RouteId(rawValue: "r1"),
+            title: "Test Walk",
+            summary: "s",
+            orderedExperiences: [a, b],
+            cityCode: "VTE",
+            source: .userCreated
+        )
+        XCTAssertEqual(route.experienceIds, ["a", "b"])
+        XCTAssertEqual(route.distanceMeters, RouteBuilder.totalDistanceMeters([a, b]))
+        XCTAssertEqual(route.estimatedDuration, RouteBuilder.estimatedDurationMinutes([a, b]))
+        XCTAssertEqual(route.source, .userCreated)
+        XCTAssertEqual(route.verification.status, .proposed)
+    }
+}

--- a/apps/ios/SoloCompass/Views/Companion/Components/RouteCard.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Components/RouteCard.swift
@@ -311,6 +311,11 @@ public struct RouteCard: View {
             ? CT.verifiedGreenDot
             : (isCompleted ? CT.fgSubtle : CT.accent)
 
+        // Open / forming slots are joinable, so the strip carries a trailing
+        // "查看 >" affordance hinting the card opens the recruit detail. Closed /
+        // completed states are terminal, so they omit the chevron.
+        let showsChevron = !isFormed && !isCompleted
+
         return HStack(spacing: 8) {
             statusDot(dotColor, pulsing: !isCompleted)
             Text(mini.text)
@@ -318,6 +323,16 @@ public struct RouteCard: View {
                 .foregroundStyle(mini.tone)
                 .lineLimit(2)
                 .frame(maxWidth: .infinity, alignment: .leading)
+            if showsChevron {
+                HStack(spacing: 2) {
+                    Text(NSLocalizedString("route.card.recruit.view", comment: "查看 — open recruit detail"))
+                        .font(CT.mono(10.5, .semibold))
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                }
+                .foregroundStyle(mini.tone)
+                .layoutPriority(1)
+            }
         }
         .padding(.horizontal, 11)
         .padding(.vertical, 9)

--- a/apps/ios/SoloCompass/Views/Companion/CreateRouteView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/CreateRouteView.swift
@@ -1,0 +1,304 @@
+import SwiftUI
+import CoreLocation
+
+// MARK: - CreateRouteEntryCard
+
+/// Dashed entry card shown beneath the routes section in the bottom sheet:
+/// "創建你自己的路線 · 串聯幾個地點 · 可選擇招募同伴一起走". Tapping it opens
+/// `CreateRouteView`. Mirrors the reference design's create-route affordance.
+struct CreateRouteEntryCard: View {
+    let onTap: () -> Void
+
+    @State private var pressed = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 14) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(CT.accent)
+                        .frame(width: 44, height: 44)
+                    Image(systemName: "plus")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(.white)
+                }
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(NSLocalizedString("route.create.entry.title", comment: "Create your own route"))
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(CT.fgPrimary)
+                    Text(NSLocalizedString("route.create.entry.subtitle", comment: "Link a few stops · optionally recruit companions"))
+                        .font(.caption)
+                        .foregroundStyle(CT.fgMuted)
+                        .lineLimit(2)
+                }
+                Spacer(minLength: 4)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(CT.fgSubtle)
+            }
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(CT.surfaceWhite)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .strokeBorder(
+                        CT.borderDefault,
+                        style: StrokeStyle(lineWidth: 1, dash: [5, 4])
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(pressed ? 0.985 : 1)
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.18), value: pressed)
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in pressed = true }
+                .onEnded { _ in pressed = false }
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(NSLocalizedString("route.create.entry.title", comment: "Create your own route")))
+        .accessibilityHint(Text(NSLocalizedString("route.create.entry.subtitle", comment: "Create route hint")))
+    }
+}
+
+// MARK: - CreateRouteView
+
+/// Build a route by selecting a few nearby experiences — either by hand or by
+/// letting the AI string them into a walk — then save it as a `userCreated`
+/// (or `coCreated` when AI-seeded) route. Companion recruiting is offered as a
+/// follow-up from the saved route's detail, so this flow stays focused on the
+/// walk itself.
+struct CreateRouteView: View {
+    /// Nearby experiences the user can pick stops from.
+    let candidates: [Experience]
+    let cityCode: String
+    let userCoordinate: CLLocationCoordinate2D?
+    /// Called with the saved route so the caller can persist + refresh.
+    let onSave: (Route) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(AIService.self) private var aiService
+
+    @State private var selectedIds: [String] = []
+    @State private var title: String = ""
+    @State private var pace: Pace = .relaxed
+    @State private var isGenerating = false
+    @State private var aiSummary: String?
+
+    /// Selected experiences in selection order (the walk order).
+    private var orderedSelection: [Experience] {
+        selectedIds.compactMap { id in candidates.first { $0.id == id } }
+    }
+
+    private var canSave: Bool { selectedIds.count >= 2 }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    aiGenerateButton
+                    summaryHeader
+                    titleField
+                    pacePicker
+                    pickerSection
+                }
+                .padding(16)
+            }
+            .background(CT.bgWarm)
+            .navigationTitle(NSLocalizedString("route.create.title", comment: "Create route nav title"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(NSLocalizedString("action.cancel", comment: "Cancel")) { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(NSLocalizedString("route.create.save", comment: "Save route")) { save() }
+                        .disabled(!canSave)
+                        .fontWeight(.semibold)
+                }
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var aiGenerateButton: some View {
+        Button { Task { await generate() } } label: {
+            HStack(spacing: 8) {
+                if isGenerating {
+                    ProgressView().tint(CT.accent)
+                } else {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 14, weight: .semibold))
+                }
+                Text(NSLocalizedString("route.create.ai", comment: "Let AI build the route"))
+                    .font(.subheadline.weight(.semibold))
+            }
+            .foregroundStyle(CT.sunGoldDeep)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous).fill(CT.sunGoldSoft)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(isGenerating || candidates.count < 2)
+    }
+
+    @ViewBuilder
+    private var summaryHeader: some View {
+        if let aiSummary, !aiSummary.isEmpty {
+            HStack(spacing: 6) {
+                Image(systemName: "sparkles").font(.system(size: 11, weight: .semibold))
+                Text(aiSummary).font(.caption).fixedSize(horizontal: false, vertical: true)
+            }
+            .foregroundStyle(CT.sunGoldDeep)
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(RoundedRectangle(cornerRadius: 9, style: .continuous).fill(CT.sunGoldSoft))
+        }
+    }
+
+    private var titleField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(NSLocalizedString("route.create.titleLabel", comment: "Route title field label"))
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(CT.fgMuted)
+            TextField(
+                NSLocalizedString("route.create.titlePlaceholder", comment: "Route title placeholder"),
+                text: $title
+            )
+            .textFieldStyle(.plain)
+            .padding(12)
+            .background(RoundedRectangle(cornerRadius: 10, style: .continuous).fill(CT.surfaceWhite))
+            .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous).strokeBorder(CT.borderSubtle, lineWidth: 0.5))
+        }
+    }
+
+    private var pacePicker: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(NSLocalizedString("route.create.paceLabel", comment: "Pace field label"))
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(CT.fgMuted)
+            Picker("", selection: $pace) {
+                ForEach(Pace.allCases, id: \.self) { p in
+                    Text(p.localizedLabel).tag(p)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
+    private var pickerSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(NSLocalizedString("route.create.pickLabel", comment: "Pick stops label"))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(CT.fgMuted)
+                Spacer()
+                Text(String(
+                    format: NSLocalizedString("route.create.selectedCount", comment: "N selected"),
+                    selectedIds.count
+                ))
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(CT.fgSubtle)
+            }
+            ForEach(candidates) { exp in
+                selectRow(exp)
+            }
+        }
+    }
+
+    private func selectRow(_ exp: Experience) -> some View {
+        let order = selectedIds.firstIndex(of: exp.id)
+        let isSelected = order != nil
+        return Button { toggle(exp.id) } label: {
+            HStack(spacing: 12) {
+                ZStack {
+                    Circle().fill(exp.category.color).frame(width: 34, height: 34)
+                    if let order {
+                        Text("\(order + 1)")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundStyle(.white)
+                    } else {
+                        Image(systemName: exp.category.symbol)
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(.white)
+                    }
+                }
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(exp.title).font(.subheadline.weight(.medium))
+                        .foregroundStyle(CT.fgPrimary).lineLimit(1)
+                    Text(String(format: NSLocalizedString("nearby.chip.solo", comment: "Solo score"), exp.soloScore.overall))
+                        .font(.caption2.weight(.semibold)).foregroundStyle(CT.verifiedGreen)
+                }
+                Spacer(minLength: 4)
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 20))
+                    .foregroundStyle(isSelected ? CT.accent : CT.fgSubtle)
+            }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(isSelected ? CT.accentSoft : CT.surfaceWhite)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .strokeBorder(isSelected ? CT.accentBorder : CT.borderSubtle, lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(exp.title))
+        .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
+    }
+
+    // MARK: - Actions
+
+    private func toggle(_ id: String) {
+        #if canImport(UIKit)
+        Haptics.selection()
+        #endif
+        if let idx = selectedIds.firstIndex(of: id) {
+            selectedIds.remove(at: idx)
+        } else {
+            selectedIds.append(id)
+        }
+    }
+
+    private func generate() async {
+        isGenerating = true
+        defer { isGenerating = false }
+        guard let route = try? await aiService.generateRoute(
+            from: candidates,
+            cityCode: cityCode,
+            userCoordinate: userCoordinate
+        ) else { return }
+        // Adopt the AI's ordering + copy as the editable starting point.
+        selectedIds = route.experienceIds
+        if title.isEmpty { title = route.title }
+        aiSummary = route.summary
+        pace = route.pace
+    }
+
+    private func save() {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let finalTitle = trimmed.isEmpty
+            ? NSLocalizedString("route.generate.fallback.title", comment: "Default route title")
+            : trimmed
+        let route = RouteBuilder.makeRoute(
+            id: RouteId(rawValue: "user-\(UUID().uuidString.prefix(8))"),
+            title: finalTitle,
+            summary: aiSummary ?? "",
+            orderedExperiences: orderedSelection,
+            cityCode: cityCode,
+            pace: pace,
+            source: aiSummary == nil ? .userCreated : .coCreated
+        )
+        onSave(route)
+        dismiss()
+    }
+}

--- a/apps/ios/SoloCompass/Views/Companion/DiscoverRecruitingRoutesView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/DiscoverRecruitingRoutesView.swift
@@ -48,57 +48,28 @@ public struct DiscoverRecruitingRoutesView: View {
     // MARK: - Subviews
 
     private var routeList: some View {
-        List(sortedRoutes) { route in
-            NavigationLink {
-                RouteDetailView(route: route)
-            } label: {
-                recruitingRow(route: route)
+        // A plain ScrollView + LazyVStack of self-chromed RouteCards (matching the
+        // bottom-sheet routes section) rather than an inset-grouped List. The old
+        // List wrapped each already-carded RouteCard in a second grouped-cell
+        // background and used a -16 negative-inset hack to claw the card back to
+        // full width — a fragile double-card look. RouteCard already surfaces the
+        // recruit slot (host · N/M · departure · 查看), so the separate slot chip
+        // is dropped as redundant.
+        ScrollView {
+            LazyVStack(spacing: 10) {
+                ForEach(sortedRoutes) { route in
+                    NavigationLink {
+                        RouteDetailView(route: route)
+                    } label: {
+                        RouteCard(route: route, companionOn: true)
+                    }
+                    .buttonStyle(.plain)
+                }
             }
-            .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
         }
-        .listStyle(.insetGrouped)
-    }
-
-    private func recruitingRow(route: Route) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            RouteCard(route: route)
-                .padding(.horizontal, -16)  // cancel List row insets already applied
-
-            if let companion = route.companion {
-                slotChip(companion)
-                    .padding(.leading, 54)   // align under the title (past 44px cover + 10px gap)
-                    .padding(.bottom, 4)
-            }
-        }
-    }
-
-    private func slotChip(_ companion: RouteCompanion) -> some View {
-        let filled = companion.confirmedMembers.count
-        let max = companion.maxMembers
-        let label = companion.departureLabel
-
-        return Text(
-            String(
-                format: NSLocalizedString(
-                    "discover.recruiting.chip",
-                    comment: "Slot chip: '{filled}/{max} · {departureLabel}'"
-                ),
-                filled, max, label
-            )
-        )
-        .font(.system(size: 11, weight: .medium, design: .monospaced))
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 3)
-        .background(
-            Capsule().fill(Color.secondary.opacity(0.12))
-        )
-        .accessibilityLabel(
-            String(format: NSLocalizedString(
-                "discover.recruiting.chip.a11y",
-                comment: "Slot chip accessibility: '{filled} of {max} members · {departureLabel}'"
-            ), filled, max, label)
-        )
+        .background(CT.bgWarm)
     }
 
     private var emptyState: some View {

--- a/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
@@ -150,7 +150,7 @@ public struct ItineraryListView: View {
                     Spacer()
                     Text(NSLocalizedString("action.undo", comment: "Undo action"))
                         .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.accentColor)
+                        .foregroundStyle(Color.accentColor)
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 12)

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -511,8 +511,12 @@ struct SortModeSheet: View {
 
 // MARK: - NearbyExperienceRow
 
-/// Single row in the '附近' section of the BottomInfoSheet.
-/// Layout: 36×36 category disc | title + romanized + local | mono distance + compass arrow
+/// Single card in the '附近' section of the BottomInfoSheet.
+///
+/// Card layout (mirrors the route-card chrome so the list reads as a stack of
+/// discrete cards rather than ruled rows): a left category color-bar, a filled
+/// category disc, the title + romanized·local subtitle, a chip row
+/// (walk-time · Solo score · 此刻最佳), and a trailing distance + compass arrow.
 struct NearbyExperienceRow: View {
     let experience: Experience
     let isSmartPick: Bool
@@ -525,8 +529,6 @@ struct NearbyExperienceRow: View {
     @State private var pressed = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(LocationService.self) private var locationService
-
-    private static let sunGold = Color(red: 1.0, green: 0.80, blue: 0.2)
 
     private static let distanceFormatter: MeasurementFormatter = {
         let f = MeasurementFormatter()
@@ -549,9 +551,19 @@ struct NearbyExperienceRow: View {
 
         var dotColor: Color {
             switch self {
-            case .near: return .green
-            case .mid: return .orange
-            case .far: return Color(.tertiaryLabel)
+            case .near: return CT.verifiedGreenDot
+            case .mid: return CT.toneForming
+            case .far: return CT.fgSubtle
+            }
+        }
+
+        /// Localized density word shown next to the chip row (稀疏 / 中等 / 较远),
+        /// mirroring the screenshot's proximity caption.
+        var labelKey: String {
+            switch self {
+            case .near: return "nearby.proximity.sparse"
+            case .mid:  return "nearby.proximity.moderate"
+            case .far:  return "nearby.proximity.far"
             }
         }
     }
@@ -606,25 +618,37 @@ struct NearbyExperienceRow: View {
             #endif
             onTap()
         } label: {
-            HStack(spacing: 10) {
+            HStack(alignment: .top, spacing: 12) {
                 categoryDisc
-                titleStack
-                Spacer(minLength: 4)
-                distancePill
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
-            .background(rowBackground)
-            .overlay(alignment: .leading) {
-                if isSmartPick {
-                    RoundedRectangle(cornerRadius: 3)
-                        .fill(Self.sunGold)
-                        .frame(width: 3)
+                VStack(alignment: .leading, spacing: 7) {
+                    titleStack
+                    chipRow
                 }
+                Spacer(minLength: 4)
+                distanceColumn
             }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background(cardBackground)
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .strokeBorder(isSmartPick ? CT.accentBorder : CT.borderSubtle, lineWidth: 0.5)
+            )
+            .overlay(alignment: .leading) {
+                // Left color-bar: golden for smart picks, else the category tint.
+                UnevenRoundedRectangle(
+                    topLeadingRadius: 14, bottomLeadingRadius: 14,
+                    bottomTrailingRadius: 0, topTrailingRadius: 0,
+                    style: .continuous
+                )
+                .fill(isSmartPick ? CT.sunGold : experience.category.color)
+                .frame(width: 3)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .shadow(color: .black.opacity(0.04), radius: 1, x: 0, y: 1)
         }
         .buttonStyle(.plain)
-        .scaleEffect(pressed ? 0.86 : 1.0)
+        .scaleEffect(pressed ? 0.97 : 1.0)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint(Text(NSLocalizedString("experience.card.hint", comment: "Double tap to view details")))
@@ -635,53 +659,102 @@ struct NearbyExperienceRow: View {
     private var categoryDisc: some View {
         ZStack {
             Circle()
-                .fill(experience.category.color.opacity(0.18))
-                .frame(width: 36, height: 36)
+                .fill(experience.category.color)
+                .frame(width: 40, height: 40)
             Image(systemName: experience.category.symbol)
-                .font(.system(size: 16, weight: .medium))
-                .foregroundStyle(experience.category.color)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(.white)
         }
+        .accessibilityHidden(true)
     }
 
     @ViewBuilder
     private var titleStack: some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(experience.title)
-                .font(.subheadline.weight(.medium))
-                .foregroundStyle(.primary)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(CT.fgPrimary)
                 .lineLimit(1)
 
             let sub = subtitleText
             if !sub.isEmpty {
                 Text(sub)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(CT.fgMuted)
                     .lineLimit(1)
             }
+        }
+    }
 
+    /// Horizontal chip row: walk-time · Solo score · (此刻最佳) · proximity word.
+    private var chipRow: some View {
+        HStack(spacing: 6) {
+            if let meters = distanceMeters, meters < 1500 {
+                walkTimeChip(meters: meters)
+            }
+            soloScoreChip
             if isOpenNow {
-                openNowPill
+                bestNowChip
                     .transition(
                         reduceMotion ? .identity :
                             .scale(scale: 0.8).combined(with: .opacity)
                     )
             }
+            if let prox = proximity {
+                Text(NSLocalizedString(prox.labelKey, comment: "Proximity density word"))
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(prox.dotColor)
+            }
         }
         .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7), value: isOpenNow)
     }
 
-    private var openNowPill: some View {
-        HStack(spacing: 3) {
-            Image(systemName: "sunset.fill")
-                .font(.caption2)
-                .foregroundStyle(.green)
-            Text(NSLocalizedString("sheet.nearby.openNow", comment: "Open now pill label"))
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.green)
+    /// Neutral chip: estimated walk minutes (≈ 80 m/min) for nearby experiences.
+    private func walkTimeChip(meters: Double) -> some View {
+        let minutes = max(1, Int((meters / 80).rounded()))
+        let label = String(
+            format: NSLocalizedString("nearby.chip.walkMin", comment: "Walk minutes chip, e.g. '4 分钟'"),
+            minutes
+        )
+        return HStack(spacing: 3) {
+            Image(systemName: "figure.walk")
+                .font(.system(size: 9.5, weight: .semibold))
+            Text(label)
+                .font(.caption2.weight(.medium))
         }
-        .padding(.horizontal, 6)
-        .padding(.vertical, 2)
-        .background(Capsule().fill(Color.green.opacity(0.12)))
+        .foregroundStyle(CT.fgMuted)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(CT.surfaceSunken))
+    }
+
+    /// Green chip: Solo score (e.g. "Solo 7.5").
+    private var soloScoreChip: some View {
+        Text(
+            String(
+                format: NSLocalizedString("nearby.chip.solo", comment: "Solo score chip, e.g. 'Solo 7.5'"),
+                experience.soloScore.overall
+            )
+        )
+        .font(.caption2.weight(.bold))
+        .foregroundStyle(CT.verifiedGreen)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(CT.verifiedGreen.opacity(0.12)))
+    }
+
+    /// Golden chip: 此刻最佳 — shown when the experience is open in the current hour.
+    private var bestNowChip: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 9, weight: .semibold))
+            Text(NSLocalizedString("nearby.chip.bestNow", comment: "此刻最佳 chip"))
+                .font(.caption2.weight(.semibold))
+        }
+        .foregroundStyle(CT.sunGoldDeep)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(CT.sunGoldSoft))
     }
 
     private var subtitleText: String {
@@ -695,47 +768,41 @@ struct NearbyExperienceRow: View {
         return parts.joined(separator: " · ")
     }
 
-    private var distancePill: some View {
+    /// Trailing column: compass arrow over the formatted distance, right-aligned.
+    private var distanceColumn: some View {
         let bearing = relativeBearing
         let hasLiveBearing = bearing != nil
-        return HStack(spacing: 3) {
-            if let meters = distanceMeters {
-                if let prox = proximity {
-                    Circle()
-                        .fill(prox.dotColor)
-                        .frame(width: 6, height: 6)
-                        .accessibilityHidden(true)
-                }
-                Text(formattedDistance(meters))
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
-            }
+        return VStack(alignment: .trailing, spacing: 4) {
             Image(systemName: "location.north.line.fill")
                 .font(.caption2)
-                .foregroundStyle(hasLiveBearing ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tertiary))
+                .foregroundStyle(hasLiveBearing ? AnyShapeStyle(CT.fgMuted) : AnyShapeStyle(CT.fgSubtle))
                 .rotationEffect(.degrees(bearing ?? 0))
                 .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: bearing)
+            if let meters = distanceMeters {
+                Text(formattedDistance(meters))
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(CT.fgSubtle)
+            }
         }
+        .accessibilityHidden(true)
     }
 
-    @ViewBuilder
-    private var rowBackground: some View {
-        if isSmartPick {
-            LinearGradient(
-                colors: [
-                    Self.sunGold.opacity(0.10),
-                    Self.sunGold.opacity(0.04)
-                ],
-                startPoint: .leading,
-                endPoint: .trailing
-            )
-        } else {
-            Color.clear
-        }
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .fill(isSmartPick ? AnyShapeStyle(smartPickGradient) : AnyShapeStyle(CT.surfaceWhite))
+    }
+
+    private var smartPickGradient: LinearGradient {
+        LinearGradient(
+            colors: [CT.sunGoldSoft.opacity(0.55), CT.surfaceWhite],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
     }
 
     private var accessibilityLabel: Text {
         var label = experience.title
+        label += ", Solo \(String(format: "%.1f", experience.soloScore.overall))"
         if let meters = distanceMeters {
             label += ", \(formattedDistance(meters))"
         }
@@ -926,16 +993,17 @@ struct NearbySection: View {
             // US-036: inset divider + localized "Nearby" header separates this
             // section from Routes above (showsDivider gated by composition).
             SheetSectionSeparator(titleKey: "sheet.section.nearby", showsDivider: showsSectionDivider)
-            Divider()
-                .padding(.horizontal, 16)
             if experiences.isEmpty {
                 // US-050: empty Nearby list. Announce on appear so VoiceOver
                 // users learn the list is empty rather than thinking the sheet
                 // froze; a visible row keeps the state legible to everyone.
                 EmptySheetListView(onExploreElsewhere: onExploreElsewhere)
             } else {
+                // Each row now carries its own card chrome, so we separate them
+                // with a 10pt gap (matching RoutesSection) rather than full-bleed
+                // dividers — the list reads as a stack of discrete cards.
                 ScrollView {
-                    LazyVStack(spacing: 0) {
+                    LazyVStack(spacing: 10) {
                         ForEach(sortedExperiences) { exp in
                             NearbyExperienceRow(
                                 experience: exp,
@@ -944,10 +1012,11 @@ struct NearbySection: View {
                                 isOpenNow: sortMode == .now && isOpenNow(exp),
                                 onTap: { onSelectExperience(exp) }
                             )
-                            Divider()
-                                .padding(.leading, 62)
                         }
                     }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 10)
+                    .padding(.bottom, 8)
                 }
             }
         }

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -113,6 +113,7 @@ struct CompassMapContentView: View {
     @State private var nearbyRoutes: [Route] = []
     @State private var selectedRoute: Route? = nil
     @State private var isShowingRouteDetail: Bool = false
+    @State private var isShowingCreateRoute: Bool = false
 
     // Single chat sheet (replaces former plus-menu + voice-overlay split).
     // Presentation is driven by `voiceOrchestrator` via `.sheet(item:)`.
@@ -495,6 +496,13 @@ struct CompassMapContentView: View {
                                     }
                                 )
 
+                                // Create-your-own-route entry, between Routes and Nearby.
+                                CreateRouteEntryCard {
+                                    isShowingCreateRoute = true
+                                }
+                                .padding(.horizontal, 16)
+                                .padding(.top, 8)
+
                                 NearbySection(
                                     experiences: viewModel.visibleExperiences,
                                     smartPickIds: viewModel.aiSmartPickIds,
@@ -538,6 +546,22 @@ struct CompassMapContentView: View {
                             .environment(experienceService)
                         }
                     }
+                }
+                .sheet(isPresented: $isShowingCreateRoute) {
+                    CreateRouteView(
+                        candidates: viewModel.visibleExperiences,
+                        cityCode: viewModel.selectedCity ?? "",
+                        userCoordinate: locationService.currentLocation?.coordinate
+                            ?? viewModel.defaultCenterForSelectedCity
+                    ) { route in
+                        // Persist + open the new route's detail; RouteStore.didChange
+                        // refreshes the sheet's routes section automatically.
+                        routeStore.save(route)
+                        selectedRoute = route
+                        isShowingRouteDetail = true
+                    }
+                    .environment(aiService)
+                    .environment(experienceService)
                 }
 
                 // Selected-experience card floats ABOVE the BottomInfoSheet

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -1047,7 +1047,7 @@ private extension FavoritesListView {
                     Spacer()
                     Text(NSLocalizedString("action.undo", comment: "Undo action"))
                         .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.accentColor)
+                        .foregroundStyle(Color.accentColor)
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 12)

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -39,7 +39,7 @@ public struct SoloScoreBadge: View {
                     Image(systemName: "star.fill")
                         .font(.caption2)
                         .foregroundStyle(.white.opacity(0.95))
-                        .symbolEffect(.variableColor.iterative.hideInactive, options: .repeating, isActive: twinkle && !reduceMotion)
+                        .symbolEffect(.variableColor.iterative, isActive: twinkle && !reduceMotion)
                         .scaleEffect(twinkle && !reduceMotion ? 1.12 : 1.0)
                         .animation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true), value: twinkle)
                         .accessibilityHidden(true)


### PR DESCRIPTION
## 概述

围绕底部 sheet 的路线/列表体验做了一轮 UI 打磨 + 新增创建路线能力，对齐参考设计截图。

## 改动

### ① 下拉列表卡片化 (`ec8a5ae`)
`NearbyExperienceRow` 从分割线扁平行 → 独立白底圆角卡片：左侧类别色竖条（smart pick 为金色 + 浅金渐变背景）、实心圆形类别图标、标题 + 罗马音·本地名副标题、`N min / Solo X.X / 此刻最佳 / 稀疏·中等` chip 行、右侧方位箭头 + 距离。行间 10pt 间距取代全宽 Divider。

### ② 招募路线区块优化 (`632171a`)
- RouteCard recruit-mini strip 增加右侧「查看 >」可进入指示，招募文案改为 `N/M 已確認 ·`，对齐截图。
- `DiscoverRecruitingRoutesView` 去掉 `.insetGrouped` List + `-16` 负 padding 的双卡 hack，改为 `ScrollView`/`LazyVStack` 卡片流，并移除与 RouteCard 重复的 slot chip。

### ③ 创建路线入口 + 流程 (`881b7d5`)
- `CreateRouteEntryCard`：截图那张「創建你自己的路線」虚线卡，插入 sheet 路线区与附近区之间（mid/full detent）。
- `CreateRouteView`：多选附近 experiences（按点选顺序编号串联）/ 设标题·节奏 / 保存为 `userCreated`(或 AI 种子时 `coCreated`) 路线，经 `RouteStore` 持久化并打开详情。

### ④ AI 发现/生成路线 (`881b7d5`)
- `AIService.generateRoute`：让模型从周围 experiences 选 3–5 站串成 walkable 路线（标题/summary/reasonNow，JSON 返回）；无 key 或解析失败时回退到本地 Solo-score 最近邻贪心串联，保证总能产出路线。遵守 trust-boundary（只回采候选内的 id）。
- `RouteBuilder`：共享纯逻辑——Haversine 累加距离、步行时长 + 每站停留估算、最近邻排序。`RouteBuilderTests` 覆盖（7 用例）。

### 附带：修复本机 Xcode 26.4 SDK 预存编译坑 (`c932fab`)
`.foregroundStyle(.accentColor)` → `Color.accentColor`；`.symbolEffect(.variableColor.iterative.hideInactive, options:.repeating, …)` 在新 SDK 下推断歧义 → 改用 `.variableColor.iterative, isActive:`。CI 旧工具链此前一直绿，但本地 26.4 SDK 无此修复则完全无法构建。

## 验证
- 每阶段 `xcodebuild build` 通过；用 `ImageRenderer` 渲染 PNG 肉眼核对与截图一致。
- 回归测试 28 项全绿（含 RouteBuilder 7、RouteCard recruit-mini、section separation、empty state、ghost SF symbols）。

## 本地化
en + zh-Hans 同步新增 `nearby.chip.*` / `nearby.proximity.*` / `route.card.recruit.view` / `route.create.*` / `route.generate.*`。

## 备注
- 创建流程当前聚焦"走"本身，招募同伴留给保存后从路线详情发起（`OpenForCompanionsSheet` 已有）。
