### PR TITLE
feat(ios): 开始路线 → 在地图上绘制路线（polyline + 站点序号 + 相机聚焦）

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		337CAFC8B35CF36D175B27CF /* CompareTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F836182A03FC067C4A9AB9 /* CompareTokens.swift */; };
 		352247C1FBF4C8F901D17F32 /* ApprovalTrustSignalTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804618047547A9D7F3F8EAAA /* ApprovalTrustSignalTest.swift */; };
 		371DDBAF4C385267248ABC83 /* AgentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38E5736BF6DF5644D687637 /* AgentRouter.swift */; };
+		3889A861FFD32BE4EEE4F19F /* ActiveRouteOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CEA4BFADFDB1575F6655E48 /* ActiveRouteOverlay.swift */; };
 		391D6B5C48997AD74F367C0C /* GeneratedSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5642EDC714993C8EE0ECDD83 /* GeneratedSecrets.swift */; };
 		397C20402788F9B63F06A01A /* City.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFBC1C003B8745713588A23 /* City.swift */; };
 		3A91B128119A6288C6C9A9D9 /* CompassMapViewLayerToggleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0535B15C19B134898D9880BE /* CompassMapViewLayerToggleTests.swift */; };
@@ -339,6 +340,7 @@
 		2891DAE62909FE55324494D7 /* VerifiedBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedBadge.swift; sourceTree = "<group>"; };
 		295A9108AFAF3BEE4EFF7524 /* HeartBurstView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeartBurstView.swift; sourceTree = "<group>"; };
 		2C7919EAFDE363B49C4B4C47 /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
+		2CEA4BFADFDB1575F6655E48 /* ActiveRouteOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveRouteOverlay.swift; sourceTree = "<group>"; };
 		2CEFD2E522C2D9FFF8EF0B0B /* ConversationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationTests.swift; sourceTree = "<group>"; };
 		2D52E68EDCAB1AEF0737B201 /* AvatarStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarStack.swift; sourceTree = "<group>"; };
 		2DA6E405C780A5A12A9FC1D6 /* MicroSurveySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicroSurveySheet.swift; sourceTree = "<group>"; };
@@ -660,6 +662,7 @@
 		2A5B2A9CBB684C51EA76313E /* Map */ = {
 			isa = PBXGroup;
 			children = (
+				2CEA4BFADFDB1575F6655E48 /* ActiveRouteOverlay.swift */,
 				04709B5AD986143D04CA0A08 /* BottomInfoSheet.swift */,
 				873ACB737A9B43254C17B238 /* CityPickerSheet.swift */,
 				BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */,
@@ -1330,6 +1333,7 @@
 				D699D4E3E20FE7A7C0ED7E66 /* AIService.swift in Sources */,
 				F34C1A42668EF5151AFEE3C3 /* AISynthesisCacheRecord.swift in Sources */,
 				464746A44182622D4F617462 /* AIUsageRecord.swift in Sources */,
+				3889A861FFD32BE4EEE4F19F /* ActiveRouteOverlay.swift in Sources */,
 				8D5DD4E0CD6237FA70C7F99F /* AddToItinerarySheet.swift in Sources */,
 				D825B4D4C81AC33373DA1437 /* AgentMessage.swift in Sources */,
 				371DDBAF4C385267248ABC83 /* AgentRouter.swift in Sources */,

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1273,6 +1273,11 @@
 "route.create.selectedCount" = "已選 %d";
 "route.create.save" = "保存";
 
+/* Active route drawn on the map (start route) */
+"route.active.stops" = "%d 站 · 路線中";
+"route.active.stop.a11y" = "Stop %d";
+"route.active.end" = "結束路線";
+
 /* US-058 — RouteCard walked-by row (CompareCanvas A-003) */
 "route.card.walkedBy" = "%d 位旅人走过";
 

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1276,6 +1276,11 @@
 "route.create.selectedCount" = "已选 %d";
 "route.create.save" = "保存";
 
+/* Active route drawn on the map (start route) */
+"route.active.stops" = "%d 站 · 路线中";
+"route.active.stop.a11y" = "第 %d 站";
+"route.active.end" = "结束路线";
+
 /* Solo score breakdown */
 "solo.breakdown.title" = "独行评分";
 "solo.compact.a11y.hint" = "双击查看评分明细";

--- a/apps/ios/SoloCompass/Views/Companion/RouteDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/RouteDetailView.swift
@@ -15,10 +15,15 @@ import SwiftUI
 public struct RouteDetailView: View {
     let route: Route
     var onTapStop: (Experience) -> Void
+    /// Called when the traveler taps "开始路线" — the host screen draws the route
+    /// on the map and dismisses this detail. Defaults to a no-op so the other
+    /// presentation sites (chat, requests, walked-routes) need no changes.
+    var onStartRoute: (Route) -> Void
 
     @Environment(ExperienceService.self) private var service
     @Environment(UserPreferences.self) private var preferences
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
     @State private var isSaved = false
     @State private var isFavorited = false
     @State private var showJoinSheet = false
@@ -27,10 +32,15 @@ public struct RouteDetailView: View {
     // Refreshes whenever RouteStore.didChange fires (join request submitted, accepted, etc.)
     @State private var liveRoute: Route
 
-    public init(route: Route, onTapStop: @escaping (Experience) -> Void = { _ in }) {
+    public init(
+        route: Route,
+        onTapStop: @escaping (Experience) -> Void = { _ in },
+        onStartRoute: @escaping (Route) -> Void = { _ in }
+    ) {
         self.route = route
         self._liveRoute = State(initialValue: route)
         self.onTapStop = onTapStop
+        self.onStartRoute = onStartRoute
     }
 
     // MARK: - Companion recruiting helpers
@@ -316,7 +326,12 @@ public struct RouteDetailView: View {
                 label: NSLocalizedString("route.detail.start", comment: ""),
                 systemImage: "location.north.line.fill",
                 isDisabled: false,
-                action: {}
+                action: {
+                    // Hand the route up to the map host (draws the polyline +
+                    // numbered stops, frames the camera) and close this sheet.
+                    onStartRoute(liveRoute)
+                    dismiss()
+                }
             )
         }
 

--- a/apps/ios/SoloCompass/Views/Map/ActiveRouteOverlay.swift
+++ b/apps/ios/SoloCompass/Views/Map/ActiveRouteOverlay.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+import CoreLocation
+
+// MARK: - ActiveRoute
+
+/// A route currently drawn on the map: the route itself plus its stops resolved
+/// to coordinates in walking order. Held by `CompassMapContentView` and rendered
+/// as a polyline + numbered pins; `nil` means no route is active.
+struct ActiveRoute: Equatable {
+    let route: Route
+    let coordinates: [CLLocationCoordinate2D]
+
+    static func == (lhs: ActiveRoute, rhs: ActiveRoute) -> Bool {
+        lhs.route.id == rhs.route.id &&
+        lhs.coordinates.count == rhs.coordinates.count &&
+        zip(lhs.coordinates, rhs.coordinates).allSatisfy {
+            $0.latitude == $1.latitude && $0.longitude == $1.longitude
+        }
+    }
+}
+
+// MARK: - RouteStopBadge
+
+/// Numbered pin marking a stop's position along the active route. The number
+/// reads the walking order at a glance.
+struct RouteStopBadge: View {
+    let number: Int
+
+    var body: some View {
+        Text("\(number)")
+            .font(.system(size: 13, weight: .bold))
+            .foregroundStyle(.white)
+            .frame(width: 26, height: 26)
+            .background(Circle().fill(Color.accentColor))
+            .overlay(Circle().strokeBorder(.white, lineWidth: 2))
+            .shadow(color: .black.opacity(0.2), radius: 2, y: 1)
+            .accessibilityLabel(Text(String(
+                format: NSLocalizedString("route.active.stop.a11y", comment: "Route stop %d"),
+                number
+            )))
+    }
+}
+
+// MARK: - ActiveRouteBanner
+
+/// Top banner shown while a route is active: a walking glyph, the route title,
+/// the stop count, and an end button that clears the route from the map.
+struct ActiveRouteBanner: View {
+    let title: String
+    let stopCount: Int
+    let onEnd: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "figure.walk")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Text(String(
+                    format: NSLocalizedString("route.active.stops", comment: "N stops"),
+                    stopCount
+                ))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 4)
+            Button(action: onEnd) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 30, height: 30)
+                    .background(Circle().fill(Color.secondary.opacity(0.12)))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(Text(NSLocalizedString("route.active.end", comment: "End route")))
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .shadow(color: .black.opacity(0.08), radius: 6, y: 2)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#Preview("ActiveRouteBanner") {
+    ActiveRouteBanner(title: "湄公河日落散步", stopCount: 3, onEnd: {})
+        .padding()
+}

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -114,6 +114,9 @@ struct CompassMapContentView: View {
     @State private var selectedRoute: Route? = nil
     @State private var isShowingRouteDetail: Bool = false
     @State private var isShowingCreateRoute: Bool = false
+    // The route currently drawn on the map (polyline + numbered stops), set when
+    // the traveler taps "开始路线" in RouteDetailView. nil = no active route.
+    @State private var activeRoute: ActiveRoute? = nil
 
     // Single chat sheet (replaces former plus-menu + voice-overlay split).
     // Presentation is driven by `voiceOrchestrator` via `.sheet(item:)`.
@@ -538,11 +541,18 @@ struct CompassMapContentView: View {
                 .sheet(isPresented: $isShowingRouteDetail) {
                     if let route = selectedRoute {
                         NavigationStack {
-                            RouteDetailView(route: route) { exp in
-                                isShowingRouteDetail = false
-                                viewModel.selectExperience(exp)
-                                viewModel.isShowingDetail = true
-                            }
+                            RouteDetailView(
+                                route: route,
+                                onTapStop: { exp in
+                                    isShowingRouteDetail = false
+                                    viewModel.selectExperience(exp)
+                                    viewModel.isShowingDetail = true
+                                },
+                                onStartRoute: { route in
+                                    isShowingRouteDetail = false
+                                    startRouteOnMap(route)
+                                }
+                            )
                             .environment(experienceService)
                         }
                     }
@@ -580,6 +590,24 @@ struct CompassMapContentView: View {
                         .padding(.bottom, cardBottomInset)
                     }
                     .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+
+                // Active-route banner: a top pill naming the walk with an end
+                // button. Floats above the map; tapping ⨯ clears the polyline.
+                if let active = activeRoute {
+                    VStack {
+                        ActiveRouteBanner(
+                            title: active.route.title,
+                            stopCount: active.coordinates.count,
+                            onEnd: {
+                                withAnimation(.easeInOut(duration: 0.25)) { activeRoute = nil }
+                            }
+                        )
+                        .padding(.horizontal, 16)
+                        .padding(.top, 8)
+                        Spacer()
+                    }
+                    .transition(.move(edge: .top).combined(with: .opacity))
                 }
         }
     }
@@ -738,6 +766,50 @@ struct CompassMapContentView: View {
         )
         .environment(experienceService)
         .environment(preferences)
+    }
+
+    // MARK: - Start route on map
+
+    /// Resolve a route's stops to coordinates, store them as the active route so
+    /// the map draws the polyline + numbered pins, and frame the camera around
+    /// the whole walk. Called when the traveler taps "开始路线".
+    private func startRouteOnMap(_ route: Route) {
+        let coords = route.experienceIds
+            .compactMap { experienceService.getExperience(id: $0)?.coordinate }
+        guard !coords.isEmpty else {
+            // No geocoded stops at all — nothing to show. Clear any prior route.
+            activeRoute = nil
+            return
+        }
+        // 1 stop → no polyline (handled by the Map's count>=2 guard) but we still
+        // mark the stop and fly there, so "start" always gives visible feedback.
+        activeRoute = ActiveRoute(route: route, coordinates: coords)
+        viewModel.cameraPosition = .region(Self.region(enclosing: coords))
+        HapticService.shared.impact(style: .medium)
+    }
+
+    /// A region that comfortably encloses all `coords`, with ~30% padding so the
+    /// end pins aren't flush against the screen edge. Falls back to a tight box
+    /// for a single point (shouldn't happen — callers require ≥2).
+    private static func region(enclosing coords: [CLLocationCoordinate2D]) -> MKCoordinateRegion {
+        let lats = coords.map(\.latitude)
+        let lons = coords.map(\.longitude)
+        guard let minLat = lats.min(), let maxLat = lats.max(),
+              let minLon = lons.min(), let maxLon = lons.max() else {
+            return MKCoordinateRegion(
+                center: coords.first ?? CLLocationCoordinate2D(latitude: 0, longitude: 0),
+                span: MKCoordinateSpan(latitudeDelta: 0.02, longitudeDelta: 0.02)
+            )
+        }
+        let center = CLLocationCoordinate2D(
+            latitude: (minLat + maxLat) / 2,
+            longitude: (minLon + maxLon) / 2
+        )
+        let span = MKCoordinateSpan(
+            latitudeDelta: max((maxLat - minLat) * 1.3, 0.005),
+            longitudeDelta: max((maxLon - minLon) * 1.3, 0.005)
+        )
+        return MKCoordinateRegion(center: center, span: span)
     }
 
     @ViewBuilder
@@ -914,6 +986,22 @@ struct CompassMapContentView: View {
                     MapCircle(center: ring.center, radius: ring.radiusMeters)
                         .foregroundStyle(Color.accentColor.opacity(0.08))
                         .stroke(Color.accentColor.opacity(0.35), lineWidth: 1.5)
+                }
+
+                // Active route: a connecting polyline plus numbered stop pins so
+                // the walk reads as an ordered sequence on the map. Drawn last so
+                // the line and numbers sit above the radius ring.
+                if let active = activeRoute, active.coordinates.count >= 2 {
+                    MapPolyline(coordinates: active.coordinates, contourStyle: .straight)
+                        .stroke(
+                            Color.accentColor,
+                            style: StrokeStyle(lineWidth: 4, lineCap: .round, lineJoin: .round)
+                        )
+                    ForEach(Array(active.coordinates.enumerated()), id: \.offset) { index, coord in
+                        Annotation("", coordinate: coord) {
+                            RouteStopBadge(number: index + 1)
+                        }
+                    }
                 }
             }
             .mapStyle(.standard(elevation: .flat, pointsOfInterest: .excludingAll))


### PR DESCRIPTION
## 问题

底部 sheet 路线详情里的「开始路线」按钮是个空 stub —— `action: {}`，点击什么都不发生（用户反馈"点击开始路线还是不行"）。而且地图层此前完全没有路线绘制能力。

## 改动：把「开始路线」打通到地图

- **RouteDetailView**：新增 `onStartRoute: (Route) -> Void` 回调（带默认 no-op，其它 5 个呈现点无需改）；「开始路线」CTA 从 `{}` 改为 `onStartRoute(liveRoute)` + `dismiss()`。
- **CompassMapContentView**：
  - 新增 `startRouteOnMap(_:)` —— 把 route 的 `experienceIds` 经 `experienceService.getExperience(id:)` 解析成坐标序列，存为 `ActiveRoute`，并把相机 region 框到整条路线（带 ~30% padding）。
  - Map 内新增 `MapPolyline` 连线 + 每个站点的 `RouteStopBadge`（蓝底白数字序号）。
  - 顶部 `ActiveRouteBanner`：步行图标 + 路线名 + `N 站 · 路線中` + ⨯ 结束按钮（清除路线）。
- **单站路线兜底**：`mekong-sunset` 这类只有 1 站的 seed 路线，不画线但仍标记该点 + 飞过去，所以「开始」永远有视觉反馈（避免又一次"点了没反应"）。
- **新增** `ActiveRouteOverlay.swift`（ActiveRoute / RouteStopBadge / ActiveRouteBanner）。

## 验证

- 模拟器实机验证：以 `Vientiane Monuments`（万象 3 地标）启动「开始路线」→ 地图画出蓝色 polyline 串起 3 个站点、站点带序号、相机自动框住整条路线、顶部 banner 正确显示。（截图见下方评论 / 已肉眼确认）
- 组件 PNG 渲染确认 banner + badge 外观。
- 构建通过；回归测试 18 项全绿（RouteBuilder / RouteCard / SF symbols）。

## 本地化
en + zh-Hans 新增 `route.active.stops` / `route.active.stop.a11y` / `route.active.end`。

## 备注
seed 数据核查：4 条 seed 路线中 3 条 ≥2 站可画线，mekong-sunset 单站走兜底路径。
