### PR TITLE
feat(ios): draw a route on the map when 开始路线 is tapped

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -241,6 +241,7 @@
 		D7ABC99B7839B64FF014D344 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70AF2705AB2F24B69DE8CB4F /* PerformanceTests.swift */; };
 		D7CC906B358ED5337880A942 /* seed_experiences.json in Resources */ = {isa = PBXBuildFile; fileRef = 61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */; };
 		D825B4D4C81AC33373DA1437 /* AgentMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DCEFC3560FED53D0CB5D19 /* AgentMessage.swift */; };
+		DB1CF6212A00A37058317559 /* StartRouteCoordinateResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377590D8F67E082E58EDEAB9 /* StartRouteCoordinateResolutionTests.swift */; };
 		DD17BA9771494EA9F0E4ECC5 /* TopOverlayLayoutTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30D09E054C6CE013359301E /* TopOverlayLayoutTest.swift */; };
 		DD2D33487360F16C48C55EE8 /* HeartBurstView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295A9108AFAF3BEE4EFF7524 /* HeartBurstView.swift */; };
 		DE7491E6540301BC07A37D10 /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39F3D5F813E5C3B23C7EE30 /* FlowLayout.swift */; };
@@ -356,6 +357,7 @@
 		35E8F519A353F18BDE4C3307 /* FilterChipContrastTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterChipContrastTest.swift; sourceTree = "<group>"; };
 		362DB30A847EE598631A10B2 /* HitTargetSizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitTargetSizeTests.swift; sourceTree = "<group>"; };
 		363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceCardView.swift; sourceTree = "<group>"; };
+		377590D8F67E082E58EDEAB9 /* StartRouteCoordinateResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartRouteCoordinateResolutionTests.swift; sourceTree = "<group>"; };
 		37C75D64D462A03DBEFFC4EB /* FilterNowMapSyncTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterNowMapSyncTest.swift; sourceTree = "<group>"; };
 		387808A923EC7A99AD5390FD /* CompletionMoment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionMoment.swift; sourceTree = "<group>"; };
 		397E1B23A9CF2D6470C7C954 /* ItineraryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItineraryStore.swift; sourceTree = "<group>"; };
@@ -760,6 +762,7 @@
 				ED3CB5045CE59A613B5CAAF5 /* SoloCompassTests.swift */,
 				0C6FC4A3B60FA8D9DC3A4779 /* SoloScoreRadarA11yTest.swift */,
 				61C0472D19B6973CF720ADBD /* SortButtonA11yValueTest.swift */,
+				377590D8F67E082E58EDEAB9 /* StartRouteCoordinateResolutionTests.swift */,
 				B14FE2118ED82DD0593F5C3C /* StringsParityTests.swift */,
 				331B2AE74EFAD9589AF60498 /* TodoIssueReferenceTests.swift */,
 				D30D09E054C6CE013359301E /* TopOverlayLayoutTest.swift */,
@@ -1311,6 +1314,7 @@
 				EBE1ACB7D574EE000B028B23 /* SoloCompassTests.swift in Sources */,
 				BEBD238595F699B6B8EA75F5 /* SoloScoreRadarA11yTest.swift in Sources */,
 				8632F28AFD6C3E52A0536BA2 /* SortButtonA11yValueTest.swift in Sources */,
+				DB1CF6212A00A37058317559 /* StartRouteCoordinateResolutionTests.swift in Sources */,
 				3EF7E97963960C09B7A5575D /* StringsParityTests.swift in Sources */,
 				CA89195562C759E6F118465B /* TodoIssueReferenceTests.swift in Sources */,
 				DD17BA9771494EA9F0E4ECC5 /* TopOverlayLayoutTest.swift in Sources */,

--- a/apps/ios/SoloCompass/Persistence/RouteStore.swift
+++ b/apps/ios/SoloCompass/Persistence/RouteStore.swift
@@ -71,12 +71,14 @@ public final class RouteStore {
     }
 
     /// Routes in a given city, capped at `limit` results. Non-positive
-    /// `limit` returns an empty array. Order is unspecified beyond the city
-    /// filter — sort at the call site if needed.
+    /// `limit` returns an empty array. Sorted by `title` so the Routes section
+    /// shows a stable, deterministic order across app restarts (the fetch is
+    /// otherwise unordered, which made the list shuffle on each cold start).
     public func nearby(cityCode: String, limit: Int) -> [Route] {
         guard limit > 0 else { return [] }
         var descriptor = FetchDescriptor<RouteRecord>(
-            predicate: #Predicate { $0.cityCode == cityCode }
+            predicate: #Predicate { $0.cityCode == cityCode },
+            sortBy: [SortDescriptor(\.title)]
         )
         descriptor.fetchLimit = limit
         return (try? context.fetch(descriptor))?.map(\.asValue) ?? []

--- a/apps/ios/SoloCompass/Tests/MapViewModelCityRegionSyncTests.swift
+++ b/apps/ios/SoloCompass/Tests/MapViewModelCityRegionSyncTests.swift
@@ -68,4 +68,44 @@ final class MapViewModelCityRegionSyncTests: XCTestCase {
             "Camera must center on San Francisco within 1 km after switching"
         )
     }
+
+    // MARK: - V-006: Vientiane (VTE) center resolution
+
+    /// The seed code `VTE` must resolve to the authoritative Vientiane center
+    /// (added in V-006). A cold start here previously fell through to the live
+    /// centroid, which was empty during init → black screen.
+    func testDefaultCenterForVTESeedCodeResolvesCatalog() throws {
+        let vm = makeViewModel(startingCity: "VTE")
+        let expected = try XCTUnwrap(MapViewModel.knownCityCenters["VTE"])
+        XCTAssertLessThan(
+            distanceKm(vm.defaultCenterForSelectedCity, expected), 0.1,
+            "VTE must resolve to the catalog Vientiane center"
+        )
+        // ~17.96°N, 102.6°E — Vientiane proper.
+        XCTAssertEqual(vm.defaultCenterForSelectedCity.latitude, 17.9757, accuracy: 0.05)
+        XCTAssertEqual(vm.defaultCenterForSelectedCity.longitude, 102.6331, accuracy: 0.05)
+    }
+
+    /// The human slug `vientiane` resolves to the same center via the catalog's
+    /// slug key (kept in lockstep with the `VTE` seed code).
+    func testDefaultCenterForVientianeSlugResolvesCatalog() throws {
+        let vm = makeViewModel(startingCity: "vientiane")
+        let vte = try XCTUnwrap(MapViewModel.knownCityCenters["VTE"])
+        XCTAssertLessThan(
+            distanceKm(vm.defaultCenterForSelectedCity, vte), 0.1,
+            "vientiane slug must resolve to the same center as the VTE seed code"
+        )
+    }
+
+    /// A city the catalog doesn't cover and that has no seeded experiences falls
+    /// back to the global default center rather than crashing or returning NaN.
+    func testDefaultCenterForUnknownCityFallsBackToDefault() throws {
+        let vm = makeViewModel(startingCity: "zzz-nonexistent")
+        let center = vm.defaultCenterForSelectedCity
+        XCTAssertTrue(CLLocationCoordinate2DIsValid(center))
+        XCTAssertLessThan(
+            distanceKm(center, MapViewModel.defaultCenter), 0.1,
+            "Unknown, unseeded city must fall back to the default center"
+        )
+    }
 }

--- a/apps/ios/SoloCompass/Tests/RouteStoreTests.swift
+++ b/apps/ios/SoloCompass/Tests/RouteStoreTests.swift
@@ -167,6 +167,17 @@ final class RouteStoreTests: XCTestCase {
         XCTAssertTrue(store.nearby(cityCode: "tyo", limit: -1).isEmpty)
     }
 
+    /// `nearby` sorts by title so the Routes section order is stable across
+    /// restarts. Saving out of alphabetical order must still return sorted.
+    func testNearbySortsByTitleForStableOrder() {
+        store.save(makeRoute(id: "route_c", title: "Charlie", cityCode: "tyo"))
+        store.save(makeRoute(id: "route_a", title: "Alpha", cityCode: "tyo"))
+        store.save(makeRoute(id: "route_b", title: "Bravo", cityCode: "tyo"))
+
+        let titles = store.nearby(cityCode: "tyo", limit: 10).map(\.title)
+        XCTAssertEqual(titles, ["Alpha", "Bravo", "Charlie"])
+    }
+
     // MARK: - didChange notification
 
     func testSavePostsDidChangeNotification() {

--- a/apps/ios/SoloCompass/Tests/StartRouteCoordinateResolutionTests.swift
+++ b/apps/ios/SoloCompass/Tests/StartRouteCoordinateResolutionTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+import CoreLocation
+import MapKit
+@testable import SoloCompass
+
+/// Guards the data contract behind 开始路线 → draw-on-map. `CompassMapContentView`
+/// resolves a route's `experienceIds` to coordinates and only draws a connecting
+/// `MapPolyline` when ≥2 resolve (single-stop routes just drop a pin). These tests
+/// pin that the seeded routes actually resolve, so the map draw is reachable —
+/// the original bug was that the Routes section was empty on a cold start, so the
+/// CTA was never even tappable.
+final class StartRouteCoordinateResolutionTests: XCTestCase {
+
+    /// Every stop of every seed route resolves to a coordinate. A miss here means
+    /// 开始路线 would silently no-op (the `coords.isEmpty` guard clears the route).
+    func testEverySeedRouteStopResolvesToACoordinate() throws {
+        let routes = try loadRoutes()
+        let byId = try experiencesById()
+
+        for route in routes {
+            let coords = route.experienceIds.compactMap { byId[$0]?.coordinate }
+            XCTAssertEqual(
+                coords.count,
+                route.experienceIds.count,
+                "Route \(route.id.rawValue): \(coords.count)/\(route.experienceIds.count) stops resolved — unresolved stops break the map draw"
+            )
+            for c in coords {
+                XCTAssertTrue(CLLocationCoordinate2DIsValid(c), "Resolved coordinate must be valid")
+            }
+        }
+    }
+
+    /// A multi-stop route (vientiane-monuments, 3 stops) resolves to ≥2 coordinates
+    /// so the polyline branch (`active.coordinates.count >= 2`) actually fires, and
+    /// the enclosing region has a finite, non-zero span (a 0/NaN span is what made
+    /// the map render a 0×0 Metal layer → black screen).
+    func testMultiStopRouteProducesDrawablePolylineAndRegion() throws {
+        let routes = try loadRoutes()
+        let byId = try experiencesById()
+
+        let monuments = try XCTUnwrap(
+            routes.first { $0.id.rawValue == "vientiane-monuments" },
+            "vientiane-monuments seed route must exist"
+        )
+        let coords = monuments.experienceIds.compactMap { byId[$0]?.coordinate }
+        XCTAssertGreaterThanOrEqual(coords.count, 2, "Polyline requires ≥2 resolved stops")
+
+        let region = Self.region(enclosing: coords)
+        XCTAssertTrue(region.span.latitudeDelta.isFinite && region.span.latitudeDelta > 0)
+        XCTAssertTrue(region.span.longitudeDelta.isFinite && region.span.longitudeDelta > 0)
+        XCTAssertTrue(CLLocationCoordinate2DIsValid(region.center))
+        // Vientiane sits at ~17.96°N, 102.6°E — sanity-check the camera lands there.
+        XCTAssertEqual(region.center.latitude, 17.96, accuracy: 0.2)
+        XCTAssertEqual(region.center.longitude, 102.6, accuracy: 0.3)
+    }
+
+    /// A single-stop route (mekong-sunset) frames at the minimum span — centered
+    /// on the lone pin at street level, not slammed all the way in. The polyline
+    /// branch won't fire (only 1 coord), which is the intended "pin + fly" path.
+    func testSingleStopRouteFramesAtMinimumSpan() throws {
+        let routes = try loadRoutes()
+        let byId = try experiencesById()
+
+        let mekong = try XCTUnwrap(
+            routes.first { $0.id.rawValue == "mekong-sunset" },
+            "mekong-sunset seed route must exist"
+        )
+        let coords = mekong.experienceIds.compactMap { byId[$0]?.coordinate }
+        XCTAssertEqual(coords.count, 1, "mekong-sunset is the single-stop seed route")
+
+        let region = Self.region(enclosing: coords)
+        XCTAssertEqual(region.span.latitudeDelta, Self.minRegionSpan, accuracy: 1e-9)
+        XCTAssertEqual(region.span.longitudeDelta, Self.minRegionSpan, accuracy: 1e-9)
+        XCTAssertEqual(region.center.latitude, coords[0].latitude, accuracy: 1e-9)
+        XCTAssertEqual(region.center.longitude, coords[0].longitude, accuracy: 1e-9)
+    }
+
+    /// Partial resolution drops only the unresolvable stops (compactMap), so a
+    /// route whose middle stop is missing still yields the resolvable ones — the
+    /// polyline bridges the gap. This pins the count contract `startRouteOnMap`
+    /// relies on (and that the os_log warning reports against).
+    func testPartialResolutionKeepsOnlyResolvableStops() throws {
+        let byId = try experiencesById()
+        let known = try XCTUnwrap(byId["exp_vte_patuxai_view"]?.coordinate)
+        let known2 = try XCTUnwrap(byId["exp_vte_pha_that_luang_dawn"]?.coordinate)
+
+        let ids = ["exp_vte_patuxai_view", "exp_does_not_exist", "exp_vte_pha_that_luang_dawn"]
+        let coords = ids.compactMap { byId[$0]?.coordinate }
+
+        XCTAssertEqual(coords.count, 2, "Only the two resolvable stops survive compactMap")
+        XCTAssertEqual(coords[0].latitude, known.latitude, accuracy: 1e-9)
+        XCTAssertEqual(coords[1].latitude, known2.latitude, accuracy: 1e-9)
+    }
+
+    /// A route whose stops all fail to resolve yields no coordinates — the caller
+    /// (`startRouteOnMap`) then clears `activeRoute` rather than drawing nothing.
+    func testAllStopsUnresolvedYieldsNoCoordinates() throws {
+        let byId = try experiencesById()
+        let coords = ["nope_1", "nope_2"].compactMap { byId[$0]?.coordinate }
+        XCTAssertTrue(coords.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    /// Mirrors `CompassMapContentView.region(enclosing:)` (a private method) so the
+    /// test exercises the same bounding-box + 30% padding math the map uses.
+    private static func region(enclosing coords: [CLLocationCoordinate2D]) -> MKCoordinateRegion {
+        let lats = coords.map(\.latitude)
+        let lons = coords.map(\.longitude)
+        let minLat = lats.min() ?? 0, maxLat = lats.max() ?? 0
+        let minLon = lons.min() ?? 0, maxLon = lons.max() ?? 0
+        let center = CLLocationCoordinate2D(
+            latitude: (minLat + maxLat) / 2,
+            longitude: (minLon + maxLon) / 2
+        )
+        let span = MKCoordinateSpan(
+            latitudeDelta: max((maxLat - minLat) * 1.3, Self.minRegionSpan),
+            longitudeDelta: max((maxLon - minLon) * 1.3, Self.minRegionSpan)
+        )
+        return MKCoordinateRegion(center: center, span: span)
+    }
+
+    /// Mirrors `CompassMapContentView.minRegionSpan`.
+    private static let minRegionSpan: CLLocationDegrees = 0.01
+
+    private func loadRoutes() throws -> [Route] {
+        let data = try Data(contentsOf: try url(for: "seed_routes"))
+        return try JSONDecoder().decode([Route].self, from: data)
+    }
+
+    private func experiencesById() throws -> [String: Experience] {
+        let data = try Data(contentsOf: try url(for: "seed_experiences"))
+        let experiences = try JSONDecoder.iso8601Decoder.decode([Experience].self, from: data)
+        return Dictionary(uniqueKeysWithValues: experiences.map { ($0.id, $0) })
+    }
+
+    private func url(for name: String) throws -> URL {
+        let testBundle = Bundle(for: type(of: self))
+        if let url = testBundle.url(forResource: name, withExtension: "json") { return url }
+        if let url = Bundle.main.url(forResource: name, withExtension: "json") { return url }
+        throw NSError(
+            domain: "StartRouteCoordinateResolutionTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Missing bundled resource \(name).json"]
+        )
+    }
+}

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -283,6 +283,13 @@ public final class MapViewModel {
         "cmi": CLLocationCoordinate2D(latitude: 18.7877, longitude: 98.9938),
         "chiang-mai": CLLocationCoordinate2D(latitude: 18.7877, longitude: 98.9938),
         "san-francisco": CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
+        // V-006: Vientiane (VTE) seeds existed (5 experiences + 4 routes) but the
+        // city had no authoritative center, so a cold start on VTE fell through to
+        // the live centroid — unstable, and empty if `availableCities` hasn't
+        // populated yet during init. Pin the city proper, keyed by both seed code
+        // and slug like the other cities.
+        "VTE": CLLocationCoordinate2D(latitude: 17.9757, longitude: 102.6331),
+        "vientiane": CLLocationCoordinate2D(latitude: 17.9757, longitude: 102.6331),
     ]
 
     /// V-004: human-readable city slugs (used by the city header / persisted
@@ -566,9 +573,19 @@ public final class MapViewModel {
         self.foursquareService = foursquareService
         self.geocodeService = geocodeService
         self.preferences = preferences
-        self.selectedCity = preferences.lastSelectedCity
+        // DEBUG-only: `-startCity <cityCode>` launch argument forces the initial
+        // city (e.g. VTE) so UI tests / manual verification can land directly on
+        // a seeded city without persisting through the picker. Release builds and
+        // launches without the flag fall back to the persisted last-selected city.
+        #if DEBUG
+        let resolvedStartCity = UserDefaults.standard.string(forKey: "startCity")
+            ?? preferences.lastSelectedCity
+        #else
+        let resolvedStartCity = preferences.lastSelectedCity
+        #endif
+        self.selectedCity = resolvedStartCity
         let initialCenter: CLLocationCoordinate2D
-        if let savedCity = preferences.lastSelectedCity {
+        if let savedCity = resolvedStartCity {
             // Resolve center lazily — availableCities depends on experienceService which is set above.
             // We compute inline here since computed properties aren't accessible before init ends.
             var cityExps: [String: [CLLocationCoordinate2D]] = [:]

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import MapKit
+import os
 
 /// THE root view. Map-first means: this is what the app *is*. No tabs. No
 /// drawer. Filters and the bottom info bar overlay it; an experience card
@@ -267,6 +268,13 @@ struct CompassMapContentView: View {
                     if preferences.lastSelectedCity == nil && locationService.currentLocation == nil {
                         isShowingCityPicker = true
                     }
+                    // Populate the Routes section for the initial city. `selectedCity`
+                    // is resolved in the view model's init (from a persisted city or
+                    // the -startCity override), so `onChange(of:selectedCity)` never
+                    // fires for that initial value — without this, a cold start that
+                    // lands directly on a city with seeded routes shows an empty
+                    // Routes section, and 开始路线 is unreachable from the map.
+                    refreshNearbyRoutes(cityCode: viewModel.selectedCity)
                 }
                 viewModel.checkForPendingCheckIns()
             }
@@ -314,6 +322,13 @@ struct CompassMapContentView: View {
             }
             .onChange(of: viewModel.selectedCity) { _, cityCode in
                 refreshNearbyRoutes(cityCode: cityCode)
+                // Clear an active route that belongs to the city we just left —
+                // otherwise its polyline + numbered pins stay drawn at the old
+                // city's coordinates while the camera and experiences have moved
+                // to the new city (an orphan walk floating over the wrong map).
+                if let active = activeRoute, active.route.cityCode != cityCode {
+                    activeRoute = nil
+                }
             }
             .onReceive(NotificationCenter.default.publisher(for: RouteStore.didChange)) { _ in
                 refreshNearbyRoutes(cityCode: viewModel.selectedCity)
@@ -592,8 +607,12 @@ struct CompassMapContentView: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                 }
 
-                // Active-route banner: a top pill naming the walk with an end
-                // button. Floats above the map; tapping ⨯ clears the polyline.
+                // Active-route banner: a pill naming the walk with an end button.
+                // Floats above the map; tapping ⨯ clears the polyline. It sits
+                // BELOW the city pill + filter bar (offset by the filter bar's
+                // bottom edge) so it never overlaps the top controls — including
+                // at large Dynamic Type, where a top-pinned banner would collide.
+                // `.zIndex` keeps it above every other overlay layer.
                 if let active = activeRoute {
                     VStack {
                         ActiveRouteBanner(
@@ -604,10 +623,12 @@ struct CompassMapContentView: View {
                             }
                         )
                         .padding(.horizontal, 16)
-                        .padding(.top, 8)
+                        .padding(.top, MapOverlayMetrics.filterBarTopOffset
+                            + MapOverlayMetrics.filterBarHeight + 8)
                         Spacer()
                     }
                     .transition(.move(edge: .top).combined(with: .opacity))
+                    .zIndex(10)
                 }
         }
     }
@@ -770,16 +791,38 @@ struct CompassMapContentView: View {
 
     // MARK: - Start route on map
 
+    private static let routeLog = OSLog(subsystem: "com.solocompass.app", category: "RouteOnMap")
+
     /// Resolve a route's stops to coordinates, store them as the active route so
     /// the map draws the polyline + numbered pins, and frame the camera around
     /// the whole walk. Called when the traveler taps "开始路线".
     private func startRouteOnMap(_ route: Route) {
-        let coords = route.experienceIds
-            .compactMap { experienceService.getExperience(id: $0)?.coordinate }
+        let resolved = route.experienceIds
+            .map { (id: $0, coord: experienceService.getExperience(id: $0)?.coordinate) }
+        let coords = resolved.compactMap(\.coord)
         guard !coords.isEmpty else {
-            // No geocoded stops at all — nothing to show. Clear any prior route.
+            // No geocoded stops at all — nothing to draw. Clear any prior route and
+            // surface the failure (a stale/broken route) instead of a silent no-op,
+            // which reads to the user as "开始路线 did nothing".
+            os_log(
+                "startRouteOnMap: route %{public}@ has 0 resolvable stops (ids=%{public}@) — nothing drawn",
+                log: Self.routeLog, type: .error,
+                route.id.rawValue, route.experienceIds.joined(separator: ",")
+            )
             activeRoute = nil
             return
+        }
+        // Partial resolution: the polyline silently bridges the gap (stop 1 → stop 3
+        // if stop 2 is missing), which misrepresents the walk. We still draw what we
+        // can but log the dropped stops so the data drift is visible, not silent.
+        let missing = resolved.filter { $0.coord == nil }.map(\.id)
+        if !missing.isEmpty {
+            os_log(
+                "startRouteOnMap: route %{public}@ drew %d/%d stops; unresolved=%{public}@",
+                log: Self.routeLog, type: .info,
+                route.id.rawValue, coords.count, route.experienceIds.count,
+                missing.joined(separator: ",")
+            )
         }
         // 1 stop → no polyline (handled by the Map's count>=2 guard) but we still
         // mark the stop and fly there, so "start" always gives visible feedback.
@@ -788,9 +831,15 @@ struct CompassMapContentView: View {
         HapticService.shared.impact(style: .medium)
     }
 
+    /// Minimum half-comfortable region span (~1.1 km at the equator). Used as the
+    /// floor for a route's bounding box so a single-stop route — or stops that sit
+    /// almost on top of each other — frames at a sensible street-level zoom rather
+    /// than slamming all the way in.
+    private static let minRegionSpan: CLLocationDegrees = 0.01
+
     /// A region that comfortably encloses all `coords`, with ~30% padding so the
-    /// end pins aren't flush against the screen edge. Falls back to a tight box
-    /// for a single point (shouldn't happen — callers require ≥2).
+    /// end pins aren't flush against the screen edge. A single point (1-stop route)
+    /// frames at `minRegionSpan` so the lone pin reads at street level.
     private static func region(enclosing coords: [CLLocationCoordinate2D]) -> MKCoordinateRegion {
         let lats = coords.map(\.latitude)
         let lons = coords.map(\.longitude)
@@ -798,7 +847,7 @@ struct CompassMapContentView: View {
               let minLon = lons.min(), let maxLon = lons.max() else {
             return MKCoordinateRegion(
                 center: coords.first ?? CLLocationCoordinate2D(latitude: 0, longitude: 0),
-                span: MKCoordinateSpan(latitudeDelta: 0.02, longitudeDelta: 0.02)
+                span: MKCoordinateSpan(latitudeDelta: minRegionSpan, longitudeDelta: minRegionSpan)
             )
         }
         let center = CLLocationCoordinate2D(
@@ -806,8 +855,8 @@ struct CompassMapContentView: View {
             longitude: (minLon + maxLon) / 2
         )
         let span = MKCoordinateSpan(
-            latitudeDelta: max((maxLat - minLat) * 1.3, 0.005),
-            longitudeDelta: max((maxLon - minLon) * 1.3, 0.005)
+            latitudeDelta: max((maxLat - minLat) * 1.3, minRegionSpan),
+            longitudeDelta: max((maxLon - minLon) * 1.3, minRegionSpan)
         )
         return MKCoordinateRegion(center: center, span: span)
     }


### PR DESCRIPTION
## What & why

Tapping **开始路线** in a route's detail used to do nothing — the CTA was a no-op (`action: {}`). This PR makes it actually draw the walk on the map, and fixes the surrounding bugs that meant the entry point was often unreachable in the first place.

## Changes

**Feature (`9ce356c`)**
- `RouteDetailView` gains an `onStartRoute` callback; the start CTA calls it + dismisses. Other presentation sites keep the default no-op (Companion-context only).
- `CompassMapContentView` resolves a route's stops to coordinates, holds them as an `ActiveRoute`, draws a `MapPolyline` with numbered `RouteStopBadge` pins, and frames the camera around the whole walk.
- Top `ActiveRouteBanner` names the walk (title · N 站 · 路線中) with an end button that clears the route.
- `route.active.*` strings in en + zh-Hans.

**Fixes & hardening (`7ec5265`)**
- **Cold-start reachability**: `refreshNearbyRoutes` only ran on `onChange(selectedCity)` / `didChange`, neither of which fires for the init-time city — so a cold start landing directly on a city showed an empty Routes section and 开始路线 was unreachable. Now also refreshed in `onAppear`'s first run.
- **VTE black screen**: Vientiane had seeds but no `knownCityCenters` entry → degenerate camera region → `CAMetalLayer 0×0` → black screen. Added VTE/vientiane to the catalog.
- **City-switch orphan**: switching cities now clears an `activeRoute` belonging to the city we left, so its polyline/pins don't float over the wrong map.
- **Silent resolution failures**: `startRouteOnMap` now `os_log`s partial- and total-stop-resolution failures instead of silently mis-drawing or no-op'ing.
- **Single-stop zoom**: frames at a named `minRegionSpan` (0.01°, ~1.1 km) instead of slamming to 0.005°.
- **Banner overlap**: `ActiveRouteBanner` sits below the filter bar with an explicit `zIndex` (verified at default + AX XXL text).
- **Stable order**: `RouteStore.nearby` sorts by title.

## Testing

- New `StartRouteCoordinateResolutionTests`: single / multi / partial / zero-stop resolution + region math.
- Extended `MapViewModelCityRegionSyncTests`: VTE seed-code, vientiane slug, unknown-city fallback.
- Extended `RouteStoreTests`: `nearby` stable sort.
- **58 cases across the affected suites pass.** Regenerated the xcodeproj via `xcodegen` so the new test file is actually compiled and run.
- Verified end-to-end on the simulator: starting *Vientiane Monuments* draws the blue polyline across its 3 stops, banner shows, ⨯ clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)