### PR TITLE
Home + chat UX polish: peek summary card, Saved filter, chat redesign, sheet fixes

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		337CAFC8B35CF36D175B27CF /* CompareTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F836182A03FC067C4A9AB9 /* CompareTokens.swift */; };
 		352247C1FBF4C8F901D17F32 /* ApprovalTrustSignalTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804618047547A9D7F3F8EAAA /* ApprovalTrustSignalTest.swift */; };
 		371DDBAF4C385267248ABC83 /* AgentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38E5736BF6DF5644D687637 /* AgentRouter.swift */; };
+		37D5A0FD622C9649308BD14D /* FavoriteFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA17ED8FE9ABA2F5CC1D557E /* FavoriteFilterTests.swift */; };
 		3889A861FFD32BE4EEE4F19F /* ActiveRouteOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CEA4BFADFDB1575F6655E48 /* ActiveRouteOverlay.swift */; };
 		391D6B5C48997AD74F367C0C /* GeneratedSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5642EDC714993C8EE0ECDD83 /* GeneratedSecrets.swift */; };
 		397C20402788F9B63F06A01A /* City.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFBC1C003B8745713588A23 /* City.swift */; };
@@ -488,6 +489,7 @@
 		A8670B08F2AB2779C31E0870 /* RouteItineraryBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteItineraryBridgeTests.swift; sourceTree = "<group>"; };
 		A95DD95393E5BF9C89FB4977 /* BilingualCityRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualCityRow.swift; sourceTree = "<group>"; };
 		A98E594C5575B41E32382209 /* MyRequestsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRequestsListView.swift; sourceTree = "<group>"; };
+		AA17ED8FE9ABA2F5CC1D557E /* FavoriteFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteFilterTests.swift; sourceTree = "<group>"; };
 		AB46D6F6F8942CD390A5CCF4 /* SoloCompass.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SoloCompass.entitlements; sourceTree = "<group>"; };
 		AF007DB5F72E30021CADA555 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		B14FE2118ED82DD0593F5C3C /* StringsParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringsParityTests.swift; sourceTree = "<group>"; };
@@ -703,6 +705,7 @@
 				649ECD409B685D38E30527FD /* CompletionMomentTests.swift */,
 				2CEFD2E522C2D9FFF8EF0B0B /* ConversationTests.swift */,
 				763DF01F638C99097DD5FE20 /* EmptyStateAnnouncementTest.swift */,
+				AA17ED8FE9ABA2F5CC1D557E /* FavoriteFilterTests.swift */,
 				F8547EB44AE47A5D653D3994 /* FavoritesBounceAvailabilityTest.swift */,
 				5C94CC0395CC7FCC0A56D077 /* FavoritesClosingSoonThresholdTest.swift */,
 				FFED848E66BBE2A234AAA3CC /* FilterBarScrollAffordanceTest.swift */,
@@ -1255,6 +1258,7 @@
 				1130F4E1887551F856FCB9DB /* CompletionMomentTests.swift in Sources */,
 				AA5C5AEBFB7B2266A4781877 /* ConversationTests.swift in Sources */,
 				30293CB7BCCE6B600A82C292 /* EmptyStateAnnouncementTest.swift in Sources */,
+				37D5A0FD622C9649308BD14D /* FavoriteFilterTests.swift in Sources */,
 				F721E7FE777AF2AFA0FA264D /* FavoritesBounceAvailabilityTest.swift in Sources */,
 				4617863D79206886BE4A5586 /* FavoritesClosingSoonThresholdTest.swift in Sources */,
 				63A45A90C2748A2729742C2F /* FilterBarScrollAffordanceTest.swift in Sources */,

--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		3E24606FB907D7BB18E3C496 /* Itinerary.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F5D58C93D87AC9205148CC /* Itinerary.swift */; };
 		3E92704051F386C38C3A5533 /* RouteBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C8EE9D6C64872261609DEF /* RouteBuilderTests.swift */; };
 		3EF7E97963960C09B7A5575D /* StringsParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14FE2118ED82DD0593F5C3C /* StringsParityTests.swift */; };
+		40C8E92653FC718890E3CA5D /* PressableButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A744E7B767BDEC07E9C58F4D /* PressableButtonStyle.swift */; };
 		42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */; };
 		436C2BF0D0723B2B07428F07 /* CompanionBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBBF77E10D341C38C093D22D /* CompanionBlock.swift */; };
 		45A4E8EED0300F00253EC049 /* MarkdownExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F3FDE4BC9458E490AEA67A /* MarkdownExporter.swift */; };
@@ -132,6 +133,7 @@
 		72FF134F24A2BB7A31714A6C /* CompanionMapLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C04120C63712F09D8357CEE /* CompanionMapLayer.swift */; };
 		73A99E8CB82341F557681FCF /* GlassmorphismCapsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5933575E731D8AC09356AB9F /* GlassmorphismCapsule.swift */; };
 		7428B9017BC39BE7BAA4946A /* BottomInfoSheetHandleHitTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88553B5578C07FA890183A0D /* BottomInfoSheetHandleHitTargetTests.swift */; };
+		75B727F4A7C24DF157FFBBAB /* PeekSummaryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554BDD1F80E1A3D35F7FDF2B /* PeekSummaryCard.swift */; };
 		76F57DBD1B6F0020E8BF91E5 /* RecruitingModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612BA64E761957615DD63D34 /* RecruitingModule.swift */; };
 		78EA2DE7E8AA6F5847BE4FAA /* ShareCardScoreL10nTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314F06EBA1DCBD3AC987BEEF /* ShareCardScoreL10nTest.swift */; };
 		79E4FD6C7F9522BDB1106F56 /* PublicAPIDocCommentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCD0D2CE7423C29CD668866 /* PublicAPIDocCommentTests.swift */; };
@@ -194,6 +196,7 @@
 		B42207A02271655D3498B723 /* NoProductionPrintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE95C3399C8616CBDE8B44BE /* NoProductionPrintTests.swift */; };
 		B478C92BB2249C0D5009AABD /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6163572F4644BF852B35FDA4 /* SyncService.swift */; };
 		B4A33EDD3C85BBA89CD4EC05 /* ThemeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AF85DC8F90CA4721DDAEA6 /* ThemeService.swift */; };
+		B5D2608A5B16B07B6E9005DC /* ChatBubbleContrastTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF5100EFECEC87BDC2B007B /* ChatBubbleContrastTest.swift */; };
 		B7366111257111EC98F4A0C4 /* ChatSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9263FC2737FA209F3CD4B5E /* ChatSheet.swift */; };
 		B9EDA827F7E00B19DF97512C /* ConversationRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12888843433B2A00D7CAB18 /* ConversationRecord.swift */; };
 		BA0DD7D5C46016E81A23B2B4 /* ChatInputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88D9F377D7AF634DAE07A3E /* ChatInputBar.swift */; };
@@ -219,6 +222,7 @@
 		C48ABACD6775568202229577 /* LocalizationCoverageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555AA83E46CA214D7F71D811 /* LocalizationCoverageTest.swift */; };
 		C5098ADCDADB1759BD132E62 /* SettingsSheetPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADE6272DBBF6FAE452195AB /* SettingsSheetPresentationTests.swift */; };
 		C53DB60CA9E95907A2CBF2C0 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C215AE07BA32182A887226F9 /* NotificationService.swift */; };
+		C546F3C71BD0E99D59E91630 /* PeekPickResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73B8E83B3522CC4FFEBE10B /* PeekPickResolver.swift */; };
 		C68E48A7B9D9E45647898D4C /* MapViewModelEagerInitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 774D16A741A01ECD6F878025 /* MapViewModelEagerInitTest.swift */; };
 		C72A178F41BDB482E0E02C39 /* ShareCardComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97E92D314B6B62ED3B6EA2AE /* ShareCardComponents.swift */; };
 		C735986DAC69807F27CC0E39 /* FeatureFlags.plist in Resources */ = {isa = PBXBuildFile; fileRef = 409FB4B0922C4A1D8AAEB1D1 /* FeatureFlags.plist */; };
@@ -242,6 +246,7 @@
 		D7ABC99B7839B64FF014D344 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70AF2705AB2F24B69DE8CB4F /* PerformanceTests.swift */; };
 		D7CC906B358ED5337880A942 /* seed_experiences.json in Resources */ = {isa = PBXBuildFile; fileRef = 61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */; };
 		D825B4D4C81AC33373DA1437 /* AgentMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DCEFC3560FED53D0CB5D19 /* AgentMessage.swift */; };
+		D8A9D1CB20E6D46FD5EE373C /* PeekSummarySelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710E82F0D31AB629848EA729 /* PeekSummarySelectionTests.swift */; };
 		DB1CF6212A00A37058317559 /* StartRouteCoordinateResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377590D8F67E082E58EDEAB9 /* StartRouteCoordinateResolutionTests.swift */; };
 		DD17BA9771494EA9F0E4ECC5 /* TopOverlayLayoutTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30D09E054C6CE013359301E /* TopOverlayLayoutTest.swift */; };
 		DD2D33487360F16C48C55EE8 /* HeartBurstView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295A9108AFAF3BEE4EFF7524 /* HeartBurstView.swift */; };
@@ -256,6 +261,7 @@
 		E5A671C7D6965762EEE8A93A /* MapTopOverlayRenderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792E683DA00FBA63A77161A3 /* MapTopOverlayRenderTest.swift */; };
 		E5F463CE3CE822F7F96CA82C /* SoloCompassApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71DE291BE5569E719413B74 /* SoloCompassApp.swift */; };
 		E611DCAFD85FC84D6BF6CADD /* FoursquareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DAE302128E657E150C4B0D /* FoursquareService.swift */; };
+		E6A3296293F74FFD51E56B4C /* InlineBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7A24EA7AB5379E0D5DC2B2 /* InlineBanner.swift */; };
 		E7454BEAD925FCC11C83D83E /* OnboardingSkipTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BCDB936C9D0BE9138C617B /* OnboardingSkipTest.swift */; };
 		E7B5B022519434F7C07818CF /* ExperienceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F087E4FA7161529378098C /* ExperienceService.swift */; };
 		E881A71769542A7C58CF5D10 /* FavoritesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C3BA25EFA9F149FB4FAAB3 /* FavoritesListView.swift */; };
@@ -332,9 +338,11 @@
 		1A9FE3BB447D84732CCE0B07 /* RouteCardWalkedByTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCardWalkedByTest.swift; sourceTree = "<group>"; };
 		1C04120C63712F09D8357CEE /* CompanionMapLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionMapLayer.swift; sourceTree = "<group>"; };
 		1C23113554E651AA08FD2430 /* POILoadingBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POILoadingBanner.swift; sourceTree = "<group>"; };
+		1D7A24EA7AB5379E0D5DC2B2 /* InlineBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineBanner.swift; sourceTree = "<group>"; };
 		1D951F9EC55C09A219D97D55 /* JoinRequestValidationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinRequestValidationTest.swift; sourceTree = "<group>"; };
 		1F39081CF797874064A33814 /* seed_routes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = seed_routes.json; sourceTree = "<group>"; };
 		1FA8C8BF234F3C74D0D8A9BD /* SecretsRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretsRuntime.swift; sourceTree = "<group>"; };
+		1FF5100EFECEC87BDC2B007B /* ChatBubbleContrastTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatBubbleContrastTest.swift; sourceTree = "<group>"; };
 		20208D92E4F564C474E8AEED /* VoiceAgentToolRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAgentToolRouter.swift; sourceTree = "<group>"; };
 		2294AF173D063B1F55894696 /* CompletionCelebrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionCelebrationView.swift; sourceTree = "<group>"; };
 		23043E51C493093CF7244629 /* MicroSurveyRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicroSurveyRecord.swift; sourceTree = "<group>"; };
@@ -386,6 +394,7 @@
 		535B5FA4ADF216CEC74FE056 /* RouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteTests.swift; sourceTree = "<group>"; };
 		53F836182A03FC067C4A9AB9 /* CompareTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompareTokens.swift; sourceTree = "<group>"; };
 		54F3FDE4BC9458E490AEA67A /* MarkdownExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownExporter.swift; sourceTree = "<group>"; };
+		554BDD1F80E1A3D35F7FDF2B /* PeekSummaryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeekSummaryCard.swift; sourceTree = "<group>"; };
 		555AA83E46CA214D7F71D811 /* LocalizationCoverageTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationCoverageTest.swift; sourceTree = "<group>"; };
 		5642EDC714993C8EE0ECDD83 /* GeneratedSecrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedSecrets.swift; sourceTree = "<group>"; };
 		56AF27F0567AACEA9E6D916E /* CompiledPlaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompiledPlaceTests.swift; sourceTree = "<group>"; };
@@ -423,6 +432,7 @@
 		6DFBC1C003B8745713588A23 /* City.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = City.swift; sourceTree = "<group>"; };
 		7022B4362225428DCEB74D59 /* SettingsAdminUnlockTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAdminUnlockTest.swift; sourceTree = "<group>"; };
 		70AF2705AB2F24B69DE8CB4F /* PerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
+		710E82F0D31AB629848EA729 /* PeekSummarySelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeekSummarySelectionTests.swift; sourceTree = "<group>"; };
 		7112C1C0DEDB8C518D83CC18 /* SettingsViewQuerySortTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewQuerySortTest.swift; sourceTree = "<group>"; };
 		7295DF9392F0361C0B2E313D /* AIProviderSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderSettingsView.swift; sourceTree = "<group>"; };
 		72F48906724062C4636DE947 /* MyWalkedRoutesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyWalkedRoutesListView.swift; sourceTree = "<group>"; };
@@ -485,6 +495,7 @@
 		A38E5736BF6DF5644D687637 /* AgentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRouter.swift; sourceTree = "<group>"; };
 		A5435FBA9527C07A9FB07D46 /* SoloCompassModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassModelContainer.swift; sourceTree = "<group>"; };
 		A644911E7B2824A7ABBA4D6F /* SeedRoutesParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedRoutesParityTests.swift; sourceTree = "<group>"; };
+		A744E7B767BDEC07E9C58F4D /* PressableButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PressableButtonStyle.swift; sourceTree = "<group>"; };
 		A7E8E3F1E2D1A0382CC5D9A6 /* ChatService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatService.swift; sourceTree = "<group>"; };
 		A8670B08F2AB2779C31E0870 /* RouteItineraryBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteItineraryBridgeTests.swift; sourceTree = "<group>"; };
 		A95DD95393E5BF9C89FB4977 /* BilingualCityRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualCityRow.swift; sourceTree = "<group>"; };
@@ -518,6 +529,7 @@
 		C5C3BA25EFA9F149FB4FAAB3 /* FavoritesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesListView.swift; sourceTree = "<group>"; };
 		C63BC4737C3134075574125E /* BottomSheetDetentDynamicTypeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetDetentDynamicTypeTest.swift; sourceTree = "<group>"; };
 		C660F7996B1E4387C37720B3 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
+		C73B8E83B3522CC4FFEBE10B /* PeekPickResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeekPickResolver.swift; sourceTree = "<group>"; };
 		C7BCDB936C9D0BE9138C617B /* OnboardingSkipTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSkipTest.swift; sourceTree = "<group>"; };
 		CA1C7F381BB5EE2493C06407 /* RouteDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteDetailView.swift; sourceTree = "<group>"; };
 		CA1F5F43F42E03BA5F10FA2F /* ContextManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextManager.swift; sourceTree = "<group>"; };
@@ -609,6 +621,7 @@
 				D22A9156A8CA2E798375C5C9 /* HitTargetMetrics.swift */,
 				5C62D0EFA5859698D9C70B7D /* OfflineBanner.swift */,
 				130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */,
+				A744E7B767BDEC07E9C58F4D /* PressableButtonStyle.swift */,
 				659B2C7C4B36A086968A28EF /* SkeletonBadgeView.swift */,
 				BEDD4F6238B484BB7C20904B /* SkeletonView.swift */,
 				EB579F3F4EBBA014AA306DD1 /* SoloScoreBadge.swift */,
@@ -675,6 +688,8 @@
 				323B1BAB8D4A2BE116D8A789 /* LocationPickerSheet.swift */,
 				D3DBD8BED52DB4E9DD339BFD /* MapPinPickerView.swift */,
 				0E0157D30FF53B21FF31D519 /* MarkerIconView.swift */,
+				C73B8E83B3522CC4FFEBE10B /* PeekPickResolver.swift */,
+				554BDD1F80E1A3D35F7FDF2B /* PeekSummaryCard.swift */,
 				1C23113554E651AA08FD2430 /* POILoadingBanner.swift */,
 				9EDF4F9F84F50797290FF9E0 /* VoiceProcessingToast.swift */,
 			);
@@ -694,6 +709,7 @@
 				C63BC4737C3134075574125E /* BottomSheetDetentDynamicTypeTest.swift */,
 				999E8DA69CB660A94E71D02A /* BottomSheetSectionSeparationTest.swift */,
 				0674DC5D526883C657A63C38 /* CardBottomInsetClearanceTest.swift */,
+				1FF5100EFECEC87BDC2B007B /* ChatBubbleContrastTest.swift */,
 				308B7A34171C74B1CF2DE3F9 /* CityPillHitTargetTests.swift */,
 				907EA19EC9B84B93AB110C70 /* ColdStartExperienceLoadTests.swift */,
 				A00295FF044E4D732D1EB2EA /* ColorExtensionScopeTest.swift */,
@@ -735,6 +751,7 @@
 				FF7D0A1F8E3B8909F465194C /* ObsidianThemeContrastTest.swift */,
 				61D000D2E41CDD0DBF2B54C1 /* OnboardingA11yOrderTest.swift */,
 				C7BCDB936C9D0BE9138C617B /* OnboardingSkipTest.swift */,
+				710E82F0D31AB629848EA729 /* PeekSummarySelectionTests.swift */,
 				D26F2087E12E63A73B812D7E /* PendingCheckInBannerTests.swift */,
 				70AF2705AB2F24B69DE8CB4F /* PerformanceTests.swift */,
 				A267CD0DA0A8053B0AB072BC /* PrivacyAcknowledgementSheetSnapshotTest.swift */,
@@ -945,6 +962,7 @@
 			children = (
 				B88D9F377D7AF634DAE07A3E /* ChatInputBar.swift */,
 				F9263FC2737FA209F3CD4B5E /* ChatSheet.swift */,
+				1D7A24EA7AB5379E0D5DC2B2 /* InlineBanner.swift */,
 				086B3C207483BA0EBD27451F /* MessageBubble.swift */,
 			);
 			path = Chat;
@@ -1247,6 +1265,7 @@
 				AB8E6644540AE90657471002 /* BottomSheetDetentDynamicTypeTest.swift in Sources */,
 				BF7D61FAEF133A0E77C585C9 /* BottomSheetSectionSeparationTest.swift in Sources */,
 				3CBA775B8C215CBAE3A73EA0 /* CardBottomInsetClearanceTest.swift in Sources */,
+				B5D2608A5B16B07B6E9005DC /* ChatBubbleContrastTest.swift in Sources */,
 				D2BCD302B16BBC174B71F84A /* CityPillHitTargetTests.swift in Sources */,
 				81470D06CD0593B278B110CC /* ColdStartExperienceLoadTests.swift in Sources */,
 				53C4F7B11856CF3D1313A228 /* ColorExtensionScopeTest.swift in Sources */,
@@ -1288,6 +1307,7 @@
 				546A552C93C3537B9A070220 /* ObsidianThemeContrastTest.swift in Sources */,
 				1DAB805A68DF18F2AC776160 /* OnboardingA11yOrderTest.swift in Sources */,
 				E7454BEAD925FCC11C83D83E /* OnboardingSkipTest.swift in Sources */,
+				D8A9D1CB20E6D46FD5EE373C /* PeekSummarySelectionTests.swift in Sources */,
 				045740DB5060EBE8D6D2EEA0 /* PendingCheckInBannerTests.swift in Sources */,
 				D7ABC99B7839B64FF014D344 /* PerformanceTests.swift in Sources */,
 				A5D3EF6A05AD9B93FA5ACD8A /* PrivacyAcknowledgementSheetSnapshotTest.swift in Sources */,
@@ -1412,6 +1432,7 @@
 				26BDD8E9011EE16C9FB5931C /* Haptics.swift in Sources */,
 				DD2D33487360F16C48C55EE8 /* HeartBurstView.swift in Sources */,
 				E36B474221A5D2A355D1226C /* HitTargetMetrics.swift in Sources */,
+				E6A3296293F74FFD51E56B4C /* InlineBanner.swift in Sources */,
 				D28FA83853E30AF27C34876F /* IntentAgent.swift in Sources */,
 				3E24606FB907D7BB18E3C496 /* Itinerary.swift in Sources */,
 				63059F4B8EFE54C8E2699330 /* ItineraryDetailView.swift in Sources */,
@@ -1450,10 +1471,13 @@
 				B28F15C454376D86258FCD77 /* OverpassService.swift in Sources */,
 				03FDD2032C0B0D8B59A1EE8E /* POILoadingBanner.swift in Sources */,
 				193FE8EBE03520DF740EE78D /* PaywallView.swift in Sources */,
+				C546F3C71BD0E99D59E91630 /* PeekPickResolver.swift in Sources */,
+				75B727F4A7C24DF157FFBBAB /* PeekSummaryCard.swift in Sources */,
 				AA75B3147A29FDA55E61B24A /* PendingCheckInBanner.swift in Sources */,
 				ACBA4CEE6B78AA04DBD26709 /* PendingCheckInRecord.swift in Sources */,
 				641D80BD116D6F255A9ED26A /* PendingSyncRecord.swift in Sources */,
 				60FA57D3A56ED061C1F9B899 /* PresenceService.swift in Sources */,
+				40C8E92653FC718890E3CA5D /* PressableButtonStyle.swift in Sources */,
 				48DF01972A1FB107BFFF0684 /* QueryAgent.swift in Sources */,
 				9C8CC563D33FDBB3DF57A841 /* RecentExploreRegion.swift in Sources */,
 				76F57DBD1B6F0020E8BF91E5 /* RecruitingModule.swift in Sources */,

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -11,6 +11,8 @@
 /* Filters */
 "filter.now" = "Now";
 "filter.all" = "All";
+"filter.saved" = "Saved";
+"filter.saved.a11y" = "Saved, %d favourited experiences";
 "filter.pill.clear.hint" = "Double tap to clear this filter";
 "filter.now.a11y" = "Now, %d experiences at their best";
 "filter.matches.one" = "%d match";

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1383,3 +1383,11 @@
 "compass.pointing.title" = "Pointing toward";
 "compass.direction.a11y" = "%1$@ away, pointing %2$@";
 "nearby.direction.suffix" = "to the %@";
+
+/* BottomInfoSheet peek summary card ("此刻最值得去") */
+"peek.pick.header" = "Best for right now";
+"peek.empty.hint" = "Move the map to discover nearby spots";
+"peek.card.hint" = "Double tap to see all nearby spots";
+"peek.card.aiPick" = "AI Pick";
+"peek.card.aiPick.a11y" = "AI pick for right now";
+"sheet.handle.hint" = "Tap to expand, drag to resize";

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -228,6 +228,8 @@
 "filter.empty.message.a11y" = "Nothing matches the active filter in this area. Double tap Show all to reset.";
 "filter.empty.showAll.a11y" = "Show all experiences";
 
+"map.recenter" = "Recenter on my location";
+
 /* Map empty / loading */
 "map.empty.title" = "No experiences nearby";
 "map.empty.hint" = "Try clearing filters or moving the map.";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -11,6 +11,8 @@
 /* Filters */
 "filter.now" = "此刻";
 "filter.all" = "全部";
+"filter.saved" = "收藏";
+"filter.saved.a11y" = "收藏，%d 个已收藏的体验";
 "filter.a11y.resultsAnnounce" = "%1$@：找到 %2$d 个";
 "filter.a11y.noResultsAnnounce" = "%@：无匹配结果";
 

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -125,6 +125,8 @@
 /* Solo score accessibility */
 "solo.a11y" = "独行评分 %@ / 10";
 
+"map.recenter" = "回到我的位置";
+
 /* Map empty / loading */
 "map.empty.title" = "附近暂无体验";
 "map.empty.hint" = "试试清除筛选或拖动地图。";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1309,3 +1309,11 @@
 "voice.recording.maxReached" = "已达最大时长";
 "voice.recording.maxReached.a11y" = "已达最大录音时长 — 转写已保存";
 "voice.recording.timer.a11y" = "录音中 — 已 %d 秒";
+
+/* BottomInfoSheet 底部 sheet peek 摘要卡 */
+"peek.pick.header" = "此刻最值得去";
+"peek.empty.hint" = "移动地图发现附近地点";
+"peek.card.hint" = "双击查看附近全部地点";
+"peek.card.aiPick" = "AI 精选";
+"peek.card.aiPick.a11y" = "此刻 AI 精选";
+"sheet.handle.hint" = "点击展开，拖动调整";

--- a/apps/ios/SoloCompass/Tests/ChatBubbleContrastTest.swift
+++ b/apps/ios/SoloCompass/Tests/ChatBubbleContrastTest.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import SoloCompass
+
+/// Visual-polish guard for the chat surface: the new bubble + input + banner
+/// color pairings must stay legible. Mirrors the WCAG relative-luminance math
+/// in `FilterChipContrastTest` so the chat redesign can't silently regress the
+/// way the old gold filter chip did.
+@MainActor
+final class ChatBubbleContrastTest: XCTestCase {
+
+    // MARK: - WCAG helpers (same algorithm as FilterChipContrastTest)
+
+    /// WCAG 2.x relative luminance for an 8-bit sRGB channel triple.
+    /// https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+    private func relativeLuminance(_ rgb: (r: Int, g: Int, b: Int)) -> Double {
+        func linearize(_ channel: Int) -> Double {
+            let c = Double(channel) / 255.0
+            return c <= 0.03928 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * linearize(rgb.r)
+             + 0.7152 * linearize(rgb.g)
+             + 0.0722 * linearize(rgb.b)
+    }
+
+    /// WCAG contrast ratio: (L_lighter + 0.05) / (L_darker + 0.05).
+    private func contrastRatio(
+        _ a: (r: Int, g: Int, b: Int),
+        _ b: (r: Int, g: Int, b: Int)
+    ) -> Double {
+        let la = relativeLuminance(a)
+        let lb = relativeLuminance(b)
+        return (max(la, lb) + 0.05) / (min(la, lb) + 0.05)
+    }
+
+    // MARK: - Token RGB (mirrors CompareTokens.CT light-mode values)
+
+    private let white         = (r: 0xFF, g: 0xFF, b: 0xFF)
+    private let accent        = (r: 0x5D, g: 0x30, b: 0x00) // CT.accent — user bubble fill
+    private let fgPrimary     = (r: 0x1F, g: 0x1A, b: 0x14) // CT.fgPrimary — body text
+    private let chatInputBg   = (r: 0xF5, g: 0xF0, b: 0xEB) // CT.chatInputBg — input fill
+    private let bannerError   = (r: 0xC0, g: 0x3B, b: 0x1E) // CT.bannerError — banner rail/icon
+    private let surfaceSunken = (r: 0xF3, g: 0xEE, b: 0xE6) // CT.surfaceSunken — banner bg
+
+    // MARK: - Tests
+
+    /// White body text on the user bubble (CT.accent) must clear the stricter
+    /// AAA bar (7:1), matching the filter-chip selected-state spec.
+    func testUserBubbleTextMeetsWCAGAAA() {
+        let ratio = contrastRatio(white, accent)
+        XCTAssertGreaterThanOrEqual(
+            ratio, 7.0,
+            "White text on CT.accent user bubble must clear AAA (7:1); got \(ratio)"
+        )
+    }
+
+    /// Primary body text on the warm chat input fill must meet WCAG AA (4.5:1).
+    func testInputTextMeetsWCAGAA() {
+        let ratio = contrastRatio(fgPrimary, chatInputBg)
+        XCTAssertGreaterThanOrEqual(
+            ratio, 4.5,
+            "CT.fgPrimary on CT.chatInputBg must meet AA (4.5:1); got \(ratio)"
+        )
+    }
+
+    /// The error banner's rail/icon tone on the sunken surface must clear the
+    /// 3:1 non-text / large-text bar so the accent reads as a deliberate cue.
+    func testBannerErrorMeetsNonTextContrast() {
+        let ratio = contrastRatio(bannerError, surfaceSunken)
+        XCTAssertGreaterThanOrEqual(
+            ratio, 3.0,
+            "CT.bannerError on CT.surfaceSunken must meet 3:1 non-text contrast; got \(ratio)"
+        )
+    }
+}

--- a/apps/ios/SoloCompass/Tests/FavoriteFilterTests.swift
+++ b/apps/ios/SoloCompass/Tests/FavoriteFilterTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+import CoreLocation
+import SwiftData
+@testable import SoloCompass
+
+/// "Saved" map filter (the heart pill next to All): `MapViewModel.isFavoriteFilter`
+/// keeps only favourited experiences, and is mutually exclusive with the
+/// category / custom-tag / Now filters. The favourite *data* already existed
+/// end-to-end; these tests pin the new map-filter entry point.
+@MainActor
+final class FavoriteFilterTests: XCTestCase {
+
+    private func makeIsolatedDefaults() -> UserDefaults {
+        let suite = "favorite.filter.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    private func makeExperience(id: String, cityCode: String, lon: Double, lat: Double) -> Experience {
+        let now = Date()
+        return Experience(
+            id: id,
+            title: "Fixture \(id)",
+            oneLiner: "Fixture \(id)",
+            whyItMatters: "Favorite filter fixture",
+            category: .food,
+            location: ExperienceLocation(coordinates: [lon, lat], cityCode: cityCode),
+            bestTimes: [],
+            durationMinutes: .init(min: 30, max: 60),
+            howTo: [],
+            realInconveniences: [],
+            soloScore: SoloScore(
+                overall: 5,
+                breakdown: .init(
+                    seatingFriendly: 7, soloPatronRatio: 7, staffPressure: 7,
+                    soloPortioning: 7, ambianceFit: 7, safety: 7
+                ),
+                basedOnCount: 1
+            ),
+            sources: [InformationSource(type: .user, attribution: "test", verifiedAt: now)],
+            confidence: Confidence(
+                level: 3,
+                lastVerifiedAt: now,
+                reason: "Test fixture",
+                signals: .init(aiScrapeAgeDays: 1, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)
+            ),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .active,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    /// Build a view model whose seed has three Chiang-Mai experiences, with one
+    /// of them favourited. Starts on the `cmi` city so all three are nearby.
+    private func makeViewModel(favoriting favoriteId: String?) -> MapViewModel {
+        let prefs = UserPreferences(defaults: makeIsolatedDefaults())
+        prefs.lastSelectedCity = "cmi"
+        if let favoriteId {
+            prefs.toggleFavorite(favoriteId)
+        }
+        let seed = [
+            makeExperience(id: "cmi_1", cityCode: "cmi", lon: 98.9938, lat: 18.7877),
+            makeExperience(id: "cmi_2", cityCode: "cmi", lon: 98.9940, lat: 18.7880),
+            makeExperience(id: "cmi_3", cityCode: "cmi", lon: 98.9942, lat: 18.7882)
+        ]
+        let service = ExperienceService(seed: seed)
+        return MapViewModel(
+            locationService: LocationService(),
+            experienceService: service,
+            aiService: AIService(),
+            preferences: prefs
+        )
+    }
+
+    // MARK: - Filtering
+
+    func testFavoriteFilterKeepsOnlyFavorited() {
+        let vm = makeViewModel(favoriting: "cmi_2")
+        XCTAssertFalse(vm.isFavoriteFilter, "starts inactive")
+        XCTAssertGreaterThan(vm.visibleExperiences.count, 1, "all nearby visible before filtering")
+
+        vm.selectFavoriteFilter()
+
+        XCTAssertTrue(vm.isFavoriteFilter, "filter is active after selecting")
+        XCTAssertEqual(vm.visibleExperiences.map(\.id), ["cmi_2"],
+                       "only the favourited experience remains visible")
+    }
+
+    func testFavoriteFilterTogglesOff() {
+        let vm = makeViewModel(favoriting: "cmi_2")
+        let baseline = vm.visibleExperiences.count
+
+        vm.selectFavoriteFilter()
+        XCTAssertTrue(vm.isFavoriteFilter)
+
+        // Tapping the active pill again clears it back to All.
+        vm.selectFavoriteFilter()
+        XCTAssertFalse(vm.isFavoriteFilter, "re-tap toggles the filter off")
+        XCTAssertEqual(vm.visibleExperiences.count, baseline,
+                       "clearing the filter restores the full nearby list")
+    }
+
+    // MARK: - Mutual exclusivity
+
+    func testSelectingFavoriteClearsOtherFilters() {
+        let vm = makeViewModel(favoriting: "cmi_2")
+        vm.selectNowFilter()
+        vm.selectCategory(.food)              // now category is active
+        XCTAssertNotNil(vm.selectedCategory)
+
+        vm.selectFavoriteFilter()
+
+        XCTAssertTrue(vm.isFavoriteFilter)
+        XCTAssertNil(vm.selectedCategory, "category cleared when Saved activates")
+        XCTAssertNil(vm.selectedCustomTag, "custom tag cleared when Saved activates")
+        XCTAssertFalse(vm.isNowFilter, "Now cleared when Saved activates")
+    }
+
+    func testSelectingOtherFilterClearsFavorite() {
+        let vm = makeViewModel(favoriting: "cmi_2")
+        vm.selectFavoriteFilter()
+        XCTAssertTrue(vm.isFavoriteFilter)
+
+        vm.selectNowFilter()
+        XCTAssertFalse(vm.isFavoriteFilter, "Now clears the Saved filter")
+
+        vm.selectFavoriteFilter()
+        XCTAssertTrue(vm.isFavoriteFilter)
+        vm.selectCategory(.food)
+        XCTAssertFalse(vm.isFavoriteFilter, "category clears the Saved filter")
+
+        vm.selectFavoriteFilter()
+        XCTAssertTrue(vm.isFavoriteFilter)
+        vm.clearFilters()
+        XCTAssertFalse(vm.isFavoriteFilter, "clearFilters clears the Saved filter")
+    }
+}

--- a/apps/ios/SoloCompass/Tests/PeekSummarySelectionTests.swift
+++ b/apps/ios/SoloCompass/Tests/PeekSummarySelectionTests.swift
@@ -1,0 +1,186 @@
+import XCTest
+import CoreLocation
+@testable import SoloCompass
+
+/// Unit coverage for `PeekPickResolver` — the pure selector that picks the single
+/// experience surfaced in the BottomInfoSheet's peek summary card.
+///
+/// The selection rule is the load-bearing part of the "此刻最值得去" peek card, so
+/// it lives in a side-effect-free resolver that can be exercised without a
+/// SwiftUI graph or a live MapViewModel. These tests pin every branch:
+///  - empty visible set → nil
+///  - first visible smart pick wins
+///  - smart pick not visible → nearest fallback
+///  - multiple smart picks → the first one
+///  - localization keys resolve in both shipped locales
+@MainActor
+final class PeekSummarySelectionTests: XCTestCase {
+
+    /// Minimal experience fixture at the given coordinate. Mirrors the
+    /// `makeExperience` pattern used by FavoriteFilterTests / ColdStartTests.
+    private func makeExperience(id: String, lon: Double, lat: Double) -> Experience {
+        let now = Date()
+        return Experience(
+            id: id,
+            title: "Peek Fixture \(id)",
+            oneLiner: "Fixture \(id)",
+            whyItMatters: "Peek summary fixture",
+            category: .food,
+            location: ExperienceLocation(coordinates: [lon, lat], cityCode: "cmi"),
+            bestTimes: [],
+            durationMinutes: .init(min: 30, max: 60),
+            howTo: [],
+            realInconveniences: [],
+            soloScore: SoloScore(
+                overall: 5,
+                breakdown: .init(
+                    seatingFriendly: 7, soloPatronRatio: 7, staffPressure: 7,
+                    soloPortioning: 7, ambianceFit: 7, safety: 7
+                ),
+                basedOnCount: 1
+            ),
+            sources: [InformationSource(type: .user, attribution: "test", verifiedAt: now)],
+            confidence: Confidence(
+                level: 3,
+                lastVerifiedAt: now,
+                reason: "Test fixture",
+                signals: .init(aiScrapeAgeDays: 1, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)
+            ),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .active,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    /// Chiang Mai reference coordinate used as the distance origin.
+    private let cmiCenter = CLLocationCoordinate2D(latitude: 18.7877, longitude: 98.9938)
+
+    // MARK: - Empty
+
+    func testEmptyVisibleSetResolvesToNil() {
+        let result = PeekPickResolver.resolve(
+            experiences: [],
+            smartPickIds: ["anything"],
+            referenceCoordinate: cmiCenter
+        )
+        XCTAssertNil(result, "no visible experiences → no peek pick")
+    }
+
+    // MARK: - Smart pick precedence
+
+    func testFirstSmartPickWinsOverNearest() {
+        // `far` is the AI's pick but is geographically the farthest — it must
+        // still be chosen because smart picks outrank distance.
+        let near = makeExperience(id: "near", lon: 98.9939, lat: 18.7878) // ~15m
+        let far = makeExperience(id: "far", lon: 99.5000, lat: 18.7877)   // ~50km+
+        let result = PeekPickResolver.resolve(
+            experiences: [near, far],
+            smartPickIds: ["far"],
+            referenceCoordinate: cmiCenter
+        )
+        XCTAssertEqual(result?.id, "far", "the visible smart pick wins regardless of distance")
+        XCTAssertTrue(
+            PeekPickResolver.isSmartPick(resolved: result, smartPickIds: ["far"]),
+            "resolved smart pick is flagged as smart"
+        )
+    }
+
+    func testMultipleSmartPicksTakesFirst() {
+        let a = makeExperience(id: "a", lon: 98.9940, lat: 18.7880)
+        let b = makeExperience(id: "b", lon: 98.9942, lat: 18.7882)
+        let result = PeekPickResolver.resolve(
+            experiences: [a, b],
+            smartPickIds: ["b", "a"], // b is first in the ranked list
+            referenceCoordinate: cmiCenter
+        )
+        XCTAssertEqual(result?.id, "b", "the first smart-pick id in the ranked list wins")
+    }
+
+    // MARK: - Nearest fallback
+
+    func testSmartPickNotVisibleFallsBackToNearest() {
+        let near = makeExperience(id: "near", lon: 98.9939, lat: 18.7878) // ~15m
+        let far = makeExperience(id: "far", lon: 99.2000, lat: 18.9000)   // far away
+        // The smart pick id is not present in the visible set, so the resolver
+        // must fall back to the nearest visible experience.
+        let result = PeekPickResolver.resolve(
+            experiences: [far, near],
+            smartPickIds: ["ghost-id-not-visible"],
+            referenceCoordinate: cmiCenter
+        )
+        XCTAssertEqual(result?.id, "near", "with no visible smart pick, the nearest experience wins")
+        XCTAssertFalse(
+            PeekPickResolver.isSmartPick(resolved: result, smartPickIds: ["ghost-id-not-visible"]),
+            "a nearest-fallback pick is not flagged as a smart pick"
+        )
+    }
+
+    func testNoSmartPicksFallsBackToNearest() {
+        let near = makeExperience(id: "near", lon: 98.9939, lat: 18.7878)
+        let far = makeExperience(id: "far", lon: 99.2000, lat: 18.9000)
+        let result = PeekPickResolver.resolve(
+            experiences: [far, near],
+            smartPickIds: [],
+            referenceCoordinate: cmiCenter
+        )
+        XCTAssertEqual(result?.id, "near", "empty smart-pick list → nearest experience")
+    }
+
+    func testNilReferenceFallsBackToFirstExperience() {
+        let a = makeExperience(id: "a", lon: 98.99, lat: 18.78)
+        let b = makeExperience(id: "b", lon: 98.98, lat: 18.77)
+        let result = PeekPickResolver.resolve(
+            experiences: [a, b],
+            smartPickIds: [],
+            referenceCoordinate: nil
+        )
+        XCTAssertEqual(result?.id, "a", "with no reference coordinate, the first experience is the fallback")
+    }
+
+    // MARK: - Localization key presence (both shipped locales)
+
+    /// The peek-card keys this feature introduces. Both shipped `.lproj` tables
+    /// must define every one (the QA brief checks bilingual coverage).
+    private static let peekKeys = ["peek.pick.header", "peek.empty.hint", "sheet.handle.hint"]
+
+    func testPeekLocalizationKeysResolveInEnglish() throws {
+        let defined = try definedKeys(localeID: "en")
+        for key in Self.peekKeys {
+            XCTAssertTrue(defined.contains(key), "en/Localizable.strings is missing \(key)")
+        }
+    }
+
+    func testPeekLocalizationKeysResolveInSimplifiedChinese() throws {
+        let defined = try definedKeys(localeID: "zh-Hans")
+        for key in Self.peekKeys {
+            XCTAssertTrue(defined.contains(key), "zh-Hans/Localizable.strings is missing \(key)")
+        }
+    }
+
+    /// Parse the keys defined in a locale's `Localizable.strings`, read straight
+    /// from the source tree via `#filePath` (the iOS test bundle runs in the
+    /// Simulator sandbox where the source tree may be absent, so `XCTSkip` when it
+    /// isn't reachable — mirrors `ZhHansPunctuationTest`).
+    private func definedKeys(localeID: String, file: StaticString = #filePath) throws -> Set<String> {
+        let url = URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent()   // Tests/
+            .deletingLastPathComponent()   // SoloCompass/
+            .appendingPathComponent("Resources/\(localeID).lproj/Localizable.strings")
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw XCTSkip("Source tree not reachable in this run: \(url.path)")
+        }
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        var keys = Set<String>()
+        for line in contents.split(separator: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            // Match `"key" = "value";` — capture the first quoted token as the key.
+            guard trimmed.hasPrefix("\"") else { continue }
+            let afterFirstQuote = trimmed.dropFirst()
+            guard let endQuote = afterFirstQuote.firstIndex(of: "\"") else { continue }
+            keys.insert(String(afterFirstQuote[..<endQuote]))
+        }
+        return keys
+    }
+}

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -464,6 +464,13 @@ public final class MapViewModel {
     // True when a "Now" filter is active (best-now experiences only).
     public var isNowFilter: Bool = false
 
+    /// True when the "Saved" filter is active — keeps only experiences the user
+    /// has favourited. Mutually exclusive with `selectedCategory`,
+    /// `selectedCustomTag`, and `isNowFilter` (selecting any of those clears
+    /// this, and vice-versa). The favourite set already exists end-to-end
+    /// (`preferences.favoritedExperiences`); this is the map filter entry point.
+    public var isFavoriteFilter: Bool = false
+
     // MARK: - Location error surfacing (US-026)
 
     /// Tracks the most recent `LocationService.lastError` we already reported to
@@ -727,6 +734,10 @@ public final class MapViewModel {
         if isNowFilter {
             nearby = nearby.filter { $0.isBestNow() }
         }
+        if isFavoriteFilter {
+            let favorites = preferences.favoritedExperiences
+            nearby = nearby.filter { favorites.contains($0.id) }
+        }
         if !preferences.dislikedCategories.isEmpty {
             let disliked = Set(preferences.dislikedCategories)
             nearby = nearby.filter { !disliked.contains($0.category) }
@@ -740,6 +751,7 @@ public final class MapViewModel {
         selectedCategory = category
         selectedCustomTag = nil
         isNowFilter = false
+        isFavoriteFilter = false
         loadNearbyExperiences()
         updateBottomInfo()
         // US-011: empty category inside a seeded city → debounced auto-Explore.
@@ -752,6 +764,24 @@ public final class MapViewModel {
         isNowFilter = true
         selectedCategory = nil
         selectedCustomTag = nil
+        isFavoriteFilter = false
+        loadNearbyExperiences()
+        updateBottomInfo()
+    }
+
+    /// Toggle the "Saved" filter. Tapping it again clears it (back to All),
+    /// matching the toggle behaviour of the category/Now pills. Activating it
+    /// clears every other active filter so the four filter modes stay mutually
+    /// exclusive. The favourite set lives in `preferences.favoritedExperiences`.
+    public func selectFavoriteFilter() {
+        if isFavoriteFilter {
+            isFavoriteFilter = false
+        } else {
+            isFavoriteFilter = true
+            selectedCategory = nil
+            selectedCustomTag = nil
+            isNowFilter = false
+        }
         loadNearbyExperiences()
         updateBottomInfo()
     }
@@ -761,6 +791,7 @@ public final class MapViewModel {
         selectedCategory = nil
         selectedCustomTag = nil
         isNowFilter = false
+        isFavoriteFilter = false
         loadNearbyExperiences()
         updateBottomInfo()
     }
@@ -829,6 +860,7 @@ public final class MapViewModel {
             selectedCustomTag = tag
             selectedCategory = nil
             isNowFilter = false
+            isFavoriteFilter = false
         }
         loadNearbyExperiences()
         updateBottomInfo()

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -132,6 +132,21 @@ public final class MapViewModel {
         autoExploreIfEmpty(at: coordinate)
     }
 
+    /// Whether a GPS fix is available right now — drives the custom recenter
+    /// button's enabled state in the map overlay.
+    public var hasUserLocation: Bool {
+        locationService.currentLocation != nil
+    }
+
+    /// Recenter the camera on the user's current location on demand (the custom
+    /// "locate me" button). Unlike `bindToLocation` this ignores the
+    /// `hasAutoCentered` guard, so the user can re-center any time after panning
+    /// away. No-op when there is no GPS fix yet.
+    public func recenterOnUser() {
+        guard let coordinate = locationService.currentLocation?.coordinate else { return }
+        recenter(on: coordinate)
+    }
+
     /// Auto-trigger Explore when the user lands in a data-sparse area
     /// (e.g. Vientiane with zero seed data). Fires once after the first
     /// GPS fix. Skips when there's already ≥3 experiences within 5 km,

--- a/apps/ios/SoloCompass/Views/Chat/ChatInputBar.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatInputBar.swift
@@ -43,6 +43,12 @@ public struct ChatInputBar: View {
     /// (usually re-running the last user transcript).
     public let onRetry: () -> Void
 
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Drives the soft pulse on the "Listening" status dot.
+    @State private var listeningPulse: Bool = false
+
     public init(
         draftText: Binding<String>,
         micState: MicState,
@@ -64,7 +70,12 @@ public struct ChatInputBar: View {
     public var body: some View {
         VStack(spacing: 8) {
             if let errorMessage {
-                errorBanner(errorMessage)
+                InlineBanner(
+                    tone: .error,
+                    title: errorMessage,
+                    ctaLabel: NSLocalizedString("chat.error.retry", comment: "Retry"),
+                    onCTA: onRetry
+                )
             }
 
             stateLabel
@@ -77,7 +88,15 @@ public struct ChatInputBar: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
-        .background(.bar)
+        .background(alignment: .top) {
+            // Hairline top divider + opaque surface (replaces `.bar`).
+            ZStack(alignment: .top) {
+                Color(.systemBackground)
+                Rectangle()
+                    .fill(CT.borderDefault)
+                    .frame(height: 0.5)
+            }
+        }
     }
 
     // MARK: - Subviews
@@ -88,14 +107,24 @@ public struct ChatInputBar: View {
         case .listening:
             HStack(spacing: 6) {
                 Circle()
-                    .fill(Color.red)
+                    .fill(CT.sunGold)
                     .frame(width: 8, height: 8)
+                    .scaleEffect(listeningPulse ? 1.35 : 1.0)
+                    .opacity(listeningPulse ? 0.5 : 1.0)
+                    .animation(
+                        reduceMotion
+                            ? nil
+                            : .easeInOut(duration: 0.7).repeatForever(autoreverses: true),
+                        value: listeningPulse
+                    )
                 Text(NSLocalizedString("chat.state.listening", comment: "Listening — release to send"))
                     .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(CT.sunGoldDeep)
                 Spacer()
             }
             .transition(.opacity)
+            .onAppear { if !reduceMotion { listeningPulse = true } }
+            .onDisappear { listeningPulse = false }
         case .thinking:
             HStack(spacing: 6) {
                 ProgressView()
@@ -111,6 +140,16 @@ public struct ChatInputBar: View {
         }
     }
 
+    /// Light mode uses the warm input fill; dark mode falls back to a system
+    /// semantic surface so the parchment tint doesn't glow on black.
+    private var inputFieldFill: Color {
+        colorScheme == .dark ? Color(.secondarySystemBackground) : CT.chatInputBg
+    }
+
+    private var inputBorder: Color {
+        colorScheme == .dark ? Color(.separator) : CT.borderSubtle
+    }
+
     private var textField: some View {
         // Multi-line growth comes free with `axis: .vertical` + lineLimit range.
         TextField(
@@ -124,7 +163,11 @@ public struct ChatInputBar: View {
         .padding(.vertical, 8)
         .background(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(Color(.secondarySystemBackground))
+                .fill(inputFieldFill)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .strokeBorder(inputBorder, lineWidth: 0.5)
         )
         .submitLabel(.send)
         .onSubmit(submitDraft)
@@ -136,10 +179,10 @@ public struct ChatInputBar: View {
         let canSend = !trimmed.isEmpty
         return Button(action: submitDraft) {
             Image(systemName: "arrow.up.circle.fill")
-                .font(.title)
-                .foregroundStyle(canSend ? Color.accentColor : Color.secondary.opacity(0.5))
+                .font(.title2)
+                .foregroundStyle(canSend ? CT.accent : Color.secondary.opacity(0.5))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(PressableButtonStyle(pressedScale: 0.88))
         .disabled(!canSend)
         .accessibilityLabel(Text(NSLocalizedString("chat.input.send.a11y", comment: "Send")))
     }
@@ -151,18 +194,26 @@ public struct ChatInputBar: View {
         // gesture below handles toggle mode.
         let micColor: Color = {
             switch micState {
-            case .listening: return .red
-            case .thinking: return .blue
-            case .error: return .orange
-            case .idle: return .primary
+            case .listening: return CT.sunGoldDeep
+            case .thinking:  return CT.accent
+            case .error:     return CT.bannerError
+            case .idle:      return .primary
             }
         }()
+        let isListening = micState == .listening
+        let shape = RoundedRectangle(cornerRadius: 12, style: .continuous)
 
         return ZStack {
-            Circle()
-                .fill(Color(.tertiarySystemBackground))
+            shape
+                .fill(isListening ? CT.sunGoldSoft : Color(.tertiarySystemBackground))
                 .frame(width: 40, height: 40)
-            Image(systemName: micState == .listening ? "waveform" : "mic.fill")
+                .overlay(
+                    shape.strokeBorder(
+                        isListening ? CT.sunGold : CT.borderSubtle,
+                        lineWidth: isListening ? 1 : 0.5
+                    )
+                )
+            Image(systemName: isListening ? "waveform" : "mic.fill")
                 .font(.body.weight(.semibold))
                 .foregroundStyle(micColor)
                 .symbolEffect(
@@ -170,9 +221,9 @@ public struct ChatInputBar: View {
                     isActive: micState == .listening || micState == .thinking
                 )
         }
-        .scaleEffect(micState == .listening ? 1.1 : 1.0)
+        .scaleEffect(isListening ? 1.08 : 1.0)
         .animation(.spring(response: 0.2, dampingFraction: 0.7), value: micState)
-        .contentShape(Circle())
+        .contentShape(shape)
         .onLongPressGesture(
             minimumDuration: 0.0,
             maximumDistance: .infinity,
@@ -190,27 +241,6 @@ public struct ChatInputBar: View {
         .accessibilityLabel(Text(NSLocalizedString("chat.input.mic.a11y", comment: "Voice")))
         .accessibilityHint(Text(NSLocalizedString("chat.input.mic.hint", comment: "Tap to start or stop voice, hold to push-to-talk")))
         .accessibilityAddTraits(.startsMediaSession)
-    }
-
-    private func errorBanner(_ message: String) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.orange)
-            Text(message)
-                .font(.caption)
-                .foregroundStyle(.primary)
-                .lineLimit(2)
-            Spacer()
-            Button(action: onRetry) {
-                Text(NSLocalizedString("chat.error.retry", comment: "Retry"))
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.tint)
-            }
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
-        .transition(.move(edge: .bottom).combined(with: .opacity))
     }
 
     private func submitDraft() {

--- a/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
@@ -45,6 +45,12 @@ public struct ChatSheet: View {
     /// classic chat list with a single tap.
     @State private var showVoiceSurface: Bool = false
     @State private var starterPromptsAppeared: Bool = false
+    /// Drives the sun-gold pulse dot on the live-transcript bubble while the
+    /// mic is hot. Toggled in begin/endPushToTalk; reduceMotion-guarded.
+    @State private var recordingPulse: Bool = false
+
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private static let starterPrompts: [String] = [
         NSLocalizedString("chat.empty.prompt.nearby",  comment: "Starter chip — what's good around me"),
@@ -117,56 +123,33 @@ public struct ChatSheet: View {
         )
     }
 
-    /// Inline amber card surfaced when the orchestrator started in the
+    /// Inline card surfaced when the orchestrator started in the
     /// `.unconfigured` state (no DeepSeek key and no Edge proxy). Without it
     /// the user can type, hit send, and get no reaction at all.
     private var unconfiguredBanner: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "key.fill")
-                .foregroundStyle(.orange)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(NSLocalizedString(
-                    "chat.unconfigured.title",
-                    comment: "Title shown when no AI key is configured"
-                ))
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.primary)
-                Text(NSLocalizedString(
-                    "chat.unconfigured.subtitle",
-                    comment: "Subtitle explaining the user needs to add a key"
-                ))
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-            }
-            Spacer()
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        InlineBanner(
+            tone: .permission,
+            title: NSLocalizedString(
+                "chat.unconfigured.title",
+                comment: "Title shown when no AI key is configured"
+            ),
+            subtitle: NSLocalizedString(
+                "chat.unconfigured.subtitle",
+                comment: "Subtitle explaining the user needs to add a key"
+            ),
+            icon: "key.fill"
+        )
         .padding(.horizontal, 12)
         .padding(.bottom, 6)
-        .transition(.move(edge: .bottom).combined(with: .opacity))
     }
 
     /// Slim transient banner used to surface non-fatal send failures (e.g.
     /// the orchestrator is still seeding the system prompt). Pinned above
     /// the input bar so the user sees it without losing the text field.
     private func sendHintBanner(_ message: String) -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: "info.circle.fill")
-                .foregroundStyle(.tint)
-            Text(message)
-                .font(.caption)
-                .foregroundStyle(.primary)
-                .lineLimit(2)
-            Spacer()
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 10))
-        .padding(.horizontal, 12)
-        .padding(.bottom, 4)
-        .transition(.move(edge: .bottom).combined(with: .opacity))
+        InlineBanner(tone: .info, title: message)
+            .padding(.horizontal, 12)
+            .padding(.bottom, 4)
     }
 
     /// First real user/assistant message → drop the voice surface so the
@@ -191,9 +174,11 @@ public struct ChatSheet: View {
                 .font(.headline)
             Spacer()
             Button(action: closeSheet) {
-                Image(systemName: "xmark.circle.fill")
-                    .font(.title3)
+                Image(systemName: "xmark")
+                    .font(.footnote.weight(.semibold))
                     .foregroundStyle(.secondary)
+                    .frame(width: 28, height: 28)
+                    .background(closeButtonFill, in: Circle())
             }
             .buttonStyle(.plain)
             .accessibilityLabel(Text(NSLocalizedString("common.close", comment: "Close")))
@@ -203,58 +188,34 @@ public struct ChatSheet: View {
     }
 
     private var permissionDeniedBanner: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "mic.slash.fill")
-                .foregroundStyle(.orange)
-            Text(NSLocalizedString("voiceAgent.permissionDenied", comment: "Microphone access needed — enable in Settings"))
-                .font(.caption.weight(.medium))
-                .foregroundStyle(.primary)
-            Spacer()
-            Button {
+        InlineBanner(
+            tone: .permission,
+            title: NSLocalizedString("voiceAgent.permissionDenied", comment: "Microphone access needed — enable in Settings"),
+            icon: "mic.slash.fill",
+            ctaLabel: NSLocalizedString("common.settings", comment: "Settings"),
+            onCTA: {
                 if let url = URL(string: UIApplication.openSettingsURLString) {
                     UIApplication.shared.open(url)
                 }
-            } label: {
-                Text(NSLocalizedString("common.settings", comment: "Settings"))
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.tint)
             }
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        )
         .padding(.horizontal, 12)
         .padding(.top, 8)
-        .transition(.move(edge: .top).combined(with: .opacity))
     }
 
     /// US-027: dismissible toast surfaced when the live voice stream ends via an
     /// error instead of being silently dropped. Tappable / has an explicit
     /// close affordance, and auto-dismisses after a few seconds.
     private func voiceInterruptionBanner(_ message: String) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: "waveform.slash")
-                .foregroundStyle(.orange)
-            Text(message)
-                .font(.caption.weight(.medium))
-                .foregroundStyle(.primary)
-                .lineLimit(3)
-            Spacer(minLength: 4)
-            Button(action: dismissVoiceInterruptionToast) {
-                Image(systemName: "xmark.circle.fill")
-                    .foregroundStyle(.secondary)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel(Text(NSLocalizedString("common.dismiss", comment: "Dismiss")))
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        InlineBanner(
+            tone: .warning,
+            title: message,
+            icon: "waveform.slash",
+            onDismiss: dismissVoiceInterruptionToast
+        )
         .padding(.horizontal, 12)
         .padding(.top, 8)
-        .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isStaticText)
-        .transition(.move(edge: .top).combined(with: .opacity))
     }
 
     @ViewBuilder
@@ -287,13 +248,17 @@ public struct ChatSheet: View {
                         if !liveTranscript.isEmpty {
                             // Mirror the live transcript as a tentative
                             // user bubble so the chat shows what's being
-                            // captured in real time.
+                            // captured in real time, with a small sun-gold
+                            // pulse dot marking that the mic is still hot.
                             MessageBubble(
                                 role: .user,
                                 text: liveTranscript
                             )
                             .id(Self.liveTranscriptID)
-                            .opacity(0.6)
+                            .opacity(0.85)
+                            .overlay(alignment: .topLeading) {
+                                recordingPulseDot
+                            }
                         }
 
                         if isAgentWorking {
@@ -312,6 +277,8 @@ public struct ChatSheet: View {
                     .padding(.horizontal, 12)
                     .padding(.vertical, 12)
                 }
+                .scrollContentBackground(.hidden)
+                .background(messageListBackground)
                 .scrollDismissesKeyboard(.interactively)
                 .onChange(of: visibleMessages.count) { _, _ in
                     scrollToBottom(proxy: proxy)
@@ -444,8 +411,12 @@ public struct ChatSheet: View {
         VStack(spacing: 14) {
             Spacer()
             Image(systemName: "bubble.left.and.bubble.right.fill")
-                .font(.largeTitle)
-                .foregroundStyle(.secondary)
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(CT.accent)
+                .frame(width: 64, height: 64)
+                .background(CT.accentSoft, in: Circle())
+                .overlay(Circle().strokeBorder(CT.accentBorder, lineWidth: 0.5))
+                .shadow(color: CT.accent.opacity(0.12), radius: 8, y: 3)
             Text(NSLocalizedString("chat.empty.title", comment: "Ask me anything about places near you"))
                 .font(.subheadline.weight(.medium))
                 .foregroundStyle(.primary)
@@ -473,26 +444,103 @@ public struct ChatSheet: View {
                     Haptics.impact(.light)
                     handleSend(prompt)
                 } label: {
-                    Text(prompt)
-                        .font(.body)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 10)
-                        .frame(maxWidth: .infinity)
-                        .background(Color(.secondarySystemBackground))
-                        .clipShape(Capsule())
+                    starterPromptCard(index: index, prompt: prompt)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(PressableButtonStyle())
                 .accessibilityLabel(prompt)
                 .opacity(starterPromptsAppeared ? 1 : 0)
                 .offset(y: starterPromptsAppeared ? 0 : 8)
                 .animation(
-                    .easeOut(duration: 0.35).delay(Double(index) * 0.08),
+                    reduceMotion
+                        ? nil
+                        : .easeOut(duration: 0.35).delay(Double(index) * 0.08),
                     value: starterPromptsAppeared
                 )
             }
         }
-        .padding(.horizontal, 32)
+        .padding(.horizontal, 28)
         .padding(.top, 4)
+    }
+
+    private func starterPromptCard(index: Int, prompt: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: promptIcon(for: index))
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(promptIconColor(for: index))
+                .frame(width: 22)
+            Text(prompt)
+                .font(.body)
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.leading)
+            Spacer(minLength: 8)
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(CT.fgSubtle)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(starterCardFill, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(starterCardBorder, lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.04), radius: 2, y: 1)
+    }
+
+    private func promptIcon(for index: Int) -> String {
+        switch index {
+        case 0:  return "mappin.and.ellipse"
+        case 1:  return "cup.and.saucer.fill"
+        default: return "moon.stars.fill"
+        }
+    }
+
+    private func promptIconColor(for index: Int) -> Color {
+        switch index {
+        case 0:  return CT.accent
+        case 1:  return CT.sunGoldDeep
+        default: return .indigo
+        }
+    }
+
+    // MARK: - Visual helpers (dark-mode aware)
+
+    /// Warm parchment in light mode; system grouped background in dark so the
+    /// CT tint doesn't glow on a near-black sheet.
+    private var messageListBackground: Color {
+        colorScheme == .dark ? Color(.systemBackground) : CT.bgWarm
+    }
+
+    private var closeButtonFill: Color {
+        colorScheme == .dark ? Color(.secondarySystemBackground) : CT.surfaceSunken
+    }
+
+    private var starterCardFill: Color {
+        colorScheme == .dark ? Color(.secondarySystemBackground) : CT.surfaceSunken
+    }
+
+    private var starterCardBorder: Color {
+        colorScheme == .dark ? Color(.separator) : CT.borderDefault
+    }
+
+    /// Small sun-gold pulse marking that the mic is hot while the tentative
+    /// live-transcript bubble is shown. reduceMotion drops the pulse to a
+    /// static dot.
+    private var recordingPulseDot: some View {
+        Circle()
+            .fill(CT.sunGold)
+            .frame(width: 8, height: 8)
+            .scaleEffect(recordingPulse ? 1.4 : 1.0)
+            .opacity(recordingPulse ? 0.4 : 1.0)
+            .animation(
+                reduceMotion
+                    ? nil
+                    : .easeInOut(duration: 0.7).repeatForever(autoreverses: true),
+                value: recordingPulse
+            )
+            .offset(x: -2, y: -2)
+            .accessibilityHidden(true)
     }
 
     // MARK: - Derived state
@@ -667,6 +715,7 @@ public struct ChatSheet: View {
             do {
                 liveTranscript = ""
                 let stream = try voiceService.startListening()
+                if !reduceMotion { recordingPulse = true }
                 Haptics.impact(.light)
                 voiceStreamTask = Task { @MainActor in
                     do {
@@ -692,6 +741,7 @@ public struct ChatSheet: View {
 
     private func endPushToTalk(send: Bool) {
         voiceService.stopListening()
+        recordingPulse = false
         voiceStreamTask?.cancel()
         voiceStreamTask = nil
         let final = liveTranscript
@@ -714,6 +764,7 @@ public struct ChatSheet: View {
         if voiceService.isListening {
             voiceService.stopListening()
         }
+        recordingPulse = false
         liveTranscript = ""
     }
 

--- a/apps/ios/SoloCompass/Views/Chat/InlineBanner.swift
+++ b/apps/ios/SoloCompass/Views/Chat/InlineBanner.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+
+/// Unified inline banner for the chat surface. Replaces the five ad-hoc
+/// `HStack + material` banners that used to live in `ChatSheet` / `ChatInputBar`
+/// (error, unconfigured, send-hint, permission-denied, voice-interruption) with
+/// one consistent card: a 3pt tone-colored left rail, an icon, title/subtitle
+/// text, and optional CTA / dismiss affordances.
+///
+/// Tone drives the rail + icon color and the default SF Symbol. Callers supply
+/// the localized copy and any actions; everything is optional past `title`.
+@MainActor
+public struct InlineBanner: View {
+    public enum Tone {
+        case error
+        case warning
+        case permission
+        case info
+
+        var railColor: Color {
+            switch self {
+            case .error:      return CT.bannerError
+            case .warning:    return CT.toneForming
+            case .permission: return CT.sunGoldDeep
+            case .info:       return CT.fgSubtle
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .error:      return "exclamationmark.triangle.fill"
+            case .warning:    return "exclamationmark.circle.fill"
+            case .permission: return "lock.fill"
+            case .info:       return "info.circle.fill"
+            }
+        }
+    }
+
+    private let tone: Tone
+    private let title: String
+    private let subtitle: String?
+    private let icon: String?
+    private let ctaLabel: String?
+    private let onCTA: (() -> Void)?
+    private let onDismiss: (() -> Void)?
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    public init(
+        tone: Tone,
+        title: String,
+        subtitle: String? = nil,
+        icon: String? = nil,
+        ctaLabel: String? = nil,
+        onCTA: (() -> Void)? = nil,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.tone = tone
+        self.title = title
+        self.subtitle = subtitle
+        self.icon = icon
+        self.ctaLabel = ctaLabel
+        self.onCTA = onCTA
+        self.onDismiss = onDismiss
+    }
+
+    public var body: some View {
+        HStack(spacing: 0) {
+            Rectangle()
+                .fill(tone.railColor)
+                .frame(width: 3)
+
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: icon ?? tone.icon)
+                    .font(.callout)
+                    .foregroundStyle(tone.railColor)
+                    .padding(.top, 1)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.primary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if let subtitle, !subtitle.isEmpty {
+                        Text(subtitle)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                Spacer(minLength: 4)
+
+                if let ctaLabel, let onCTA {
+                    Button(action: onCTA) {
+                        Text(ctaLabel)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(CT.accent)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                if let onDismiss {
+                    Button(action: onDismiss) {
+                        Image(systemName: "xmark")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 24, height: 24)
+                            .background(surfaceFill, in: Circle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(Text(NSLocalizedString("common.dismiss", comment: "Dismiss")))
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+        }
+        .background(surfaceFill)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(borderColor, lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .shadow(color: .black.opacity(0.04), radius: 2, y: 1)
+        .accessibilityElement(children: .combine)
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+
+    /// Dark mode keeps the warm sunken tint off so the banner stays legible on
+    /// a near-black background; light mode uses the parchment surface token.
+    private var surfaceFill: Color {
+        colorScheme == .dark ? Color(.secondarySystemBackground) : CT.surfaceSunken
+    }
+
+    private var borderColor: Color {
+        colorScheme == .dark ? Color(.separator) : CT.borderDefault
+    }
+}
+
+#Preview("Tones") {
+    VStack(spacing: 10) {
+        InlineBanner(
+            tone: .error,
+            title: "Connection interrupted",
+            subtitle: "Please try again in a moment.",
+            ctaLabel: "Retry",
+            onCTA: {}
+        )
+        InlineBanner(
+            tone: .permission,
+            title: "Microphone access needed",
+            subtitle: "Enable it in Settings to talk.",
+            ctaLabel: "Settings",
+            onCTA: {}
+        )
+        InlineBanner(
+            tone: .info,
+            title: "Waking up the agent…",
+            subtitle: "Give it a second, then send again."
+        )
+        InlineBanner(
+            tone: .warning,
+            title: "Recording was interrupted",
+            onDismiss: {}
+        )
+    }
+    .padding()
+    .background(CT.bgWarm)
+}

--- a/apps/ios/SoloCompass/Views/Chat/MessageBubble.swift
+++ b/apps/ios/SoloCompass/Views/Chat/MessageBubble.swift
@@ -17,9 +17,11 @@ public struct MessageBubble: View {
     /// For tool rows: the tool name (e.g. "explore_nearby"). Ignored for
     /// user/assistant rows.
     public let toolName: String?
-    /// When true, renders a soft pulse on the trailing edge to signal that
+    /// When true, renders a blinking caret on the trailing edge to signal that
     /// content is still arriving from the model.
     public let isStreaming: Bool
+
+    @Environment(\.colorScheme) private var colorScheme
 
     public init(
         role: VoiceAgentSession.Role,
@@ -57,7 +59,9 @@ public struct MessageBubble: View {
                 .foregroundStyle(.white)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 9)
-                .background(Color.accentColor, in: bubbleShape)
+                .background(CT.accent, in: bubbleShape)
+                .overlay(bubbleShape.strokeBorder(CT.accentBorder, lineWidth: 0.5))
+                .shadow(color: .black.opacity(0.12), radius: 6, y: 2)
                 .accessibilityLabel(Text(String(
                     format: NSLocalizedString("chat.bubble.user.a11y", comment: "You said: %@"),
                     text
@@ -82,14 +86,21 @@ public struct MessageBubble: View {
 
     private var assistantBubble: some View {
         HStack(alignment: .top, spacing: 8) {
-            assistantAvatar
+            AssistantAvatar()
             VStack(alignment: .leading, spacing: 0) {
                 Text(text.isEmpty ? " " : text)
                     .font(.body)
                     .foregroundStyle(.primary)
                     .padding(.horizontal, 14)
                     .padding(.vertical, 9)
-                    .background(.thinMaterial, in: bubbleShape)
+                    // background{shape.fill.shadow} lets the soft shadow escape
+                    // the rounded clip instead of being chopped by it.
+                    .background {
+                        bubbleShape
+                            .fill(MessageBubble.assistantFill(colorScheme))
+                            .shadow(color: .black.opacity(0.06), radius: 4, y: 1)
+                    }
+                    .overlay(bubbleShape.strokeBorder(CT.borderSubtle, lineWidth: 0.5))
                     .overlay(alignment: .trailing) {
                         if isStreaming {
                             StreamingCursor()
@@ -120,16 +131,10 @@ public struct MessageBubble: View {
         }
     }
 
-    private var assistantAvatar: some View {
-        Circle()
-            .fill(Color.accentColor.opacity(0.15))
-            .frame(width: 28, height: 28)
-            .overlay {
-                Image(systemName: "location.north.line.fill")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(Color.accentColor)
-            }
-            .accessibilityHidden(true)
+    /// AI bubble fill: warm white in light mode, the dark token in dark mode so
+    /// the parchment surface doesn't glare on a near-black background.
+    static func assistantFill(_ scheme: ColorScheme) -> Color {
+        scheme == .dark ? CT.chatAIBubbleBgDark : CT.surfaceWhite
     }
 
     private var toolIndicator: some View {
@@ -143,13 +148,13 @@ public struct MessageBubble: View {
                 .foregroundStyle(.secondary)
             Spacer()
         }
-        .padding(.leading, 36) // align under assistant avatar
+        .padding(.leading, 40) // align under assistant avatar (32 + 8 spacing)
         .padding(.trailing, 16)
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
     }
 
-    private var bubbleShape: some Shape {
+    private var bubbleShape: some InsettableShape {
         RoundedRectangle(cornerRadius: 18, style: .continuous)
     }
 
@@ -206,11 +211,34 @@ public struct MessageBubble: View {
     }
 }
 
+/// Shared compass-mark avatar for the assistant. Used by both `MessageBubble`
+/// and `TypingIndicatorBubble` so the two stay visually in sync and we don't
+/// duplicate the styling.
+@MainActor
+struct AssistantAvatar: View {
+    var body: some View {
+        Circle()
+            .fill(CT.sunGoldSoft)
+            .frame(width: 32, height: 32)
+            .overlay {
+                Image(systemName: "location.north.line.fill")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(CT.sunGoldDeep)
+            }
+            .overlay(Circle().strokeBorder(CT.accentBorder, lineWidth: 0.5))
+            .shadow(color: .black.opacity(0.08), radius: 3, y: 1)
+            .accessibilityHidden(true)
+    }
+}
+
 /// Animated three-dot 'typing' bubble shown while the agent is thinking or
 /// executing a tool and no streamed text has arrived yet.
+@MainActor
 public struct TypingIndicatorBubble: View {
     /// Optional localized step label (e.g. "🔍 Searching nearby…").
     public let label: String?
+
+    @Environment(\.colorScheme) private var colorScheme
 
     public init(label: String? = nil) {
         self.label = label
@@ -218,8 +246,8 @@ public struct TypingIndicatorBubble: View {
 
     public var body: some View {
         HStack(alignment: .top, spacing: 8) {
-            assistantAvatar
-            VStack(alignment: .leading, spacing: 4) {
+            AssistantAvatar()
+            VStack(alignment: .leading, spacing: 6) {
                 HStack(spacing: 5) {
                     ForEach(0..<3, id: \.self) { index in
                         BouncingDot(delay: Double(index) * 0.18)
@@ -227,13 +255,24 @@ public struct TypingIndicatorBubble: View {
                 }
                 .padding(.horizontal, 14)
                 .padding(.vertical, 11)
-                .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .background {
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .fill(MessageBubble.assistantFill(colorScheme))
+                        .shadow(color: .black.opacity(0.06), radius: 4, y: 1)
+                }
+                .overlay(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .strokeBorder(CT.borderSubtle, lineWidth: 0.5)
+                )
 
                 if let label, !label.isEmpty {
                     Text(label)
                         .font(.caption2)
                         .foregroundStyle(.secondary)
-                        .padding(.leading, 4)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(stepPillFill, in: Capsule())
+                        .overlay(Capsule().strokeBorder(CT.borderSubtle, lineWidth: 0.5))
                         .transition(.opacity)
                 }
             }
@@ -246,56 +285,55 @@ public struct TypingIndicatorBubble: View {
         )))
     }
 
-    private var assistantAvatar: some View {
-        Circle()
-            .fill(Color.accentColor.opacity(0.15))
-            .frame(width: 28, height: 28)
-            .overlay {
-                Image(systemName: "location.north.line.fill")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(Color.accentColor)
-            }
-            .accessibilityHidden(true)
+    private var stepPillFill: Color {
+        colorScheme == .dark ? Color(.secondarySystemBackground) : CT.surfaceSunken
     }
 }
 
 /// Single dot in the typing indicator, bouncing with a staggered delay.
 private struct BouncingDot: View {
     let delay: Double
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var bouncing = false
 
     var body: some View {
         Circle()
-            .fill(Color.secondary.opacity(0.6))
+            .fill(CT.fgSubtle)
             .frame(width: 7, height: 7)
             .offset(y: bouncing ? -4 : 0)
             .opacity(bouncing ? 1.0 : 0.5)
             .animation(
-                .easeInOut(duration: 0.5)
-                    .repeatForever(autoreverses: true)
-                    .delay(delay),
+                reduceMotion
+                    ? nil
+                    : .easeInOut(duration: 0.5)
+                        .repeatForever(autoreverses: true)
+                        .delay(delay),
                 value: bouncing
             )
-            .onAppear { bouncing = true }
+            .onAppear { if !reduceMotion { bouncing = true } }
             .accessibilityHidden(true)
     }
 }
 
-/// Soft pulsing dot rendered on the trailing edge of a streaming bubble.
-/// Pure visual — has no semantic meaning for VoiceOver.
+/// Blinking caret rendered on the trailing edge of a streaming bubble, echoing
+/// a text-cursor so the live response reads as "still typing". Pure visual —
+/// no semantic meaning for VoiceOver.
 private struct StreamingCursor: View {
-    @State private var pulse = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var visible = true
 
     var body: some View {
-        Circle()
-            .fill(Color.accentColor)
-            .frame(width: 6, height: 6)
-            .opacity(pulse ? 0.3 : 1.0)
+        RoundedRectangle(cornerRadius: 1, style: .continuous)
+            .fill(CT.accent)
+            .frame(width: 2, height: 14)
+            .opacity(visible ? 1.0 : 0.15)
             .animation(
-                .easeInOut(duration: 0.6).repeatForever(autoreverses: true),
-                value: pulse
+                reduceMotion
+                    ? nil
+                    : .easeInOut(duration: 0.55).repeatForever(autoreverses: true),
+                value: visible
             )
-            .onAppear { pulse = true }
+            .onAppear { if !reduceMotion { visible = false } }
             .accessibilityHidden(true)
     }
 }
@@ -307,6 +345,7 @@ private struct StreamingCursor: View {
     }
     .padding()
     .frame(maxWidth: .infinity, alignment: .leading)
+    .background(CT.bgWarm)
 }
 
 #Preview("Conversation") {
@@ -330,4 +369,5 @@ private struct StreamingCursor: View {
     }
     .padding()
     .frame(maxWidth: .infinity, alignment: .leading)
+    .background(CT.bgWarm)
 }

--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -541,16 +541,8 @@ private struct FilterViewportWidthKey: PreferenceKey {
     }
 }
 
-// MARK: - PressableButtonStyle
-
-/// Scales down ~8% on press and springs back, giving pills a physical feel.
-private struct PressableButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .scaleEffect(configuration.isPressed ? 0.92 : 1.0)
-            .animation(.spring(response: 0.25, dampingFraction: 0.6), value: configuration.isPressed)
-    }
-}
+// MARK: - PressableButtonStyle moved to Views/Shared/PressableButtonStyle.swift
+// (shared with ChatInputBar to avoid duplication)
 
 #Preview {
     VStack {

--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -11,8 +11,12 @@ public struct FilterBarView: View {
     /// Currently-selected custom tag pill (mirrors `MapViewModel.selectedCustomTag`).
     /// nil when no custom tag is active. US-008.
     let selectedCustomTag: String?
+    /// True when the "Saved" filter is active (mirrors `MapViewModel.isFavoriteFilter`).
+    let isFavoriteSelected: Bool
     let onSelectNow: () -> Void
     let onSelectAll: () -> Void
+    /// Tap handler for the "Saved" pill — shows only favourited experiences.
+    let onSelectFavorite: () -> Void
     /// Called when the user re-taps an already-active pill to deselect it back to 'All'.
     let onClear: () -> Void
     let onSelectCategory: (ExperienceCategory) -> Void
@@ -63,9 +67,11 @@ public struct FilterBarView: View {
         selectedCategory: ExperienceCategory?,
         isNowSelected: Bool,
         selectedCustomTag: String? = nil,
+        isFavoriteSelected: Bool = false,
         nowCount: Int = 0,
         onSelectNow: @escaping () -> Void,
         onSelectAll: @escaping () -> Void,
+        onSelectFavorite: @escaping () -> Void = {},
         onClear: @escaping () -> Void = {},
         onSelectCategory: @escaping (ExperienceCategory) -> Void,
         onSelectCustomTag: @escaping (String) -> Void = { _ in },
@@ -75,9 +81,11 @@ public struct FilterBarView: View {
         self.selectedCategory = selectedCategory
         self.isNowSelected = isNowSelected
         self.selectedCustomTag = selectedCustomTag
+        self.isFavoriteSelected = isFavoriteSelected
         self.nowCount = nowCount
         self.onSelectNow = onSelectNow
         self.onSelectAll = onSelectAll
+        self.onSelectFavorite = onSelectFavorite
         self.onClear = onClear
         self.onSelectCategory = onSelectCategory
         self.onSelectCustomTag = onSelectCustomTag
@@ -88,6 +96,7 @@ public struct FilterBarView: View {
     /// Stable string ID for the currently selected pill — drives matchedGeometryEffect.
     private var selectionID: String {
         if isNowSelected { return "now" }
+        if isFavoriteSelected { return "saved" }
         if let tag = selectedCustomTag { return "tag-\(tag)" }
         if let cat = selectedCategory { return cat.rawValue }
         return "all"
@@ -139,10 +148,17 @@ public struct FilterBarView: View {
                             id: "all",
                             label: NSLocalizedString("filter.all", comment: "All"),
                             isSelected: !isNowSelected && selectedCategory == nil && selectedCustomTag == nil,
-                            color: Color.primary,
+                            // Use the shared brown selected-fill (same as Now and
+                            // category chips) so the active 'All' filter carries
+                            // real visual weight. The old Color.primary fill was
+                            // near-invisible on the dark glass bar — the currently
+                            // active filter read as the least prominent chip.
+                            color: Self.selectedFill,
                             action: onSelectAll
                         )
                         .id("all")
+                        favoritePill(isSelected: isFavoriteSelected, action: onSelectFavorite)
+                            .id("saved")
                         ForEach(visibleCategories) { category in
                             iconPill(
                                 category: category,
@@ -331,31 +347,89 @@ public struct FilterBarView: View {
         Button {
             handleTap(isSelected: isSelected, select: action)
         } label: {
-            Text(label)
-                .font(.subheadline.weight(.medium))
-                .padding(.horizontal, 14)
-                .padding(.vertical, 8)
-                .foregroundStyle(isSelected ? .white : .primary)
-                .background {
-                    if isSelected {
-                        Capsule()
-                            .fill(color)
-                            .matchedGeometryEffect(id: "filterHighlight", in: pillHighlight)
-                    }
+            HStack(spacing: 5) {
+                Text(label)
+                    .font(.subheadline.weight(.medium))
+
+                // Inline result count — mirrors the Now pill's inline badge so
+                // every filter chip speaks one visual language. Replaces the old
+                // floating topTrailing badge, which read as a stray dot hovering
+                // off the chip's corner.
+                if isSelected && resultCount > 0 {
+                    Text(Self.compactCount(resultCount))
+                        .font(.caption2.monospacedDigit().weight(.semibold))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(Color.white.opacity(0.28)))
+                        .transition(.scale.combined(with: .opacity))
                 }
-                .overlay(
-                    Capsule().stroke(isSelected ? Color.clear : Color.primary.opacity(0.2), lineWidth: 1)
-                )
-                .overlay(alignment: .topTrailing) {
-                    if isSelected && resultCount > 0 {
-                        countBadge(count: resultCount, tint: color)
-                            .offset(x: 6, y: -6)
-                            .transition(.scale.combined(with: .opacity))
-                    }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .foregroundStyle(isSelected ? .white : .primary)
+            .background {
+                if isSelected {
+                    Capsule()
+                        .fill(color)
+                        .matchedGeometryEffect(id: "filterHighlight", in: pillHighlight)
                 }
-                .animation(.spring(response: 0.3, dampingFraction: 0.65), value: resultCount)
+            }
+            .overlay(
+                Capsule().stroke(isSelected ? Color.clear : Color.primary.opacity(0.2), lineWidth: 1)
+            )
+            .animation(.spring(response: 0.3, dampingFraction: 0.65), value: resultCount)
         }
         .buttonStyle(PressableButtonStyle())
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityValue(isSelected && resultCount > 0 ? Text("\(resultCount) results") : Text(""))
+    }
+
+    /// "Saved" pill — a heart glyph + localized label that filters the map to
+    /// the user's favourited experiences. It toggles (the parent's
+    /// `onSelectFavorite` flips `isFavoriteFilter`), so we always route taps to
+    /// `action` rather than the All-reverting `onClear` path. Selected state uses
+    /// a warm red fill that matches the heart-favourite affordance elsewhere in
+    /// the app; the inline count mirrors the All/Now chips' visual language.
+    private func favoritePill(isSelected: Bool, action: @escaping () -> Void) -> some View {
+        let label = NSLocalizedString("filter.saved", comment: "Saved (favourites filter)")
+        let tint = Color(red: 0xE0/255, green: 0x3A/255, blue: 0x3A/255)
+        return Button {
+            Haptics.selection()
+            action()
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: isSelected ? "heart.fill" : "heart")
+                    .font(.caption.weight(.semibold))
+
+                Text(label)
+                    .font(.subheadline.weight(.medium))
+
+                if isSelected && resultCount > 0 {
+                    Text(Self.compactCount(resultCount))
+                        .font(.caption2.monospacedDigit().weight(.semibold))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(Color.white.opacity(0.28)))
+                        .transition(.scale.combined(with: .opacity))
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .foregroundStyle(isSelected ? .white : tint)
+            .background {
+                if isSelected {
+                    Capsule()
+                        .fill(tint)
+                        .matchedGeometryEffect(id: "filterHighlight", in: pillHighlight)
+                }
+            }
+            .overlay(
+                Capsule().stroke(isSelected ? Color.clear : tint.opacity(0.7), lineWidth: 1)
+            )
+            .animation(.spring(response: 0.3, dampingFraction: 0.65), value: resultCount)
+        }
+        .buttonStyle(PressableButtonStyle())
+        .accessibilityLabel(Text(label))
         .accessibilityAddTraits(isSelected ? .isSelected : [])
         .accessibilityValue(isSelected && resultCount > 0 ? Text("\(resultCount) results") : Text(""))
     }

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -48,7 +48,7 @@ public enum SortMode: String, CaseIterable, Identifiable {
 /// heights are derived from these via `BottomSheetDetent.scaledHeight` so that
 /// at large Dynamic Type sizes (up to AX5) the sheet grows enough to show its
 /// content without clipping.
-private let basePeekHeight: CGFloat = 170
+private let basePeekHeight: CGFloat = 240
 private let baseMidHeight: CGFloat = 500
 private let baseFullHeight: CGFloat = 800
 private let baseMinHeight: CGFloat = 120
@@ -188,17 +188,31 @@ public struct BottomInfoSheet<Content: View>: View {
     private let aiHint: String
     private let count: Int
     private let isNowMode: Bool
+    /// The experience featured in the peek summary card ("此刻最值得去"). When
+    /// nil, the peek state shows `PeekEmptyCard` instead.
+    private let peekExperience: Experience?
+    /// Whether `peekExperience` is the AI smart pick (gold treatment + AI tag).
+    private let isSmartPick: Bool
+    /// Reference coordinate (user location or map center) for the peek card's
+    /// distance + compass bearing.
+    private let referenceCoordinate: CLLocationCoordinate2D?
     private let content: (BottomSheetDetent, Binding<SortMode>) -> Content
 
     public init(
         aiHint: String,
         count: Int,
         isNowMode: Bool,
+        peekExperience: Experience? = nil,
+        isSmartPick: Bool = false,
+        referenceCoordinate: CLLocationCoordinate2D? = nil,
         @ViewBuilder content: @escaping (BottomSheetDetent, Binding<SortMode>) -> Content
     ) {
         self.aiHint = aiHint
         self.count = count
         self.isNowMode = isNowMode
+        self.peekExperience = peekExperience
+        self.isSmartPick = isSmartPick
+        self.referenceCoordinate = referenceCoordinate
         self.content = content
     }
 
@@ -251,37 +265,18 @@ public struct BottomInfoSheet<Content: View>: View {
             // Sheet
             VStack(spacing: 0) {
                 dragHandleArea
-                NowHintRow(hint: aiHint)
+                peekContentArea
                     .padding(.horizontal, 16)
                     .padding(.top, 6)
-                SortCountToolbar(count: count, isNowMode: isNowMode, sortMode: $sortMode)
-                    .padding(.horizontal, 16)
-                    .padding(.top, 8)
-                // Single unified scroll layer for all sheet sections (Routes →
-                // Create-route → Nearby). Previously the sheet header rows were
-                // non-scrollable and only Nearby carried its own inner ScrollView,
-                // which meant a long Routes list pushed Nearby off-screen and could
-                // never be scrolled away — the two regions fought over one viewport.
-                // Hosting the whole content closure in one ScrollView makes the
-                // sections a continuous, naturally scrollable stream (like Apple
-                // Maps / Find My). At .peek the closure is empty, so the ScrollView
-                // is a cheap no-op. `Spacer` is gone: the ScrollView expands to fill
-                // the remaining sheet height itself.
-                ScrollView {
-                    content(currentDetent, $sortMode)
-                        // Pin content to the top so a changing viewport height
-                        // (during a drag) never re-centres the column — without
-                        // this the rows visibly jump frame-to-frame as the sheet
-                        // grows/shrinks, reading as a flicker.
-                        .frame(maxWidth: .infinity, alignment: .top)
+                // The sort/count toolbar only belongs above the *list*; in the
+                // peek state the summary card stands alone, so it is gated out.
+                if currentDetent != .peek {
+                    SortCountToolbar(count: count, isNowMode: isNowMode, sortMode: $sortMode)
+                        .padding(.horizontal, 16)
+                        .padding(.top, 8)
                 }
-                // While the handle is being dragged, freeze the ScrollView. The
-                // sheet's height animates every frame; an active ScrollView would
-                // re-clamp its contentOffset against that moving viewport and
-                // fight the drag gesture, producing the flicker. Re-enabled the
-                // moment the drag ends.
-                .scrollDisabled(isDragging)
-                .scrollDismissesKeyboard(.interactively)
+                content(currentDetent, $sortMode)
+                Spacer(minLength: 0)
             }
             .frame(maxWidth: .infinity)
             .frame(height: displayHeight)
@@ -295,15 +290,73 @@ public struct BottomInfoSheet<Content: View>: View {
                 .fill(.ultraThinMaterial)
             )
         }
-        // Animate ONLY the discrete detent settle (which changes once, on release),
-        // never the continuously finger-driven `displayHeight`. Watching
-        // `displayHeight` here meant every drag frame nudged a value an active
-        // spring was tracking, so the spring kept restarting-then-being-interrupted
-        // frame-to-frame — the sheet edge jittered larger/smaller (the "flicker").
-        // With the value pinned to `currentDetent`, the drag is pure, immediate
-        // finger-tracking (no animation), and only the release-to-nearest-detent
-        // gets the spring.
-        .animation(.spring(response: 0.3, dampingFraction: 0.85), value: currentDetent)
+        .animation(isDragging ? nil : .spring(response: 0.3, dampingFraction: 0.85), value: displayHeight)
+    }
+
+    // MARK: - Peek content
+
+    /// Peek state shows the "此刻最值得去" summary card (or the empty card);
+    /// every other detent reverts to the compact now-hint row above the list.
+    @ViewBuilder
+    private var peekContentArea: some View {
+        if currentDetent == .peek {
+            peekSummaryArea
+        } else {
+            NowHintRow(hint: aiHint)
+        }
+    }
+
+    /// Golden section label + the summary card. Tapping anywhere in this area —
+    /// the label, the card, or the surrounding whitespace — expands the sheet to
+    /// `.mid`. `currentDetent` is assigned directly; the outer ZStack's
+    /// `.animation(value:)` provides the spring, so no `withAnimation` wrapper is
+    /// used here (that would fight the implicit animation).
+    @ViewBuilder
+    private var peekSummaryArea: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            peekHeaderLabel
+            if let experience = peekExperience {
+                PeekSummaryCard(
+                    experience: experience,
+                    isSmartPick: isSmartPick,
+                    referenceCoordinate: referenceCoordinate,
+                    onTap: {
+                        currentDetent = .mid
+                        #if canImport(UIKit)
+                        Haptics.selection()
+                        #endif
+                    }
+                )
+            } else {
+                PeekEmptyCard()
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            currentDetent = .mid
+            #if canImport(UIKit)
+            Haptics.selection()
+            #endif
+        }
+    }
+
+    /// Golden "此刻最值得去" header, mirroring `RouteNowSectionHeader`'s left side
+    /// (sparkles + uppercase sun-gold-deep display text).
+    private var peekHeaderLabel: some View {
+        HStack(spacing: 7) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(CT.sunGoldDeep)
+            Text(NSLocalizedString("peek.pick.header", comment: "此刻最值得去 peek section header"))
+                .font(CT.display(11, .bold))
+                .tracking(1.3)
+                .textCase(.uppercase)
+                .foregroundStyle(CT.sunGoldDeep)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 4)
+        .accessibilityAddTraits(.isHeader)
     }
 
     // MARK: - Drag Handle
@@ -336,8 +389,20 @@ public struct BottomInfoSheet<Content: View>: View {
                     dragOffset = 0
                 }
         )
+        // A discrete tap on the handle steps up one detent. `DragGesture`'s
+        // `minimumDistance: 4` means a tap never registers as a drag, so the two
+        // gestures coexist without conflict.
+        .simultaneousGesture(
+            TapGesture().onEnded {
+                currentDetent = currentDetent.nextHigher
+                #if canImport(UIKit)
+                Haptics.selection()
+                #endif
+            }
+        )
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(Text(NSLocalizedString("sheet.handle", comment: "Bottom sheet drag handle")))
+        .accessibilityHint(Text(NSLocalizedString("sheet.handle.hint", comment: "Tap to expand, drag to resize")))
         .accessibilityAddTraits(.allowsDirectInteraction)
         .accessibilityAdjustableAction { direction in
             switch direction {
@@ -1033,27 +1098,22 @@ struct NearbySection: View {
                 // Each row now carries its own card chrome, so we separate them
                 // with a 10pt gap (matching RoutesSection) rather than full-bleed
                 // dividers — the list reads as a stack of discrete cards.
-                //
-                // No inner ScrollView: the host BottomInfoSheet wraps the whole
-                // content closure in one ScrollView, so Nearby lays its rows out
-                // inline as part of that single scroll stream. A nested ScrollView
-                // here would re-introduce the two-viewport conflict that hid this
-                // list when the Routes section above grew long. LazyVStack keeps
-                // rows lazily realized for long lists.
-                LazyVStack(spacing: 10) {
-                    ForEach(sortedExperiences) { exp in
-                        NearbyExperienceRow(
-                            experience: exp,
-                            isSmartPick: sortMode == .smart && smartPickIds.contains(exp.id),
-                            distanceMeters: distance(to: exp),
-                            isOpenNow: sortMode == .now && isOpenNow(exp),
-                            onTap: { onSelectExperience(exp) }
-                        )
+                ScrollView {
+                    LazyVStack(spacing: 10) {
+                        ForEach(sortedExperiences) { exp in
+                            NearbyExperienceRow(
+                                experience: exp,
+                                isSmartPick: sortMode == .smart && smartPickIds.contains(exp.id),
+                                distanceMeters: distance(to: exp),
+                                isOpenNow: sortMode == .now && isOpenNow(exp),
+                                onTap: { onSelectExperience(exp) }
+                            )
+                        }
                     }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 10)
+                    .padding(.bottom, 8)
                 }
-                .padding(.horizontal, 16)
-                .padding(.top, 10)
-                .padding(.bottom, 8)
             }
         }
         .padding(.top, 8)
@@ -1187,7 +1247,10 @@ struct EmptySheetListView: View {
         BottomInfoSheet(
             aiHint: NSLocalizedString("ai.now.hint", comment: "AI now hint"),
             count: 7,
-            isNowMode: false
+            isNowMode: false,
+            peekExperience: ExperienceService.hardcodedSeed.first,
+            isSmartPick: true,
+            referenceCoordinate: ExperienceService.hardcodedSeed.first?.coordinate
         ) { detent, _ in
             if detent != .peek {
                 Text("Nearby list goes here")

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -257,8 +257,31 @@ public struct BottomInfoSheet<Content: View>: View {
                 SortCountToolbar(count: count, isNowMode: isNowMode, sortMode: $sortMode)
                     .padding(.horizontal, 16)
                     .padding(.top, 8)
-                content(currentDetent, $sortMode)
-                Spacer(minLength: 0)
+                // Single unified scroll layer for all sheet sections (Routes →
+                // Create-route → Nearby). Previously the sheet header rows were
+                // non-scrollable and only Nearby carried its own inner ScrollView,
+                // which meant a long Routes list pushed Nearby off-screen and could
+                // never be scrolled away — the two regions fought over one viewport.
+                // Hosting the whole content closure in one ScrollView makes the
+                // sections a continuous, naturally scrollable stream (like Apple
+                // Maps / Find My). At .peek the closure is empty, so the ScrollView
+                // is a cheap no-op. `Spacer` is gone: the ScrollView expands to fill
+                // the remaining sheet height itself.
+                ScrollView {
+                    content(currentDetent, $sortMode)
+                        // Pin content to the top so a changing viewport height
+                        // (during a drag) never re-centres the column — without
+                        // this the rows visibly jump frame-to-frame as the sheet
+                        // grows/shrinks, reading as a flicker.
+                        .frame(maxWidth: .infinity, alignment: .top)
+                }
+                // While the handle is being dragged, freeze the ScrollView. The
+                // sheet's height animates every frame; an active ScrollView would
+                // re-clamp its contentOffset against that moving viewport and
+                // fight the drag gesture, producing the flicker. Re-enabled the
+                // moment the drag ends.
+                .scrollDisabled(isDragging)
+                .scrollDismissesKeyboard(.interactively)
             }
             .frame(maxWidth: .infinity)
             .frame(height: displayHeight)
@@ -272,7 +295,15 @@ public struct BottomInfoSheet<Content: View>: View {
                 .fill(.ultraThinMaterial)
             )
         }
-        .animation(isDragging ? nil : .spring(response: 0.3, dampingFraction: 0.85), value: displayHeight)
+        // Animate ONLY the discrete detent settle (which changes once, on release),
+        // never the continuously finger-driven `displayHeight`. Watching
+        // `displayHeight` here meant every drag frame nudged a value an active
+        // spring was tracking, so the spring kept restarting-then-being-interrupted
+        // frame-to-frame — the sheet edge jittered larger/smaller (the "flicker").
+        // With the value pinned to `currentDetent`, the drag is pure, immediate
+        // finger-tracking (no animation), and only the release-to-nearest-detent
+        // gets the spring.
+        .animation(.spring(response: 0.3, dampingFraction: 0.85), value: currentDetent)
     }
 
     // MARK: - Drag Handle
@@ -1002,22 +1033,27 @@ struct NearbySection: View {
                 // Each row now carries its own card chrome, so we separate them
                 // with a 10pt gap (matching RoutesSection) rather than full-bleed
                 // dividers — the list reads as a stack of discrete cards.
-                ScrollView {
-                    LazyVStack(spacing: 10) {
-                        ForEach(sortedExperiences) { exp in
-                            NearbyExperienceRow(
-                                experience: exp,
-                                isSmartPick: sortMode == .smart && smartPickIds.contains(exp.id),
-                                distanceMeters: distance(to: exp),
-                                isOpenNow: sortMode == .now && isOpenNow(exp),
-                                onTap: { onSelectExperience(exp) }
-                            )
-                        }
+                //
+                // No inner ScrollView: the host BottomInfoSheet wraps the whole
+                // content closure in one ScrollView, so Nearby lays its rows out
+                // inline as part of that single scroll stream. A nested ScrollView
+                // here would re-introduce the two-viewport conflict that hid this
+                // list when the Routes section above grew long. LazyVStack keeps
+                // rows lazily realized for long lists.
+                LazyVStack(spacing: 10) {
+                    ForEach(sortedExperiences) { exp in
+                        NearbyExperienceRow(
+                            experience: exp,
+                            isSmartPick: sortMode == .smart && smartPickIds.contains(exp.id),
+                            distanceMeters: distance(to: exp),
+                            isOpenNow: sortMode == .now && isOpenNow(exp),
+                            onTap: { onSelectExperience(exp) }
+                        )
                     }
-                    .padding(.horizontal, 16)
-                    .padding(.top, 10)
-                    .padding(.bottom, 8)
                 }
+                .padding(.horizontal, 16)
+                .padding(.top, 10)
+                .padding(.bottom, 8)
             }
         }
         .padding(.top, 8)

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -229,6 +229,29 @@ struct CompassMapContentView: View {
         return BottomSheetDetent.peekHeight(for: traits)
     }
 
+    /// The single experience featured in the BottomInfoSheet's peek summary card
+    /// ("此刻最值得去"). Prefers the first visible AI smart pick, else the nearest
+    /// visible experience to the user (or the selected city's centre when GPS is
+    /// unavailable). Resolved by the pure `PeekPickResolver` so the rule is unit-
+    /// tested independently of the view graph.
+    private var peekExperience: Experience? {
+        PeekPickResolver.resolve(
+            experiences: viewModel.visibleExperiences,
+            smartPickIds: viewModel.aiSmartPickIds,
+            referenceCoordinate: locationService.currentLocation?.coordinate
+                ?? viewModel.defaultCenterForSelectedCity
+        )
+    }
+
+    /// Whether `peekExperience` is the AI smart pick — drives the peek card's
+    /// gold gradient and "AI Pick" tag.
+    private var peekExperienceIsSmartPick: Bool {
+        PeekPickResolver.isSmartPick(
+            resolved: peekExperience,
+            smartPickIds: viewModel.aiSmartPickIds
+        )
+    }
+
     @ViewBuilder
     var body: some View {
         mapContent
@@ -502,7 +525,11 @@ struct CompassMapContentView: View {
                         count: viewModel.isNowFilter
                             ? viewModel.nowCount
                             : viewModel.visibleExperiences.count,
-                        isNowMode: viewModel.isNowFilter
+                        isNowMode: viewModel.isNowFilter,
+                        peekExperience: peekExperience,
+                        isSmartPick: peekExperienceIsSmartPick,
+                        referenceCoordinate: locationService.currentLocation?.coordinate
+                            ?? viewModel.defaultCenterForSelectedCity
                     ) { detent, sortMode in
                         if detent != .peek {
                             VStack(spacing: 0) {

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -1083,9 +1083,16 @@ struct CompassMapContentView: View {
                 }
             }
             .mapStyle(.standard(elevation: .flat, pointsOfInterest: .excludingAll))
+            // Only keep the compass (which auto-hides unless the map is
+            // rotated). The built-in MapUserLocationButton is intentionally
+            // dropped: because the map sets `.ignoresSafeArea()` to bleed tiles
+            // under the status bar, MapKit lays the control out against the
+            // ignored margins and pins it into the status-bar strip, where it
+            // collided with the system battery glyph. A custom recenter button
+            // (see `recenterButton` in the overlay) gives us a safe-area-aware,
+            // fully controllable placement instead.
             .mapControls {
                 MapCompass()
-                MapUserLocationButton()
             }
             .onMapCameraChange(frequency: .continuous) { _ in
                 isMapPanning = true
@@ -1255,6 +1262,13 @@ private struct MapOverlayView: View {
                 cityPill
                     .padding(.leading, 12)
                 Spacer()
+                // Custom "locate me" button — replaces the built-in
+                // MapUserLocationButton, which MapKit pinned into the status bar
+                // (it collided with the battery glyph) because the map ignores
+                // the top safe area. Living in this safe-area-respecting overlay
+                // row keeps it clear of the status bar, on the city-pill line.
+                recenterButton
+                    .padding(.trailing, 12)
             }
             .frame(height: MapOverlayMetrics.cityPillRowHeight)
             .padding(.top, MapOverlayMetrics.cityPillTopPadding)
@@ -1627,6 +1641,27 @@ private struct MapOverlayView: View {
         }
         .accessibilityLabel(Text(cityName))
         .accessibilityHint(Text(NSLocalizedString("city.picker.title", comment: "City picker sheet title")))
+    }
+
+    /// Custom "locate me" control. Recenters the camera on the user's current
+    /// location. Shows a filled arrow when a GPS fix is available, an outline
+    /// (and disabled) when not. Visual treatment matches the bottom FAB cluster
+    /// (.regularMaterial circle + soft shadow) so the controls read as one set.
+    private var recenterButton: some View {
+        let located = viewModel.hasUserLocation
+        return Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            viewModel.recenterOnUser()
+        } label: {
+            Image(systemName: located ? "location.fill" : "location")
+                .font(.body.weight(.semibold))
+                .foregroundStyle(located ? CT.accent : CT.fgSubtle)
+                .frame(width: 44, height: 44)
+                .background(Circle().fill(.regularMaterial))
+                .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+        }
+        .disabled(!located)
+        .accessibilityLabel(Text(NSLocalizedString("map.recenter", comment: "Recenter map on my location")))
     }
 }
 

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -139,7 +139,7 @@ struct CompassMapContentView: View {
     private let networkMonitor = NetworkMonitor.shared
 
     private var isFilterActive: Bool {
-        (viewModel.selectedCategory != nil) || (viewModel.selectedCustomTag != nil) || viewModel.isNowFilter
+        (viewModel.selectedCategory != nil) || (viewModel.selectedCustomTag != nil) || viewModel.isNowFilter || viewModel.isFavoriteFilter
     }
 
     private var activeFilterName: String {
@@ -149,6 +149,8 @@ struct CompassMapContentView: View {
             return tag
         } else if viewModel.isNowFilter {
             return NSLocalizedString("filter.now", comment: "Now filter label")
+        } else if viewModel.isFavoriteFilter {
+            return NSLocalizedString("filter.saved", comment: "Saved filter label")
         }
         return ""
     }
@@ -1239,9 +1241,11 @@ private struct MapOverlayView: View {
                 selectedCategory: viewModel.selectedCategory,
                 isNowSelected: viewModel.isNowFilter,
                 selectedCustomTag: viewModel.selectedCustomTag,
+                isFavoriteSelected: viewModel.isFavoriteFilter,
                 nowCount: viewModel.nowCount,
                 onSelectNow: { viewModel.selectNowFilter() },
                 onSelectAll: { viewModel.clearFilters() },
+                onSelectFavorite: { viewModel.selectFavoriteFilter() },
                 onClear: { viewModel.clearFilters() },
                 onSelectCategory: { viewModel.selectCategory($0) },
                 onSelectCustomTag: { viewModel.selectCustomTag($0) },

--- a/apps/ios/SoloCompass/Views/Map/PeekPickResolver.swift
+++ b/apps/ios/SoloCompass/Views/Map/PeekPickResolver.swift
@@ -1,0 +1,66 @@
+import CoreLocation
+
+/// Pure resolver for the single experience surfaced in the BottomInfoSheet's
+/// peek summary card ("此刻最值得去").
+///
+/// Extracted as a free-standing, side-effect-free function so the selection
+/// logic is unit-testable without standing up a SwiftUI graph. `CompassMapView`
+/// calls `resolve` from its `peekExperience` computed property.
+///
+/// Precedence:
+///  1. The first AI smart-pick id (`smartPickIds.first`) that is present in
+///     `experiences` — the AI's top recommendation, when it is currently visible.
+///  2. Otherwise the experience nearest the reference coordinate.
+///  3. `nil` when `experiences` is empty.
+enum PeekPickResolver {
+    /// Resolve the peek experience from the visible set.
+    ///
+    /// - Parameters:
+    ///   - experiences: the currently visible experiences.
+    ///   - smartPickIds: AI-ranked top pick ids (highest priority first).
+    ///   - referenceCoordinate: user location or map center; used for the
+    ///     nearest-fallback. When `nil`, the first visible experience is returned
+    ///     as the fallback (no distance ordering is possible).
+    /// - Returns: the experience to feature in the peek card, or `nil` if none.
+    static func resolve(
+        experiences: [Experience],
+        smartPickIds: [String],
+        referenceCoordinate: CLLocationCoordinate2D?
+    ) -> Experience? {
+        guard !experiences.isEmpty else { return nil }
+
+        // 1. Prefer the first smart pick that is actually visible.
+        for id in smartPickIds {
+            if let match = experiences.first(where: { $0.id == id }) {
+                return match
+            }
+        }
+
+        // 2. Fallback: nearest to the reference coordinate.
+        guard let ref = referenceCoordinate else {
+            return experiences.first
+        }
+        // Allocate the reference CLLocation once, outside the comparison closure.
+        let refLocation = CLLocation(latitude: ref.latitude, longitude: ref.longitude)
+        return experiences.min(by: { lhs, rhs in
+            distance(from: refLocation, to: lhs) < distance(from: refLocation, to: rhs)
+        })
+    }
+
+    /// Whether the resolved peek experience is the AI smart pick (drives the gold
+    /// gradient + AI Pick tag). True only when the resolution returned a
+    /// smart-pick id.
+    static func isSmartPick(
+        resolved: Experience?,
+        smartPickIds: [String]
+    ) -> Bool {
+        guard let resolved else { return false }
+        return smartPickIds.contains(resolved.id)
+    }
+
+    /// Great-circle distance in meters; missing coordinates sort last.
+    private static func distance(from origin: CLLocation, to experience: Experience) -> CLLocationDistance {
+        guard let coord = experience.coordinate else { return .greatestFiniteMagnitude }
+        return origin.distance(from: CLLocation(latitude: coord.latitude, longitude: coord.longitude))
+    }
+}

--- a/apps/ios/SoloCompass/Views/Map/PeekSummaryCard.swift
+++ b/apps/ios/SoloCompass/Views/Map/PeekSummaryCard.swift
@@ -1,0 +1,314 @@
+import SwiftUI
+import CoreLocation
+
+// MARK: - PeekSummaryCard
+
+/// "此刻最值得去" summary card shown in the BottomInfoSheet's peek state.
+///
+/// Replaces the empty single-line hint with one concrete, tappable suggestion so
+/// the resting sheet earns its 240pt height. Tapping the card expands the sheet
+/// to `.mid` (the full nearby list) rather than opening the detail sheet — the
+/// expand semantics are owned by the caller via `onTap`.
+///
+/// The card's chrome is a *visual* port of `NearbyExperienceRow` (the disc,
+/// title stack, chip row, distance column are all private to that view in a
+/// different parent context, so they are reproduced here rather than extracted):
+/// a 3pt left color bar (sun-gold for the AI smart pick, else the category tint),
+/// a 40×40 category disc, the title + romanized·local subtitle, a chip row
+/// (`SoloScoreBadge(.compact)` + an optional 此刻最佳 chip) and a trailing
+/// compass-arrow + distance column.
+struct PeekSummaryCard: View {
+    let experience: Experience
+    /// True when this card is the AI smart pick — drives the warm gold gradient
+    /// background and the "AI Pick" marker.
+    let isSmartPick: Bool
+    /// Reference coordinate (user location or map center) for distance + bearing.
+    let referenceCoordinate: CLLocationCoordinate2D?
+    /// Fired when the card is tapped — the caller expands the sheet to `.mid`.
+    let onTap: () -> Void
+
+    @State private var pressed = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(LocationService.self) private var locationService
+    @Environment(BestNowClock.self) private var clock
+
+    /// Single shared formatter — re-allocating a `MeasurementFormatter` per body
+    /// evaluation is wasteful (it parses locale data each time).
+    private static let distanceFormatter: MeasurementFormatter = {
+        let f = MeasurementFormatter()
+        f.unitOptions = .naturalScale
+        f.unitStyle = .short
+        f.numberFormatter.maximumFractionDigits = 1
+        return f
+    }()
+
+    var body: some View {
+        Button {
+            #if canImport(UIKit)
+            Haptics.selection()
+            if !reduceMotion {
+                withAnimation(.spring(response: 0.18, dampingFraction: 0.5)) { pressed = true }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
+                    withAnimation(.spring(response: 0.18, dampingFraction: 0.5)) { pressed = false }
+                }
+            }
+            #endif
+            onTap()
+        } label: {
+            HStack(alignment: .top, spacing: 12) {
+                categoryDisc
+                VStack(alignment: .leading, spacing: 7) {
+                    titleStack
+                    chipRow
+                }
+                Spacer(minLength: 4)
+                distanceColumn
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background(cardBackground)
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .strokeBorder(isSmartPick ? CT.accentBorder : CT.borderSubtle, lineWidth: 0.5)
+            )
+            .overlay(alignment: .leading) {
+                // 3pt left color bar: gold for the smart pick, else the category tint.
+                UnevenRoundedRectangle(
+                    topLeadingRadius: 14, bottomLeadingRadius: 14,
+                    bottomTrailingRadius: 0, topTrailingRadius: 0,
+                    style: .continuous
+                )
+                .fill(isSmartPick ? CT.sunGold : experience.category.color)
+                .frame(width: 3)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .shadow(color: .black.opacity(0.04), radius: 1, x: 0, y: 1)
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(pressed ? 0.97 : 1.0)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint(Text(NSLocalizedString("peek.card.hint", comment: "Double tap to expand the nearby list")))
+    }
+
+    // MARK: - Sub-views
+
+    private var categoryDisc: some View {
+        ZStack {
+            Circle()
+                .fill(experience.category.color)
+                .frame(width: 40, height: 40)
+            Image(systemName: experience.category.symbol)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(.white)
+        }
+        .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private var titleStack: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 6) {
+                Text(experience.title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(CT.fgPrimary)
+                    .lineLimit(1)
+                if isSmartPick {
+                    aiPickTag
+                }
+            }
+            let sub = subtitleText
+            if !sub.isEmpty {
+                Text(sub)
+                    .font(.caption)
+                    .foregroundStyle(CT.fgMuted)
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    /// Small "AI Pick" marker shown beside the title on the smart pick.
+    private var aiPickTag: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 8, weight: .semibold))
+            Text(NSLocalizedString("peek.card.aiPick", comment: "AI Pick tag"))
+                .font(.system(size: 9, weight: .bold))
+                .tracking(0.3)
+        }
+        .foregroundStyle(CT.sunGoldDeep)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(Capsule().fill(CT.sunGoldSoft))
+        .accessibilityHidden(true)
+    }
+
+    /// Chip row: Solo-Score badge + (optional) 此刻最佳 chip.
+    private var chipRow: some View {
+        HStack(spacing: 6) {
+            SoloScoreBadge(score: experience.soloScore, style: .compact)
+            if isOpenNow {
+                bestNowChip
+            }
+        }
+    }
+
+    /// Golden chip: 此刻最佳 — shown when the experience is open in the current hour.
+    private var bestNowChip: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 9, weight: .semibold))
+            Text(NSLocalizedString("nearby.chip.bestNow", comment: "此刻最佳 chip"))
+                .font(.caption2.weight(.semibold))
+        }
+        .foregroundStyle(CT.sunGoldDeep)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(CT.sunGoldSoft))
+        .accessibilityHidden(true)
+    }
+
+    /// Trailing column: compass arrow over the formatted distance, right-aligned.
+    private var distanceColumn: some View {
+        let bearing = relativeBearing
+        let hasLiveBearing = bearing != nil
+        return VStack(alignment: .trailing, spacing: 4) {
+            Image(systemName: "location.north.line.fill")
+                .font(.caption2)
+                .foregroundStyle(hasLiveBearing ? AnyShapeStyle(CT.fgMuted) : AnyShapeStyle(CT.fgSubtle))
+                .rotationEffect(.degrees(bearing ?? 0))
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: bearing)
+            if let meters = distanceMeters {
+                Text(formattedDistance(meters))
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(CT.fgSubtle)
+            }
+        }
+        .accessibilityHidden(true)
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .fill(isSmartPick ? AnyShapeStyle(smartPickGradient) : AnyShapeStyle(CT.surfaceWhite))
+    }
+
+    private var smartPickGradient: LinearGradient {
+        LinearGradient(
+            colors: [CT.sunGoldSoft.opacity(0.55), CT.surfaceWhite],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+    }
+
+    // MARK: - Derived values
+
+    private var subtitleText: String {
+        let parts = [
+            experience.location.placeNameRomanized,
+            experience.location.placeNameLocal
+        ].compactMap { $0?.isEmpty == false ? $0 : nil }
+        if parts.isEmpty {
+            return experience.location.addressHint ?? ""
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private var isOpenNow: Bool {
+        let hour = Calendar.current.component(.hour, from: clock.tick)
+        return experience.bestTimes.contains { $0.contains(hour: hour) }
+    }
+
+    private var relativeBearing: Double? {
+        guard let coord = experience.coordinate else { return nil }
+        return locationService.relativeBearing(to: coord)
+    }
+
+    /// Distance (m) from the reference coordinate to the experience.
+    private var distanceMeters: Double? {
+        guard let ref = referenceCoordinate,
+              let coord = experience.coordinate else { return nil }
+        let from = CLLocation(latitude: ref.latitude, longitude: ref.longitude)
+        let to = CLLocation(latitude: coord.latitude, longitude: coord.longitude)
+        return from.distance(from: to)
+    }
+
+    private func formattedDistance(_ meters: Double) -> String {
+        Self.distanceFormatter.string(from: Measurement(value: meters, unit: UnitLength.meters))
+    }
+
+    private var accessibilityLabel: Text {
+        var label = experience.title
+        if isSmartPick {
+            label += ", " + NSLocalizedString("peek.card.aiPick.a11y", comment: "AI pick for right now")
+        }
+        label += ", Solo \(String(format: "%.1f", experience.soloScore.overall))"
+        if let meters = distanceMeters {
+            label += ", \(formattedDistance(meters))"
+        }
+        return Text(label)
+    }
+}
+
+// MARK: - PeekEmptyCard
+
+/// Peek-state placeholder shown when no experiences are visible. A calm, single
+/// horizontal row (no breathing animation, unlike the mid-list empty state) that
+/// nudges the traveler to pan the map.
+struct PeekEmptyCard: View {
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "mappin.slash")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(CT.fgSubtle)
+            Text(NSLocalizedString("peek.empty.hint", comment: "Move the map to discover nearby spots"))
+                .font(.subheadline)
+                .foregroundStyle(CT.fgMuted)
+                .lineLimit(2)
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 14)
+        .frame(minHeight: 44)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(CT.surfaceWhite)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(CT.borderSubtle, lineWidth: 0.5)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(NSLocalizedString("peek.empty.hint", comment: "Move the map to discover nearby spots")))
+    }
+}
+
+// MARK: - Preview
+
+#Preview("PeekSummaryCard") {
+    let seed = ExperienceService.hardcodedSeed
+    return ZStack {
+        Color(.systemGroupedBackground).ignoresSafeArea()
+        VStack(spacing: 16) {
+            if let pick = seed.first {
+                PeekSummaryCard(
+                    experience: pick,
+                    isSmartPick: true,
+                    referenceCoordinate: pick.coordinate,
+                    onTap: {}
+                )
+            }
+            if seed.count > 1 {
+                PeekSummaryCard(
+                    experience: seed[1],
+                    isSmartPick: false,
+                    referenceCoordinate: seed.first?.coordinate,
+                    onTap: {}
+                )
+            }
+            PeekEmptyCard()
+        }
+        .padding(16)
+    }
+    .environment(LocationService.shared)
+    .environment(BestNowClock.shared)
+}

--- a/apps/ios/SoloCompass/Views/Shared/CompareTokens.swift
+++ b/apps/ios/SoloCompass/Views/Shared/CompareTokens.swift
@@ -24,6 +24,12 @@ public enum CT {
     public static let sunGoldDeep   = rgb(0xA0, 0x7F, 0x4B)
     public static let sunGoldSoft   = rgb(0xF5, 0xE9, 0xD2)
 
+    // Chat surface tokens. All light-fixed values — pair with a colorScheme
+    // check at the call site so the warm tints don't fight dark mode.
+    public static let chatInputBg         = rgb(0xF5, 0xF0, 0xEB) // warm input-field fill
+    public static let bannerError         = rgb(0xC0, 0x3B, 0x1E) // #C03B1E — banner error tone
+    public static let chatAIBubbleBgDark  = rgb(0x28, 0x24, 0x1E) // dark-mode AI bubble fill
+
     // Verified green (路线已验证 / closed companion) — #1F7B4D text, #2FA46A dot.
     public static let verifiedGreen    = rgb(0x1F, 0x7B, 0x4D)
     public static let verifiedGreenDot = rgb(0x2F, 0xA4, 0x6A)

--- a/apps/ios/SoloCompass/Views/Shared/PressableButtonStyle.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PressableButtonStyle.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+/// Scales the label down ~8% on press and springs back, giving tappable
+/// surfaces a physical, tactile feel. Shared between the filter pills and the
+/// chat input bar so the press feedback stays consistent across the app.
+public struct PressableButtonStyle: ButtonStyle {
+    /// Press-down scale. Default 0.92 matches the filter pills; the send button
+    /// passes a slightly punchier value.
+    private let pressedScale: CGFloat
+
+    public init(pressedScale: CGFloat = 0.92) {
+        self.pressedScale = pressedScale
+    }
+
+    public func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? pressedScale : 1.0)
+            .animation(.spring(response: 0.25, dampingFraction: 0.6), value: configuration.isPressed)
+    }
+}


### PR DESCRIPTION
## What

A pass over the map home screen and the chat sheet, plus two real bug fixes found along the way.

### Bottom sheet
- **Flicker fix** — dragging the sheet no longer jitters. Root cause: `.animation(value: displayHeight)` was watching a finger-driven value, so the spring restarted every frame. Pinned to the discrete `currentDetent` instead.
- **Unified scroll** — Routes + Create-route + Nearby now share one ScrollView (was a non-scrollable header + a nested Nearby ScrollView that fought over one viewport).
- **Peek summary card** — the peek state used to show one empty-feeling hint line. It now surfaces a "best for right now" card (AI smart pick → nearest fallback): category disc, title + local place name, Solo score, best-now chip, distance. Peek height 170→240pt.
- **Tap to expand** — tapping the peek card / area / handle expands the sheet (peek→mid), in addition to dragging.

### Filter bar
- **Saved filter** — a heart "Saved / 收藏" pill next to All shows only favourited experiences (reuses the existing favourite store; fourth mutually-exclusive filter mode).
- Inline count on the All chip (was a floating corner badge); active All chip gets real fill weight.

### Chat sheet (visual only — no logic/flow changes)
- Bubbles gain depth (border + shadow), assistant avatar redesigned in sun-gold.
- Empty-state starter prompts → tappable cards with icons.
- Input bar: warm TextField, unified mic/send buttons, top divider.
- New shared `InlineBanner` unifies the five ad-hoc error/permission/info banners.
- Streaming caret, refined typing dots, clearer live transcript. Dark mode per-token, reduceMotion-guarded.

### Location button fix
- The built-in `MapUserLocationButton` was pinned into the status bar (colliding with the battery glyph) because the map sets `.ignoresSafeArea()`. Replaced with a custom safe-area-aware "locate me" button on the city-pill row.

## Tests
- New: `FavoriteFilterTests`, `PeekSummarySelectionTests`, `ChatBubbleContrastTest`.
- All relevant suites green (favourite filtering/exclusivity, peek pick resolution, WCAG contrast, filter-bar, bottom-sheet detent/clearance regressions).
- Build clean on iPhone 17 Pro simulator; peek card + recenter button + filter bar visually verified in-sim.

## Notes
- iOS-only; no TS workspace changes.
- 5 focused commits (flicker, Saved filter, chat polish, peek card, location/wiring).