### PR TITLE
fix(ios): make route cards tappable + add elegant route sharing

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		58B7C9B20945838F81081941 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14A22A40550CF207AB36C18 /* SettingsView.swift */; };
 		58C9B0E8A0A2DB38E1078E9D /* HapticService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277318E6238F2F885ED2334 /* HapticService.swift */; };
 		58EC3C9838462DCD66F11975 /* RouteRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6BAB6EA03E81F52D00CCD59 /* RouteRecordTests.swift */; };
+		59A9E2DAC8378384BBCD8A57 /* RouteShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4181409CE6A219B1C07502 /* RouteShareSheet.swift */; };
 		5B22BAF4AD26B9941361351B /* CompanionCrossTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA531A7BAD8A34652BA4801 /* CompanionCrossTests.swift */; };
 		5C05B87EA78458094612AC01 /* BottomInfoBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13350B81187FB64B252B8A46 /* BottomInfoBar.swift */; };
 		5F3ACD03660F3E8B88814C56 /* MyHostedRoutesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E055BAC372B75F743428920 /* MyHostedRoutesListView.swift */; };
@@ -338,6 +339,7 @@
 		1A9FE3BB447D84732CCE0B07 /* RouteCardWalkedByTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCardWalkedByTest.swift; sourceTree = "<group>"; };
 		1C04120C63712F09D8357CEE /* CompanionMapLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionMapLayer.swift; sourceTree = "<group>"; };
 		1C23113554E651AA08FD2430 /* POILoadingBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POILoadingBanner.swift; sourceTree = "<group>"; };
+		1D4181409CE6A219B1C07502 /* RouteShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteShareSheet.swift; sourceTree = "<group>"; };
 		1D7A24EA7AB5379E0D5DC2B2 /* InlineBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineBanner.swift; sourceTree = "<group>"; };
 		1D951F9EC55C09A219D97D55 /* JoinRequestValidationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinRequestValidationTest.swift; sourceTree = "<group>"; };
 		1F39081CF797874064A33814 /* seed_routes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = seed_routes.json; sourceTree = "<group>"; };
@@ -670,6 +672,7 @@
 				023CB5AE8B0D41EBB5E17DAC /* ReportBlockSheet.swift */,
 				F86CFA31CA2B66F6AA221ECB /* RequestInboxView.swift */,
 				CA1C7F381BB5EE2493C06407 /* RouteDetailView.swift */,
+				1D4181409CE6A219B1C07502 /* RouteShareSheet.swift */,
 				99D914894172F5E81C250A6A /* SendRequestSheet.swift */,
 				BBF9B944FE7F4CC3492DF727 /* Components */,
 			);
@@ -1494,6 +1497,7 @@
 				7DE0D7D331590BFAC64D55B9 /* RouteDetailView.swift in Sources */,
 				8D67669050D844812FA06CC8 /* RouteItineraryBridge.swift in Sources */,
 				F3B6B76087182DEAF1BD0556 /* RouteRecord.swift in Sources */,
+				59A9E2DAC8378384BBCD8A57 /* RouteShareSheet.swift in Sources */,
 				963BC062494BCC3B655AFDC0 /* RouteStore.swift in Sources */,
 				CE75A768DA8AD2A14C3046AF /* SavedCity.swift in Sources */,
 				FBE9F5951D501A611EB19EEC /* SecretsRuntime.swift in Sources */,

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -584,6 +584,7 @@
 "paywall.restore" = "Restore purchases";
 "paywall.manage" = "Manage subscription";
 "paywall.error.title" = "Purchase didn't complete";
+"paywall.error.unavailable" = "Subscriptions aren't available right now. Please check your connection and try again in a moment.";
 "paywall.close" = "Close";
 "paywall.continueFree" = "Continue with Free";
 
@@ -783,6 +784,15 @@
 "share.style.twitterLandscape" = "Twitter 1.91:1";
 "share.style.instagramSquare" = "Square 1:1";
 "share.style.minimalText" = "Minimal 9:16";
+/* Route share sheet (route detail → share). */
+"route.share.title" = "Share Route";
+"route.share.kicker" = "Route · Solo Compass";
+"route.share.mode.card" = "Card";
+"route.share.mode.text" = "Text";
+"route.share.min" = "min";
+"route.share.stops" = "stops";
+/* %d = number of travelers who have walked this route. */
+"route.share.walkedBy" = "Walked by %d travelers";
 /* Share-card image brand label (US-038) — kept as "Solo Compass" in both locales, but routed through l10n. */
 "sharecard.brand" = "Solo Compass";
 /* Share-card score suffix (US-039) — rendered after the numeric Solo Score on the share card. */

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -341,6 +341,7 @@
 "paywall.restore" = "恢复购买";
 "paywall.manage" = "管理订阅";
 "paywall.error.title" = "购买未完成";
+"paywall.error.unavailable" = "订阅暂时不可用。请检查网络后稍候重试。";
 "paywall.close" = "关闭";
 "paywall.continueFree" = "免费继续使用";
 
@@ -506,6 +507,15 @@
 "share.style.twitterLandscape" = "横版 1.91:1";
 "share.style.instagramSquare" = "方形 1:1";
 "share.style.minimalText" = "极简 9:16";
+/* Route share sheet (route detail → share). */
+"route.share.title" = "分享路线";
+"route.share.kicker" = "路线 · Solo Compass";
+"route.share.mode.card" = "图片卡";
+"route.share.mode.text" = "纯文本";
+"route.share.min" = "分钟";
+"route.share.stops" = "站";
+/* %d = number of travelers who have walked this route. */
+"route.share.walkedBy" = "已有 %d 位旅行者走过";
 /* Share-card image brand label (US-038) — kept as "Solo Compass" in both locales, but routed through l10n. */
 "sharecard.brand" = "Solo Compass";
 /* Share-card score suffix (US-039) — rendered after the numeric Solo Score on the share card. */

--- a/apps/ios/SoloCompass/Views/Companion/RouteDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/RouteDetailView.swift
@@ -26,9 +26,13 @@ public struct RouteDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var isSaved = false
     @State private var isFavorited = false
-    @State private var showJoinSheet = false
     @State private var showCompletionMoment = false
     @State private var showApprovalQueue = false
+    // Single source of truth for the join / share sheets. Stacking two
+    // `.sheet(isPresented:)` on one view collapses to only the last in SwiftUI
+    // (the outer modifier overrides the inner), so a `.sheet(item:)` keyed on
+    // this enum keeps both presentations working.
+    @State private var activeSheet: RouteDetailSheet? = nil
     // Refreshes whenever RouteStore.didChange fires (join request submitted, accepted, etc.)
     @State private var liveRoute: Route
 
@@ -92,8 +96,13 @@ public struct RouteDetailView: View {
         .safeAreaInset(edge: .bottom) { bottomDock }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar { shareButton }
-        .sheet(isPresented: $showJoinSheet) {
-            JoinRouteRequestSheet(route: liveRoute)
+        .sheet(item: $activeSheet) { sheet in
+            switch sheet {
+            case .join:
+                JoinRouteRequestSheet(route: liveRoute)
+            case .share:
+                RouteShareSheet(payload: sharePayload)
+            }
         }
         .fullScreenCover(isPresented: $showCompletionMoment) {
             CompletionMoment(route: liveRoute, onDismiss: { showCompletionMoment = false })
@@ -177,7 +186,7 @@ public struct RouteDetailView: View {
                     hasMyRequest: hasMyRequest,
                     strength: preferences.companionModuleStrength,
                     onRequestJoin: {
-                        showJoinSheet = true
+                        activeSheet = .join
                     },
                     onViewRequests: {
                         showApprovalQueue = true
@@ -359,7 +368,7 @@ public struct RouteDetailView: View {
                 label: NSLocalizedString("route.detail.cta.requestJoin", comment: ""),
                 systemImage: "person.2.fill",
                 isDisabled: false,
-                action: { showJoinSheet = true }
+                action: { activeSheet = .join }
             )
         }
         // closed / completed → group chat entry (falls back to completion replay
@@ -432,9 +441,39 @@ public struct RouteDetailView: View {
     @ToolbarContentBuilder
     private var shareButton: some ToolbarContent {
         ToolbarItem(placement: .topBarTrailing) {
-            ShareLink(item: liveRoute.title) {
+            Button {
+                activeSheet = .share
+            } label: {
                 Image(systemName: "square.and.arrow.up")
             }
+            .accessibilityLabel(NSLocalizedString("route.share.title", comment: "Share route"))
+        }
+    }
+
+    /// Pre-built payload for the share sheet — resolves the primary category and
+    /// stop count once so the sheet stays a pure visual layer.
+    private var sharePayload: RouteSharePayload {
+        RouteSharePayload(
+            route: liveRoute,
+            category: primaryCategory,
+            stopCount: liveRoute.experienceIds.count
+        )
+    }
+}
+
+// MARK: - RouteDetailSheet
+
+/// Which modal RouteDetailView is presenting. A single `.sheet(item:)` keyed on
+/// this enum avoids stacking two `.sheet(isPresented:)` modifiers (SwiftUI keeps
+/// only the last, breaking the other).
+enum RouteDetailSheet: Identifiable {
+    case join
+    case share
+
+    var id: String {
+        switch self {
+        case .join:  return "join"
+        case .share: return "share"
         }
     }
 }

--- a/apps/ios/SoloCompass/Views/Companion/RouteShareSheet.swift
+++ b/apps/ios/SoloCompass/Views/Companion/RouteShareSheet.swift
@@ -1,0 +1,516 @@
+import SwiftUI
+import UIKit
+
+// MARK: - RouteSharePayload
+
+/// Pure-data input to the route share card. Decoupled from `Route` so the card
+/// can be previewed / rendered without standing up the experience service, and
+/// so the visual layer never reaches back into model logic.
+struct RouteSharePayload: Hashable {
+    let title: String
+    let summary: String
+    let placeLabel: String          // region / city, already human-readable
+    let category: ExperienceCategory // drives gradient + emoji (mirrors RouteDetailView hero)
+    let durationMinutes: Int
+    let distanceMeters: Int
+    let paceLabel: String
+    let stopCount: Int
+    let walkedByCount: Int
+    let tags: [String]
+    let brandHandle: String
+
+    init(
+        title: String,
+        summary: String,
+        placeLabel: String,
+        category: ExperienceCategory,
+        durationMinutes: Int,
+        distanceMeters: Int,
+        paceLabel: String,
+        stopCount: Int,
+        walkedByCount: Int,
+        tags: [String],
+        brandHandle: String = "solocompass.app"
+    ) {
+        self.title = title
+        self.summary = summary
+        self.placeLabel = placeLabel
+        self.category = category
+        self.durationMinutes = durationMinutes
+        self.distanceMeters = distanceMeters
+        self.paceLabel = paceLabel
+        self.stopCount = stopCount
+        self.walkedByCount = walkedByCount
+        self.tags = Array(tags.prefix(3))
+        self.brandHandle = brandHandle
+    }
+
+    /// Build from a `Route` plus its resolved primary category and stop count.
+    init(route: Route, category: ExperienceCategory, stopCount: Int) {
+        self.init(
+            title: route.title,
+            summary: route.summary,
+            placeLabel: route.region.isEmpty ? route.cityCode : route.region,
+            category: category,
+            durationMinutes: route.estimatedDuration,
+            distanceMeters: route.distanceMeters,
+            paceLabel: route.pace.localizedLabel,
+            stopCount: stopCount,
+            walkedByCount: route.verification.walkedByCount,
+            tags: route.tags
+        )
+    }
+
+    /// Human distance: "1.2 km" above 1000 m, else "650 m".
+    var distanceLabel: String {
+        if distanceMeters >= 1000 {
+            let km = Double(distanceMeters) / 1000
+            return String(format: "%.1f km", km)
+        }
+        return "\(distanceMeters) m"
+    }
+
+    /// Multi-line plain-text share body — the "copy as text" / fallback path.
+    var shareText: String {
+        var lines: [String] = []
+        lines.append("🧭 \(title)")
+        if !summary.isEmpty { lines.append(summary) }
+        var facts: [String] = []
+        if !placeLabel.isEmpty { facts.append("📍 \(placeLabel)") }
+        facts.append("⏱ \(durationMinutes) min")
+        facts.append("📏 \(distanceLabel)")
+        facts.append("👣 \(stopCount) \(NSLocalizedString("route.share.stops", comment: "stops unit"))")
+        lines.append(facts.joined(separator: "  ·  "))
+        if walkedByCount > 0 {
+            let fmt = NSLocalizedString("route.share.walkedBy", comment: "walked-by social proof")
+            lines.append(String(format: fmt, walkedByCount))
+        }
+        if !tags.isEmpty {
+            lines.append(tags.map { "#\($0)" }.joined(separator: " "))
+        }
+        lines.append("— \(brandHandle)")
+        return lines.joined(separator: "\n")
+    }
+}
+
+// MARK: - RouteShareCardView
+
+/// 1080×1920 portrait share card for a route. Mirrors the `RouteDetailView`
+/// hero language (category gradient + emoji) so a shared image reads as the
+/// same product. Laid out at half-pixel `renderSize`; `ImageRenderer` scales up.
+struct RouteShareCardView: View {
+    let payload: RouteSharePayload
+
+    /// On-screen render size in points (half of the 1080×1920 pixel target).
+    static let renderSize = CGSize(width: 540, height: 960)
+    static let renderScale: CGFloat = 2.0
+
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            CategoryVisual.gradient(for: payload.category)
+
+            // Subtle scrim so bottom text stays legible over bright gradients.
+            LinearGradient(
+                colors: [.clear, .black.opacity(0.35)],
+                startPoint: .center,
+                endPoint: .bottom
+            )
+
+            VStack(alignment: .leading, spacing: 0) {
+                // Top: emoji + brand
+                HStack(alignment: .top) {
+                    Text(CategoryVisual.emoji(for: payload.category))
+                        .font(.system(size: 64))
+                    Spacer()
+                    Text(NSLocalizedString("route.share.kicker", comment: "Route share card kicker"))
+                        .font(.system(size: 18, weight: .semibold))
+                        .tracking(2)
+                        .textCase(.uppercase)
+                        .foregroundStyle(.white.opacity(0.85))
+                }
+
+                Spacer(minLength: 0)
+
+                // Bottom block: title, summary, stats, tags, walked-by, brand
+                VStack(alignment: .leading, spacing: 18) {
+                    if !payload.placeLabel.isEmpty {
+                        Label(payload.placeLabel, systemImage: "mappin.circle.fill")
+                            .font(.system(size: 22, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.9))
+                    }
+
+                    Text(payload.title)
+                        .font(.system(size: 48, weight: .heavy))
+                        .foregroundStyle(.white)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .lineLimit(3)
+
+                    if !payload.summary.isEmpty {
+                        Text(payload.summary)
+                            .font(.system(size: 22))
+                            .foregroundStyle(.white.opacity(0.88))
+                            .lineLimit(3)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    statRow
+
+                    if payload.walkedByCount > 0 {
+                        let fmt = NSLocalizedString("route.share.walkedBy", comment: "walked-by social proof")
+                        Text(String(format: fmt, payload.walkedByCount))
+                            .font(.system(size: 20, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.85))
+                    }
+
+                    if !payload.tags.isEmpty {
+                        HStack(spacing: 8) {
+                            ForEach(payload.tags, id: \.self) { tag in
+                                Text("#\(tag)")
+                                    .font(.system(size: 18, weight: .semibold))
+                                    .padding(.horizontal, 14)
+                                    .padding(.vertical, 7)
+                                    .background(Capsule().fill(.white.opacity(0.2)))
+                                    .foregroundStyle(.white)
+                            }
+                        }
+                    }
+
+                    Text(payload.brandHandle)
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundStyle(.white.opacity(0.95))
+                        .padding(.top, 4)
+                }
+            }
+            .padding(40)
+        }
+        .frame(width: Self.renderSize.width, height: Self.renderSize.height)
+    }
+
+    /// Three glass stat chips: duration · distance · stops.
+    private var statRow: some View {
+        HStack(spacing: 12) {
+            statChip(icon: "clock.fill", value: "\(payload.durationMinutes)",
+                     unit: NSLocalizedString("route.share.min", comment: "minutes unit"))
+            statChip(icon: "ruler.fill", value: payload.distanceLabel, unit: "")
+            statChip(icon: "figure.walk", value: "\(payload.stopCount)",
+                     unit: NSLocalizedString("route.share.stops", comment: "stops unit"))
+        }
+    }
+
+    private func statChip(icon: String, value: String, unit: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 18, weight: .semibold))
+            Text(value)
+                .font(.system(size: 22, weight: .bold))
+            if !unit.isEmpty {
+                Text(unit)
+                    .font(.system(size: 16, weight: .medium))
+                    .opacity(0.8)
+            }
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Capsule().fill(.white.opacity(0.2)))
+    }
+}
+
+// MARK: - RouteShareRenderer
+
+/// Renders `RouteShareCardView` to a `UIImage` / temp PNG. Mirrors
+/// `ShareCardRenderer` so both share surfaces share the same pipeline shape.
+@MainActor
+enum RouteShareRenderer {
+    enum RenderError: Error {
+        case imageGenerationFailed
+        case pngEncodingFailed
+        case fileWriteFailed
+    }
+
+    static func renderImage(payload: RouteSharePayload) throws -> UIImage {
+        let view = RouteShareCardView(payload: payload)
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = RouteShareCardView.renderScale
+        renderer.isOpaque = true
+        guard let image = renderer.uiImage else { throw RenderError.imageGenerationFailed }
+        return image
+    }
+
+    static func renderTempPNG(payload: RouteSharePayload) throws -> URL {
+        let image = try renderImage(payload: payload)
+        guard let data = image.pngData() else { throw RenderError.pngEncodingFailed }
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let filename = "solocompass-route-\(UUID().uuidString.prefix(8)).png"
+        let url = dir.appendingPathComponent(filename)
+        do {
+            try data.write(to: url, options: .atomic)
+        } catch {
+            throw RenderError.fileWriteFailed
+        }
+        return url
+    }
+}
+
+// MARK: - RouteShareSheet
+
+/// The route share entry point. Lets the traveler pick between a visual card
+/// (image) and a plain-text summary, preview it, then hand it to the system
+/// share sheet. Replaces the bare `ShareLink(item: title)` that only shared a
+/// title string.
+struct RouteShareSheet: View {
+    let payload: RouteSharePayload
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var selectedMode: Mode = .card
+    @State private var previewImage: UIImage? = nil
+    @State private var activityItems: [Any]? = nil
+    @State private var statusMessage: String? = nil
+    @State private var statusIsError = false
+
+    enum Mode: String, CaseIterable, Identifiable {
+        case card
+        case text
+
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .card: return NSLocalizedString("route.share.mode.card", comment: "Visual card mode")
+            case .text: return NSLocalizedString("route.share.mode.text", comment: "Plain text mode")
+            }
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                modePicker
+                previewArea
+                if let status = statusMessage {
+                    Text(status)
+                        .font(.caption)
+                        .foregroundStyle(statusIsError ? Color.red : Color.green)
+                        .transition(.opacity)
+                }
+                actionButtons
+            }
+            .padding(20)
+            .navigationTitle(NSLocalizedString("route.share.title", comment: "Share route"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(NSLocalizedString("common.close", comment: "Close")) { dismiss() }
+                }
+            }
+        }
+        .sheet(item: Binding(
+            get: { activityItems.map { RouteActivityPayload(items: $0) } },
+            set: { if $0 == nil { activityItems = nil } }
+        )) { payload in
+            RouteActivityViewControllerWrapper(items: payload.items)
+        }
+        .presentationDetents([.large])
+    }
+
+    // MARK: - Mode picker
+
+    private var modePicker: some View {
+        HStack(spacing: 10) {
+            ForEach(Mode.allCases) { mode in
+                Button {
+                    selectedMode = mode
+                    statusMessage = nil
+                } label: {
+                    Text(mode.label)
+                        .font(.system(size: 13, weight: .semibold))
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(
+                            Capsule().fill(selectedMode == mode ? Color.accentColor : Color(.secondarySystemBackground))
+                        )
+                        .foregroundStyle(selectedMode == mode ? .white : .primary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Preview
+
+    @ViewBuilder
+    private var previewArea: some View {
+        switch selectedMode {
+        case .card: cardPreview
+        case .text: textPreview
+        }
+    }
+
+    private var cardPreview: some View {
+        let aspect = RouteShareCardView.renderSize.width / RouteShareCardView.renderSize.height
+        return ZStack {
+            if let image = previewImage {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(aspect, contentMode: .fit)
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                    .shadow(color: .black.opacity(0.12), radius: 12, x: 0, y: 6)
+            } else {
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(Color(.secondarySystemBackground))
+                    .aspectRatio(aspect, contentMode: .fit)
+                    .overlay(ProgressView())
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .task { await renderPreview() }
+    }
+
+    @MainActor
+    private func renderPreview() async {
+        if previewImage != nil { return }
+        previewImage = try? RouteShareRenderer.renderImage(payload: payload)
+    }
+
+    private var textPreview: some View {
+        ScrollView {
+            Text(payload.shareText)
+                .font(.system(.body))
+                .foregroundStyle(.primary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(14)
+                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 10))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Actions
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        switch selectedMode {
+        case .card: cardActions
+        case .text: textActions
+        }
+    }
+
+    private var cardActions: some View {
+        VStack(spacing: 10) {
+            Button {
+                shareCard()
+            } label: {
+                Label(
+                    NSLocalizedString("share.systemShare", comment: "Share via system sheet"),
+                    systemImage: "square.and.arrow.up"
+                )
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+
+            Button {
+                copyImage()
+            } label: {
+                Label(
+                    NSLocalizedString("share.copyImage", comment: "Copy image"),
+                    systemImage: "doc.on.doc"
+                )
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+
+            Text(NSLocalizedString("share.saveHint", comment: "Hint to use Save Image in the system share sheet"))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    private var textActions: some View {
+        VStack(spacing: 10) {
+            Button {
+                UIPasteboard.general.string = payload.shareText
+                flashStatus(NSLocalizedString("share.copied", comment: "Copied"), error: false)
+            } label: {
+                Label(
+                    NSLocalizedString("export.copy", comment: "Copy text"),
+                    systemImage: "doc.on.clipboard"
+                )
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+
+            Button {
+                activityItems = [payload.shareText]
+            } label: {
+                Label(
+                    NSLocalizedString("export.share", comment: "Share…"),
+                    systemImage: "square.and.arrow.up"
+                )
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    // MARK: - Impl
+
+    private func shareCard() {
+        do {
+            let url = try RouteShareRenderer.renderTempPNG(payload: payload)
+            activityItems = [url]
+        } catch {
+            flashStatus(NSLocalizedString("share.renderFailed", comment: "Render failed"), error: true)
+        }
+    }
+
+    private func copyImage() {
+        do {
+            let image = try RouteShareRenderer.renderImage(payload: payload)
+            UIPasteboard.general.image = image
+            flashStatus(NSLocalizedString("share.imageCopied", comment: "Image copied"), error: false)
+        } catch {
+            flashStatus(NSLocalizedString("share.renderFailed", comment: "Render failed"), error: true)
+        }
+    }
+
+    private func flashStatus(_ message: String, error: Bool) {
+        withAnimation { statusMessage = message; statusIsError = error }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            withAnimation { statusMessage = nil }
+        }
+    }
+}
+
+// MARK: - ActivityViewController bridging
+
+private struct RouteActivityPayload: Identifiable {
+    let id = UUID()
+    let items: [Any]
+}
+
+private struct RouteActivityViewControllerWrapper: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}
+
+// MARK: - Preview
+
+#Preview {
+    RouteShareSheet(payload: RouteSharePayload(
+        title: "黄昏河岸慢走",
+        summary: "从老城咖啡馆出发，沿河散步到日落观景台，途经三处隐藏角落。",
+        placeLabel: "Bangkok",
+        category: .coffee,
+        durationMinutes: 120,
+        distanceMeters: 2400,
+        paceLabel: "Relaxed",
+        stopCount: 4,
+        walkedByCount: 37,
+        tags: ["sunset", "riverside", "coffee"]
+    ))
+}

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -2,6 +2,24 @@ import SwiftUI
 import MapKit
 import os
 
+/// Which route-related sheet is currently presented over the map. A single
+/// `.sheet(item:)` keyed on this enum replaces the two stacked
+/// `.sheet(isPresented:)` modifiers that SwiftUI silently collapsed (only the
+/// last won), which left route cards un-tappable.
+enum RouteSheet: Identifiable {
+    /// Open a route's detail view.
+    case detail(Route)
+    /// Open the create-your-own-route flow.
+    case create
+
+    var id: String {
+        switch self {
+        case .detail(let route): return "detail-\(route.id.rawValue)"
+        case .create:            return "create"
+        }
+    }
+}
+
 /// THE root view. Map-first means: this is what the app *is*. No tabs. No
 /// drawer. Filters and the bottom info bar overlay it; an experience card
 /// floats up when a marker is tapped.
@@ -112,9 +130,12 @@ struct CompassMapContentView: View {
     // US-025: Routes section in BottomInfoSheet
     @State private var routeStore = RouteStore()
     @State private var nearbyRoutes: [Route] = []
-    @State private var selectedRoute: Route? = nil
-    @State private var isShowingRouteDetail: Bool = false
-    @State private var isShowingCreateRoute: Bool = false
+    // Single source of truth for the route detail / create-route sheets. Two
+    // separate `.sheet(isPresented:)` modifiers on the same view silently
+    // collapse to only the last one in SwiftUI — which is why tapping a route
+    // card used to do nothing (the create-route sheet shadowed the detail one).
+    // A single `.sheet(item:)` driven by this enum presents whichever is active.
+    @State private var routeSheet: RouteSheet? = nil
     // The route currently drawn on the map (polyline + numbered stops), set when
     // the traveler taps "开始路线" in RouteDetailView. nil = no active route.
     @State private var activeRoute: ActiveRoute? = nil
@@ -538,14 +559,13 @@ struct CompassMapContentView: View {
                                     routes: nearbyRoutes,
                                     isNowFilter: viewModel.isNowFilter,
                                     onSelectRoute: { route in
-                                        selectedRoute = route
-                                        isShowingRouteDetail = true
+                                        routeSheet = .detail(route)
                                     }
                                 )
 
                                 // Create-your-own-route entry, between Routes and Nearby.
                                 CreateRouteEntryCard {
-                                    isShowingCreateRoute = true
+                                    routeSheet = .create
                                 }
                                 .padding(.horizontal, 16)
                                 .padding(.top, 8)
@@ -582,40 +602,43 @@ struct CompassMapContentView: View {
                     }
                 }
                 .ignoresSafeArea(edges: .bottom)
-                .sheet(isPresented: $isShowingRouteDetail) {
-                    if let route = selectedRoute {
+                // One sheet for both route flows. Driven by `routeSheet` so the
+                // detail and create presentations never shadow each other.
+                .sheet(item: $routeSheet) { sheet in
+                    switch sheet {
+                    case .detail(let route):
                         NavigationStack {
                             RouteDetailView(
                                 route: route,
                                 onTapStop: { exp in
-                                    isShowingRouteDetail = false
+                                    routeSheet = nil
                                     viewModel.selectExperience(exp)
                                     viewModel.isShowingDetail = true
                                 },
                                 onStartRoute: { route in
-                                    isShowingRouteDetail = false
+                                    routeSheet = nil
                                     startRouteOnMap(route)
                                 }
                             )
                             .environment(experienceService)
                         }
+                    case .create:
+                        CreateRouteView(
+                            candidates: viewModel.visibleExperiences,
+                            cityCode: viewModel.selectedCity ?? "",
+                            userCoordinate: locationService.currentLocation?.coordinate
+                                ?? viewModel.defaultCenterForSelectedCity
+                        ) { route in
+                            // Persist + open the new route's detail; RouteStore.didChange
+                            // refreshes the sheet's routes section automatically.
+                            // Swapping `routeSheet` from .create → .detail replaces
+                            // the sheet's content in place.
+                            routeStore.save(route)
+                            routeSheet = .detail(route)
+                        }
+                        .environment(aiService)
+                        .environment(experienceService)
                     }
-                }
-                .sheet(isPresented: $isShowingCreateRoute) {
-                    CreateRouteView(
-                        candidates: viewModel.visibleExperiences,
-                        cityCode: viewModel.selectedCity ?? "",
-                        userCoordinate: locationService.currentLocation?.coordinate
-                            ?? viewModel.defaultCenterForSelectedCity
-                    ) { route in
-                        // Persist + open the new route's detail; RouteStore.didChange
-                        // refreshes the sheet's routes section automatically.
-                        routeStore.save(route)
-                        selectedRoute = route
-                        isShowingRouteDetail = true
-                    }
-                    .environment(aiService)
-                    .environment(experienceService)
                 }
 
                 // Selected-experience card floats ABOVE the BottomInfoSheet


### PR DESCRIPTION
## 背景

用户报告：首页推荐路线的卡片点击没有任何反应，进不去详情；并希望路线能以优雅的方式分享出去。

## 修复 ①：路线卡片点不动

**根因**：`CompassMapView` 内层 ZStack 上叠了两个 `.sheet(isPresented:)`（路线详情 + 创建路线）。SwiftUI 中同一视图叠多个 `.sheet(isPresented:)`，外层修饰符覆盖内层，**只有最后一个生效** —— 路线详情 sheet 被「创建路线」sheet 静默覆盖，永远不呈现，表现为"点击没反应"。已用 Stack Overflow / Apple 开发者论坛权威来源确认 iOS 17 仍有此行为。

**修法**：把两个互斥 sheet 收敛成单一 `.sheet(item:)` + `RouteSheet` 枚举（社区标准做法，与项目里 chat 已用的 `.sheet(item:)` 一致）。

同时在 `RouteDetailView` 预防性地用 `RouteDetailSheet` 枚举合并了 join + share 两个 sheet —— 否则会二次引入同一个坑。

## 修复 ②：优雅的路线分享

原来只有 `ShareLink(item: title)`，分享一个标题字符串。新增 `RouteShareSheet`：

- **视觉卡片**（1080×1920 竖版）：类目渐变背景 + emoji（镜像路线详情页 hero 视觉）、地点徽标 + 标题 + 摘要 + 三个玻璃 stat chip（时长 / 距离 / 停靠点）+ "已有 N 位旅行者走过"社交证明 + 标签胶囊 + 品牌署名。可直接发小红书 / IG。
- **纯文本模式**：格式化多行摘要，可复制 / 系统分享。
- 复用既有 `CategoryVisual` 配色体系与 `ImageRenderer` 渲染管线。

## 验证

- `xcodebuild build` ✅ BUILD SUCCEEDED
- 临时 XCTest 渲染分享卡 + 文本逻辑 ✅ Executed 2 tests, 0 failures（已删除临时文件）
- 分享卡视觉在模拟器渲染确认

## 改动文件

- `Views/Map/CompassMapView.swift` — 双 sheet 合并为 `.sheet(item:)`
- `Views/Companion/RouteDetailView.swift` — join/share 合并 + 接入 RouteShareSheet
- `Views/Companion/RouteShareSheet.swift` — 新增（payload + 视觉卡 + 渲染器 + sheet）
- `Resources/{en,zh-Hans}.lproj/Localizable.strings` — 新增 route.share.* 键
- `SoloCompass.xcodeproj/project.pbxproj` — 纳入新文件

🤖 Generated with [Claude Code](https://claude.com/claude-code)