### PR TITLE
fix(ios): unified sheet scroll + paywall CTA reliability

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		066FE809A43C937B7EFA7609 /* VoiceToastA11yTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A3AF5B9538F583142315C2 /* VoiceToastA11yTests.swift */; };
 		0A830B26D4A18948D16F3A42 /* Experience.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C97F8159A6FA7953D28DAB /* Experience.swift */; };
 		0B7CC2BD1359B8AB3E4A590D /* HapticServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4609B3C2E77F98A59871C26E /* HapticServiceTests.swift */; };
+		0C0580E1BF61F5C02C2EE640 /* BottomSheetUnifiedScrollGuardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E41DCA29798B5D8E49B7CA /* BottomSheetUnifiedScrollGuardTest.swift */; };
 		0DE8ECCE242F2FDFFD69C199 /* VoiceInterruptionToastTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E7AFBAAF6E42AE8043F476D /* VoiceInterruptionToastTest.swift */; };
 		0EAA3D2EEA89D212150A6B57 /* ExploreConsentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8B58A4F608F9951CBDF3C /* ExploreConsentSheet.swift */; };
 		1130F4E1887551F856FCB9DB /* CompletionMomentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649ECD409B685D38E30527FD /* CompletionMomentTests.swift */; };
@@ -368,6 +369,7 @@
 		35E8F519A353F18BDE4C3307 /* FilterChipContrastTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterChipContrastTest.swift; sourceTree = "<group>"; };
 		362DB30A847EE598631A10B2 /* HitTargetSizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitTargetSizeTests.swift; sourceTree = "<group>"; };
 		363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceCardView.swift; sourceTree = "<group>"; };
+		36E41DCA29798B5D8E49B7CA /* BottomSheetUnifiedScrollGuardTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetUnifiedScrollGuardTest.swift; sourceTree = "<group>"; };
 		377590D8F67E082E58EDEAB9 /* StartRouteCoordinateResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartRouteCoordinateResolutionTests.swift; sourceTree = "<group>"; };
 		37C75D64D462A03DBEFFC4EB /* FilterNowMapSyncTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterNowMapSyncTest.swift; sourceTree = "<group>"; };
 		387808A923EC7A99AD5390FD /* CompletionMoment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionMoment.swift; sourceTree = "<group>"; };
@@ -711,6 +713,7 @@
 				56F91067B8A0FACD9369243B /* BottomInfoSheetTests.swift */,
 				C63BC4737C3134075574125E /* BottomSheetDetentDynamicTypeTest.swift */,
 				999E8DA69CB660A94E71D02A /* BottomSheetSectionSeparationTest.swift */,
+				36E41DCA29798B5D8E49B7CA /* BottomSheetUnifiedScrollGuardTest.swift */,
 				0674DC5D526883C657A63C38 /* CardBottomInsetClearanceTest.swift */,
 				1FF5100EFECEC87BDC2B007B /* ChatBubbleContrastTest.swift */,
 				308B7A34171C74B1CF2DE3F9 /* CityPillHitTargetTests.swift */,
@@ -1267,6 +1270,7 @@
 				C2AE6B28BA196E2EDEE89012 /* BottomInfoSheetTests.swift in Sources */,
 				AB8E6644540AE90657471002 /* BottomSheetDetentDynamicTypeTest.swift in Sources */,
 				BF7D61FAEF133A0E77C585C9 /* BottomSheetSectionSeparationTest.swift in Sources */,
+				0C0580E1BF61F5C02C2EE640 /* BottomSheetUnifiedScrollGuardTest.swift in Sources */,
 				3CBA775B8C215CBAE3A73EA0 /* CardBottomInsetClearanceTest.swift in Sources */,
 				B5D2608A5B16B07B6E9005DC /* ChatBubbleContrastTest.swift in Sources */,
 				D2BCD302B16BBC174B71F84A /* CityPillHitTargetTests.swift in Sources */,

--- a/apps/ios/SoloCompass/Tests/BottomSheetDetentDynamicTypeTest.swift
+++ b/apps/ios/SoloCompass/Tests/BottomSheetDetentDynamicTypeTest.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// heights (peek / mid / full) must scale so the enlarged content — handle,
 /// AI-hint row, sort/count toolbar, nearby list — is not clipped.
 ///
-/// The base detents (170 / 500 / 800 pt) are sized for the default content size
+/// The base detents (240 / 500 / 800 pt) are sized for the default content size
 /// category. `BottomSheetDetent.scaledHeight(for:)` multiplies them by
 /// `UIFontMetrics.default.scaledValue(for: 1.0)` for the active trait
 /// collection. This test asserts:
@@ -68,8 +68,10 @@ final class BottomSheetDetentDynamicTypeTest: XCTestCase {
     }
 
     func testBaseDetentHeightsMatchSpec() {
-        // The base (unscaled) ladder must remain 170 / 500 / 800.
-        XCTAssertEqual(BottomSheetDetent.peek.scaledHeight(for: defaultTraits), 170, accuracy: 0.5)
+        // The base (unscaled) ladder is 240 / 500 / 800. Peek grew from 170 → 240
+        // in f351c37 to fit the "best for right now" summary card; this spec test
+        // tracks the current peek height so the ladder stays pinned to intent.
+        XCTAssertEqual(BottomSheetDetent.peek.scaledHeight(for: defaultTraits), 240, accuracy: 0.5)
         XCTAssertEqual(BottomSheetDetent.mid.scaledHeight(for: defaultTraits), 500, accuracy: 0.5)
         XCTAssertEqual(BottomSheetDetent.full.scaledHeight(for: defaultTraits), 800, accuracy: 0.5)
     }

--- a/apps/ios/SoloCompass/Tests/BottomSheetUnifiedScrollGuardTest.swift
+++ b/apps/ios/SoloCompass/Tests/BottomSheetUnifiedScrollGuardTest.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import SoloCompass
+
+/// Structural regression guard for the BottomInfoSheet's *single, unified*
+/// scroll stream.
+///
+/// History: commit 1635c29 fixed a "two-viewport scroll conflict" — Routes +
+/// Create-route were a non-scrollable header and only `NearbySection` carried
+/// its own inner `ScrollView`, so a long Routes list pushed Nearby off-screen
+/// and, at the `mid` detent, the route cards could not be scrolled at all (the
+/// user's "拉一半…路线卡片滑不动"). The fix hosts the whole content closure in
+/// ONE `ScrollView` and drops Nearby's nested one.
+///
+/// Commit f351c37 (peek summary card) then silently *reverted* both halves of
+/// that fix, re-breaking the scroll. SwiftUI view trees can't be introspected
+/// from XCTest, and `ImageRenderer` doesn't expand `ScrollView`/`LazyVStack`,
+/// so behavioural assertion isn't available here. Instead this test scans the
+/// source the same way `SFSymbolExistenceTests` does and asserts the two
+/// structural invariants that together guarantee one continuous scroll stream:
+///
+///   1. The host `body` wraps the `content(currentDetent, $sortMode)` closure
+///      in a `ScrollView` (the unified scroll layer exists).
+///   2. `NearbySection`'s body contains NO `ScrollView` (no nested scroll
+///      island that would re-create the two-viewport conflict).
+///
+/// If a future refactor reverts either invariant, this fails loudly instead of
+/// shipping a sheet whose route cards silently won't scroll.
+final class BottomSheetUnifiedScrollGuardTest: XCTestCase {
+
+    private func sheetSource() throws -> String {
+        let url = Self.sourceRoot().appendingPathComponent("Views/Map/BottomInfoSheet.swift")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// Invariant 1: the content closure is hosted inside a `ScrollView` in the
+    /// sheet body, so Routes → Create-route → Nearby form one scroll stream.
+    func testContentClosureIsWrappedInScrollView() throws {
+        let source = try sheetSource()
+
+        // The body must contain a `ScrollView {` whose body invokes the content
+        // closure. We assert both tokens exist and that a `ScrollView` opens
+        // before the `content(currentDetent` call (the closure lives inside it).
+        guard let scrollRange = source.range(of: "ScrollView {"),
+              let contentRange = source.range(of: "content(currentDetent") else {
+            XCTFail("Expected a `ScrollView {` hosting `content(currentDetent…)` in the sheet body")
+            return
+        }
+        XCTAssertLessThan(
+            scrollRange.lowerBound, contentRange.lowerBound,
+            "The content closure must be nested INSIDE the unified ScrollView "
+                + "(ScrollView must open before `content(currentDetent…)`). A bare "
+                + "`content + Spacer` makes the Routes/Create rows un-scrollable at mid."
+        )
+    }
+
+    /// Invariant 2: `NearbySection` must NOT host its own `ScrollView` — a
+    /// nested scroll island re-creates the two-viewport conflict that hid the
+    /// list and froze the route cards at `mid`.
+    func testNearbySectionHasNoNestedScrollView() throws {
+        let source = try sheetSource()
+
+        guard let structRange = source.range(of: "struct NearbySection: View {") else {
+            XCTFail("Could not locate `struct NearbySection` to scan")
+            return
+        }
+        // Scan from the struct declaration to the next top-level `// MARK:` (the
+        // section that follows NearbySection), which bounds its body cheaply
+        // without a full Swift parse.
+        let afterStruct = source[structRange.upperBound...]
+        let rawBody: Substring
+        if let nextMark = afterStruct.range(of: "\n// MARK:") {
+            rawBody = afterStruct[..<nextMark.lowerBound]
+        } else {
+            rawBody = afterStruct
+        }
+
+        // Strip comment lines before scanning: the explanatory comments
+        // intentionally mention `ScrollView` ("no nested ScrollView here…"),
+        // and matching those would be a false positive. We only care whether
+        // *code* re-introduces a nested ScrollView.
+        let codeOnly = rawBody
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line -> Substring in
+                let trimmed = line.drop(while: { $0 == " " || $0 == "\t" })
+                return trimmed.hasPrefix("//") ? "" : line
+            }
+            .joined(separator: "\n")
+
+        XCTAssertFalse(
+            codeOnly.contains("ScrollView"),
+            "NearbySection must NOT contain a nested `ScrollView` in CODE — the "
+                + "host BottomInfoSheet already wraps the whole content closure in "
+                + "one ScrollView. A nested one re-introduces the two-viewport "
+                + "conflict (regression of 1635c29 by f351c37)."
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// `apps/ios/SoloCompass/` — derived from this test file's compile-time path
+    /// (`…/SoloCompass/Tests/BottomSheetUnifiedScrollGuardTest.swift`).
+    private static func sourceRoot(file: StaticString = #filePath) -> URL {
+        URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // SoloCompass/
+    }
+}

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -275,8 +275,43 @@ public struct BottomInfoSheet<Content: View>: View {
                         .padding(.horizontal, 16)
                         .padding(.top, 8)
                 }
-                content(currentDetent, $sortMode)
-                Spacer(minLength: 0)
+                // Single unified scroll layer for every sheet section (Routes →
+                // Create-route → Nearby). The sheet header rows above (handle,
+                // peek/now-hint, toolbar) stay pinned; only the content closure
+                // scrolls. Previously this was a bare `content + Spacer`, so the
+                // Routes + Create-route rows were non-scrollable and only Nearby
+                // carried its own inner ScrollView — a long Routes list pushed
+                // Nearby off-screen with no way to scroll it back, and dragging up
+                // to mid left the route cards stuck (the user's "滑不动"). Hosting
+                // the whole closure in one ScrollView makes the sections a
+                // continuous, naturally scrollable stream (like Apple Maps / Find
+                // My) at *any* detent — mid scrolls the full list, no need to first
+                // expand to full. At .peek the closure is empty, so this is a cheap
+                // no-op.
+                ScrollView {
+                    content(currentDetent, $sortMode)
+                        // Pin content to the top so a changing viewport height
+                        // (mid→full during a drag) never re-centres the column —
+                        // without this the rows visibly jump frame-to-frame as the
+                        // sheet grows/shrinks, reading as a flicker.
+                        .frame(maxWidth: .infinity, alignment: .top)
+                        // Trailing breathing room so the last card never sits flush
+                        // against the sheet's lower edge / home indicator.
+                        .padding(.bottom, 28)
+                }
+                // Freeze the ScrollView while the handle is being dragged. The
+                // sheet height animates every frame during a settle; an active
+                // ScrollView would re-clamp its contentOffset against that moving
+                // viewport and fight the drag, producing flicker. Re-enabled the
+                // instant the drag ends.
+                .scrollDisabled(isDragging)
+                .scrollDismissesKeyboard(.interactively)
+                // Show the indicator at mid/full as an affordance that more
+                // content lies below; peek has no scroll content so it stays clean.
+                .scrollIndicators(currentDetent == .peek ? .hidden : .automatic)
+                // Suppress the empty bottom rubber-band when content is shorter
+                // than the viewport, so a short list doesn't feel "loose".
+                .scrollBounceBehavior(.basedOnSize)
             }
             .frame(maxWidth: .infinity)
             .frame(height: displayHeight)
@@ -290,7 +325,15 @@ public struct BottomInfoSheet<Content: View>: View {
                 .fill(.ultraThinMaterial)
             )
         }
-        .animation(isDragging ? nil : .spring(response: 0.3, dampingFraction: 0.85), value: displayHeight)
+        // Animate ONLY the discrete detent settle (which changes once, on
+        // release), never the continuously finger-driven `displayHeight`.
+        // Watching `displayHeight` meant every drag frame nudged a value an
+        // active spring was tracking, so the spring kept restarting-then-being-
+        // interrupted frame to frame — the sheet edge jittered larger/smaller
+        // (the "flicker"). Pinned to `currentDetent`, the drag is pure immediate
+        // finger-tracking (no animation) and only the release-to-nearest-detent
+        // gets the spring.
+        .animation(.spring(response: 0.3, dampingFraction: 0.85), value: currentDetent)
     }
 
     // MARK: - Peek content
@@ -385,8 +428,19 @@ public struct BottomInfoSheet<Content: View>: View {
                     isDragging = false
                     let projectedHeight = detentBaseHeight - value.predictedEndTranslation.height
                     let clampedHeight = max(scaledMinHeight, min(scaledMaxHeight, projectedHeight))
-                    currentDetent = BottomSheetDetent.nearest(to: clampedHeight, traits: dynamicTypeTraits)
-                    dragOffset = 0
+                    // Settle to the nearest detent with an EXPLICIT spring. Both
+                    // `currentDetent` and `dragOffset` feed `displayHeight`, but the
+                    // implicit `.animation(value: currentDetent)` only fires when the
+                    // detent actually changes. On a small drag that lands back on the
+                    // same detent, `currentDetent` is unchanged, so zeroing
+                    // `dragOffset` outside an animation would snap the sheet back with
+                    // no spring (the "生硬" settle). Wrapping the state collapse in
+                    // `withAnimation` guarantees the release always springs home —
+                    // whether or not the detent changed.
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+                        currentDetent = BottomSheetDetent.nearest(to: clampedHeight, traits: dynamicTypeTraits)
+                        dragOffset = 0
+                    }
                 }
         )
         // A discrete tap on the handle steps up one detent. `DragGesture`'s
@@ -1098,22 +1152,28 @@ struct NearbySection: View {
                 // Each row now carries its own card chrome, so we separate them
                 // with a 10pt gap (matching RoutesSection) rather than full-bleed
                 // dividers — the list reads as a stack of discrete cards.
-                ScrollView {
-                    LazyVStack(spacing: 10) {
-                        ForEach(sortedExperiences) { exp in
-                            NearbyExperienceRow(
-                                experience: exp,
-                                isSmartPick: sortMode == .smart && smartPickIds.contains(exp.id),
-                                distanceMeters: distance(to: exp),
-                                isOpenNow: sortMode == .now && isOpenNow(exp),
-                                onTap: { onSelectExperience(exp) }
-                            )
-                        }
+                //
+                // No inner ScrollView: the host BottomInfoSheet wraps the whole
+                // content closure in one ScrollView, so Nearby lays its rows out
+                // inline as part of that single scroll stream. A nested ScrollView
+                // here re-introduced the two-viewport conflict that hid this list
+                // when the Routes section above grew long (and left the route cards
+                // un-scrollable at mid). LazyVStack keeps rows lazily realized for
+                // long lists.
+                LazyVStack(spacing: 10) {
+                    ForEach(sortedExperiences) { exp in
+                        NearbyExperienceRow(
+                            experience: exp,
+                            isSmartPick: sortMode == .smart && smartPickIds.contains(exp.id),
+                            distanceMeters: distance(to: exp),
+                            isOpenNow: sortMode == .now && isOpenNow(exp),
+                            onTap: { onSelectExperience(exp) }
+                        )
                     }
-                    .padding(.horizontal, 16)
-                    .padding(.top, 10)
-                    .padding(.bottom, 8)
                 }
+                .padding(.horizontal, 16)
+                .padding(.top, 10)
+                .padding(.bottom, 8)
             }
         }
         .padding(.top, 8)

--- a/apps/ios/SoloCompass/Views/Paywall/PaywallView.swift
+++ b/apps/ios/SoloCompass/Views/Paywall/PaywallView.swift
@@ -180,16 +180,14 @@ public struct PaywallView: View {
     }
 
     private var ctaButton: some View {
-        // In DEBUG builds the StoreKit catalog may be empty (no StoreKit
-        // configuration attached to the scheme), which would otherwise leave
-        // the CTA permanently disabled and make the paywall un-testable on a
-        // bare simulator. Allow taps in that case and fall back to a local
-        // unlock inside `runPurchase()`.
-        #if DEBUG
+        // The CTA must always be tappable (except mid-purchase). Previously
+        // Release builds disabled it whenever `products.isEmpty`, which made
+        // the button physically un-tappable on device when App Store Connect
+        // hadn't returned the catalog yet — the user got a dead button with no
+        // feedback. Instead we keep it tappable and, on tap, retry the product
+        // load and surface an explicit error if the catalog is still empty
+        // (see `runPurchase()`).
         let isDisabled = purchaseInFlight
-        #else
-        let isDisabled = purchaseInFlight || subscription.products.isEmpty
-        #endif
         return Button {
             Task { await runPurchase() }
         } label: {
@@ -250,21 +248,37 @@ public struct PaywallView: View {
     // MARK: - Actions
 
     private func runPurchase() async {
-        guard let product = subscription.products.first(where: { $0.id == selectedProductID }) else {
+        purchaseInFlight = true
+        defer { purchaseInFlight = false }
+
+        // The catalog can be empty on first tap if App Store Connect was slow
+        // (or the network blipped) during `.task`'s initial load. Retry once
+        // before giving up so the user isn't stuck behind a transient miss.
+        if subscription.products.isEmpty {
+            await subscription.loadProducts()
+        }
+
+        guard let product = subscription.products.first(where: { $0.id == selectedProductID })
+            ?? subscription.products.first
+        else {
             #if DEBUG
             // DEBUG-only escape hatch: when StoreKit returned no products
             // (e.g. simulator without a .storekit config), flip entitlement
             // locally so the rest of the flow is testable.
-            purchaseInFlight = true
-            defer { purchaseInFlight = false }
             subscription._setEntitlementForTesting(.proTrial)
             onUnlocked()
             dismiss()
+            #else
+            // Release: no products even after a retry — surface an explicit,
+            // actionable error instead of a silent dead button. Common causes
+            // are an unsigned Paid Apps Agreement or products not yet "Ready
+            // to Submit" in App Store Connect.
+            purchaseError = subscription.lastError
+                ?? NSLocalizedString("paywall.error.unavailable", comment: "Products unavailable")
             #endif
             return
         }
-        purchaseInFlight = true
-        defer { purchaseInFlight = false }
+
         let success = await subscription.purchase(product)
         if success {
             onUnlocked()


### PR DESCRIPTION
## What

Two independent UX/reliability fixes on the home-chat polish branch.

### 1. Bottom sheet — one unified scroll stream (`bfb0d02`)
- Host the whole content closure (Routes → Create-route → Nearby) in a single `ScrollView`; drop `NearbySection`'s nested `ScrollView`.
- Fixes the user-reported regression: pulling the sheet to **mid** left the route cards un-scrollable and a long Routes list pushed Nearby off-screen.
- Smooth the settle: drive the implicit animation off `currentDetent` (not the finger-tracked `displayHeight`) to kill drag-frame jitter; wrap the release state-collapse in `withAnimation` so a same-detent landing still springs home.
- Add **BottomSheetUnifiedScrollGuardTest** as a source-level regression guard — this fix was silently reverted once before (by `f351c37`). Sync the peek detent spec to its current 240pt height.

### 2. Paywall CTA always tappable (`3e660c7`)
- Release builds disabled the CTA whenever StoreKit returned no products → a physically dead button on device when App Store Connect hadn't returned the catalog.
- Keep the button enabled (except mid-purchase); on tap, retry `loadProducts()` once and surface an explicit localized error if still empty.

## Testing
- Not run locally — relying on CI (iOS build + test) on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)