### PR TITLE
fix(ios): make route cards tappable inside the bottom sheet

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		63DCAC4B5E83B26B9B175344 /* AIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4515228D70D8804596299D /* AIProvider.swift */; };
 		641D80BD116D6F255A9ED26A /* PendingSyncRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A92E0AE1868C3A165F3E95 /* PendingSyncRecord.swift */; };
 		65E57E8B02E7889BD8EE8DD4 /* ContextManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1F5F43F42E03BA5F10FA2F /* ContextManager.swift */; };
+		66C352786CB25AA13017F933 /* CreateRouteEntryTappableGuardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BB36326BBDD7860ECD722B /* CreateRouteEntryTappableGuardTest.swift */; };
 		680774109C2AD675E26ADA18 /* CreateRouteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0782F4AA0496B97DDAAA380 /* CreateRouteView.swift */; };
 		690ED25AA3EDA8529E915850 /* MyWalkedRoutesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F48906724062C4636DE947 /* MyWalkedRoutesListView.swift */; };
 		6AA87132BC6ACDDDC6D98735 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF007DB5F72E30021CADA555 /* NetworkMonitor.swift */; };
@@ -173,6 +174,7 @@
 		9A7AAC7B68BA10A53CAC0A8B /* VoiceServiceActorIsolationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F10413877E80238BD52F34C /* VoiceServiceActorIsolationTest.swift */; };
 		9B906CA9BF24104FB2BF7773 /* RouteCardWalkedByTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9FE3BB447D84732CCE0B07 /* RouteCardWalkedByTest.swift */; };
 		9C8CC563D33FDBB3DF57A841 /* RecentExploreRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9748B0A808BC06F6EDED3C3B /* RecentExploreRegion.swift */; };
+		9D799B457AC16C84BB460D18 /* RouteCardTappableGuardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4317C293B762EA1C8A436B8A /* RouteCardTappableGuardTest.swift */; };
 		9D81327AE55FA8142F9E5B8D /* ChatUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0709110B381DEDA32C3292AE /* ChatUIState.swift */; };
 		9F8D8133FC74C4E206A11DB9 /* ItineraryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD7871A003B28A7C46AC8D7 /* ItineraryStoreTests.swift */; };
 		A12DF78B6B05519D2177A519 /* RouteCompanionForceUnwrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF2CEF9FE62124F51460453 /* RouteCompanionForceUnwrapTests.swift */; };
@@ -383,9 +385,11 @@
 		405A56207920EA0DDADF8FC5 /* CompanionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionRequest.swift; sourceTree = "<group>"; };
 		409FB4B0922C4A1D8AAEB1D1 /* FeatureFlags.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = FeatureFlags.plist; sourceTree = "<group>"; };
 		42FC5ADBFDDA89BC42C8748D /* AppleSignInService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInService.swift; sourceTree = "<group>"; };
+		4317C293B762EA1C8A436B8A /* RouteCardTappableGuardTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCardTappableGuardTest.swift; sourceTree = "<group>"; };
 		431DC31A80132F719AFEE471 /* CompanionPost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionPost.swift; sourceTree = "<group>"; };
 		433C1552FC95F4E8ECF4C695 /* LocalRouteCompanionRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalRouteCompanionRemote.swift; sourceTree = "<group>"; };
 		4442EDB5CE3602DA3EA32725 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		45BB36326BBDD7860ECD722B /* CreateRouteEntryTappableGuardTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRouteEntryTappableGuardTest.swift; sourceTree = "<group>"; };
 		4609B3C2E77F98A59871C26E /* HapticServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticServiceTests.swift; sourceTree = "<group>"; };
 		4617984392FDCCA6F2F9FAD7 /* BestNowClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BestNowClock.swift; sourceTree = "<group>"; };
 		48ADAE2497800574C4E8819B /* GroupConversationAutoCreateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupConversationAutoCreateTests.swift; sourceTree = "<group>"; };
@@ -726,6 +730,7 @@
 				56AF27F0567AACEA9E6D916E /* CompiledPlaceTests.swift */,
 				649ECD409B685D38E30527FD /* CompletionMomentTests.swift */,
 				2CEFD2E522C2D9FFF8EF0B0B /* ConversationTests.swift */,
+				45BB36326BBDD7860ECD722B /* CreateRouteEntryTappableGuardTest.swift */,
 				763DF01F638C99097DD5FE20 /* EmptyStateAnnouncementTest.swift */,
 				AA17ED8FE9ABA2F5CC1D557E /* FavoriteFilterTests.swift */,
 				F8547EB44AE47A5D653D3994 /* FavoritesBounceAvailabilityTest.swift */,
@@ -767,6 +772,7 @@
 				6D31F422914779D9228B0278 /* RouteCardNowReasonTests.swift */,
 				4EAB2E028C69B7C63DCAF860 /* RouteCardRecruitMiniTest.swift */,
 				EAFD5561863516F6E60AEDE3 /* RouteCardStopStripTest.swift */,
+				4317C293B762EA1C8A436B8A /* RouteCardTappableGuardTest.swift */,
 				1A9FE3BB447D84732CCE0B07 /* RouteCardWalkedByTest.swift */,
 				5BF2CEF9FE62124F51460453 /* RouteCompanionForceUnwrapTests.swift */,
 				10F48D7FA14E29D606FD11EA /* RouteCompanionStateMachineTests.swift */,
@@ -1283,6 +1289,7 @@
 				259F1E0030F914782D632794 /* CompiledPlaceTests.swift in Sources */,
 				1130F4E1887551F856FCB9DB /* CompletionMomentTests.swift in Sources */,
 				AA5C5AEBFB7B2266A4781877 /* ConversationTests.swift in Sources */,
+				66C352786CB25AA13017F933 /* CreateRouteEntryTappableGuardTest.swift in Sources */,
 				30293CB7BCCE6B600A82C292 /* EmptyStateAnnouncementTest.swift in Sources */,
 				37D5A0FD622C9649308BD14D /* FavoriteFilterTests.swift in Sources */,
 				F721E7FE777AF2AFA0FA264D /* FavoritesBounceAvailabilityTest.swift in Sources */,
@@ -1324,6 +1331,7 @@
 				2EC741296992D9D0A4F3077D /* RouteCardNowReasonTests.swift in Sources */,
 				3253E70A5F98389A985CA7B9 /* RouteCardRecruitMiniTest.swift in Sources */,
 				4A32BD98962770BAAB48B504 /* RouteCardStopStripTest.swift in Sources */,
+				9D799B457AC16C84BB460D18 /* RouteCardTappableGuardTest.swift in Sources */,
 				9B906CA9BF24104FB2BF7773 /* RouteCardWalkedByTest.swift in Sources */,
 				A12DF78B6B05519D2177A519 /* RouteCompanionForceUnwrapTests.swift in Sources */,
 				8BF4070A63A8B52C58F0E93E /* RouteCompanionStateMachineTests.swift in Sources */,

--- a/apps/ios/SoloCompass/Tests/CreateRouteEntryTappableGuardTest.swift
+++ b/apps/ios/SoloCompass/Tests/CreateRouteEntryTappableGuardTest.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import SoloCompass
+
+/// Structural regression guard for the *tappability* of `CreateRouteEntryCard`
+/// — the dashed "創建你自己的路線" entry that sits between the Routes and Nearby
+/// sections inside the BottomInfoSheet.
+///
+/// History: the card wrapped its `Button` in a press-feedback hack —
+/// `.simultaneousGesture(DragGesture(minimumDistance: 0))` toggling a `pressed`
+/// @State to drive a manual `scaleEffect`. Because the card lives inside the
+/// sheet's single unified `ScrollView` (see `BottomSheetUnifiedScrollGuardTest`),
+/// a *zero-distance* drag gesture claims the touch the instant the finger lands.
+/// On release the host scroll view classifies the interaction as a drag, so the
+/// `Button`'s tap recognizer never fires and the card is silently un-tappable —
+/// the neighbouring `RouteCard` (a plain `Button`, no such gesture) stayed
+/// tappable, which is exactly the asymmetry the user reported ("創建的路線的卡
+/// 片這個還是沒辦法點擊"). Kin to [[project_dead_fab_sheet_wiring]].
+///
+/// The fix replaces the hand-rolled gesture with `PressableButtonStyle`, which
+/// derives its press-scale from the system's own `ButtonStyle.isPressed` and
+/// registers no competing gesture recognizer, so the tap reaches `onTap`.
+///
+/// SwiftUI view trees can't be introspected from XCTest, so — like the sibling
+/// sheet/symbol guards — this scans the source for the two structural invariants
+/// that together keep the card tappable inside a ScrollView.
+final class CreateRouteEntryTappableGuardTest: XCTestCase {
+
+    private func source() throws -> String {
+        let url = Self.sourceRoot().appendingPathComponent("Views/Companion/CreateRouteView.swift")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// Bounds the `CreateRouteEntryCard` struct body cheaply (declaration → next
+    /// top-level `// MARK:`) without a full Swift parse, then strips comment
+    /// lines so the explanatory prose mentioning the old gesture is not a false
+    /// positive.
+    private func entryCardCode() throws -> String {
+        let src = try source()
+        guard let structRange = src.range(of: "struct CreateRouteEntryCard: View {") else {
+            XCTFail("Could not locate `struct CreateRouteEntryCard` to scan")
+            return ""
+        }
+        let afterStruct = src[structRange.upperBound...]
+        let rawBody: Substring
+        if let nextMark = afterStruct.range(of: "\n// MARK:") {
+            rawBody = afterStruct[..<nextMark.lowerBound]
+        } else {
+            rawBody = afterStruct
+        }
+        return rawBody
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line -> Substring in
+                let trimmed = line.drop(while: { $0 == " " || $0 == "\t" })
+                return trimmed.hasPrefix("//") ? "" : line
+            }
+            .joined(separator: "\n")
+    }
+
+    /// Invariant 1: the card must NOT register a zero-distance drag gesture —
+    /// that hack swallows the tap inside the sheet's ScrollView.
+    func testNoTapSwallowingZeroDistanceDragGesture() throws {
+        let code = try entryCardCode()
+        XCTAssertFalse(
+            code.contains("DragGesture(minimumDistance: 0)"),
+            "CreateRouteEntryCard must NOT use `DragGesture(minimumDistance: 0)` "
+                + "for press feedback — inside the BottomInfoSheet's ScrollView a "
+                + "zero-distance drag claims the touch and the Button's tap never "
+                + "fires, leaving the card un-tappable. Use PressableButtonStyle."
+        )
+        XCTAssertFalse(
+            code.contains("simultaneousGesture"),
+            "CreateRouteEntryCard must NOT attach a `simultaneousGesture` — it "
+                + "competes with the host scroll view + Button tap and swallows the tap."
+        )
+    }
+
+    /// Invariant 2: press feedback must come from `PressableButtonStyle`, which
+    /// uses the system tap recognizer and keeps the card tappable.
+    func testUsesPressableButtonStyle() throws {
+        let code = try entryCardCode()
+        XCTAssertTrue(
+            code.contains("PressableButtonStyle"),
+            "CreateRouteEntryCard should drive press feedback via "
+                + "`PressableButtonStyle` so the tap is not stolen by a custom gesture."
+        )
+        XCTAssertTrue(
+            code.contains("Button(action: onTap)") || code.contains("Button {"),
+            "CreateRouteEntryCard must remain a real `Button` wired to `onTap`."
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// `apps/ios/SoloCompass/` — derived from this test file's compile-time path
+    /// (`…/SoloCompass/Tests/CreateRouteEntryTappableGuardTest.swift`).
+    private static func sourceRoot(file: StaticString = #filePath) -> URL {
+        URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // SoloCompass/
+    }
+}

--- a/apps/ios/SoloCompass/Tests/RouteCardTappableGuardTest.swift
+++ b/apps/ios/SoloCompass/Tests/RouteCardTappableGuardTest.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import SoloCompass
+
+/// Structural regression guard for the *tappability* of `RouteCard` inside the
+/// BottomInfoSheet's Routes section.
+///
+/// History: `RouteCard` drove its own press feedback with
+/// `.simultaneousGesture(DragGesture(minimumDistance: 0))` toggling a `pressed`
+/// @State for a manual `scaleEffect`. The card is rendered as the *label* of a
+/// wrapping `Button { onSelectRoute(route) }` inside the sheet's single unified
+/// `ScrollView`. A zero-distance drag claims the touch the instant a finger
+/// lands: it played the press animation (so the card *looked* tappable — the
+/// user saw "有按下效果") but on release the host scroll view classified the
+/// interaction as a drag, so the wrapping Button's tap never fired and the route
+/// detail never opened ("不跳转"). The neighbouring peek summary card (a plain
+/// tap target, no such gesture) opened fine — exactly the asymmetry reported.
+/// Kin to [[project_dead_fab_sheet_wiring]].
+///
+/// The fix removes the card's local gesture and moves press feedback to the
+/// hosting Button via `PressableButtonStyle`, which derives its press-scale from
+/// the system's own `ButtonStyle.isPressed` and registers no competing
+/// recognizer, so the tap reaches the Button's action.
+///
+/// SwiftUI view trees can't be introspected from XCTest, so — like the sibling
+/// sheet/symbol guards — this scans source for the structural invariants that
+/// together keep the card tappable inside a ScrollView.
+final class RouteCardTappableGuardTest: XCTestCase {
+
+    private func source(_ relativePath: String) throws -> String {
+        let url = Self.sourceRoot().appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// Bounds the `RouteCard` struct body (declaration → next top-level
+    /// `// MARK:`) and strips comment lines so the explanatory prose mentioning
+    /// the old gesture is not a false positive.
+    private func routeCardCode() throws -> String {
+        let src = try source("Views/Companion/Components/RouteCard.swift")
+        guard let structRange = src.range(of: "public struct RouteCard: View {") else {
+            XCTFail("Could not locate `struct RouteCard` to scan")
+            return ""
+        }
+        let afterStruct = src[structRange.upperBound...]
+        let rawBody: Substring
+        if let nextMark = afterStruct.range(of: "\n// MARK: - Preview") {
+            rawBody = afterStruct[..<nextMark.lowerBound]
+        } else {
+            rawBody = afterStruct
+        }
+        return rawBody
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line -> Substring in
+                let trimmed = line.drop(while: { $0 == " " || $0 == "\t" })
+                return trimmed.hasPrefix("//") ? "" : line
+            }
+            .joined(separator: "\n")
+    }
+
+    /// Invariant 1: RouteCard must NOT register a tap-swallowing zero-distance
+    /// drag gesture — inside the sheet's ScrollView it steals the wrapping
+    /// Button's tap.
+    func testRouteCardHasNoTapSwallowingGesture() throws {
+        let code = try routeCardCode()
+        XCTAssertFalse(
+            code.contains("DragGesture(minimumDistance: 0)"),
+            "RouteCard must NOT use `DragGesture(minimumDistance: 0)` for press "
+                + "feedback — inside the BottomInfoSheet ScrollView it claims the "
+                + "touch and the wrapping Button's tap never fires, so the route "
+                + "detail won't open. Press feedback belongs on the host Button "
+                + "(PressableButtonStyle)."
+        )
+        XCTAssertFalse(
+            code.contains("simultaneousGesture"),
+            "RouteCard must NOT attach a `simultaneousGesture` — it competes with "
+                + "the host scroll view + Button tap and swallows the tap."
+        )
+    }
+
+    /// Invariant 2: the Routes section's Button hosting RouteCard must use
+    /// `PressableButtonStyle` (press feedback via the system tap recognizer), not
+    /// `.plain` — so the tap opens the route detail AND the card still depresses.
+    func testRoutesSectionButtonUsesPressableButtonStyle() throws {
+        let sheet = try source("Views/Map/BottomInfoSheet.swift")
+        guard let sectionRange = sheet.range(of: "struct RoutesSection: View {") else {
+            XCTFail("Could not locate `struct RoutesSection` to scan")
+            return
+        }
+        let afterSection = sheet[sectionRange.upperBound...]
+        let body: Substring
+        if let nextMark = afterSection.range(of: "\n// MARK:") {
+            body = afterSection[..<nextMark.lowerBound]
+        } else {
+            body = afterSection
+        }
+        XCTAssertTrue(
+            body.contains("PressableButtonStyle"),
+            "RoutesSection's RouteCard Button should use PressableButtonStyle so "
+                + "the tap reaches its action while still showing press feedback."
+        )
+        XCTAssertTrue(
+            body.contains("onSelectRoute(route)"),
+            "RoutesSection must keep a real Button wired to `onSelectRoute(route)`."
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// `apps/ios/SoloCompass/` — derived from this test file's compile-time path
+    /// (`…/SoloCompass/Tests/RouteCardTappableGuardTest.swift`).
+    private static func sourceRoot(file: StaticString = #filePath) -> URL {
+        URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // SoloCompass/
+    }
+}

--- a/apps/ios/SoloCompass/Views/Companion/Components/RouteCard.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Components/RouteCard.swift
@@ -20,7 +20,6 @@ public struct RouteCard: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var pulse = false
-    @State private var pressed = false
 
     public init(route: Route, companionOn: Bool = false, nowContext: Bool = false) {
         self.route = route
@@ -99,21 +98,16 @@ public struct RouteCard: View {
                 .strokeBorder(nowContext ? CT.accentBorder : CT.borderSubtle, lineWidth: 0.5)
         )
         .shadow(color: .black.opacity(0.04), radius: 1, x: 0, y: 1)
-        .scaleEffect(reduceMotion ? 1 : (pressed ? 0.985 : 1))
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.18), value: pressed)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in
-                    guard !pressed else { return }
-                    pressed = true
-                    #if canImport(UIKit)
-                    if !reduceMotion { Haptics.impact(.soft) }
-                    #endif
-                }
-                .onEnded { _ in
-                    pressed = false
-                }
-        )
+        // Press feedback is owned by the hosting Button's ButtonStyle
+        // (PressableButtonStyle in RoutesSection), NOT a local gesture. The card
+        // previously drove its own press-scale via
+        // `.simultaneousGesture(DragGesture(minimumDistance: 0))`. Inside the
+        // BottomInfoSheet's ScrollView that zero-distance drag claimed the touch
+        // the instant a finger landed — it played the press animation (so the card
+        // *looked* tappable, "有按下效果") but on release the host scroll view
+        // classified the interaction as a drag, so the wrapping Button's tap never
+        // fired and the route detail never opened ("不跳转"). Removing the gesture
+        // lets the tap reach the Button. Kin to [[project_dead_fab_sheet_wiring]].
         .contentShape(Rectangle())
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(route.title + ", " + monoBaseline))

--- a/apps/ios/SoloCompass/Views/Companion/CreateRouteView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/CreateRouteView.swift
@@ -9,9 +9,6 @@ import CoreLocation
 struct CreateRouteEntryCard: View {
     let onTap: () -> Void
 
-    @State private var pressed = false
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
     var body: some View {
         Button(action: onTap) {
             HStack(spacing: 14) {
@@ -50,14 +47,13 @@ struct CreateRouteEntryCard: View {
                     )
             )
         }
-        .buttonStyle(.plain)
-        .scaleEffect(pressed ? 0.985 : 1)
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.18), value: pressed)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in pressed = true }
-                .onEnded { _ in pressed = false }
-        )
+        // PressableButtonStyle drives the press-scale via the system's own tap
+        // recognizer. The previous `.simultaneousGesture(DragGesture(minimumDistance: 0))`
+        // press-feedback hack swallowed the tap inside the BottomInfoSheet's
+        // ScrollView — a zero-distance drag claims the touch and the host scroll
+        // view classifies the release as a drag, so the Button action never fired
+        // and the card was un-tappable. See [[project_dead_fab_sheet_wiring]] kin.
+        .buttonStyle(PressableButtonStyle(pressedScale: 0.985))
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(NSLocalizedString("route.create.entry.title", comment: "Create your own route")))
         .accessibilityHint(Text(NSLocalizedString("route.create.entry.subtitle", comment: "Create route hint")))

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -179,7 +179,19 @@ public enum BottomSheetDetent: CaseIterable {
 // MARK: - BottomInfoSheet
 
 public struct BottomInfoSheet<Content: View>: View {
-    @State private var currentDetent: BottomSheetDetent = .peek
+    @State private var currentDetent: BottomSheetDetent = BottomInfoSheet.initialDetent
+
+    /// Resting detent on appear. DEBUG-only `-expandSheet` launch argument forces
+    /// the sheet to open at `.mid` on cold start so UI automation (idb/XCUITest)
+    /// can reach the Routes/Nearby cards without synthesising an unreliable drag
+    /// gesture to expand it (the custom drag-driven detent ignores idb swipes).
+    /// Release builds always rest at `.peek`. Mirrors the `-startCity` debug hook.
+    private static var initialDetent: BottomSheetDetent {
+        #if DEBUG
+        if ProcessInfo.processInfo.arguments.contains("-expandSheet") { return .mid }
+        #endif
+        return .peek
+    }
     @State private var dragOffset: CGFloat = 0
     @State private var isDragging: Bool = false
     @State var sortMode: SortMode = .smart
@@ -1054,7 +1066,12 @@ struct RoutesSection: View {
                         Button { onSelectRoute(route) } label: {
                             RouteCard(route: route, nowContext: isNowFilter)
                         }
-                        .buttonStyle(.plain)
+                        // PressableButtonStyle drives the press-scale via the
+                        // system tap recognizer. RouteCard no longer owns a local
+                        // zero-distance DragGesture (which swallowed the tap inside
+                        // this ScrollView — see RouteCard), so the tap now reaches
+                        // this Button's action and opens the route detail.
+                        .buttonStyle(PressableButtonStyle(pressedScale: 0.985))
                     }
                 }
                 .padding(.horizontal, 16)

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -415,8 +415,55 @@ struct CompassMapContentView: View {
             // dropped this line, leaving the bottom-left settings FAB inert — its
             // `isShowingSettings = true` had no presenter to observe it.
             .sheet(isPresented: settingsSheetBinding) { settingsSheetContent }
+            // One sheet for both route flows (detail + create), driven by the
+            // `routeSheet` enum. Hosted here on the outer `mapContent` chain — not
+            // on the inner BottomInfoSheet ZStack — so SwiftUI arbitrates it
+            // alongside the other top-level sheets instead of silently dropping a
+            // deeply-nested presenter (which left RouteCards un-openable).
+            .sheet(item: $routeSheet) { sheet in routeSheetContent(sheet) }
             .modifier(ExploreConsentSheetModifier(viewModel: viewModel, preferences: preferences))
             .fullScreenCover(isPresented: onboardingCoverBinding) { onboardingCoverContent }
+    }
+
+    /// Content for the route detail / create sheet, driven by `routeSheet`.
+    /// Extracted so the presenter can live on the outer `mapContent` modifier
+    /// chain (next to the other sheets) rather than buried on the inner
+    /// BottomInfoSheet ZStack where SwiftUI's arbitration dropped it.
+    @ViewBuilder
+    private func routeSheetContent(_ sheet: RouteSheet) -> some View {
+        switch sheet {
+        case .detail(let route):
+            NavigationStack {
+                RouteDetailView(
+                    route: route,
+                    onTapStop: { exp in
+                        routeSheet = nil
+                        viewModel.selectExperience(exp)
+                        viewModel.isShowingDetail = true
+                    },
+                    onStartRoute: { route in
+                        routeSheet = nil
+                        startRouteOnMap(route)
+                    }
+                )
+                .environment(experienceService)
+            }
+        case .create:
+            CreateRouteView(
+                candidates: viewModel.visibleExperiences,
+                cityCode: viewModel.selectedCity ?? "",
+                userCoordinate: locationService.currentLocation?.coordinate
+                    ?? viewModel.defaultCenterForSelectedCity
+            ) { route in
+                // Persist + open the new route's detail; RouteStore.didChange
+                // refreshes the sheet's routes section automatically. Swapping
+                // `routeSheet` from .create → .detail replaces content in place.
+                routeStore.save(route)
+                routeSheet = .detail(route)
+            }
+            .environment(aiService)
+            .environment(experienceService)
+        }
     }
 
     @ViewBuilder
@@ -602,44 +649,15 @@ struct CompassMapContentView: View {
                     }
                 }
                 .ignoresSafeArea(edges: .bottom)
-                // One sheet for both route flows. Driven by `routeSheet` so the
-                // detail and create presentations never shadow each other.
-                .sheet(item: $routeSheet) { sheet in
-                    switch sheet {
-                    case .detail(let route):
-                        NavigationStack {
-                            RouteDetailView(
-                                route: route,
-                                onTapStop: { exp in
-                                    routeSheet = nil
-                                    viewModel.selectExperience(exp)
-                                    viewModel.isShowingDetail = true
-                                },
-                                onStartRoute: { route in
-                                    routeSheet = nil
-                                    startRouteOnMap(route)
-                                }
-                            )
-                            .environment(experienceService)
-                        }
-                    case .create:
-                        CreateRouteView(
-                            candidates: viewModel.visibleExperiences,
-                            cityCode: viewModel.selectedCity ?? "",
-                            userCoordinate: locationService.currentLocation?.coordinate
-                                ?? viewModel.defaultCenterForSelectedCity
-                        ) { route in
-                            // Persist + open the new route's detail; RouteStore.didChange
-                            // refreshes the sheet's routes section automatically.
-                            // Swapping `routeSheet` from .create → .detail replaces
-                            // the sheet's content in place.
-                            routeStore.save(route)
-                            routeSheet = .detail(route)
-                        }
-                        .environment(aiService)
-                        .environment(experienceService)
-                    }
-                }
+                // NOTE: the `routeSheet` presenter is intentionally NOT attached
+                // here. When `.sheet(item: $routeSheet)` was hosted on this inner
+                // nested ZStack while the outer `mapContent` chain already carried
+                // ~8 `.sheet`/`.fullScreenCover` modifiers, SwiftUI's presentation
+                // arbitration silently dropped this deeply-nested presenter — so
+                // tapping a RouteCard flipped `routeSheet = .detail(route)` but no
+                // sheet ever appeared (the route cards "點不進去"). It now lives on
+                // the outer chain next to the other sheets — see `routeSheetContent`.
+                // Kin to [[project_stacked_sheets_only_last_wins]].
 
                 // Selected-experience card floats ABOVE the BottomInfoSheet
                 // (declared after it → higher z-order) and rests on a Dynamic-


### PR DESCRIPTION
## 问题

底部 sheet 展开后,ROUTES 区的路线卡**有按下效果但点不进详情**(用户反馈:「有按下效果但不跳转」)。

## 根因

\`RouteCard\` 内部用 \`.simultaneousGesture(DragGesture(minimumDistance: 0))\` 翻 \`@State pressed\` 做手写按压缩放。这张卡是外层 \`Button { onSelectRoute(route) }\` 的 label,挂在 \`BottomInfoSheet\` 的**单一 ScrollView** 内。

\`minimumDistance: 0\` 的拖拽手势在手指落下瞬间就抢走触摸:
- 它播放按下缩放动画 → 用户看到的「**有按下效果**」
- 松手时宿主 ScrollView 把交互判定为拖动 → 外层 Button 的 tap **永不触发** → 「**不跳转**」

旁边的 peek 概览卡(无此手势)能正常跳转——正是观察到的不对称。同源于 dead-fab-sheet-wiring / stacked-sheets-only-last-wins 类问题。

## 修复

1. **RouteCard**:移除吞 tap 的本地手势,按压反馈改由宿主 Button 的 \`PressableButtonStyle\` 提供(走系统 \`ButtonStyle.isPressed\`,不注册竞争识别器,tap 正常到达 action)。
2. **CreateRouteEntryCard**:同样的零距离拖拽 hack,一并改用 \`PressableButtonStyle\`。
3. **routeSheet 接线**:把路线详情/创建的 \`.sheet(item: \$routeSheet)\` 从内层嵌套 ZStack 提到外层 \`mapContent\` 修饰符链(抽成 \`routeSheetContent\`),与其他顶层 sheet 同层仲裁,避免深埋的呈现器被静默丢弃。
4. **DEBUG \`-expandSheet\` 启动参数**(对标 \`-startCity\`):冷启动让 sheet 停在 \`.mid\`,便于 UI 自动化直达路线/附近卡,无需合成不可靠的拖拽来展开。

## 测试

- 新增 \`RouteCardTappableGuardTest\` + \`CreateRouteEntryTappableGuardTest\` 作为源码级回归守卫,锁死吞 tap 手势模式。
- 模拟器实测:sheet 展开后点路线卡可正常进入详情(已人工确认)。
- \`xcodebuild build\` 通过。

## 说明

\`docs/architecture/agent-memory-context.md\` 是本仓库另外产生的无关文件,**未包含**在本 PR。