### PR TITLE
fix(ios): unify experience preview-card flow (no stray card after detail dismiss)

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 		9A6B147D089D0942438D8972 /* BestTimesSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3645957E10E52142EBF468C0 /* BestTimesSignal.swift */; };
 		9A7AAC7B68BA10A53CAC0A8B /* VoiceServiceActorIsolationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F10413877E80238BD52F34C /* VoiceServiceActorIsolationTest.swift */; };
 		9B906CA9BF24104FB2BF7773 /* RouteCardWalkedByTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9FE3BB447D84732CCE0B07 /* RouteCardWalkedByTest.swift */; };
+		9BEDEF446F2D554A7F1ABA6F /* PreviewCardLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AED8B43F4C4059CD005C0A /* PreviewCardLifecycleTests.swift */; };
 		9C8CC563D33FDBB3DF57A841 /* RecentExploreRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9748B0A808BC06F6EDED3C3B /* RecentExploreRegion.swift */; };
 		9D799B457AC16C84BB460D18 /* RouteCardTappableGuardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4317C293B762EA1C8A436B8A /* RouteCardTappableGuardTest.swift */; };
 		9D81327AE55FA8142F9E5B8D /* ChatUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0709110B381DEDA32C3292AE /* ChatUIState.swift */; };
@@ -332,6 +333,7 @@
 		001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIUsageRecord.swift; sourceTree = "<group>"; };
 		013CB7ADB0525E4F4E8EE959 /* DiscoverRecruitingRoutesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverRecruitingRoutesView.swift; sourceTree = "<group>"; };
 		023CB5AE8B0D41EBB5E17DAC /* ReportBlockSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportBlockSheet.swift; sourceTree = "<group>"; };
+		02AED8B43F4C4059CD005C0A /* PreviewCardLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCardLifecycleTests.swift; sourceTree = "<group>"; };
 		038BEE46BF2DFAF762B605D5 /* Route.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
 		04709B5AD986143D04CA0A08 /* BottomInfoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomInfoSheet.swift; sourceTree = "<group>"; };
 		051AD3C3A41FDF75D2C4BD8C /* SunsetSignalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunsetSignalTests.swift; sourceTree = "<group>"; };
@@ -817,6 +819,7 @@
 				710E82F0D31AB629848EA729 /* PeekSummarySelectionTests.swift */,
 				D26F2087E12E63A73B812D7E /* PendingCheckInBannerTests.swift */,
 				70AF2705AB2F24B69DE8CB4F /* PerformanceTests.swift */,
+				02AED8B43F4C4059CD005C0A /* PreviewCardLifecycleTests.swift */,
 				A267CD0DA0A8053B0AB072BC /* PrivacyAcknowledgementSheetSnapshotTest.swift */,
 				EBCD0D2CE7423C29CD668866 /* PublicAPIDocCommentTests.swift */,
 				7A6F9AAA8749FA23B91F7C93 /* ReviewsServiceTests.swift */,
@@ -1405,6 +1408,7 @@
 				D8A9D1CB20E6D46FD5EE373C /* PeekSummarySelectionTests.swift in Sources */,
 				045740DB5060EBE8D6D2EEA0 /* PendingCheckInBannerTests.swift in Sources */,
 				D7ABC99B7839B64FF014D344 /* PerformanceTests.swift in Sources */,
+				9BEDEF446F2D554A7F1ABA6F /* PreviewCardLifecycleTests.swift in Sources */,
 				A5D3EF6A05AD9B93FA5ACD8A /* PrivacyAcknowledgementSheetSnapshotTest.swift in Sources */,
 				79E4FD6C7F9522BDB1106F56 /* PublicAPIDocCommentTests.swift in Sources */,
 				49C48BE7027B3D172A0BD9B1 /* ReviewsServiceTests.swift in Sources */,

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1411,6 +1411,7 @@
 "peek.card.hint" = "Double tap to see all nearby spots";
 "peek.card.aiPick" = "AI Pick";
 "peek.card.aiPick.a11y" = "AI pick for right now";
+"peek.preview.active.hint" = "Viewing your pick · pull up for all nearby";
 "sheet.handle.hint" = "Tap to expand, drag to resize";
 
 /* NowScore weather signal (US-005) — %d is the temperature in whole °C. */

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1337,6 +1337,7 @@
 "peek.card.hint" = "双击查看附近全部地点";
 "peek.card.aiPick" = "AI 精选";
 "peek.card.aiPick.a11y" = "此刻 AI 精选";
+"peek.preview.active.hint" = "正在查看你选中的 · 上拉看全部";
 "sheet.handle.hint" = "点击展开，拖动调整";
 
 /* NowScore 天气信号 (US-005) — %d 为整数温度（°C）。 */

--- a/apps/ios/SoloCompass/Tests/PreviewCardLifecycleTests.swift
+++ b/apps/ios/SoloCompass/Tests/PreviewCardLifecycleTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import SoloCompass
+
+/// Lifecycle tests for the floating preview card that sits above the
+/// BottomInfoSheet. The card's on-screen visibility in `CompassMapView` is
+/// gated purely on derived state:
+///
+///     selectedExperience != nil && !isShowingDetail
+///
+/// Unified-preview model (all entry points behave the same):
+///   • selecting an experience (map pin, Nearby row, favorites) floats the
+///     preview card — it does NOT jump straight to detail;
+///   • the card's expand action opens the detail sheet (isShowingDetail = true);
+///   • backing out of detail (dismissDetail) FALLS BACK to the preview card —
+///     selection is retained, because detail is a layer above the preview;
+///   • the card's own dismiss (clearSelection) is the only thing that returns
+///     to the bare map.
+///
+/// Regression guard for the "退出详情后悬窗残留" report: the original surprise
+/// was that a list row skipped the card on the way in but the card popped up on
+/// the way out. Now the card is consistently present on both legs, so the
+/// return is expected rather than jarring — and `clearSelection` gives a clean
+/// exit.
+@MainActor
+final class PreviewCardLifecycleTests: XCTestCase {
+
+    private func makeViewModel() -> MapViewModel {
+        MapViewModel(
+            locationService: LocationService(),
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: UserPreferences()
+        )
+    }
+
+    /// Mirrors the `if let selected = viewModel.selectedExperience,
+    /// !viewModel.isShowingDetail` guard in CompassMapView.
+    private func cardIsFloating(_ vm: MapViewModel) -> Bool {
+        vm.selectedExperience != nil && !vm.isShowingDetail
+    }
+
+    private func firstExperience(_ vm: MapViewModel) throws -> Experience {
+        try XCTUnwrap(vm.visibleExperiences.first, "seed expected ≥1 experience")
+    }
+
+    // MARK: - Unified entry: selecting floats the card, never auto-opens detail
+
+    func testSelectExperienceFloatsCardWithoutOpeningDetail() throws {
+        let vm = makeViewModel()
+        let exp = try firstExperience(vm)
+
+        vm.selectExperience(exp)
+        XCTAssertTrue(cardIsFloating(vm),
+                      "selecting an experience must float the preview card")
+        XCTAssertFalse(vm.isShowingDetail,
+                       "selecting must NOT auto-open the detail sheet — "
+                       + "every entry point previews first")
+    }
+
+    // MARK: - Card → detail → back lands on the card again
+
+    func testExpandThenDismissDetailFallsBackToCard() throws {
+        let vm = makeViewModel()
+        let exp = try firstExperience(vm)
+
+        vm.selectExperience(exp)             // card up
+        vm.isShowingDetail = true            // onExpand → detail
+        XCTAssertFalse(cardIsFloating(vm), "card hidden behind detail")
+
+        vm.dismissDetail()                   // back out of detail
+        XCTAssertTrue(cardIsFloating(vm),
+                      "dismissing detail must fall back to the preview card")
+        XCTAssertEqual(vm.selectedExperience?.id, exp.id,
+                       "selection is retained on detail dismiss")
+    }
+
+    // MARK: - Card dismiss is the only full exit to the bare map
+
+    func testClearSelectionReturnsToBareMap() throws {
+        let vm = makeViewModel()
+        let exp = try firstExperience(vm)
+
+        vm.selectExperience(exp)
+        vm.clearSelection()                  // the card's own ⨯ / swipe-down
+        XCTAssertFalse(cardIsFloating(vm), "card gone")
+        XCTAssertNil(vm.selectedExperience, "selection fully cleared")
+        XCTAssertFalse(vm.isShowingDetail)
+    }
+
+    // MARK: - In-detail switch keeps detail open on the new experience
+
+    func testInDetailSwitchStaysInDetailOnNewExperience() throws {
+        let vm = makeViewModel()
+        let experiences = vm.visibleExperiences
+        try XCTSkipIf(experiences.count < 2, "needs ≥2 seeds to switch between")
+        let first = experiences[0]
+        let second = experiences[1]
+
+        vm.selectExperience(first)
+        vm.isShowingDetail = true            // in detail on `first`
+
+        // In-detail "nearby" tap → selectExperience(second), detail stays up.
+        vm.selectExperience(second)
+        XCTAssertEqual(vm.selectedExperience?.id, second.id,
+                       "in-detail switch must re-point the selection")
+        XCTAssertTrue(vm.isShowingDetail,
+                      "switching inside detail keeps the detail sheet open")
+        XCTAssertFalse(cardIsFloating(vm),
+                       "the floating card must not flash during an in-detail switch")
+    }
+}

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -1013,9 +1013,27 @@ public final class MapViewModel {
         }
     }
 
-    /// Close the expanded detail sheet, returning to the map view.
+    /// Close the expanded detail sheet, falling back to the floating preview
+    /// card for the same experience.
+    ///
+    /// Every entry point (map pin, Nearby list row, favorites) now routes
+    /// through the preview card first — selecting an experience floats the
+    /// card, and the card's expand action opens the detail. Backing out of the
+    /// detail therefore lands back on that preview card (selectedExperience is
+    /// deliberately retained), which is the consistent mental model: detail is
+    /// a layer *above* the preview, not a replacement for it. The card is only
+    /// fully cleared when the user dismisses the card itself (`clearSelection`).
     public func dismissDetail() {
         isShowingDetail = false
+    }
+
+    /// Fully dismiss the floating preview card and its selection, returning to
+    /// the bare map. This is the card's own swipe-down / close action — the one
+    /// place selection is cleared, distinct from `dismissDetail` which only
+    /// peels off the detail layer.
+    public func clearSelection() {
+        isShowingDetail = false
+        selectedExperience = nil
     }
 
     /// US-VA-03 tool `dismiss_recommendation`: hide one experience from

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -208,6 +208,11 @@ public struct BottomInfoSheet<Content: View>: View {
     /// Reference coordinate (user location or map center) for the peek card's
     /// distance + compass bearing.
     private let referenceCoordinate: CLLocationCoordinate2D?
+    /// True while the floating preview card is up for a user-selected
+    /// experience. The peek summary card ("此刻最值得去") fades out and yields
+    /// to a lightweight hint so two competing "best pick" cards never stack —
+    /// the user's active selection owns the focus.
+    private let isPreviewActive: Bool
     private let content: (BottomSheetDetent, Binding<SortMode>) -> Content
 
     public init(
@@ -217,6 +222,7 @@ public struct BottomInfoSheet<Content: View>: View {
         peekExperience: Experience? = nil,
         isSmartPick: Bool = false,
         referenceCoordinate: CLLocationCoordinate2D? = nil,
+        isPreviewActive: Bool = false,
         @ViewBuilder content: @escaping (BottomSheetDetent, Binding<SortMode>) -> Content
     ) {
         self.aiHint = aiHint
@@ -225,6 +231,7 @@ public struct BottomInfoSheet<Content: View>: View {
         self.peekExperience = peekExperience
         self.isSmartPick = isSmartPick
         self.referenceCoordinate = referenceCoordinate
+        self.isPreviewActive = isPreviewActive
         self.content = content
     }
 
@@ -370,7 +377,12 @@ public struct BottomInfoSheet<Content: View>: View {
     private var peekSummaryArea: some View {
         VStack(alignment: .leading, spacing: 8) {
             peekHeaderLabel
-            if let experience = peekExperience {
+            if isPreviewActive {
+                // A floating preview card already owns the "best pick" focus —
+                // collapse this card to a one-line hint so the two never
+                // compete on screen. The sheet stays pull-up-able.
+                previewActiveHint
+            } else if let experience = peekExperience {
                 PeekSummaryCard(
                     experience: experience,
                     isSmartPick: isSmartPick,
@@ -386,6 +398,7 @@ public struct BottomInfoSheet<Content: View>: View {
                 PeekEmptyCard()
             }
         }
+        .animation(.easeInOut(duration: 0.25), value: isPreviewActive)
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
         .onTapGesture {
@@ -412,6 +425,30 @@ public struct BottomInfoSheet<Content: View>: View {
         }
         .padding(.horizontal, 4)
         .accessibilityAddTraits(.isHeader)
+    }
+
+    /// One-line stand-in shown in place of the peek summary card while a
+    /// floating preview card is active, so the sheet's peek region keeps a
+    /// stable height and remains tappable to pull up the full list.
+    private var previewActiveHint: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "hand.tap")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(NSLocalizedString(
+                "peek.preview.active.hint",
+                comment: "Shown in the peek area while a preview card is up"
+            ))
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        .transition(.opacity)
     }
 
     // MARK: - Drag Handle

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -597,7 +597,12 @@ struct CompassMapContentView: View {
                         peekExperience: peekExperience,
                         isSmartPick: peekExperienceIsSmartPick,
                         referenceCoordinate: locationService.currentLocation?.coordinate
-                            ?? viewModel.defaultCenterForSelectedCity
+                            ?? viewModel.defaultCenterForSelectedCity,
+                        // D 双卡片冲突: while the floating preview card is up for
+                        // a user-selected experience, the peek summary card
+                        // yields so only one "best pick" card is on screen.
+                        isPreviewActive: viewModel.selectedExperience != nil
+                            && !viewModel.isShowingDetail
                     ) { detent, sortMode in
                         if detent != .peek {
                             VStack(spacing: 0) {
@@ -640,8 +645,18 @@ struct CompassMapContentView: View {
                                         }
                                     },
                                     onSelectExperience: { exp in
-                                        viewModel.selectExperience(exp)
-                                        viewModel.isShowingDetail = true
+                                        // Unified preview path: every entry
+                                        // point floats the preview card first
+                                        // (no longer jumps straight to detail),
+                                        // so the list row and a map-pin tap
+                                        // feel identical and backing out of the
+                                        // detail lands on the same card.
+                                        // withAnimation drives the card's
+                                        // move+fade transition for a layered
+                                        // reveal instead of a hard cut.
+                                        withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                                            viewModel.selectExperience(exp)
+                                        }
                                     }
                                 )
                             }
@@ -670,7 +685,14 @@ struct CompassMapContentView: View {
                         ExperienceCardView(
                             experience: selected,
                             onExpand: { viewModel.isShowingDetail = true },
-                            onDismiss: { viewModel.selectedExperience = nil },
+                            onDismiss: {
+                                // The card's own dismiss is the only place the
+                                // selection is fully cleared — detail dismiss
+                                // falls back to this card, not to the bare map.
+                                withAnimation(.easeInOut(duration: 0.25)) {
+                                    viewModel.clearSelection()
+                                }
+                            },
                             onRecompile: {
                                 Task { await viewModel.recompileExperience(selected) }
                             },
@@ -733,7 +755,10 @@ struct CompassMapContentView: View {
     private var detailSheetBinding: Binding<Bool> {
         Binding(
             get: { viewModel.isShowingDetail },
-            set: { if !$0 { viewModel.isShowingDetail = false } }
+            // Route swipe-to-dismiss through dismissDetail() too, matching the
+            // chevron close button: both peel off only the detail layer and
+            // fall back to the floating preview card (selection retained).
+            set: { if !$0 { viewModel.dismissDetail() } }
         )
     }
 
@@ -835,9 +860,26 @@ struct CompassMapContentView: View {
                         voiceOrchestrator?.rebindContext(experience)
                     },
                     onSelectExperience: { experience in
-                        viewModel.selectExperience(experience)
+                        // In-detail "nearby" tap swaps the featured experience.
+                        // withAnimation drives the .id-keyed content transition
+                        // below so the switch is perceptible, not a silent
+                        // data swap. (B 详情内切体验加转场)
+                        withAnimation(.easeInOut(duration: 0.3)) {
+                            viewModel.selectExperience(experience)
+                        }
                     }
                 )
+                // Bind SwiftUI identity to the experience so selecting a
+                // different one rebuilds the detail view AND its @State
+                // view model. Without this, ExperienceDetailView's @State
+                // viewModel kept the original experience and an in-detail
+                // "nearby" tap changed nothing on screen. The transition
+                // gives the rebuild a visible cross-fade + slide.
+                .id(exp.id)
+                .transition(.asymmetric(
+                    insertion: .move(edge: .trailing).combined(with: .opacity),
+                    removal: .move(edge: .leading).combined(with: .opacity)
+                ))
             }
             // Approach C: when the detail sheet opens for a shallow (not yet
             // AI-enriched) place, silently deep cross-compile it in the
@@ -862,8 +904,11 @@ struct CompassMapContentView: View {
         FavoritesListView(
             onSelectExperience: { exp in
                 isShowingFavorites = false
-                viewModel.selectExperience(exp)
-                viewModel.isShowingDetail = true
+                // Unified preview path (see Nearby onSelectExperience): float
+                // the preview card rather than jumping straight to detail.
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                    viewModel.selectExperience(exp)
+                }
             },
             onExplore: { isShowingFavorites = false }
         )


### PR DESCRIPTION
## Summary

修复用户报告的「退出详情后悬窗残留」，并顺手解决了同源的三个相邻交互问题。

**根因**：浮动预览卡片的显隐由派生状态 `selectedExperience != nil && !isShowingDetail` 决定。列表行/收藏行点击时直接 `selectExperience() + isShowingDetail = true` 跳进详情，**跳过了悬窗**；从详情返回时 `isShowingDetail` 翻回 false 但 `selectedExperience` 没清，于是悬窗「凭空冒出来」——即便用户进详情前根本没见过它。

**统一预览路径**（所有入口行为一致）：
- 地图 pin / Nearby 列表行 / 收藏行点击 → `selectExperience()` 先浮出悬窗，不再直接进详情
- 悬窗 `onExpand` → 进详情；`dismissDetail()` 返回时**回落悬窗**（保留选中态）
- `clearSelection()`（悬窗自身的关闭/下滑）是**唯一**清空选中、回到纯地图的出口
- 详情 sheet 的下滑关闭也走 `dismissDetail()`，与 chevron 关闭一致

**附带修复**（追踪流程时发现）：
- **D 双卡片冲突**：悬窗显示时，`BottomInfoSheet` 的 peek 卡片（"此刻最值得去"）通过新增的 `isPreviewActive` 让位为一行提示，避免两张「最值得去」卡片同屏打架。
- **B 详情内切体验不刷新（隐藏 bug）**：详情里点「附近」卡片切换体验时，`ExperienceDetailView` 的 `@State viewModel` 保留旧实例 → 屏幕内容不变。现用 `.id(exp.id)` 绑定 SwiftUI identity 强制重建，并配合 cross-fade + slide 转场让切换可感知。
- **E 列表进详情零动画**：统一路径后，列表→悬窗→详情天然有层级递进动画，不再「啪」地硬切。

新增 en + zh-Hans `peek.preview.active.hint` 本地化串。

## Test Coverage

新增 `PreviewCardLifecycleTests`，覆盖派生显隐规则与各导航路径：
- selecting 浮出悬窗、不自动进详情
- expand → `dismissDetail` 回落悬窗（保留选中）
- `clearSelection` 回到纯地图
- 详情内切换保持详情打开、悬窗不闪

**回归验证**（全部 `Executed N>0` 通过）：
- PreviewCardLifecycleTests: 4/4 ✅
- BottomInfoSheet（接口加 `isPreviewActive` 不破坏）: 12/12 ✅
- PeekPickResolver: 8/8 ✅
- VoiceAgentToolRouter `show_details`（语音直达详情路径**故意未改**）: 2/2 ✅

## Build

`xcodebuild build -scheme SoloCompass -destination 'iPhone 17 Pro'` → **BUILD SUCCEEDED**

## Pre-Landing Review

自审发现并修正了一处 comment rot：`detailSheetBinding` 注释原称 "clears selectedExperience"，与回落悬窗的新语义矛盾，已改正。

## Test plan
- [x] iOS 构建通过（iPhone 17 Pro 模拟器）
- [x] 16 个相关单元测试通过（生命周期 + BottomSheet + Peek + ShowDetails）
- [ ] 模拟器手动走查三入口流程（地图 pin / 列表 / 收藏 → 进详情 → 返回，确认无残留悬窗、切换有转场）— 建议 reviewer 验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)