### PR TITLE
feat(ios): share routes as a map card with the route line on it

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		15530E784D55EED02B3EE21F /* CompanionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405A56207920EA0DDADF8FC5 /* CompanionRequest.swift */; };
 		15A48470CBEBB6D31C2201D9 /* Configuration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = D4C10384834D53FE83113D51 /* Configuration.storekit */; };
 		160DDEADA76E50A05D4F76EE /* VoiceProcessingToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EDF4F9F84F50797290FF9E0 /* VoiceProcessingToast.swift */; };
+		16B059DFB0D658D2DC38C972 /* RoutePolylineShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0C9228AD213C6D5FE01FCE /* RoutePolylineShape.swift */; };
 		18D372538603D7A46EE6C86F /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B73212B8F704EABD27EF5B /* FeatureFlags.swift */; };
 		1917588F1289C48C928ACF6C /* CompanionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8062A7E6BA3EE88C6DAF02 /* CompanionService.swift */; };
 		193FE8EBE03520DF740EE78D /* PaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92F9A65ACFD3B9518A364B0 /* PaywallView.swift */; };
@@ -62,6 +63,7 @@
 		31F9538643C362D7EEF64C6B /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7919EAFDE363B49C4B4C47 /* LocationService.swift */; };
 		321C062B9C6CA3558BC88C91 /* VerifiedBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2891DAE62909FE55324494D7 /* VerifiedBadge.swift */; };
 		3253E70A5F98389A985CA7B9 /* RouteCardRecruitMiniTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EAB2E028C69B7C63DCAF860 /* RouteCardRecruitMiniTest.swift */; };
+		32C5B270129CEC0562C6D640 /* RouteShareCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF934B8ECFB7BB99C9C4791 /* RouteShareCardView.swift */; };
 		337CAFC8B35CF36D175B27CF /* CompareTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F836182A03FC067C4A9AB9 /* CompareTokens.swift */; };
 		352247C1FBF4C8F901D17F32 /* ApprovalTrustSignalTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804618047547A9D7F3F8EAAA /* ApprovalTrustSignalTest.swift */; };
 		371DDBAF4C385267248ABC83 /* AgentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38E5736BF6DF5644D687637 /* AgentRouter.swift */; };
@@ -119,6 +121,7 @@
 		5F3ACD03660F3E8B88814C56 /* MyHostedRoutesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E055BAC372B75F743428920 /* MyHostedRoutesListView.swift */; };
 		60D39CDEAEF16ADA45BE5A84 /* ForEachStringIDStabilityTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B54F95BDD9FB4A3CF8C5B1 /* ForEachStringIDStabilityTest.swift */; };
 		60FA57D3A56ED061C1F9B899 /* PresenceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BF40BDAD5E085808BE633E /* PresenceService.swift */; };
+		61183D492854C69DDFFA3F06 /* RouteShareCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEF9ECFBFF7B7CE5246F37B /* RouteShareCardTests.swift */; };
 		615FCA91C2260950BFE3E4F3 /* ShareCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30705AFFEB819044661EC871 /* ShareCardView.swift */; };
 		61951D68523CF51B987F4385 /* NowScoreEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3900AAACEFB8C75AC3F123C3 /* NowScoreEngine.swift */; };
 		627258EB2A310E2C979787E8 /* SkeletonBadgeViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B418AD0352AC3402D6609E4C /* SkeletonBadgeViewTests.swift */; };
@@ -155,8 +158,10 @@
 		8004F51AA0F117D38EC71610 /* BilingualCityRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95DD95393E5BF9C89FB4977 /* BilingualCityRow.swift */; };
 		81470D06CD0593B278B110CC /* ColdStartExperienceLoadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907EA19EC9B84B93AB110C70 /* ColdStartExperienceLoadTests.swift */; };
 		83328E4B13133FBCDA9E0A5D /* DiscoverListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADDD17473F138874328A33E /* DiscoverListView.swift */; };
+		83BF31EF553028D19D695105 /* RouteSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C6C906BAD8DBC107491B7F /* RouteSharePayload.swift */; };
 		842E955B0ED4DC5255816199 /* NowScore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75D6A32EAF01F792AFAE15E /* NowScore.swift */; };
 		84C7525626CF30AF8AD92C19 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 154BDAAACF2DDCFE0953E722 /* Secrets.plist */; };
+		8592C07C234EA6B55619D0D1 /* RouteShareRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A453FDDE85569DCA8FF70A8A /* RouteShareRenderer.swift */; };
 		85B238721EB01B78DDC078F0 /* RouteCompanionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA9EA4E29955D78499E3AAC /* RouteCompanionTests.swift */; };
 		85C233AB7998521788B2BB5F /* WeatherCacheTTLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E536D4CFF44CF4CEFD1EFF4F /* WeatherCacheTTLTests.swift */; };
 		8632F28AFD6C3E52A0536BA2 /* SortButtonA11yValueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C0472D19B6973CF720ADBD /* SortButtonA11yValueTest.swift */; };
@@ -216,6 +221,7 @@
 		B478C92BB2249C0D5009AABD /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6163572F4644BF852B35FDA4 /* SyncService.swift */; };
 		B4A33EDD3C85BBA89CD4EC05 /* ThemeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AF85DC8F90CA4721DDAEA6 /* ThemeService.swift */; };
 		B5D2608A5B16B07B6E9005DC /* ChatBubbleContrastTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF5100EFECEC87BDC2B007B /* ChatBubbleContrastTest.swift */; };
+		B6FA45D117293C3829DE99A9 /* RouteMapSnapshotter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8970A53A6D6C42A614F7B414 /* RouteMapSnapshotter.swift */; };
 		B7366111257111EC98F4A0C4 /* ChatSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9263FC2737FA209F3CD4B5E /* ChatSheet.swift */; };
 		B9EDA827F7E00B19DF97512C /* ConversationRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12888843433B2A00D7CAB18 /* ConversationRecord.swift */; };
 		BA0DD7D5C46016E81A23B2B4 /* ChatInputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88D9F377D7AF634DAE07A3E /* ChatInputBar.swift */; };
@@ -253,6 +259,7 @@
 		C9DAF262896CB6CFBA6F97D3 /* IOS18AvailabilityGuardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFF9ECB175F4D2219406952 /* IOS18AvailabilityGuardTest.swift */; };
 		CA06289D4E0D0C24C2079B40 /* VoiceWaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0CBFD5114CC6728D6AA876 /* VoiceWaveformView.swift */; };
 		CA89195562C759E6F118465B /* TodoIssueReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331B2AE74EFAD9589AF60498 /* TodoIssueReferenceTests.swift */; };
+		CB7524D681F638DFD45BA1FA /* RouteShareStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EB8B6538D85C6E3641D778 /* RouteShareStyle.swift */; };
 		CC29AD50727EA68C4064F56F /* NowSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97FCA9C12D9640983F75474E /* NowSignal.swift */; };
 		CD73E1A29E0D2EB8D8AC93AC /* OpenForCompanionsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5D9508FCA9CDB8EA088D76 /* OpenForCompanionsSheet.swift */; };
 		CD74E5E501088F7BECA74FBC /* WeatherServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F20A91F36C7CA4041BEEC9 /* WeatherServiceTests.swift */; };
@@ -390,6 +397,7 @@
 		30E9EE8B07B66490112B696A /* ChatStateModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStateModifier.swift; sourceTree = "<group>"; };
 		314F06EBA1DCBD3AC987BEEF /* ShareCardScoreL10nTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareCardScoreL10nTest.swift; sourceTree = "<group>"; };
 		31C6279345E826F9B01AE41C /* StopsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopsList.swift; sourceTree = "<group>"; };
+		31C6C906BAD8DBC107491B7F /* RouteSharePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteSharePayload.swift; sourceTree = "<group>"; };
 		323B1BAB8D4A2BE116D8A789 /* LocationPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationPickerSheet.swift; sourceTree = "<group>"; };
 		331B2AE74EFAD9589AF60498 /* TodoIssueReferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoIssueReferenceTests.swift; sourceTree = "<group>"; };
 		33B8A80F048D74BEDB8C1132 /* SubscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionService.swift; sourceTree = "<group>"; };
@@ -407,6 +415,7 @@
 		3A7A57DAFF92B20BE0BAB1F4 /* IntentAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentAgent.swift; sourceTree = "<group>"; };
 		3ADE6272DBBF6FAE452195AB /* SettingsSheetPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSheetPresentationTests.swift; sourceTree = "<group>"; };
 		3AF871B84DDAAD8453B8258D /* RouteStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteStoreTests.swift; sourceTree = "<group>"; };
+		3B0C9228AD213C6D5FE01FCE /* RoutePolylineShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutePolylineShape.swift; sourceTree = "<group>"; };
 		3C9A1F22AAE512199548C269 /* FilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarView.swift; sourceTree = "<group>"; };
 		3E7AFBAAF6E42AE8043F476D /* VoiceInterruptionToastTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInterruptionToastTest.swift; sourceTree = "<group>"; };
 		402644EEDBCD7DD3658E6DD5 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -429,6 +438,7 @@
 		4FE945F792AFD68B33B7E8B5 /* UserDirectoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDirectoryTests.swift; sourceTree = "<group>"; };
 		520EDA3B7A8A6136FB0355A4 /* SupabaseRouteCompanionRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseRouteCompanionRemote.swift; sourceTree = "<group>"; };
 		535B5FA4ADF216CEC74FE056 /* RouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteTests.swift; sourceTree = "<group>"; };
+		53EB8B6538D85C6E3641D778 /* RouteShareStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteShareStyle.swift; sourceTree = "<group>"; };
 		53F836182A03FC067C4A9AB9 /* CompareTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompareTokens.swift; sourceTree = "<group>"; };
 		54F3FDE4BC9458E490AEA67A /* MarkdownExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownExporter.swift; sourceTree = "<group>"; };
 		55143D2090E3E5CADF4246B6 /* SolarEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolarEvents.swift; sourceTree = "<group>"; };
@@ -506,6 +516,7 @@
 		88553B5578C07FA890183A0D /* BottomInfoSheetHandleHitTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomInfoSheetHandleHitTargetTests.swift; sourceTree = "<group>"; };
 		88863482E2CD46BBE315B59D /* LocationErrorSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationErrorSurfaceTests.swift; sourceTree = "<group>"; };
 		8964F4628C43BB7311B48D38 /* ApprovalQueueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalQueueView.swift; sourceTree = "<group>"; };
+		8970A53A6D6C42A614F7B414 /* RouteMapSnapshotter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteMapSnapshotter.swift; sourceTree = "<group>"; };
 		8B95FD264D171F4F70DFEB26 /* HourOfDaySignal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HourOfDaySignal.swift; sourceTree = "<group>"; };
 		8C1DD2BA0AF4E693B9E36F90 /* CompiledPlace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompiledPlace.swift; sourceTree = "<group>"; };
 		8C8D88BCFAC97E436BE97274 /* seed_users.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = seed_users.json; sourceTree = "<group>"; };
@@ -540,6 +551,7 @@
 		A267CD0DA0A8053B0AB072BC /* PrivacyAcknowledgementSheetSnapshotTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyAcknowledgementSheetSnapshotTest.swift; sourceTree = "<group>"; };
 		A2BE90CD51D94B3FEE2F5AFA /* CompanionReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionReport.swift; sourceTree = "<group>"; };
 		A38E5736BF6DF5644D687637 /* AgentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRouter.swift; sourceTree = "<group>"; };
+		A453FDDE85569DCA8FF70A8A /* RouteShareRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteShareRenderer.swift; sourceTree = "<group>"; };
 		A5435FBA9527C07A9FB07D46 /* SoloCompassModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassModelContainer.swift; sourceTree = "<group>"; };
 		A5F2BB13078B86C9BEDE7ADD /* WeatherCacheRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherCacheRecord.swift; sourceTree = "<group>"; };
 		A644911E7B2824A7ABBA4D6F /* SeedRoutesParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedRoutesParityTests.swift; sourceTree = "<group>"; };
@@ -601,6 +613,7 @@
 		D5DCEFC3560FED53D0CB5D19 /* AgentMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentMessage.swift; sourceTree = "<group>"; };
 		D60647FA4E64B48E215B9D2F /* RouteCompanionRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCompanionRemote.swift; sourceTree = "<group>"; };
 		D9CF57D3342E9C609CD56801 /* AISynthesisQualityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISynthesisQualityTests.swift; sourceTree = "<group>"; };
+		DAF934B8ECFB7BB99C9C4791 /* RouteShareCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteShareCardView.swift; sourceTree = "<group>"; };
 		DE4515228D70D8804596299D /* AIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProvider.swift; sourceTree = "<group>"; };
 		DFA9968E168052C0DC0E1B36 /* SFSymbolExistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSymbolExistenceTests.swift; sourceTree = "<group>"; };
 		E03076AD221F78BBDE981C3A /* ExperienceRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceRecord.swift; sourceTree = "<group>"; };
@@ -644,6 +657,7 @@
 		FF7D0A1F8E3B8909F465194C /* ObsidianThemeContrastTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObsidianThemeContrastTest.swift; sourceTree = "<group>"; };
 		FFC5559A4AAF4E3CD77E38B6 /* MapViewModelCityCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModelCityCacheTests.swift; sourceTree = "<group>"; };
 		FFED848E66BBE2A234AAA3CC /* FilterBarScrollAffordanceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarScrollAffordanceTest.swift; sourceTree = "<group>"; };
+		FFEF9ECFBFF7B7CE5246F37B /* RouteShareCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteShareCardTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -728,6 +742,7 @@
 				1D4181409CE6A219B1C07502 /* RouteShareSheet.swift */,
 				99D914894172F5E81C250A6A /* SendRequestSheet.swift */,
 				BBF9B944FE7F4CC3492DF727 /* Components */,
+				382EF7CC608A45DB8A46A2EE /* Share */,
 			);
 			path = Companion;
 			sourceTree = "<group>";
@@ -835,6 +850,7 @@
 				E79DAF94BA8A4DD5FF569EF3 /* RouteIsBestNowTests.swift */,
 				A8670B08F2AB2779C31E0870 /* RouteItineraryBridgeTests.swift */,
 				B6BAB6EA03E81F52D00CCD59 /* RouteRecordTests.swift */,
+				FFEF9ECFBFF7B7CE5246F37B /* RouteShareCardTests.swift */,
 				3AF871B84DDAAD8453B8258D /* RouteStoreTests.swift */,
 				535B5FA4ADF216CEC74FE056 /* RouteTests.swift */,
 				A644911E7B2824A7ABBA4D6F /* SeedRoutesParityTests.swift */,
@@ -878,6 +894,19 @@
 				8C8D88BCFAC97E436BE97274 /* seed_users.json */,
 			);
 			path = JSON;
+			sourceTree = "<group>";
+		};
+		382EF7CC608A45DB8A46A2EE /* Share */ = {
+			isa = PBXGroup;
+			children = (
+				8970A53A6D6C42A614F7B414 /* RouteMapSnapshotter.swift */,
+				3B0C9228AD213C6D5FE01FCE /* RoutePolylineShape.swift */,
+				DAF934B8ECFB7BB99C9C4791 /* RouteShareCardView.swift */,
+				31C6C906BAD8DBC107491B7F /* RouteSharePayload.swift */,
+				A453FDDE85569DCA8FF70A8A /* RouteShareRenderer.swift */,
+				53EB8B6538D85C6E3641D778 /* RouteShareStyle.swift */,
+			);
+			path = Share;
 			sourceTree = "<group>";
 		};
 		43E0F61FDC12FC6B691A26B8 /* Config */ = {
@@ -1424,6 +1453,7 @@
 				28B8736A9740C11F9E343040 /* RouteIsBestNowTests.swift in Sources */,
 				2C5A15DE0FCF30A3BCF1EB20 /* RouteItineraryBridgeTests.swift in Sources */,
 				58EC3C9838462DCD66F11975 /* RouteRecordTests.swift in Sources */,
+				61183D492854C69DDFFA3F06 /* RouteShareCardTests.swift in Sources */,
 				71B9FD2F300F42A5197FFA15 /* RouteStoreTests.swift in Sources */,
 				D2E9B20230FDE14CB1029DC3 /* RouteTests.swift in Sources */,
 				B32CCADAF2919BAFA66D9C94 /* SFSymbolExistenceTests.swift in Sources */,
@@ -1603,8 +1633,14 @@
 				F189082793B447112F0BA5AB /* RouteCompanionStateMachine.swift in Sources */,
 				7DE0D7D331590BFAC64D55B9 /* RouteDetailView.swift in Sources */,
 				8D67669050D844812FA06CC8 /* RouteItineraryBridge.swift in Sources */,
+				B6FA45D117293C3829DE99A9 /* RouteMapSnapshotter.swift in Sources */,
+				16B059DFB0D658D2DC38C972 /* RoutePolylineShape.swift in Sources */,
 				F3B6B76087182DEAF1BD0556 /* RouteRecord.swift in Sources */,
+				32C5B270129CEC0562C6D640 /* RouteShareCardView.swift in Sources */,
+				83BF31EF553028D19D695105 /* RouteSharePayload.swift in Sources */,
+				8592C07C234EA6B55619D0D1 /* RouteShareRenderer.swift in Sources */,
 				59A9E2DAC8378384BBCD8A57 /* RouteShareSheet.swift in Sources */,
+				CB7524D681F638DFD45BA1FA /* RouteShareStyle.swift in Sources */,
 				963BC062494BCC3B655AFDC0 /* RouteStore.swift in Sources */,
 				CE75A768DA8AD2A14C3046AF /* SavedCity.swift in Sources */,
 				FBE9F5951D501A611EB19EEC /* SecretsRuntime.swift in Sources */,

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -798,6 +798,10 @@
 "route.share.kicker" = "Route · Solo Compass";
 "route.share.mode.card" = "Card";
 "route.share.mode.text" = "Text";
+"route.share.style.map" = "Map";
+"route.share.style.trace" = "Trace";
+/* Shown when the real map basemap can't be fetched and we fell back to the vector line. */
+"route.share.mapFallback" = "Map basemap unavailable — showing the minimal line instead.";
 "route.share.min" = "min";
 "route.share.stops" = "stops";
 /* %d = number of travelers who have walked this route. */

--- a/apps/ios/SoloCompass/Tests/RouteShareCardTests.swift
+++ b/apps/ios/SoloCompass/Tests/RouteShareCardTests.swift
@@ -1,0 +1,115 @@
+import CoreLocation
+import MapKit
+import XCTest
+@testable import SoloCompass
+
+/// Covers the pure geometry + payload logic behind the route map/trace share
+/// card: coordinate normalisation (aspect-preserved, y-flipped), bounding-rect
+/// computation, and the fallback predicates that decide map → trace → gradient.
+final class RouteShareCardTests: XCTestCase {
+
+    // MARK: - Normalizer
+
+    func test_normalize_empty_returnsEmpty() {
+        XCTAssertTrue(RouteNormalizer.normalize([]).isEmpty)
+    }
+
+    func test_normalize_singlePoint_returnsCentred() {
+        let pts = RouteNormalizer.normalize([.init(latitude: 13.7, longitude: 100.5)])
+        XCTAssertEqual(pts.count, 1)
+        XCTAssertEqual(pts[0].x, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(pts[0].y, 0.5, accuracy: 0.0001)
+    }
+
+    func test_normalize_keepsAspectRatio_noStretch() {
+        // A route 2° wide in lon but only 1° tall in lat must NOT fill the unit
+        // square in both axes — the narrow axis is letterboxed (centred).
+        let coords: [CLLocationCoordinate2D] = [
+            .init(latitude: 10.0, longitude: 100.0), // SW
+            .init(latitude: 11.0, longitude: 102.0), // NE
+        ]
+        let pts = RouteNormalizer.normalize(coords)
+        // span = max(2, 1) = 2. lon maps 0..1 across the full width.
+        XCTAssertEqual(pts[0].x, 0.0, accuracy: 0.0001)
+        XCTAssertEqual(pts[1].x, 1.0, accuracy: 0.0001)
+        // lat span 1 over span 2 → occupies middle half: 0.25 .. 0.75.
+        XCTAssertEqual(pts[0].y, 0.25, accuracy: 0.0001)
+        XCTAssertEqual(pts[1].y, 0.75, accuracy: 0.0001)
+    }
+
+    func test_points_flipsY_northIsUp() {
+        // Higher latitude (north) must map to a SMALLER y (top of the rect).
+        let coords: [CLLocationCoordinate2D] = [
+            .init(latitude: 10.0, longitude: 100.0), // south
+            .init(latitude: 11.0, longitude: 100.0), // north (degenerate lon)
+        ]
+        let rect = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let pts = RouteNormalizer.points(in: rect, normalized: RouteNormalizer.normalize(coords), inset: 0)
+        XCTAssertGreaterThan(pts[0].y, pts[1].y, "south stop should sit lower (larger y) than north stop")
+    }
+
+    func test_stopPoints_countMatchesInput() {
+        let coords: [CLLocationCoordinate2D] = (0..<5).map {
+            .init(latitude: 13.0 + Double($0) * 0.01, longitude: 100.0 + Double($0) * 0.01)
+        }
+        let rect = CGRect(x: 0, y: 0, width: 200, height: 360)
+        XCTAssertEqual(RouteNormalizer.stopPoints(in: rect, coordinates: coords).count, 5)
+    }
+
+    // MARK: - Bounding map rect
+
+    func test_boundingMapRect_empty_isNull() {
+        XCTAssertTrue(RouteMapSnapshotter.boundingMapRect([]).isNull)
+    }
+
+    func test_boundingMapRect_containsAllStops() {
+        let coords: [CLLocationCoordinate2D] = [
+            .init(latitude: 13.74, longitude: 100.49),
+            .init(latitude: 13.75, longitude: 100.51),
+        ]
+        let rect = RouteMapSnapshotter.boundingMapRect(coords)
+        for c in coords {
+            XCTAssertTrue(rect.contains(MKMapPoint(c)), "rect must contain every stop")
+        }
+    }
+
+    func test_boundingMapRect_singlePoint_hasMinimumViewport() {
+        let rect = RouteMapSnapshotter.boundingMapRect([.init(latitude: 13.74, longitude: 100.49)])
+        XCTAssertGreaterThan(rect.size.width, 0, "single point must still get a non-zero viewport")
+        XCTAssertGreaterThan(rect.size.height, 0)
+    }
+
+    // MARK: - Payload fallback predicates
+
+    func test_payload_hasDrawableRoute_requiresTwoPoints() {
+        XCTAssertFalse(makePayload(coords: []).hasDrawableRoute)
+        XCTAssertFalse(makePayload(coords: [.init(latitude: 1, longitude: 1)]).hasDrawableRoute)
+        XCTAssertTrue(makePayload(coords: [
+            .init(latitude: 1, longitude: 1),
+            .init(latitude: 2, longitude: 2),
+        ]).hasDrawableRoute)
+    }
+
+    func test_payload_hasAnyCoordinate() {
+        XCTAssertFalse(makePayload(coords: []).hasAnyCoordinate)
+        XCTAssertTrue(makePayload(coords: [.init(latitude: 1, longitude: 1)]).hasAnyCoordinate)
+    }
+
+    // MARK: - Helpers
+
+    private func makePayload(coords: [CLLocationCoordinate2D]) -> RouteSharePayload {
+        RouteSharePayload(
+            title: "Test Route",
+            summary: "summary",
+            placeLabel: "Bangkok",
+            category: .coffee,
+            durationMinutes: 90,
+            distanceMeters: 1200,
+            paceLabel: "Relaxed",
+            stopCount: coords.count,
+            walkedByCount: 0,
+            tags: [],
+            coordinates: coords
+        )
+    }
+}

--- a/apps/ios/SoloCompass/Views/Companion/RouteDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/RouteDetailView.swift
@@ -450,13 +450,18 @@ public struct RouteDetailView: View {
         }
     }
 
-    /// Pre-built payload for the share sheet — resolves the primary category and
-    /// stop count once so the sheet stays a pure visual layer.
+    /// Pre-built payload for the share sheet — resolves the primary category,
+    /// stop count, and ordered stop coordinates once so the sheet stays a pure
+    /// visual layer. Coordinates drive the map-basemap / vector-trace share card.
     private var sharePayload: RouteSharePayload {
-        RouteSharePayload(
+        let coordinates = liveRoute.experienceIds
+            .compactMap { service.getExperience(id: $0) }
+            .compactMap { $0.coordinate }
+        return RouteSharePayload(
             route: liveRoute,
             category: primaryCategory,
-            stopCount: liveRoute.experienceIds.count
+            stopCount: liveRoute.experienceIds.count,
+            coordinates: coordinates
         )
     }
 }

--- a/apps/ios/SoloCompass/Views/Companion/RouteShareSheet.swift
+++ b/apps/ios/SoloCompass/Views/Companion/RouteShareSheet.swift
@@ -1,296 +1,38 @@
 import SwiftUI
 import UIKit
 
-// MARK: - RouteSharePayload
-
-/// Pure-data input to the route share card. Decoupled from `Route` so the card
-/// can be previewed / rendered without standing up the experience service, and
-/// so the visual layer never reaches back into model logic.
-struct RouteSharePayload: Hashable {
-    let title: String
-    let summary: String
-    let placeLabel: String          // region / city, already human-readable
-    let category: ExperienceCategory // drives gradient + emoji (mirrors RouteDetailView hero)
-    let durationMinutes: Int
-    let distanceMeters: Int
-    let paceLabel: String
-    let stopCount: Int
-    let walkedByCount: Int
-    let tags: [String]
-    let brandHandle: String
-
-    init(
-        title: String,
-        summary: String,
-        placeLabel: String,
-        category: ExperienceCategory,
-        durationMinutes: Int,
-        distanceMeters: Int,
-        paceLabel: String,
-        stopCount: Int,
-        walkedByCount: Int,
-        tags: [String],
-        brandHandle: String = "solocompass.app"
-    ) {
-        self.title = title
-        self.summary = summary
-        self.placeLabel = placeLabel
-        self.category = category
-        self.durationMinutes = durationMinutes
-        self.distanceMeters = distanceMeters
-        self.paceLabel = paceLabel
-        self.stopCount = stopCount
-        self.walkedByCount = walkedByCount
-        self.tags = Array(tags.prefix(3))
-        self.brandHandle = brandHandle
-    }
-
-    /// Build from a `Route` plus its resolved primary category and stop count.
-    init(route: Route, category: ExperienceCategory, stopCount: Int) {
-        self.init(
-            title: route.title,
-            summary: route.summary,
-            placeLabel: route.region.isEmpty ? route.cityCode : route.region,
-            category: category,
-            durationMinutes: route.estimatedDuration,
-            distanceMeters: route.distanceMeters,
-            paceLabel: route.pace.localizedLabel,
-            stopCount: stopCount,
-            walkedByCount: route.verification.walkedByCount,
-            tags: route.tags
-        )
-    }
-
-    /// Human distance: "1.2 km" above 1000 m, else "650 m".
-    var distanceLabel: String {
-        if distanceMeters >= 1000 {
-            let km = Double(distanceMeters) / 1000
-            return String(format: "%.1f km", km)
-        }
-        return "\(distanceMeters) m"
-    }
-
-    /// Multi-line plain-text share body — the "copy as text" / fallback path.
-    var shareText: String {
-        var lines: [String] = []
-        lines.append("🧭 \(title)")
-        if !summary.isEmpty { lines.append(summary) }
-        var facts: [String] = []
-        if !placeLabel.isEmpty { facts.append("📍 \(placeLabel)") }
-        facts.append("⏱ \(durationMinutes) min")
-        facts.append("📏 \(distanceLabel)")
-        facts.append("👣 \(stopCount) \(NSLocalizedString("route.share.stops", comment: "stops unit"))")
-        lines.append(facts.joined(separator: "  ·  "))
-        if walkedByCount > 0 {
-            let fmt = NSLocalizedString("route.share.walkedBy", comment: "walked-by social proof")
-            lines.append(String(format: fmt, walkedByCount))
-        }
-        if !tags.isEmpty {
-            lines.append(tags.map { "#\($0)" }.joined(separator: " "))
-        }
-        lines.append("— \(brandHandle)")
-        return lines.joined(separator: "\n")
-    }
-}
-
-// MARK: - RouteShareCardView
-
-/// 1080×1920 portrait share card for a route. Mirrors the `RouteDetailView`
-/// hero language (category gradient + emoji) so a shared image reads as the
-/// same product. Laid out at half-pixel `renderSize`; `ImageRenderer` scales up.
-struct RouteShareCardView: View {
-    let payload: RouteSharePayload
-
-    /// On-screen render size in points (half of the 1080×1920 pixel target).
-    static let renderSize = CGSize(width: 540, height: 960)
-    static let renderScale: CGFloat = 2.0
-
-    var body: some View {
-        ZStack(alignment: .bottomLeading) {
-            CategoryVisual.gradient(for: payload.category)
-
-            // Subtle scrim so bottom text stays legible over bright gradients.
-            LinearGradient(
-                colors: [.clear, .black.opacity(0.35)],
-                startPoint: .center,
-                endPoint: .bottom
-            )
-
-            VStack(alignment: .leading, spacing: 0) {
-                // Top: emoji + brand
-                HStack(alignment: .top) {
-                    Text(CategoryVisual.emoji(for: payload.category))
-                        .font(.system(size: 64))
-                    Spacer()
-                    Text(NSLocalizedString("route.share.kicker", comment: "Route share card kicker"))
-                        .font(.system(size: 18, weight: .semibold))
-                        .tracking(2)
-                        .textCase(.uppercase)
-                        .foregroundStyle(.white.opacity(0.85))
-                }
-
-                Spacer(minLength: 0)
-
-                // Bottom block: title, summary, stats, tags, walked-by, brand
-                VStack(alignment: .leading, spacing: 18) {
-                    if !payload.placeLabel.isEmpty {
-                        Label(payload.placeLabel, systemImage: "mappin.circle.fill")
-                            .font(.system(size: 22, weight: .semibold))
-                            .foregroundStyle(.white.opacity(0.9))
-                    }
-
-                    Text(payload.title)
-                        .font(.system(size: 48, weight: .heavy))
-                        .foregroundStyle(.white)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .lineLimit(3)
-
-                    if !payload.summary.isEmpty {
-                        Text(payload.summary)
-                            .font(.system(size: 22))
-                            .foregroundStyle(.white.opacity(0.88))
-                            .lineLimit(3)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-
-                    statRow
-
-                    if payload.walkedByCount > 0 {
-                        let fmt = NSLocalizedString("route.share.walkedBy", comment: "walked-by social proof")
-                        Text(String(format: fmt, payload.walkedByCount))
-                            .font(.system(size: 20, weight: .medium))
-                            .foregroundStyle(.white.opacity(0.85))
-                    }
-
-                    if !payload.tags.isEmpty {
-                        HStack(spacing: 8) {
-                            ForEach(payload.tags, id: \.self) { tag in
-                                Text("#\(tag)")
-                                    .font(.system(size: 18, weight: .semibold))
-                                    .padding(.horizontal, 14)
-                                    .padding(.vertical, 7)
-                                    .background(Capsule().fill(.white.opacity(0.2)))
-                                    .foregroundStyle(.white)
-                            }
-                        }
-                    }
-
-                    Text(payload.brandHandle)
-                        .font(.system(size: 20, weight: .bold))
-                        .foregroundStyle(.white.opacity(0.95))
-                        .padding(.top, 4)
-                }
-            }
-            .padding(40)
-        }
-        .frame(width: Self.renderSize.width, height: Self.renderSize.height)
-    }
-
-    /// Three glass stat chips: duration · distance · stops.
-    private var statRow: some View {
-        HStack(spacing: 12) {
-            statChip(icon: "clock.fill", value: "\(payload.durationMinutes)",
-                     unit: NSLocalizedString("route.share.min", comment: "minutes unit"))
-            statChip(icon: "ruler.fill", value: payload.distanceLabel, unit: "")
-            statChip(icon: "figure.walk", value: "\(payload.stopCount)",
-                     unit: NSLocalizedString("route.share.stops", comment: "stops unit"))
-        }
-    }
-
-    private func statChip(icon: String, value: String, unit: String) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: icon)
-                .font(.system(size: 18, weight: .semibold))
-            Text(value)
-                .font(.system(size: 22, weight: .bold))
-            if !unit.isEmpty {
-                Text(unit)
-                    .font(.system(size: 16, weight: .medium))
-                    .opacity(0.8)
-            }
-        }
-        .foregroundStyle(.white)
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-        .background(Capsule().fill(.white.opacity(0.2)))
-    }
-}
-
-// MARK: - RouteShareRenderer
-
-/// Renders `RouteShareCardView` to a `UIImage` / temp PNG. Mirrors
-/// `ShareCardRenderer` so both share surfaces share the same pipeline shape.
-@MainActor
-enum RouteShareRenderer {
-    enum RenderError: Error {
-        case imageGenerationFailed
-        case pngEncodingFailed
-        case fileWriteFailed
-    }
-
-    static func renderImage(payload: RouteSharePayload) throws -> UIImage {
-        let view = RouteShareCardView(payload: payload)
-        let renderer = ImageRenderer(content: view)
-        renderer.scale = RouteShareCardView.renderScale
-        renderer.isOpaque = true
-        guard let image = renderer.uiImage else { throw RenderError.imageGenerationFailed }
-        return image
-    }
-
-    static func renderTempPNG(payload: RouteSharePayload) throws -> URL {
-        let image = try renderImage(payload: payload)
-        guard let data = image.pngData() else { throw RenderError.pngEncodingFailed }
-        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-        let filename = "solocompass-route-\(UUID().uuidString.prefix(8)).png"
-        let url = dir.appendingPathComponent(filename)
-        do {
-            try data.write(to: url, options: .atomic)
-        } catch {
-            throw RenderError.fileWriteFailed
-        }
-        return url
-    }
-}
-
 // MARK: - RouteShareSheet
 
-/// The route share entry point. Lets the traveler pick between a visual card
-/// (image) and a plain-text summary, preview it, then hand it to the system
-/// share sheet. Replaces the bare `ShareLink(item: title)` that only shared a
-/// title string.
+/// The route share entry point. Lets the traveler pick between a map-basemap
+/// card, a minimal vector trace card, and a plain-text summary, preview it,
+/// then hand it to the system share sheet.
+///
+/// `RouteSharePayload`, `RouteShareCardView`, and `RouteShareRenderer` live in
+/// `Views/Companion/Share/`.
 struct RouteShareSheet: View {
     let payload: RouteSharePayload
 
     @Environment(\.dismiss) private var dismiss
 
-    @State private var selectedMode: Mode = .card
+    @State private var selectedStyle: RouteShareStyle = .map
     @State private var previewImage: UIImage? = nil
+    @State private var isRendering = false
     @State private var activityItems: [Any]? = nil
     @State private var statusMessage: String? = nil
     @State private var statusIsError = false
-
-    enum Mode: String, CaseIterable, Identifiable {
-        case card
-        case text
-
-        var id: String { rawValue }
-        var label: String {
-            switch self {
-            case .card: return NSLocalizedString("route.share.mode.card", comment: "Visual card mode")
-            case .text: return NSLocalizedString("route.share.mode.text", comment: "Plain text mode")
-            }
-        }
-    }
+    /// Cache rendered cards per style so flipping back and forth is instant.
+    @State private var renderedCache: [RouteShareStyle: UIImage] = [:]
 
     var body: some View {
         NavigationStack {
             VStack(spacing: 16) {
-                modePicker
+                stylePicker
                 previewArea
                 if let status = statusMessage {
                     Text(status)
                         .font(.caption)
                         .foregroundStyle(statusIsError ? Color.red : Color.green)
+                        .multilineTextAlignment(.center)
                         .transition(.opacity)
                 }
                 actionButtons
@@ -313,23 +55,23 @@ struct RouteShareSheet: View {
         .presentationDetents([.large])
     }
 
-    // MARK: - Mode picker
+    // MARK: - Style picker
 
-    private var modePicker: some View {
+    private var stylePicker: some View {
         HStack(spacing: 10) {
-            ForEach(Mode.allCases) { mode in
+            ForEach(RouteShareStyle.allCases) { style in
                 Button {
-                    selectedMode = mode
+                    selectedStyle = style
                     statusMessage = nil
                 } label: {
-                    Text(mode.label)
+                    Text(style.label)
                         .font(.system(size: 13, weight: .semibold))
                         .padding(.horizontal, 16)
                         .padding(.vertical, 8)
                         .background(
-                            Capsule().fill(selectedMode == mode ? Color.accentColor : Color(.secondarySystemBackground))
+                            Capsule().fill(selectedStyle == style ? Color.accentColor : Color(.secondarySystemBackground))
                         )
-                        .foregroundStyle(selectedMode == mode ? .white : .primary)
+                        .foregroundStyle(selectedStyle == style ? .white : .primary)
                 }
                 .buttonStyle(.plain)
             }
@@ -340,9 +82,10 @@ struct RouteShareSheet: View {
 
     @ViewBuilder
     private var previewArea: some View {
-        switch selectedMode {
-        case .card: cardPreview
-        case .text: textPreview
+        if selectedStyle == .text {
+            textPreview
+        } else {
+            cardPreview
         }
     }
 
@@ -363,13 +106,27 @@ struct RouteShareSheet: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .task { await renderPreview() }
+        .task(id: selectedStyle) { await renderPreview() }
     }
 
     @MainActor
     private func renderPreview() async {
-        if previewImage != nil { return }
-        previewImage = try? RouteShareRenderer.renderImage(payload: payload)
+        guard selectedStyle.isVisualCard else { return }
+        if let cached = renderedCache[selectedStyle] {
+            previewImage = cached
+            return
+        }
+        previewImage = nil
+        isRendering = true
+        let result = await RouteShareRenderer.render(payload: payload, style: selectedStyle)
+        isRendering = false
+        // Cache under both requested and effective style so a fallback isn't re-fetched.
+        renderedCache[selectedStyle] = result.image
+        renderedCache[result.effectiveStyle] = result.image
+        previewImage = result.image
+        if result.didFallback {
+            flashStatus(NSLocalizedString("route.share.mapFallback", comment: "Map basemap unavailable hint"), error: false)
+        }
     }
 
     private var textPreview: some View {
@@ -388,16 +145,17 @@ struct RouteShareSheet: View {
 
     @ViewBuilder
     private var actionButtons: some View {
-        switch selectedMode {
-        case .card: cardActions
-        case .text: textActions
+        if selectedStyle == .text {
+            textActions
+        } else {
+            cardActions
         }
     }
 
     private var cardActions: some View {
         VStack(spacing: 10) {
             Button {
-                shareCard()
+                Task { await shareCard() }
             } label: {
                 Label(
                     NSLocalizedString("share.systemShare", comment: "Share via system sheet"),
@@ -406,6 +164,7 @@ struct RouteShareSheet: View {
                 .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent)
+            .disabled(isRendering)
 
             Button {
                 copyImage()
@@ -417,6 +176,7 @@ struct RouteShareSheet: View {
                 .frame(maxWidth: .infinity)
             }
             .buttonStyle(.bordered)
+            .disabled(previewImage == nil)
 
             Text(NSLocalizedString("share.saveHint", comment: "Hint to use Save Image in the system share sheet"))
                 .font(.caption2)
@@ -454,9 +214,11 @@ struct RouteShareSheet: View {
 
     // MARK: - Impl
 
-    private func shareCard() {
+    @MainActor
+    private func shareCard() async {
         do {
-            let url = try RouteShareRenderer.renderTempPNG(payload: payload)
+            let (url, result) = try await RouteShareRenderer.renderTempPNG(payload: payload, style: selectedStyle)
+            renderedCache[result.effectiveStyle] = result.image
             activityItems = [url]
         } catch {
             flashStatus(NSLocalizedString("share.renderFailed", comment: "Render failed"), error: true)
@@ -464,18 +226,17 @@ struct RouteShareSheet: View {
     }
 
     private func copyImage() {
-        do {
-            let image = try RouteShareRenderer.renderImage(payload: payload)
-            UIPasteboard.general.image = image
-            flashStatus(NSLocalizedString("share.imageCopied", comment: "Image copied"), error: false)
-        } catch {
+        guard let image = previewImage else {
             flashStatus(NSLocalizedString("share.renderFailed", comment: "Render failed"), error: true)
+            return
         }
+        UIPasteboard.general.image = image
+        flashStatus(NSLocalizedString("share.imageCopied", comment: "Image copied"), error: false)
     }
 
     private func flashStatus(_ message: String, error: Bool) {
         withAnimation { statusMessage = message; statusIsError = error }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
             withAnimation { statusMessage = nil }
         }
     }
@@ -501,16 +262,5 @@ private struct RouteActivityViewControllerWrapper: UIViewControllerRepresentable
 // MARK: - Preview
 
 #Preview {
-    RouteShareSheet(payload: RouteSharePayload(
-        title: "黄昏河岸慢走",
-        summary: "从老城咖啡馆出发，沿河散步到日落观景台，途经三处隐藏角落。",
-        placeLabel: "Bangkok",
-        category: .coffee,
-        durationMinutes: 120,
-        distanceMeters: 2400,
-        paceLabel: "Relaxed",
-        stopCount: 4,
-        walkedByCount: 37,
-        tags: ["sunset", "riverside", "coffee"]
-    ))
+    RouteShareSheet(payload: .preview)
 }

--- a/apps/ios/SoloCompass/Views/Companion/Share/RouteMapSnapshotter.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Share/RouteMapSnapshotter.swift
@@ -1,0 +1,74 @@
+import CoreLocation
+import MapKit
+import UIKit
+
+// MARK: - RouteMapSnapshotter
+
+/// Wraps `MKMapSnapshotter` to produce a dark-mode street basemap fitted to a
+/// route's stops. Async + timed-out + error-typed so the share sheet can fall
+/// back to the vector `trace` style when no snapshot can be produced (offline,
+/// throttled, error).
+@MainActor
+enum RouteMapSnapshotter {
+    enum SnapshotError: Error {
+        case noCoordinates
+        case snapshotFailed
+        case timedOut
+    }
+
+    /// Pure geometry: the smallest `MKMapRect` containing all stops, padded so
+    /// the polyline never touches the edge. At least ~500m of view to avoid a
+    /// single tightly-cropped point. `nonisolated` so it's unit-testable off the
+    /// main actor.
+    nonisolated static func boundingMapRect(_ coords: [CLLocationCoordinate2D], padding: Double = 0.25) -> MKMapRect {
+        guard !coords.isEmpty else { return .null }
+        let union = coords.reduce(MKMapRect.null) { acc, c in
+            let pt = MKMapPoint(c)
+            let r = MKMapRect(x: pt.x, y: pt.y, width: 0, height: 0)
+            return acc.union(r)
+        }
+        let dx = union.size.width * padding
+        let dy = union.size.height * padding
+        // ~500m floor expressed in map points so single/near-coincident stops
+        // still get geographic context instead of an over-zoomed crop.
+        let floor = MKMapPointsPerMeterAtLatitude(coords[0].latitude) * 500
+        return union.insetBy(dx: -max(dx, floor), dy: -max(dy, floor))
+    }
+
+    /// Render a basemap image of `size` (points) fitted to `coordinates`.
+    /// Forces dark mode so the white polyline halo reads on any tile.
+    static func snapshot(
+        coordinates: [CLLocationCoordinate2D],
+        size: CGSize,
+        scale: CGFloat,
+        timeout: TimeInterval = 4.0
+    ) async throws -> UIImage {
+        guard !coordinates.isEmpty else { throw SnapshotError.noCoordinates }
+
+        let options = MKMapSnapshotter.Options()
+        options.mapRect = boundingMapRect(coordinates)
+        options.size = size
+        options.scale = scale
+        options.pointOfInterestFilter = .excludingAll
+        options.traitCollection = UITraitCollection(userInterfaceStyle: .dark)
+
+        let snapshotter = MKMapSnapshotter(options: options)
+
+        return try await withThrowingTaskGroup(of: UIImage.self) { group in
+            group.addTask {
+                let snapshot = try await snapshotter.start()
+                return snapshot.image
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                throw SnapshotError.timedOut
+            }
+            // First to finish wins; cancel the loser.
+            guard let result = try await group.next() else {
+                throw SnapshotError.snapshotFailed
+            }
+            group.cancelAll()
+            return result
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Views/Companion/Share/RoutePolylineShape.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Share/RoutePolylineShape.swift
@@ -1,0 +1,90 @@
+import CoreLocation
+import SwiftUI
+
+// MARK: - RouteNormalizer
+
+/// Pure geometry: projects `[lon, lat]` coordinates into a unit square,
+/// preserving aspect ratio (letterboxed, centred) so the route shape is never
+/// stretched. Kept separate from the `Shape` so it can be unit-tested without UI.
+///
+/// Convention: project uses `[lon, lat]` (GeoJSON). Here `x = longitude`,
+/// `y = latitude`; `y` is flipped at draw time so north points up.
+enum RouteNormalizer {
+    /// Normalised points in `[0, 1]²`, aspect-preserved & centred.
+    /// Returns `[]` for empty input, a single centred point for one coordinate.
+    static func normalize(_ coordinates: [CLLocationCoordinate2D]) -> [CGPoint] {
+        guard !coordinates.isEmpty else { return [] }
+        guard coordinates.count > 1 else { return [CGPoint(x: 0.5, y: 0.5)] }
+
+        let lons = coordinates.map(\.longitude)
+        let lats = coordinates.map(\.latitude)
+        let minLon = lons.min()!, maxLon = lons.max()!
+        let minLat = lats.min()!, maxLat = lats.max()!
+
+        let spanLon = maxLon - minLon
+        let spanLat = maxLat - minLat
+        // Degenerate (all same lon or all same lat) → fall back to even spread.
+        let span = max(spanLon, spanLat)
+        guard span > 0 else {
+            return coordinates.enumerated().map { i, _ in
+                let t = coordinates.count == 1 ? 0.5 : Double(i) / Double(coordinates.count - 1)
+                return CGPoint(x: t, y: 0.5)
+            }
+        }
+
+        // Centre the smaller axis so the shape sits in the middle (letterbox).
+        let offLon = (span - spanLon) / 2
+        let offLat = (span - spanLat) / 2
+
+        return coordinates.map { c in
+            let nx = (c.longitude - minLon + offLon) / span
+            let ny = (c.latitude - minLat + offLat) / span
+            return CGPoint(x: nx, y: ny)
+        }
+    }
+
+    /// Maps unit points into `rect` (with inset padding), flipping y so north is up.
+    static func points(in rect: CGRect, normalized: [CGPoint], inset: CGFloat = 0.12) -> [CGPoint] {
+        guard !normalized.isEmpty else { return [] }
+        let pad = min(rect.width, rect.height) * inset
+        let inner = rect.insetBy(dx: pad, dy: pad)
+        return normalized.map { p in
+            CGPoint(
+                x: inner.minX + p.x * inner.width,
+                y: inner.minY + (1 - p.y) * inner.height // flip y → north up
+            )
+        }
+    }
+}
+
+// MARK: - RoutePolylineShape
+
+/// A `Shape` that draws the normalised route polyline inside its frame. Shared
+/// by the trace card (as the main visual) and the map card (as an overlay).
+struct RoutePolylineShape: Shape {
+    let coordinates: [CLLocationCoordinate2D]
+    var inset: CGFloat = 0.12
+
+    func path(in rect: CGRect) -> Path {
+        let pts = RouteNormalizer.points(
+            in: rect,
+            normalized: RouteNormalizer.normalize(coordinates),
+            inset: inset
+        )
+        var path = Path()
+        guard let first = pts.first else { return path }
+        path.move(to: first)
+        for p in pts.dropFirst() { path.addLine(to: p) }
+        return path
+    }
+}
+
+// MARK: - Numbered stop positions
+
+extension RouteNormalizer {
+    /// Convenience for placing numbered stop badges at the same projected points
+    /// the polyline passes through.
+    static func stopPoints(in rect: CGRect, coordinates: [CLLocationCoordinate2D], inset: CGFloat = 0.12) -> [CGPoint] {
+        points(in: rect, normalized: normalize(coordinates), inset: inset)
+    }
+}

--- a/apps/ios/SoloCompass/Views/Companion/Share/RouteShareCardView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Share/RouteShareCardView.swift
@@ -1,0 +1,360 @@
+import CoreLocation
+import SwiftUI
+import UIKit
+
+// MARK: - RouteShareCardView (dispatcher)
+
+/// 1080×1920 portrait share card for a route. Dispatches on `style`:
+///   - `.map`   → `RouteMapCard` (needs a pre-rendered `basemap` snapshot)
+///   - `.trace` → `RouteTraceCard` (pure vector, no basemap)
+///   - else     → `RouteGradientCard` (legacy fallback when no coordinates)
+///
+/// Laid out at half-pixel `renderSize`; `ImageRenderer` scales up by `renderScale`.
+/// Uses plain `VStack`/`ZStack` only — `ImageRenderer` does not expand
+/// Lazy/Scroll containers.
+struct RouteShareCardView: View {
+    let payload: RouteSharePayload
+    let style: RouteShareStyle
+    /// Pre-rendered MapKit basemap (only used by `.map`). Nil → map card falls
+    /// back to the trace look so the card is never blank.
+    var basemap: UIImage? = nil
+
+    static let renderSize = CGSize(width: 540, height: 960)
+    static let renderScale: CGFloat = 2.0
+
+    var body: some View {
+        Group {
+            if style == .map, let basemap, payload.hasAnyCoordinate {
+                RouteMapCard(payload: payload, basemap: basemap)
+            } else if (style == .map || style == .trace), payload.hasAnyCoordinate {
+                RouteTraceCard(payload: payload)
+            } else {
+                RouteGradientCard(payload: payload)
+            }
+        }
+        .frame(width: Self.renderSize.width, height: Self.renderSize.height)
+    }
+}
+
+// MARK: - Shared sub-components
+
+/// Top brand strip: compass mark + product name on the left, place on the right.
+private struct ShareBrandStrip: View {
+    let placeLabel: String
+
+    var body: some View {
+        HStack {
+            HStack(spacing: 8) {
+                Text("🧭").font(.system(size: 26))
+                Text(NSLocalizedString("route.share.kicker", comment: "Route share card kicker"))
+                    .font(.system(size: 16, weight: .bold))
+                    .tracking(2)
+                    .textCase(.uppercase)
+            }
+            Spacer()
+            if !placeLabel.isEmpty {
+                Label(placeLabel, systemImage: "mappin.circle.fill")
+                    .font(.system(size: 16, weight: .semibold))
+                    .lineLimit(1)
+            }
+        }
+        .foregroundStyle(.white.opacity(0.95))
+        .padding(.horizontal, 28)
+        .padding(.vertical, 16)
+        .background(Color.black.opacity(0.28))
+    }
+}
+
+/// Bottom text block: title, summary, stat chips, walked-by, tags, brand handle.
+private struct ShareTextBlock: View {
+    let payload: RouteSharePayload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(payload.title)
+                .font(.system(size: 44, weight: .heavy))
+                .foregroundStyle(.white)
+                .fixedSize(horizontal: false, vertical: true)
+                .lineLimit(3)
+
+            if !payload.summary.isEmpty {
+                Text(payload.summary)
+                    .font(.system(size: 21))
+                    .foregroundStyle(.white.opacity(0.88))
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            statRow
+
+            if payload.walkedByCount > 0 {
+                let fmt = NSLocalizedString("route.share.walkedBy", comment: "walked-by social proof")
+                Text(String(format: fmt, payload.walkedByCount))
+                    .font(.system(size: 19, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.85))
+            }
+
+            if !payload.tags.isEmpty {
+                HStack(spacing: 8) {
+                    ForEach(payload.tags, id: \.self) { tag in
+                        Text("#\(tag)")
+                            .font(.system(size: 17, weight: .semibold))
+                            .padding(.horizontal, 13)
+                            .padding(.vertical, 6)
+                            .background(Capsule().fill(.white.opacity(0.2)))
+                            .foregroundStyle(.white)
+                    }
+                }
+            }
+
+            Text(payload.brandHandle)
+                .font(.system(size: 19, weight: .bold))
+                .foregroundStyle(.white.opacity(0.95))
+                .padding(.top, 2)
+        }
+        .padding(28)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var statRow: some View {
+        HStack(spacing: 10) {
+            statChip(icon: "clock.fill", value: "\(payload.durationMinutes)",
+                     unit: NSLocalizedString("route.share.min", comment: "minutes unit"))
+            statChip(icon: "ruler.fill", value: payload.distanceLabel, unit: "")
+            statChip(icon: "figure.walk", value: "\(payload.stopCount)",
+                     unit: NSLocalizedString("route.share.stops", comment: "stops unit"))
+        }
+    }
+
+    private func statChip(icon: String, value: String, unit: String) -> some View {
+        HStack(spacing: 7) {
+            Image(systemName: icon).font(.system(size: 16, weight: .semibold))
+            Text(value).font(.system(size: 20, weight: .bold))
+            if !unit.isEmpty {
+                Text(unit).font(.system(size: 15, weight: .medium)).opacity(0.8)
+            }
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(Capsule().fill(.white.opacity(0.22)))
+    }
+}
+
+/// The route polyline drawn with a white halo + accent core, plus numbered stop
+/// badges. Reused as an overlay by both the map card and the trace card.
+private struct RoutePolylineOverlay: View {
+    let coordinates: [CLLocationCoordinate2D]
+    var lineWidth: CGFloat = 8
+    var haloWidth: CGFloat = 14
+
+    var body: some View {
+        GeometryReader { geo in
+            let rect = CGRect(origin: .zero, size: geo.size)
+            let stops = RouteNormalizer.stopPoints(in: rect, coordinates: coordinates)
+
+            ZStack {
+                if coordinates.count >= 2 {
+                    RoutePolylineShape(coordinates: coordinates)
+                        .stroke(.white, style: StrokeStyle(lineWidth: haloWidth, lineCap: .round, lineJoin: .round))
+                    RoutePolylineShape(coordinates: coordinates)
+                        .stroke(Color.accentColor, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round))
+                }
+                ForEach(Array(stops.enumerated()), id: \.offset) { index, point in
+                    StopBadge(number: index + 1, isFirst: index == 0, isLast: index == stops.count - 1)
+                        .position(point)
+                }
+            }
+        }
+    }
+}
+
+/// White circular badge with the stop number; start/end get a tinted ring.
+private struct StopBadge: View {
+    let number: Int
+    var isFirst: Bool = false
+    var isLast: Bool = false
+
+    var body: some View {
+        Text("\(number)")
+            .font(.system(size: 16, weight: .bold))
+            .foregroundStyle(Color.accentColor)
+            .frame(width: 32, height: 32)
+            .background(Circle().fill(.white))
+            .overlay(
+                Circle().stroke(ringColor, lineWidth: isFirst || isLast ? 3 : 0)
+            )
+            .shadow(color: .black.opacity(0.3), radius: 3, x: 0, y: 1)
+    }
+
+    private var ringColor: Color {
+        if isFirst { return .green }
+        if isLast { return .red }
+        return .clear
+    }
+}
+
+// MARK: - RouteMapCard
+
+/// Real street basemap with the route polyline + numbered stops on top.
+private struct RouteMapCard: View {
+    let payload: RouteSharePayload
+    let basemap: UIImage
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Image(uiImage: basemap)
+                .resizable()
+                .scaledToFill()
+                .clipped()
+
+            RoutePolylineOverlay(coordinates: payload.coordinates)
+
+            LinearGradient(
+                colors: [.clear, .black.opacity(0.2), .black.opacity(0.72)],
+                startPoint: .center,
+                endPoint: .bottom
+            )
+
+            VStack(spacing: 0) {
+                ShareBrandStrip(placeLabel: payload.placeLabel)
+                Spacer(minLength: 0)
+                ShareTextBlock(payload: payload)
+            }
+        }
+    }
+}
+
+// MARK: - RouteTraceCard
+
+/// No basemap: the polyline is drawn as a pure vector stroke over the category
+/// gradient. The fallback target when a snapshot can't be produced.
+private struct RouteTraceCard: View {
+    let payload: RouteSharePayload
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            CategoryVisual.gradient(for: payload.category)
+
+            TraceGridBackground()
+                .opacity(0.10)
+
+            RoutePolylineOverlay(coordinates: payload.coordinates)
+                .padding(.top, 90)
+                .padding(.bottom, 360)
+                .padding(.horizontal, 24)
+
+            LinearGradient(
+                colors: [.clear, .black.opacity(0.45)],
+                startPoint: .center,
+                endPoint: .bottom
+            )
+
+            VStack(spacing: 0) {
+                ShareBrandStrip(placeLabel: payload.placeLabel)
+                Spacer(minLength: 0)
+                ShareTextBlock(payload: payload)
+            }
+        }
+    }
+}
+
+/// Subtle grid backdrop for the trace card so empty space reads as "a map".
+private struct TraceGridBackground: View {
+    var body: some View {
+        GeometryReader { geo in
+            Path { path in
+                let step: CGFloat = 48
+                var x: CGFloat = 0
+                while x <= geo.size.width {
+                    path.move(to: .init(x: x, y: 0))
+                    path.addLine(to: .init(x: x, y: geo.size.height))
+                    x += step
+                }
+                var y: CGFloat = 0
+                while y <= geo.size.height {
+                    path.move(to: .init(x: 0, y: y))
+                    path.addLine(to: .init(x: geo.size.width, y: y))
+                    y += step
+                }
+            }
+            .stroke(.white, lineWidth: 0.5)
+        }
+    }
+}
+
+// MARK: - RouteGradientCard (legacy fallback)
+
+/// The original gradient-only card. Used when there are no usable coordinates.
+private struct RouteGradientCard: View {
+    let payload: RouteSharePayload
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            CategoryVisual.gradient(for: payload.category)
+            LinearGradient(colors: [.clear, .black.opacity(0.35)], startPoint: .center, endPoint: .bottom)
+            VStack(spacing: 0) {
+                HStack(alignment: .top) {
+                    Text(CategoryVisual.emoji(for: payload.category)).font(.system(size: 60))
+                    Spacer()
+                }
+                .padding(.horizontal, 28)
+                .padding(.top, 28)
+                Spacer(minLength: 0)
+                ShareTextBlock(payload: payload)
+            }
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Trace") {
+    RouteShareCardView(payload: .preview, style: .trace)
+        .scaleEffect(0.4)
+}
+
+#Preview("Gradient fallback") {
+    RouteShareCardView(payload: .previewNoCoords, style: .map)
+        .scaleEffect(0.4)
+}
+
+extension RouteSharePayload {
+    static var preview: RouteSharePayload {
+        RouteSharePayload(
+            title: "黄昏河岸慢走",
+            summary: "从老城咖啡馆出发，沿河散步到日落观景台。",
+            placeLabel: "Bangkok",
+            category: .coffee,
+            durationMinutes: 120,
+            distanceMeters: 2400,
+            paceLabel: "Relaxed",
+            stopCount: 5,
+            walkedByCount: 37,
+            tags: ["sunset", "riverside", "coffee"],
+            coordinates: [
+                .init(latitude: 13.7460, longitude: 100.4980),
+                .init(latitude: 13.7510, longitude: 100.5030),
+                .init(latitude: 13.7490, longitude: 100.5100),
+                .init(latitude: 13.7440, longitude: 100.5140),
+                .init(latitude: 13.7400, longitude: 100.5120),
+            ]
+        )
+    }
+
+    static var previewNoCoords: RouteSharePayload {
+        RouteSharePayload(
+            title: "黄昏河岸慢走",
+            summary: "从老城咖啡馆出发。",
+            placeLabel: "Bangkok",
+            category: .coffee,
+            durationMinutes: 120,
+            distanceMeters: 2400,
+            paceLabel: "Relaxed",
+            stopCount: 5,
+            walkedByCount: 37,
+            tags: ["sunset"],
+            coordinates: []
+        )
+    }
+}

--- a/apps/ios/SoloCompass/Views/Companion/Share/RouteSharePayload.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Share/RouteSharePayload.swift
@@ -1,0 +1,140 @@
+import CoreLocation
+import Foundation
+
+// MARK: - RouteSharePayload
+
+/// Pure-data input to the route share card. Decoupled from `Route` so the card
+/// can be previewed / rendered without standing up the experience service, and
+/// so the visual layer never reaches back into model logic.
+///
+/// `coordinates` are the route's stops in walking order (`[lon, lat]` →
+/// `CLLocationCoordinate2D`). They drive the map snapshot and the vector trace.
+/// An empty array means coordinates couldn't be resolved → caller falls back to
+/// the gradient card.
+struct RouteSharePayload: Hashable {
+    let title: String
+    let summary: String
+    let placeLabel: String          // region / city, already human-readable
+    let category: ExperienceCategory // drives gradient + emoji (mirrors RouteDetailView hero)
+    let durationMinutes: Int
+    let distanceMeters: Int
+    let paceLabel: String
+    let stopCount: Int
+    let walkedByCount: Int
+    let tags: [String]
+    let brandHandle: String
+    let coordinates: [CLLocationCoordinate2D]
+
+    init(
+        title: String,
+        summary: String,
+        placeLabel: String,
+        category: ExperienceCategory,
+        durationMinutes: Int,
+        distanceMeters: Int,
+        paceLabel: String,
+        stopCount: Int,
+        walkedByCount: Int,
+        tags: [String],
+        coordinates: [CLLocationCoordinate2D] = [],
+        brandHandle: String = "solocompass.app"
+    ) {
+        self.title = title
+        self.summary = summary
+        self.placeLabel = placeLabel
+        self.category = category
+        self.durationMinutes = durationMinutes
+        self.distanceMeters = distanceMeters
+        self.paceLabel = paceLabel
+        self.stopCount = stopCount
+        self.walkedByCount = walkedByCount
+        self.tags = Array(tags.prefix(3))
+        self.coordinates = coordinates
+        self.brandHandle = brandHandle
+    }
+
+    /// Build from a `Route` plus its resolved primary category, stop count, and
+    /// ordered stop coordinates.
+    init(route: Route, category: ExperienceCategory, stopCount: Int, coordinates: [CLLocationCoordinate2D]) {
+        self.init(
+            title: route.title,
+            summary: route.summary,
+            placeLabel: route.region.isEmpty ? route.cityCode : route.region,
+            category: category,
+            durationMinutes: route.estimatedDuration,
+            distanceMeters: route.distanceMeters,
+            paceLabel: route.pace.localizedLabel,
+            stopCount: stopCount,
+            walkedByCount: route.verification.walkedByCount,
+            tags: route.tags,
+            coordinates: coordinates
+        )
+    }
+
+    /// True when there are enough points to draw a line (vs. a single pin).
+    var hasDrawableRoute: Bool { coordinates.count >= 2 }
+
+    /// True when at least one coordinate resolved (map / trace are possible).
+    var hasAnyCoordinate: Bool { !coordinates.isEmpty }
+
+    /// Human distance: "1.2 km" above 1000 m, else "650 m".
+    var distanceLabel: String {
+        if distanceMeters >= 1000 {
+            let km = Double(distanceMeters) / 1000
+            return String(format: "%.1f km", km)
+        }
+        return "\(distanceMeters) m"
+    }
+
+    /// Multi-line plain-text share body — the "copy as text" / fallback path.
+    var shareText: String {
+        var lines: [String] = []
+        lines.append("🧭 \(title)")
+        if !summary.isEmpty { lines.append(summary) }
+        var facts: [String] = []
+        if !placeLabel.isEmpty { facts.append("📍 \(placeLabel)") }
+        facts.append("⏱ \(durationMinutes) min")
+        facts.append("📏 \(distanceLabel)")
+        facts.append("👣 \(stopCount) \(NSLocalizedString("route.share.stops", comment: "stops unit"))")
+        lines.append(facts.joined(separator: "  ·  "))
+        if walkedByCount > 0 {
+            let fmt = NSLocalizedString("route.share.walkedBy", comment: "walked-by social proof")
+            lines.append(String(format: fmt, walkedByCount))
+        }
+        if !tags.isEmpty {
+            lines.append(tags.map { "#\($0)" }.joined(separator: " "))
+        }
+        lines.append("— \(brandHandle)")
+        return lines.joined(separator: "\n")
+    }
+}
+
+// MARK: - Hashable conformance
+
+extension RouteSharePayload {
+    static func == (lhs: RouteSharePayload, rhs: RouteSharePayload) -> Bool {
+        lhs.title == rhs.title &&
+        lhs.summary == rhs.summary &&
+        lhs.placeLabel == rhs.placeLabel &&
+        lhs.category == rhs.category &&
+        lhs.durationMinutes == rhs.durationMinutes &&
+        lhs.distanceMeters == rhs.distanceMeters &&
+        lhs.paceLabel == rhs.paceLabel &&
+        lhs.stopCount == rhs.stopCount &&
+        lhs.walkedByCount == rhs.walkedByCount &&
+        lhs.tags == rhs.tags &&
+        lhs.brandHandle == rhs.brandHandle &&
+        lhs.coordinates.count == rhs.coordinates.count &&
+        zip(lhs.coordinates, rhs.coordinates).allSatisfy {
+            $0.latitude == $1.latitude && $0.longitude == $1.longitude
+        }
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
+        hasher.combine(summary)
+        hasher.combine(stopCount)
+        hasher.combine(distanceMeters)
+        hasher.combine(coordinates.count)
+    }
+}

--- a/apps/ios/SoloCompass/Views/Companion/Share/RouteShareRenderer.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Share/RouteShareRenderer.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+import UIKit
+
+// MARK: - RouteShareRenderer
+
+/// Renders `RouteShareCardView` to a `UIImage` / temp PNG.
+///
+/// `map` style is async because it first obtains an `MKMapSnapshotter` basemap;
+/// on snapshot failure it transparently falls back to the `trace` style so the
+/// pipeline never returns a blank or throws to the UI. The returned
+/// `RenderResult` reports which style actually rendered so the sheet can show a
+/// "fell back to minimal line" hint.
+@MainActor
+enum RouteShareRenderer {
+    enum RenderError: Error {
+        case imageGenerationFailed
+        case pngEncodingFailed
+        case fileWriteFailed
+    }
+
+    struct RenderResult {
+        let image: UIImage
+        /// The style that was actually rendered (may differ from requested on fallback).
+        let effectiveStyle: RouteShareStyle
+        /// True when a `.map` request had to fall back to `.trace`.
+        let didFallback: Bool
+    }
+
+    /// Render the card for `style`. Handles the map-snapshot + fallback chain.
+    static func render(payload: RouteSharePayload, style: RouteShareStyle) async -> RenderResult {
+        let size = RouteShareCardView.renderSize
+        let scale = RouteShareCardView.renderScale
+
+        // Map style: try the basemap snapshot first.
+        if style == .map, payload.hasAnyCoordinate {
+            if let basemap = try? await RouteMapSnapshotter.snapshot(
+                coordinates: payload.coordinates,
+                size: size,
+                scale: scale
+            ), let image = rasterize(payload: payload, style: .map, basemap: basemap) {
+                return RenderResult(image: image, effectiveStyle: .map, didFallback: false)
+            }
+            // Snapshot failed → fall back to trace.
+            if let image = rasterize(payload: payload, style: .trace, basemap: nil) {
+                return RenderResult(image: image, effectiveStyle: .trace, didFallback: true)
+            }
+        }
+
+        // Trace / gradient-fallback path (also covers map with no coords).
+        let resolved: RouteShareStyle = (style == .map && !payload.hasAnyCoordinate) ? .trace : style
+        if let image = rasterize(payload: payload, style: resolved, basemap: nil) {
+            return RenderResult(image: image, effectiveStyle: resolved, didFallback: style != resolved)
+        }
+
+        // Last-ditch: empty image so we never crash the UI (should be unreachable).
+        return RenderResult(image: UIImage(), effectiveStyle: resolved, didFallback: true)
+    }
+
+    /// Synchronous SwiftUI → UIImage rasterisation for a fully-resolved card.
+    private static func rasterize(payload: RouteSharePayload, style: RouteShareStyle, basemap: UIImage?) -> UIImage? {
+        let view = RouteShareCardView(payload: payload, style: style, basemap: basemap)
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = RouteShareCardView.renderScale
+        renderer.isOpaque = true
+        return renderer.uiImage
+    }
+
+    /// Render and persist a temp PNG (the system-share path).
+    static func renderTempPNG(payload: RouteSharePayload, style: RouteShareStyle) async throws -> (URL, RenderResult) {
+        let result = await render(payload: payload, style: style)
+        guard let data = result.image.pngData() else { throw RenderError.pngEncodingFailed }
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let filename = "solocompass-route-\(UUID().uuidString.prefix(8)).png"
+        let url = dir.appendingPathComponent(filename)
+        do {
+            try data.write(to: url, options: .atomic)
+        } catch {
+            throw RenderError.fileWriteFailed
+        }
+        return (url, result)
+    }
+}

--- a/apps/ios/SoloCompass/Views/Companion/Share/RouteShareStyle.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Share/RouteShareStyle.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+// MARK: - RouteShareStyle
+
+/// The three ways a route can be exported from `RouteShareSheet`.
+///
+/// - `map`:   real MapKit street basemap (`MKMapSnapshotter`) with the route
+///            polyline + numbered stops drawn on top — Strava / Komoot feel.
+/// - `trace`: no basemap; the polyline is normalised and drawn as a pure vector
+///            stroke over the category gradient — minimal / 小红书 feel. Also the
+///            fallback target when a snapshot can't be produced (offline, error).
+/// - `text`:  the existing multi-line plain-text summary.
+enum RouteShareStyle: String, CaseIterable, Identifiable {
+    case map
+    case trace
+    case text
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .map:
+            return NSLocalizedString("route.share.style.map", comment: "Map basemap card style")
+        case .trace:
+            return NSLocalizedString("route.share.style.trace", comment: "Minimal vector line card style")
+        case .text:
+            return NSLocalizedString("route.share.mode.text", comment: "Plain text mode")
+        }
+    }
+
+    /// Whether this style renders a visual image (vs. plain text).
+    var isVisualCard: Bool {
+        self != .text
+    }
+}

--- a/docs/design/route-map-share-card.md
+++ b/docs/design/route-map-share-card.md
@@ -44,14 +44,14 @@
 
 ### 已有可复用资产
 
-| 资产 | 位置 | 复用方式 |
-| --- | --- | --- |
-| 分享管线 (renderImage/renderTempPNG) | `RouteShareSheet.swift:224` | 几乎不动,只替换被渲染的 View |
-| 风格切换 UI (modePicker) | `RouteShareSheet.swift:318` | 扩成三档:地图卡 / 极简线 / 文本 |
-| polyline 坐标解析 | `RouteDetailView.swift:66` 的 `service.getExperience(id:)` | 抽成 payload 构建逻辑 |
-| 地图 polyline 绘制约定 | `CompassMapView.swift:1190` (MapPolyline + 编号 badge) | 视觉语言对齐(accentColor 4pt 线 + 编号停靠点) |
-| 分类渐变/emoji | `CategoryVisual` | 作为 fallback / 极简风格背景 |
-| Experience 坐标 | `Experience.coordinate: CLLocationCoordinate2D?` | `[lon,lat]` 约定,直接取 |
+| 资产                                 | 位置                                                       | 复用方式                                      |
+| ------------------------------------ | ---------------------------------------------------------- | --------------------------------------------- |
+| 分享管线 (renderImage/renderTempPNG) | `RouteShareSheet.swift:224`                                | 几乎不动,只替换被渲染的 View                  |
+| 风格切换 UI (modePicker)             | `RouteShareSheet.swift:318`                                | 扩成三档:地图卡 / 极简线 / 文本               |
+| polyline 坐标解析                    | `RouteDetailView.swift:66` 的 `service.getExperience(id:)` | 抽成 payload 构建逻辑                         |
+| 地图 polyline 绘制约定               | `CompassMapView.swift:1190` (MapPolyline + 编号 badge)     | 视觉语言对齐(accentColor 4pt 线 + 编号停靠点) |
+| 分类渐变/emoji                       | `CategoryVisual`                                           | 作为 fallback / 极简风格背景                  |
+| Experience 坐标                      | `Experience.coordinate: CLLocationCoordinate2D?`           | `[lon,lat]` 约定,直接取                       |
 
 ---
 
@@ -111,6 +111,7 @@
 ```
 
 要点:
+
 - **底图**:`MKMapSnapshotter`,`MKMapConfiguration` 用 `.standard`,
   `traitCollection` 强制 `.dark`(深色街道更出片,且白色 polyline 对比强)。
 - **mapRect**:由所有停靠点坐标算外接 `MKMapRect`,四周加 ~25% padding,
@@ -144,6 +145,7 @@
 ```
 
 要点:
+
 - 复用 `CategoryVisual.gradient(for:)` 作背景(与 RouteDetailView hero 一致)。
 - polyline 用 SwiftUI `Path` 绘制:把坐标 **等比归一化** 到一个居中安全区
   (保持经纬度宽高比,避免拉伸变形)。
@@ -218,6 +220,7 @@ func boundingMapRect(_ coords: [CLLocationCoordinate2D], padding: Double = 0.25)
 ### 4.4 坐标 → 归一化 Path(极简风 & 叠加层)
 
 把 `[CLLocationCoordinate2D]` 投影到单位坐标系再映射到绘制 `rect`:
+
 - 经度→x,纬度→y(y 翻转,北在上)。
 - **等比缩放**:取 lon/lat 跨度的较大者作统一比例,letterbox 居中,避免变形。
 - 输出 `Path`,供 `RoutePolylineShape: Shape` 使用。
@@ -229,13 +232,13 @@ func boundingMapRect(_ coords: [CLLocationCoordinate2D], padding: Double = 0.25)
 
 ## 5. 降级策略(关键)
 
-| 触发条件 | 行为 |
-| --- | --- |
-| `coordinates.count >= 2` 且快照成功 | **Map 风格**正常渲染 |
-| `MKMapSnapshotter` 失败/超时(>4s) | 回退 **Trace 风格**,状态条提示「地图底图不可用,已用极简线条」 |
-| `coordinates.count == 1` | 单点:Map 风格只放一个停靠点 pin(无线);Trace 风格画单点 |
+| 触发条件                                 | 行为                                                                         |
+| ---------------------------------------- | ---------------------------------------------------------------------------- |
+| `coordinates.count >= 2` 且快照成功      | **Map 风格**正常渲染                                                         |
+| `MKMapSnapshotter` 失败/超时(>4s)        | 回退 **Trace 风格**,状态条提示「地图底图不可用,已用极简线条」                |
+| `coordinates.count == 1`                 | 单点:Map 风格只放一个停靠点 pin(无线);Trace 风格画单点                       |
 | `coordinates.count == 0`(坐标全解析失败) | 回退到**旧渐变卡**(现有 `RouteShareCardView` 逻辑保留为 `RouteGradientCard`) |
-| 用户手动选 Trace | 直接 Trace,不尝试快照 |
+| 用户手动选 Trace                         | 直接 Trace,不尝试快照                                                        |
 
 降级是**静默且有提示**的,绝不空白或崩溃(参照 memory 中「幽灵 SF Symbol /
 死 FAB」的教训:渲染失败要可见)。
@@ -269,7 +272,7 @@ func boundingMapRect(_ coords: [CLLocationCoordinate2D], padding: Double = 0.25)
 - **ImageRenderer 不展开 LazyVStack/ScrollView**(memory 教训):卡片内用
   `VStack` 不要用 Lazy/Scroll。
 - **深色 trait 注入**:`MKMapSnapshotter.Options.traitCollection =
-  UITraitCollection(userInterfaceStyle: .dark)`,否则浅色底图上白 halo 不明显。
+UITraitCollection(userInterfaceStyle: .dark)`,否则浅色底图上白 halo 不明显。
 - **坐标系别搞反**:`[lon,lat]` vs `[lat,lng]`,归一化 x=lon、y=lat。
 - **文件行数**:拆分到 ≤400 行/文件,符合项目约定。
 - **新增测试文件需 `xcodegen`**(memory 教训):新建 `.swift` 测试后务必

--- a/docs/design/route-map-share-card.md
+++ b/docs/design/route-map-share-card.md
@@ -1,0 +1,290 @@
+# 路线地图分享卡片 — 设计文档
+
+> 让「分享路线」的卡片把地图上那条连线本身作为视觉主体分享出去,
+> 对标 Strava / Komoot / AllTrails / 小红书旅行博主的顶级路线分享卡。
+
+- **作者**: Claude (设计交付)
+- **日期**: 2026-06-06
+- **分支**: `fix/preview-card-unified-flow`(实现时另开 `feat/route-map-share-card`)
+- **状态**: 待实现
+
+---
+
+## 1. 问题陈述
+
+### 现状
+
+`RouteShareSheet.swift` 已有完整的分享管线(`ImageRenderer` → `UIImage`/PNG →
+`UIActivityViewController` + 剪贴板),并支持 `.card` / `.text` 两种模式。但
+`.card` 模式的 `RouteShareCardView` 用的是 **分类渐变背景 + emoji + 统计芯片**,
+**完全没有展示路线在地图上的实际形状**。
+
+```
+当前 RouteShareCardView(540×960 → 1080×1920):
+┌─────────────────────┐
+│ 🍵            ROUTE  │   ← emoji + kicker
+│                     │
+│                     │   ← 一大片纯渐变,信息密度低
+│ 📍 Bangkok          │
+│ 黄昏河岸慢走         │   ← 标题
+│ 从老城咖啡馆出发…    │   ← 摘要
+│ [⏱2h][📏2.4km][👣4] │   ← 统计芯片
+│ 37 位旅人走过        │
+│ #sunset #riverside  │
+│ solocompass.app     │
+└─────────────────────┘
+```
+
+### 痛点
+
+顶级路线分享卡的**视觉核心永远是那条线本身** —— 用户一眼就能看出
+「这是一条沿河的环线 / 这是一段穿城的直线」。当前卡片把最有辨识度、最值得
+炫耀的资产(路线形状)丢掉了,退化成一张「带统计数字的渐变海报」,和任何
+一张普通体验卡没有区别。
+
+### 已有可复用资产
+
+| 资产 | 位置 | 复用方式 |
+| --- | --- | --- |
+| 分享管线 (renderImage/renderTempPNG) | `RouteShareSheet.swift:224` | 几乎不动,只替换被渲染的 View |
+| 风格切换 UI (modePicker) | `RouteShareSheet.swift:318` | 扩成三档:地图卡 / 极简线 / 文本 |
+| polyline 坐标解析 | `RouteDetailView.swift:66` 的 `service.getExperience(id:)` | 抽成 payload 构建逻辑 |
+| 地图 polyline 绘制约定 | `CompassMapView.swift:1190` (MapPolyline + 编号 badge) | 视觉语言对齐(accentColor 4pt 线 + 编号停靠点) |
+| 分类渐变/emoji | `CategoryVisual` | 作为 fallback / 极简风格背景 |
+| Experience 坐标 | `Experience.coordinate: CLLocationCoordinate2D?` | `[lon,lat]` 约定,直接取 |
+
+---
+
+## 2. 设计目标
+
+1. **路线形状是主角**:连线占据卡片视觉中心 ≥50% 面积。
+2. **两种风格可切换**(用户已确认):
+   - **地图底图风(Map)**:`MKMapSnapshotter` 截取真实街道底图,polyline + 编号
+     停靠点叠加其上 —— Strava/Komoot 质感。
+   - **极简线条风(Trace)**:无底图,把 polyline 归一化后画成纯矢量描边线 +
+     编号停靠点,配品牌渐变背景 —— 小红书/极简卡片质感。
+3. **复用现有分享管线**:产物仍是 `UIImage` / 临时 PNG,经
+   `UIActivityViewController` 分享或复制到剪贴板。不碰系统分享桥接层。
+4. **健壮降级**:坐标 <2 点、快照失败、深色模式 → 优雅回退到极简风,再不行
+   回退到旧的渐变卡,绝不空白或崩溃。
+5. **不阻塞 UI**:`MKMapSnapshotter` 是异步的,预览区显示 `ProgressView`,渲染
+   完成后填充;失败有明确状态提示。
+
+### 非目标
+
+- 不做实时可拖拽编辑路线(那是 RouteDetailView 的事)。
+- 不做服务端渲染 / 短链分享落地页(未来工作,留扩展点)。
+- 不改 Route 数据模型。
+
+---
+
+## 3. 视觉规格
+
+### 3.1 画布
+
+沿用现有 `renderSize = 540×960` (pt),`renderScale = 2.0` → **1080×1920 px**
+(竖版 9:16,适配 IG Story / 小红书 / 微信)。
+
+### 3.2 地图底图风(Map style)
+
+```
+┌───────────────────────────────┐  1080×1920
+│ 🧭 SOLO COMPASS      Bangkok   │  ← 顶部品牌条(56pt 高,半透明黑底)
+├───────────────────────────────┤
+│░░░░░░ MKMapSnapshotter ░░░░░░░│
+│░░░░░  真实街道底图(深色)  ░░░░│
+│░░░   ②───────③             ░░│  ← polyline: accentColor 主线 8pt
+│░░   ╱           ╲           ░░│     + 白色外描边 12pt(描边halo,保证任何
+│░░  ①             ④──────⑤  ░░│       底图上都清晰)
+│░░░  编号停靠点圆徽(白底accent数字)│
+│░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│
+│        (地图占 ~62% 高度)      │
+├───────────────────────────────┤
+│ 黄昏河岸慢走                   │  ← 标题区(渐变 scrim 压底)
+│ 从老城咖啡馆出发,沿河散步…     │
+│ ┌────┐┌──────┐┌────┐         │
+│ │⏱2h ││📏2.4km││👣5站│        │  ← 统计芯片(玻璃)
+│ └────┘└──────┘└────┘         │
+│ 37 位旅人走过 · #sunset        │
+│ solocompass.app               │
+└───────────────────────────────┘
+```
+
+要点:
+- **底图**:`MKMapSnapshotter`,`MKMapConfiguration` 用 `.standard`,
+  `traitCollection` 强制 `.dark`(深色街道更出片,且白色 polyline 对比强)。
+- **mapRect**:由所有停靠点坐标算外接 `MKMapRect`,四周加 ~25% padding,
+  保证线不贴边。单城内通常 1~3km 跨度。
+- **polyline 双层描边**:先画白色 12pt(halo),再画 accentColor 8pt(主线),
+  圆角 lineCap/lineJoin —— 这是 Strava/Komoot 在任意底图上保持可读的标准做法。
+- **停靠点徽章**:白底圆 + accentColor 数字,直径 ~34pt,起点/终点可用
+  旗标(`flag.fill`)区分(可选 v2)。
+- **scrim**:底部 40% 高度的 `clear→black(0.55)` 线性渐变,保证文字在任何
+  底图上可读。
+
+### 3.3 极简线条风(Trace style)
+
+```
+┌───────────────────────────────┐
+│ 🧭 SOLO COMPASS      Bangkok   │
+│                               │
+│      品牌分类渐变背景          │
+│        ②╲                     │  ← polyline 归一化到中心安全区,
+│          ╲___③                │     纯矢量描边(白 10pt + 投影)
+│   ①          ╲                │     无真实底图
+│                ╲___④___⑤      │
+│      编号停靠点(白圈accent字)  │
+│                               │
+│ 黄昏河岸慢走                   │
+│ 从老城咖啡馆出发…              │
+│ [⏱2h][📏2.4km][👣5站]         │
+│ 37 位旅人走过                  │
+│ solocompass.app               │
+└───────────────────────────────┘
+```
+
+要点:
+- 复用 `CategoryVisual.gradient(for:)` 作背景(与 RouteDetailView hero 一致)。
+- polyline 用 SwiftUI `Path` 绘制:把坐标 **等比归一化** 到一个居中安全区
+  (保持经纬度宽高比,避免拉伸变形)。
+- 同步渲染、无网络、最快最稳 → 作为 Map 风格失败时的**降级目标**。
+
+### 3.4 颜色 / 字体
+
+沿用现有卡片 token:`accentColor` 主线,`SpaceGrotesk-Bold`(若已注册,标题)
+或 `.system(.heavy)`;统计芯片复用现有 `statChip` 玻璃样式。
+
+---
+
+## 4. 架构与数据流
+
+### 4.1 新增 / 改动文件
+
+```
+Views/Companion/Share/                    ← 新建子目录(从 RouteShareSheet.swift 拆分)
+  RouteSharePayload.swift        [改]  payload 加 coordinates: [CLLocationCoordinate2D]
+  RouteShareStyle.swift          [新]  enum: map / trace / text
+  RouteMapSnapshotter.swift      [新]  MKMapSnapshotter 封装(async, 错误处理, mapRect 计算)
+  RoutePolylineShape.swift       [新]  SwiftUI Shape: 坐标归一化 → Path(给 trace 风格 & 叠加层共用)
+  RouteShareCardView.swift       [改]  按 style 分派:RouteMapCard / RouteTraceCard
+  RouteShareRenderer.swift       [改]  renderImage 改 async(因 snapshotter 异步)
+  RouteShareSheet.swift          [改]  modePicker 三档;预览异步加载;降级逻辑
+Views/Companion/RouteDetailView.swift  [改]  sharePayload 解析 stop 坐标传入
+Resources/en.lproj/Localizable.strings [改]  新增风格名 / 状态文案 key
+Tests/RouteShareCardTests.swift        [新]  payload 构建 / 归一化 / 降级 单测
+```
+
+> 注:为遵守「文件 200–400 行」约定,把当前 517 行的 `RouteShareSheet.swift`
+> 拆成上述多个文件。
+
+### 4.2 数据流
+
+```
+RouteDetailView
+  │  liveRoute.experienceIds
+  ▼
+service.getExperience(id:) → [Experience]
+  │  .compactMap { $0.coordinate }   // [lon,lat] → CLLocationCoordinate2D
+  ▼
+RouteSharePayload(route:, category:, stopCount:, coordinates:)   // 新增 coordinates
+  │
+  ▼
+RouteShareSheet  ──(style)──►  RouteShareCardView
+                                 ├─ .map   → RouteMapCard
+                                 │            └─ RouteMapSnapshotter.snapshot(coordinates:) async
+                                 │                 └─ 叠加 RoutePolylineShape + 编号 badge
+                                 ├─ .trace → RouteTraceCard
+                                 │            └─ RoutePolylineShape(归一化) 直接画
+                                 └─ .text  → 现有 shareText
+  │
+  ▼
+RouteShareRenderer.renderImage(payload:, style:) async → UIImage → PNG → 系统分享
+```
+
+### 4.3 坐标 → mapRect(地图风)
+
+```swift
+// 所有停靠点的外接矩形 + 25% padding
+func boundingMapRect(_ coords: [CLLocationCoordinate2D], padding: Double = 0.25) -> MKMapRect {
+    let rects = coords.map { MKMapRect(origin: MKMapPoint($0), size: .init(width: 0, height: 0)) }
+    var union = rects.reduce(MKMapRect.null) { $0.union($1) }
+    let dx = union.size.width * padding
+    let dy = union.size.height * padding
+    union = union.insetBy(dx: -max(dx, 1_000), dy: -max(dy, 1_000)) // 至少 ~1km 视野,避免单点贴脸
+    return union
+}
+```
+
+### 4.4 坐标 → 归一化 Path(极简风 & 叠加层)
+
+把 `[CLLocationCoordinate2D]` 投影到单位坐标系再映射到绘制 `rect`:
+- 经度→x,纬度→y(y 翻转,北在上)。
+- **等比缩放**:取 lon/lat 跨度的较大者作统一比例,letterbox 居中,避免变形。
+- 输出 `Path`,供 `RoutePolylineShape: Shape` 使用。
+
+> ⚠️ 坐标约定:项目用 `[lon, lat]`(GeoJSON)。`Experience.coordinate` 已转成
+> `CLLocationCoordinate2D(latitude:longitude:)`,在归一化时 **x=longitude, y=latitude**。
+
+---
+
+## 5. 降级策略(关键)
+
+| 触发条件 | 行为 |
+| --- | --- |
+| `coordinates.count >= 2` 且快照成功 | **Map 风格**正常渲染 |
+| `MKMapSnapshotter` 失败/超时(>4s) | 回退 **Trace 风格**,状态条提示「地图底图不可用,已用极简线条」 |
+| `coordinates.count == 1` | 单点:Map 风格只放一个停靠点 pin(无线);Trace 风格画单点 |
+| `coordinates.count == 0`(坐标全解析失败) | 回退到**旧渐变卡**(现有 `RouteShareCardView` 逻辑保留为 `RouteGradientCard`) |
+| 用户手动选 Trace | 直接 Trace,不尝试快照 |
+
+降级是**静默且有提示**的,绝不空白或崩溃(参照 memory 中「幽灵 SF Symbol /
+死 FAB」的教训:渲染失败要可见)。
+
+---
+
+## 6. 实现步骤(TDD 顺序)
+
+1. **抽 payload**:`RouteSharePayload` 加 `coordinates: [CLLocationCoordinate2D]`;
+   `init(route:category:stopCount:coordinates:)`。`RouteDetailView.sharePayload`
+   解析 stop 坐标传入。→ 单测:坐标解析 / 空降级。
+2. **RoutePolylineShape**:归一化 + Path。→ 单测:已知坐标 → 预期归一化点(等比、
+   不变形、y 翻转)。
+3. **RouteTraceCard**:纯矢量风格(无异步,先做,易测)。`#Preview`。
+4. **RouteMapSnapshotter**:async 封装 + boundingMapRect + 深色 trait。
+   → 单测:mapRect 计算(纯函数部分);快照本身在 UI 验证。
+5. **RouteMapCard**:快照底图 + polyline 叠加层 + 编号 badge + scrim + 文字块。`#Preview`。
+6. **RouteShareCardView 分派** + **RouteShareRenderer async 化**。
+7. **RouteShareSheet**:modePicker 三档、异步预览、降级提示。
+8. **Localizable.strings** 新 key。
+9. **构建 + 测试**:`xcodebuild build` & `test`(iPhone 17 Pro / iOS latest),
+   再用临时 XCTest + `ImageRenderer` 把三种卡片写 PNG 到 `/tmp` **肉眼验证**
+   (参照 memory「iOS 视觉验证路径」—— `MKMapSnapshotter` 产物也可直接存 PNG 看)。
+
+---
+
+## 7. 风险 & 注意
+
+- **MKMapSnapshotter 是异步且可能慢/失败**(无网时只有缓存瓦片)。必须 async +
+  超时 + 降级。预览区先 `ProgressView`。
+- **ImageRenderer 不展开 LazyVStack/ScrollView**(memory 教训):卡片内用
+  `VStack` 不要用 Lazy/Scroll。
+- **深色 trait 注入**:`MKMapSnapshotter.Options.traitCollection =
+  UITraitCollection(userInterfaceStyle: .dark)`,否则浅色底图上白 halo 不明显。
+- **坐标系别搞反**:`[lon,lat]` vs `[lat,lng]`,归一化 x=lon、y=lat。
+- **文件行数**:拆分到 ≤400 行/文件,符合项目约定。
+- **新增测试文件需 `xcodegen`**(memory 教训):新建 `.swift` 测试后务必
+  `cd apps/ios && xcodegen` 再跑,否则静默 0 用例假绿。
+- **品牌一致性**:polyline 用 `accentColor`,与地图上 `CompassMapView` 的活动
+  路线连线同色,分享出去和 App 内看到的是同一条线。
+
+---
+
+## 8. 验收标准
+
+- [ ] RouteDetailView 分享 → 默认 Map 风格,卡片显示真实街道底图 + 那条路线连线 + 编号停靠点。
+- [ ] 可切到 Trace(极简矢量线)和 Text(纯文本)。
+- [ ] 无网/快照失败 → 自动降级 Trace,有提示,不崩溃不空白。
+- [ ] 坐标 0 点 → 降级旧渐变卡。
+- [ ] 产物经系统分享 / 复制图片 正常(沿用现有管线)。
+- [ ] `xcodebuild build` + `test` 全绿(`Executed N>0`)。
+- [ ] `/tmp` PNG 肉眼验证三种风格出片质量。


### PR DESCRIPTION
## 摘要

路线分享卡此前只渲染分类渐变 + emoji + 统计芯片,丢掉了路线最有辨识度的资产 —— 地图上那条连线本身。本 PR 让连线成为分享卡的视觉主角,对标 Strava / Komoot / AllTrails。

分享 sheet 新增两种可切换的视觉风格(+ 原文本):
- **Map**:`MKMapSnapshotter` 深色街道底图,路线 polyline(白 halo + accent 主线)+ 编号停靠点叠加其上。
- **Trace**:无底图,坐标归一化(等比不变形、北朝上)后画成纯矢量描边线 + 编号停靠点,配品牌渐变。也是快照失败时的降级目标。

**健壮降级**:map 快照失败 → 自动降 trace(卡上提示);坐标全空 → 降回旧渐变卡。复用既有分享管线(ImageRenderer → PNG → UIActivityViewController)。

把 517 行的 `RouteShareSheet.swift` 拆进 `Views/Companion/Share/*`,符合 200–400 行约定。

设计文档:`docs/design/route-map-share-card.md`

## 提交范围说明

本 PR 含 3 个提交,其中前 2 个是尚未单独合入 main 的 preview-card 改动(本特性分支从 `fix/preview-card-unified-flow` 切出):
- `bf8f357` fix(ios): unify experience preview-card flow …
- `4953956` test(ios): cover preview-card lifecycle …
- `fa2f321` feat(ios): share routes as a map card …(本次新增)

## 测试

- `xcodebuild build` ✅
- `RouteShareCardTests`(10 用例):归一化(等比/翻转)、bounding-rect、降级判定 — 全绿
- 肉眼验证 trace + gradient-fallback 卡的 /tmp PNG 出片质量

## 待办(reviewer)

Map 风格真实底图依赖网络瓦片,测试沙箱无瓦片时会降级到 trace。建议在 Simulator 实机联网下打开路线 → 分享 → Map,确认真实街道底图出片效果。

🤖 Generated with [Claude Code](https://claude.com/claude-code)