### PR TITLE
feat(chat): markdown rendering + Instagram-style input + full-chain attachments

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		1961D53326B8AF67585215F7 /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CD4C674431C0702AD8AED3 /* Color+Hex.swift */; };
 		1AB73ECFECC13F149F971563 /* SettingsViewQuerySortTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7112C1C0DEDB8C518D83CC18 /* SettingsViewQuerySortTest.swift */; };
 		1BF34EAE036021423C1ACE2D /* ExploreCacheRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F76E8EBB87A2F70FEA1BB0 /* ExploreCacheRecord.swift */; };
+		1C87BA1A3EB6B4D7FFCE3EA0 /* CreateExperienceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C7C2D7BA51FFDDF53242A3 /* CreateExperienceSheet.swift */; };
 		1D6B1ADE4D2C1245BABD0A6B /* CompanionSafetyConsentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF90C42465B4E989A6DB9D05 /* CompanionSafetyConsentSheet.swift */; };
 		1D8CCDA07285B75840FCF194 /* AppleSignInService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FC5ADBFDDA89BC42C8748D /* AppleSignInService.swift */; };
 		1DAB805A68DF18F2AC776160 /* OnboardingA11yOrderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D000D2E41CDD0DBF2B54C1 /* OnboardingA11yOrderTest.swift */; };
@@ -101,6 +102,7 @@
 		4F41DD68CF55AD05090B0AF9 /* ObsidianTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81530191ED4AA4BFC7FF2A29 /* ObsidianTheme.swift */; };
 		4F85ADCAE47D7654A6A91068 /* MyRequestsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98E594C5575B41E32382209 /* MyRequestsListView.swift */; };
 		50140E7D5FFAC2588C141A3F /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = EE5F70FDF5F3A929496EC981 /* Supabase */; };
+		50495257AD65A0507DD43D41 /* PlacePhotoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F55E299C99F8D9916E0BA1 /* PlacePhotoStore.swift */; };
 		51C24A88B584979BC4D534F6 /* SolarEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B922F1B566195E79BD671D85 /* SolarEventsTests.swift */; };
 		51C722DEC34CF7FD0078BC5F /* ItineraryRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741295168A3FC1A94FBDDA45 /* ItineraryRecord.swift */; };
 		52B53BDA14EBACE5242FC016 /* StopsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C6279345E826F9B01AE41C /* StopsList.swift */; };
@@ -346,6 +348,7 @@
 		051AD3C3A41FDF75D2C4BD8C /* SunsetSignalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunsetSignalTests.swift; sourceTree = "<group>"; };
 		052B6F076F405C203184CB88 /* LocationPickerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationPickerState.swift; sourceTree = "<group>"; };
 		0535B15C19B134898D9880BE /* CompassMapViewLayerToggleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompassMapViewLayerToggleTests.swift; sourceTree = "<group>"; };
+		05C7C2D7BA51FFDDF53242A3 /* CreateExperienceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateExperienceSheet.swift; sourceTree = "<group>"; };
 		06086F5F9463C18F486E5694 /* QueryAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryAgent.swift; sourceTree = "<group>"; };
 		0674DC5D526883C657A63C38 /* CardBottomInsetClearanceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBottomInsetClearanceTest.swift; sourceTree = "<group>"; };
 		06B7D586552E9F1EA44F5657 /* MapKitPOIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapKitPOIService.swift; sourceTree = "<group>"; };
@@ -606,6 +609,7 @@
 		D08AFC181DB143A21E97A2ED /* NextBestExperienceClockTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextBestExperienceClockTest.swift; sourceTree = "<group>"; };
 		D22A9156A8CA2E798375C5C9 /* HitTargetMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitTargetMetrics.swift; sourceTree = "<group>"; };
 		D26F2087E12E63A73B812D7E /* PendingCheckInBannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingCheckInBannerTests.swift; sourceTree = "<group>"; };
+		D2F55E299C99F8D9916E0BA1 /* PlacePhotoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacePhotoStore.swift; sourceTree = "<group>"; };
 		D30D09E054C6CE013359301E /* TopOverlayLayoutTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopOverlayLayoutTest.swift; sourceTree = "<group>"; };
 		D3DBD8BED52DB4E9DD339BFD /* MapPinPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapPinPickerView.swift; sourceTree = "<group>"; };
 		D4C10384834D53FE83113D51 /* Configuration.storekit */ = {isa = PBXFileReference; path = Configuration.storekit; sourceTree = "<group>"; };
@@ -704,6 +708,7 @@
 		0807CE55F43B61AC22836519 /* Experience */ = {
 			isa = PBXGroup;
 			children = (
+				05C7C2D7BA51FFDDF53242A3 /* CreateExperienceSheet.swift */,
 				363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */,
 				D5B8BA7FFBD93A01E54B7E4A /* ExperienceDetailView.swift */,
 				8509E525DD268E88ED3AD4FD /* LocationCard.swift */,
@@ -1036,6 +1041,7 @@
 				AF007DB5F72E30021CADA555 /* NetworkMonitor.swift */,
 				C215AE07BA32182A887226F9 /* NotificationService.swift */,
 				67173C74F1A76C3CE5C38C0A /* OverpassService.swift */,
+				D2F55E299C99F8D9916E0BA1 /* PlacePhotoStore.swift */,
 				C5BF40BDAD5E085808BE633E /* PresenceService.swift */,
 				64BDF8B4B7CC82F3845C5068 /* ReverseGeocodeService.swift */,
 				746139AC01A1D37CE002BFCF /* ReviewsService.swift */,
@@ -1537,6 +1543,7 @@
 				C09361B1A5560755F3C5DD67 /* Conversation.swift in Sources */,
 				B9EDA827F7E00B19DF97512C /* ConversationRecord.swift in Sources */,
 				4C16F9056859D3AFA88B3355 /* ConversationStore.swift in Sources */,
+				1C87BA1A3EB6B4D7FFCE3EA0 /* CreateExperienceSheet.swift in Sources */,
 				680774109C2AD675E26ADA18 /* CreateRouteView.swift in Sources */,
 				48C924FB49F596D91D67A3B2 /* CustomCityStore.swift in Sources */,
 				42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */,
@@ -1616,6 +1623,7 @@
 				AA75B3147A29FDA55E61B24A /* PendingCheckInBanner.swift in Sources */,
 				ACBA4CEE6B78AA04DBD26709 /* PendingCheckInRecord.swift in Sources */,
 				641D80BD116D6F255A9ED26A /* PendingSyncRecord.swift in Sources */,
+				50495257AD65A0507DD43D41 /* PlacePhotoStore.swift in Sources */,
 				60FA57D3A56ED061C1F9B899 /* PresenceService.swift in Sources */,
 				40C8E92653FC718890E3CA5D /* PressableButtonStyle.swift in Sources */,
 				48DF01972A1FB107BFFF0684 /* QueryAgent.swift in Sources */,

--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		240FFFC4A2B2B8F941129783 /* ConfidenceBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8F9EFD56A2C839428AA92D /* ConfidenceBadge.swift */; };
 		2456D74F765B987172F399F8 /* CompassMapViewBodyTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC366DD24E9174448BF06A2D /* CompassMapViewBodyTypeTests.swift */; };
 		24A47D8F35DD718BD74601F6 /* ZhHansPunctuationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9BD2D777F3A487C7C211E7E /* ZhHansPunctuationTest.swift */; };
+		254325B821AD2687B3E028DA /* AttachmentInputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A9885BEB8D9686F5384BEC /* AttachmentInputBar.swift */; };
 		259F1E0030F914782D632794 /* CompiledPlaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AF27F0567AACEA9E6D916E /* CompiledPlaceTests.swift */; };
 		26BDD8E9011EE16C9FB5931C /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F336099C48E0B04CD7612E4C /* Haptics.swift */; };
 		2734D573E867497B18878D84 /* CompanionProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69068DE8A2F71601627AE3E8 /* CompanionProfileView.swift */; };
@@ -114,6 +115,7 @@
 		5544DD796A2D4987A7CB9DC9 /* WebSearchEnrichmentSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 977F66FB36894EA4088C2905 /* WebSearchEnrichmentSource.swift */; };
 		561418100F2F7D4D88DE1BC4 /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086B3C207483BA0EBD27451F /* MessageBubble.swift */; };
 		56F3055416F4A5316100F9B2 /* ExperienceCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */; };
+		574DC88CF9379A5C341679AF /* ChatVisualDumpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27E452E13E44A502FFCECDA /* ChatVisualDumpTests.swift */; };
 		585930C5FA9368923ADB2D43 /* BottomInfoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04709B5AD986143D04CA0A08 /* BottomInfoSheet.swift */; };
 		58B7C9B20945838F81081941 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14A22A40550CF207AB36C18 /* SettingsView.swift */; };
 		58C9B0E8A0A2DB38E1078E9D /* HapticService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277318E6238F2F885ED2334 /* HapticService.swift */; };
@@ -155,6 +157,7 @@
 		78EA2DE7E8AA6F5847BE4FAA /* ShareCardScoreL10nTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314F06EBA1DCBD3AC987BEEF /* ShareCardScoreL10nTest.swift */; };
 		79E4FD6C7F9522BDB1106F56 /* PublicAPIDocCommentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCD0D2CE7423C29CD668866 /* PublicAPIDocCommentTests.swift */; };
 		7A5F7752DE91A7FEE6571C7A /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038BEE46BF2DFAF762B605D5 /* Route.swift */; };
+		7B611EA960309C795E31B2B8 /* ChatAttachmentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA96BC45388A8EC99F3B29ED /* ChatAttachmentService.swift */; };
 		7C14629A3FAB31975BFBB0A6 /* ExperienceRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A250916F91C8EF0BE90DF763 /* ExperienceRepository.swift */; };
 		7D2B6DE6C27E0307CA998A5F /* CityPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873ACB737A9B43254C17B238 /* CityPickerSheet.swift */; };
 		7DE0D7D331590BFAC64D55B9 /* RouteDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1C7F381BB5EE2493C06407 /* RouteDetailView.swift */; };
@@ -544,6 +547,7 @@
 		977F66FB36894EA4088C2905 /* WebSearchEnrichmentSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchEnrichmentSource.swift; sourceTree = "<group>"; };
 		97E92D314B6B62ED3B6EA2AE /* ShareCardComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareCardComponents.swift; sourceTree = "<group>"; };
 		97FCA9C12D9640983F75474E /* NowSignal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowSignal.swift; sourceTree = "<group>"; };
+		98A9885BEB8D9686F5384BEC /* AttachmentInputBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentInputBar.swift; sourceTree = "<group>"; };
 		9945A4E03F4C75ED89674594 /* SoloCompass.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SoloCompass.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		999E8DA69CB660A94E71D02A /* BottomSheetSectionSeparationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetSectionSeparationTest.swift; sourceTree = "<group>"; };
 		99AF76F1B505EF8AF6EF2470 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
@@ -572,6 +576,7 @@
 		A95DD95393E5BF9C89FB4977 /* BilingualCityRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualCityRow.swift; sourceTree = "<group>"; };
 		A98E594C5575B41E32382209 /* MyRequestsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRequestsListView.swift; sourceTree = "<group>"; };
 		AA17ED8FE9ABA2F5CC1D557E /* FavoriteFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteFilterTests.swift; sourceTree = "<group>"; };
+		AA96BC45388A8EC99F3B29ED /* ChatAttachmentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentService.swift; sourceTree = "<group>"; };
 		AB46D6F6F8942CD390A5CCF4 /* SoloCompass.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SoloCompass.entitlements; sourceTree = "<group>"; };
 		AF007DB5F72E30021CADA555 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		B14FE2118ED82DD0593F5C3C /* StringsParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringsParityTests.swift; sourceTree = "<group>"; };
@@ -632,6 +637,7 @@
 		E03076AD221F78BBDE981C3A /* ExperienceRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceRecord.swift; sourceTree = "<group>"; };
 		E0AA21CD490B436012818D9D /* ItineraryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItineraryDetailView.swift; sourceTree = "<group>"; };
 		E1694A46513909CFE464D92E /* FilterBarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarViewTests.swift; sourceTree = "<group>"; };
+		E27E452E13E44A502FFCECDA /* ChatVisualDumpTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatVisualDumpTests.swift; sourceTree = "<group>"; };
 		E406C379247653B4AA5A3E0E /* SupabaseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseClient.swift; sourceTree = "<group>"; };
 		E536D4CFF44CF4CEFD1EFF4F /* WeatherCacheTTLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherCacheTTLTests.swift; sourceTree = "<group>"; };
 		E575898B14533C58035EFC79 /* ConversationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStore.swift; sourceTree = "<group>"; };
@@ -799,6 +805,7 @@
 				36E41DCA29798B5D8E49B7CA /* BottomSheetUnifiedScrollGuardTest.swift */,
 				0674DC5D526883C657A63C38 /* CardBottomInsetClearanceTest.swift */,
 				1FF5100EFECEC87BDC2B007B /* ChatBubbleContrastTest.swift */,
+				E27E452E13E44A502FFCECDA /* ChatVisualDumpTests.swift */,
 				308B7A34171C74B1CF2DE3F9 /* CityPillHitTargetTests.swift */,
 				907EA19EC9B84B93AB110C70 /* ColdStartExperienceLoadTests.swift */,
 				A00295FF044E4D732D1EB2EA /* ColorExtensionScopeTest.swift */,
@@ -1030,6 +1037,7 @@
 				F4814DBCEAB5975B6338558D /* AIService.swift */,
 				42FC5ADBFDDA89BC42C8748D /* AppleSignInService.swift */,
 				4617984392FDCCA6F2F9FAD7 /* BestNowClock.swift */,
+				AA96BC45388A8EC99F3B29ED /* ChatAttachmentService.swift */,
 				A7E8E3F1E2D1A0382CC5D9A6 /* ChatService.swift */,
 				1A8062A7E6BA3EE88C6DAF02 /* CompanionService.swift */,
 				7B2B85A119750C65697903E0 /* CustomCityStore.swift */,
@@ -1084,6 +1092,7 @@
 			children = (
 				9055347887EF473171916120 /* AttachmentBubble.swift */,
 				C2A6F8B0FC9EB2CABDA75A0B /* AttachmentDraftStrip.swift */,
+				98A9885BEB8D9686F5384BEC /* AttachmentInputBar.swift */,
 				B88D9F377D7AF634DAE07A3E /* ChatInputBar.swift */,
 				F9263FC2737FA209F3CD4B5E /* ChatSheet.swift */,
 				1D7A24EA7AB5379E0D5DC2B2 /* InlineBanner.swift */,
@@ -1409,6 +1418,7 @@
 				0C0580E1BF61F5C02C2EE640 /* BottomSheetUnifiedScrollGuardTest.swift in Sources */,
 				3CBA775B8C215CBAE3A73EA0 /* CardBottomInsetClearanceTest.swift in Sources */,
 				B5D2608A5B16B07B6E9005DC /* ChatBubbleContrastTest.swift in Sources */,
+				574DC88CF9379A5C341679AF /* ChatVisualDumpTests.swift in Sources */,
 				D2BCD302B16BBC174B71F84A /* CityPillHitTargetTests.swift in Sources */,
 				81470D06CD0593B278B110CC /* ColdStartExperienceLoadTests.swift in Sources */,
 				53C4F7B11856CF3D1313A228 /* ColorExtensionScopeTest.swift in Sources */,
@@ -1526,12 +1536,14 @@
 				4B4EE06B93E099D8EEDE6631 /* ApprovalQueueView.swift in Sources */,
 				9FDC9CE4E9D3B505758EDB7D /* AttachmentBubble.swift in Sources */,
 				AE7EF0304E8E72DAE72E90E7 /* AttachmentDraftStrip.swift in Sources */,
+				254325B821AD2687B3E028DA /* AttachmentInputBar.swift in Sources */,
 				11A994FC5FFCF2618FBD7A3A /* AvatarStack.swift in Sources */,
 				FC5971A3C5E9DDB7F88E58E8 /* BestNowClock.swift in Sources */,
 				9A6B147D089D0942438D8972 /* BestTimesSignal.swift in Sources */,
 				8004F51AA0F117D38EC71610 /* BilingualCityRow.swift in Sources */,
 				5C05B87EA78458094612AC01 /* BottomInfoBar.swift in Sources */,
 				585930C5FA9368923ADB2D43 /* BottomInfoSheet.swift in Sources */,
+				7B611EA960309C795E31B2B8 /* ChatAttachmentService.swift in Sources */,
 				BA0DD7D5C46016E81A23B2B4 /* ChatInputBar.swift in Sources */,
 				96A79D8DD36F5B67B3146998 /* ChatMessage.swift in Sources */,
 				31DAB367EE76F147742B2B3E /* ChatService.swift in Sources */,

--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -115,7 +115,6 @@
 		5544DD796A2D4987A7CB9DC9 /* WebSearchEnrichmentSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 977F66FB36894EA4088C2905 /* WebSearchEnrichmentSource.swift */; };
 		561418100F2F7D4D88DE1BC4 /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086B3C207483BA0EBD27451F /* MessageBubble.swift */; };
 		56F3055416F4A5316100F9B2 /* ExperienceCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */; };
-		574DC88CF9379A5C341679AF /* ChatVisualDumpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27E452E13E44A502FFCECDA /* ChatVisualDumpTests.swift */; };
 		585930C5FA9368923ADB2D43 /* BottomInfoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04709B5AD986143D04CA0A08 /* BottomInfoSheet.swift */; };
 		58B7C9B20945838F81081941 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14A22A40550CF207AB36C18 /* SettingsView.swift */; };
 		58C9B0E8A0A2DB38E1078E9D /* HapticService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277318E6238F2F885ED2334 /* HapticService.swift */; };
@@ -198,6 +197,7 @@
 		9B906CA9BF24104FB2BF7773 /* RouteCardWalkedByTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9FE3BB447D84732CCE0B07 /* RouteCardWalkedByTest.swift */; };
 		9BEDEF446F2D554A7F1ABA6F /* PreviewCardLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AED8B43F4C4059CD005C0A /* PreviewCardLifecycleTests.swift */; };
 		9C8CC563D33FDBB3DF57A841 /* RecentExploreRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9748B0A808BC06F6EDED3C3B /* RecentExploreRegion.swift */; };
+		9D2F6814C70072DE8C20865B /* ChatAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88805BD09F10F37A334CE2F0 /* ChatAttachmentTests.swift */; };
 		9D799B457AC16C84BB460D18 /* RouteCardTappableGuardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4317C293B762EA1C8A436B8A /* RouteCardTappableGuardTest.swift */; };
 		9D81327AE55FA8142F9E5B8D /* ChatUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0709110B381DEDA32C3292AE /* ChatUIState.swift */; };
 		9F8D8133FC74C4E206A11DB9 /* ItineraryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD7871A003B28A7C46AC8D7 /* ItineraryStoreTests.swift */; };
@@ -526,6 +526,7 @@
 		873ACB737A9B43254C17B238 /* CityPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityPickerSheet.swift; sourceTree = "<group>"; };
 		884AFD2A4ADF051FA9643166 /* RouteItineraryBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteItineraryBridge.swift; sourceTree = "<group>"; };
 		88553B5578C07FA890183A0D /* BottomInfoSheetHandleHitTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomInfoSheetHandleHitTargetTests.swift; sourceTree = "<group>"; };
+		88805BD09F10F37A334CE2F0 /* ChatAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentTests.swift; sourceTree = "<group>"; };
 		88863482E2CD46BBE315B59D /* LocationErrorSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationErrorSurfaceTests.swift; sourceTree = "<group>"; };
 		8964F4628C43BB7311B48D38 /* ApprovalQueueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalQueueView.swift; sourceTree = "<group>"; };
 		8970A53A6D6C42A614F7B414 /* RouteMapSnapshotter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteMapSnapshotter.swift; sourceTree = "<group>"; };
@@ -637,7 +638,6 @@
 		E03076AD221F78BBDE981C3A /* ExperienceRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceRecord.swift; sourceTree = "<group>"; };
 		E0AA21CD490B436012818D9D /* ItineraryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItineraryDetailView.swift; sourceTree = "<group>"; };
 		E1694A46513909CFE464D92E /* FilterBarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarViewTests.swift; sourceTree = "<group>"; };
-		E27E452E13E44A502FFCECDA /* ChatVisualDumpTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatVisualDumpTests.swift; sourceTree = "<group>"; };
 		E406C379247653B4AA5A3E0E /* SupabaseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseClient.swift; sourceTree = "<group>"; };
 		E536D4CFF44CF4CEFD1EFF4F /* WeatherCacheTTLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherCacheTTLTests.swift; sourceTree = "<group>"; };
 		E575898B14533C58035EFC79 /* ConversationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStore.swift; sourceTree = "<group>"; };
@@ -804,8 +804,8 @@
 				999E8DA69CB660A94E71D02A /* BottomSheetSectionSeparationTest.swift */,
 				36E41DCA29798B5D8E49B7CA /* BottomSheetUnifiedScrollGuardTest.swift */,
 				0674DC5D526883C657A63C38 /* CardBottomInsetClearanceTest.swift */,
+				88805BD09F10F37A334CE2F0 /* ChatAttachmentTests.swift */,
 				1FF5100EFECEC87BDC2B007B /* ChatBubbleContrastTest.swift */,
-				E27E452E13E44A502FFCECDA /* ChatVisualDumpTests.swift */,
 				308B7A34171C74B1CF2DE3F9 /* CityPillHitTargetTests.swift */,
 				907EA19EC9B84B93AB110C70 /* ColdStartExperienceLoadTests.swift */,
 				A00295FF044E4D732D1EB2EA /* ColorExtensionScopeTest.swift */,
@@ -1417,8 +1417,8 @@
 				BF7D61FAEF133A0E77C585C9 /* BottomSheetSectionSeparationTest.swift in Sources */,
 				0C0580E1BF61F5C02C2EE640 /* BottomSheetUnifiedScrollGuardTest.swift in Sources */,
 				3CBA775B8C215CBAE3A73EA0 /* CardBottomInsetClearanceTest.swift in Sources */,
+				9D2F6814C70072DE8C20865B /* ChatAttachmentTests.swift in Sources */,
 				B5D2608A5B16B07B6E9005DC /* ChatBubbleContrastTest.swift in Sources */,
-				574DC88CF9379A5C341679AF /* ChatVisualDumpTests.swift in Sources */,
 				D2BCD302B16BBC174B71F84A /* CityPillHitTargetTests.swift in Sources */,
 				81470D06CD0593B278B110CC /* ColdStartExperienceLoadTests.swift in Sources */,
 				53C4F7B11856CF3D1313A228 /* ColorExtensionScopeTest.swift in Sources */,

--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		32C5B270129CEC0562C6D640 /* RouteShareCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF934B8ECFB7BB99C9C4791 /* RouteShareCardView.swift */; };
 		337CAFC8B35CF36D175B27CF /* CompareTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F836182A03FC067C4A9AB9 /* CompareTokens.swift */; };
 		352247C1FBF4C8F901D17F32 /* ApprovalTrustSignalTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804618047547A9D7F3F8EAAA /* ApprovalTrustSignalTest.swift */; };
+		36E1316045802B2F642A9623 /* LocalAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C89CB8D3309FD5646E23434 /* LocalAttachment.swift */; };
 		371DDBAF4C385267248ABC83 /* AgentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38E5736BF6DF5644D687637 /* AgentRouter.swift */; };
 		37D5A0FD622C9649308BD14D /* FavoriteFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA17ED8FE9ABA2F5CC1D557E /* FavoriteFilterTests.swift */; };
 		3889A861FFD32BE4EEE4F19F /* ActiveRouteOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CEA4BFADFDB1575F6655E48 /* ActiveRouteOverlay.swift */; };
@@ -197,6 +198,7 @@
 		9D799B457AC16C84BB460D18 /* RouteCardTappableGuardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4317C293B762EA1C8A436B8A /* RouteCardTappableGuardTest.swift */; };
 		9D81327AE55FA8142F9E5B8D /* ChatUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0709110B381DEDA32C3292AE /* ChatUIState.swift */; };
 		9F8D8133FC74C4E206A11DB9 /* ItineraryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD7871A003B28A7C46AC8D7 /* ItineraryStoreTests.swift */; };
+		9FDC9CE4E9D3B505758EDB7D /* AttachmentBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9055347887EF473171916120 /* AttachmentBubble.swift */; };
 		A12DF78B6B05519D2177A519 /* RouteCompanionForceUnwrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF2CEF9FE62124F51460453 /* RouteCompanionForceUnwrapTests.swift */; };
 		A217FA55BD40922DB3B8DEE6 /* SoloScoreRadarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D557D1D0D224C725834A08D /* SoloScoreRadarChart.swift */; };
 		A49A16341F3F09EEF317FA03 /* NowScoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C04A7D4DE12B98E4801D7C4 /* NowScoreTests.swift */; };
@@ -207,6 +209,7 @@
 		A7E46B29DC0DF3EE5203B699 /* HourOfDaySignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B95FD264D171F4F70DFEB26 /* HourOfDaySignal.swift */; };
 		A84320715E7CBDA91FC3F26F /* ExperienceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */; };
 		A93EEDF38B969D10CC369C59 /* CompletionCelebrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2294AF173D063B1F55894696 /* CompletionCelebrationView.swift */; };
+		A94A887ACBF5222F85FE0FE2 /* MarkdownMessageText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6726C3959F43F1B0F9C003A7 /* MarkdownMessageText.swift */; };
 		AA5C5AEBFB7B2266A4781877 /* ConversationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CEFD2E522C2D9FFF8EF0B0B /* ConversationTests.swift */; };
 		AA75B3147A29FDA55E61B24A /* PendingCheckInBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */; };
 		AABC7AE2FEE9FD5C2ABC41BB /* LocationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340D914D24038F4A380B008C /* LocationServiceTests.swift */; };
@@ -214,6 +217,7 @@
 		AB8E6644540AE90657471002 /* BottomSheetDetentDynamicTypeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C63BC4737C3134075574125E /* BottomSheetDetentDynamicTypeTest.swift */; };
 		ACBA4CEE6B78AA04DBD26709 /* PendingCheckInRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA0BAEC05B72704552C0906 /* PendingCheckInRecord.swift */; };
 		ADD51496532A0B763048AF5B /* ReviewsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746139AC01A1D37CE002BFCF /* ReviewsService.swift */; };
+		AE7EF0304E8E72DAE72E90E7 /* AttachmentDraftStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A6F8B0FC9EB2CABDA75A0B /* AttachmentDraftStrip.swift */; };
 		AEDEF3D7DC245681904D3469 /* MapViewModelCityCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC5559A4AAF4E3CD77E38B6 /* MapViewModelCityCacheTests.swift */; };
 		AF89A5DAA5BE9C3FC9DF1675 /* MapPinPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DBD8BED52DB4E9DD339BFD /* MapPinPickerView.swift */; };
 		B0EFE759B67951C4D10B16FD /* UserDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B0465B31ABD4A057EE984F /* UserDirectory.swift */; };
@@ -263,6 +267,7 @@
 		CA89195562C759E6F118465B /* TodoIssueReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331B2AE74EFAD9589AF60498 /* TodoIssueReferenceTests.swift */; };
 		CB7524D681F638DFD45BA1FA /* RouteShareStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EB8B6538D85C6E3641D778 /* RouteShareStyle.swift */; };
 		CC29AD50727EA68C4064F56F /* NowSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97FCA9C12D9640983F75474E /* NowSignal.swift */; };
+		CD2A3B43AADB66F8DD3521E1 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 0C14DD43D1CA08BF7AAF0601 /* MarkdownUI */; };
 		CD73E1A29E0D2EB8D8AC93AC /* OpenForCompanionsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5D9508FCA9CDB8EA088D76 /* OpenForCompanionsSheet.swift */; };
 		CD74E5E501088F7BECA74FBC /* WeatherServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F20A91F36C7CA4041BEEC9 /* WeatherServiceTests.swift */; };
 		CE1A6A1D5EB25B2BEA5B29DA /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFFA243BC698EF20C6BC1EF /* MapViewModel.swift */; };
@@ -478,6 +483,7 @@
 		659B2C7C4B36A086968A28EF /* SkeletonBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonBadgeView.swift; sourceTree = "<group>"; };
 		66273C940FD90B51EBCD97BC /* RouteBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteBuilder.swift; sourceTree = "<group>"; };
 		67173C74F1A76C3CE5C38C0A /* OverpassService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverpassService.swift; sourceTree = "<group>"; };
+		6726C3959F43F1B0F9C003A7 /* MarkdownMessageText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownMessageText.swift; sourceTree = "<group>"; };
 		672C97E1FBA4FEF7EE87D59B /* WeatherSignalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherSignalTests.swift; sourceTree = "<group>"; };
 		674F2B0EE0E3C7A47802DBC4 /* SunsetSignal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunsetSignal.swift; sourceTree = "<group>"; };
 		67DAE302128E657E150C4B0D /* FoursquareService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoursquareService.swift; sourceTree = "<group>"; };
@@ -522,11 +528,13 @@
 		8970A53A6D6C42A614F7B414 /* RouteMapSnapshotter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteMapSnapshotter.swift; sourceTree = "<group>"; };
 		8B95FD264D171F4F70DFEB26 /* HourOfDaySignal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HourOfDaySignal.swift; sourceTree = "<group>"; };
 		8C1DD2BA0AF4E693B9E36F90 /* CompiledPlace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompiledPlace.swift; sourceTree = "<group>"; };
+		8C89CB8D3309FD5646E23434 /* LocalAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAttachment.swift; sourceTree = "<group>"; };
 		8C8D88BCFAC97E436BE97274 /* seed_users.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = seed_users.json; sourceTree = "<group>"; };
 		8D0CBFD5114CC6728D6AA876 /* VoiceWaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceWaveformView.swift; sourceTree = "<group>"; };
 		8D41862432A45DC023C96B8D /* FilterNowMapAnimationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterNowMapAnimationTest.swift; sourceTree = "<group>"; };
 		8E055BAC372B75F743428920 /* MyHostedRoutesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyHostedRoutesListView.swift; sourceTree = "<group>"; };
 		8FDFA5F3503B8ABC4B5CB086 /* SoloCompassTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SoloCompassTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9055347887EF473171916120 /* AttachmentBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentBubble.swift; sourceTree = "<group>"; };
 		907EA19EC9B84B93AB110C70 /* ColdStartExperienceLoadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColdStartExperienceLoadTests.swift; sourceTree = "<group>"; };
 		90B0465B31ABD4A057EE984F /* UserDirectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDirectory.swift; sourceTree = "<group>"; };
 		94CD4C674431C0702AD8AED3 /* Color+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Hex.swift"; sourceTree = "<group>"; };
@@ -591,6 +599,7 @@
 		C1C97F8159A6FA7953D28DAB /* Experience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Experience.swift; sourceTree = "<group>"; };
 		C215AE07BA32182A887226F9 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		C28A851F789C7482CD44DCAE /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		C2A6F8B0FC9EB2CABDA75A0B /* AttachmentDraftStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentDraftStrip.swift; sourceTree = "<group>"; };
 		C31343F698EBC4D2410F48A6 /* VoiceButtonAutoStopTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceButtonAutoStopTests.swift; sourceTree = "<group>"; };
 		C5BF40BDAD5E085808BE633E /* PresenceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresenceService.swift; sourceTree = "<group>"; };
 		C5C3BA25EFA9F149FB4FAAB3 /* FavoritesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesListView.swift; sourceTree = "<group>"; };
@@ -671,6 +680,7 @@
 			files = (
 				50140E7D5FFAC2588C141A3F /* Supabase in Frameworks */,
 				6F8492E7BB9870C7E4C99CA1 /* Sentry in Frameworks */,
+				CD2A3B43AADB66F8DD3521E1 /* MarkdownUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1072,9 +1082,13 @@
 		78E954A36C9CA4C8D59A4CD8 /* Chat */ = {
 			isa = PBXGroup;
 			children = (
+				9055347887EF473171916120 /* AttachmentBubble.swift */,
+				C2A6F8B0FC9EB2CABDA75A0B /* AttachmentDraftStrip.swift */,
 				B88D9F377D7AF634DAE07A3E /* ChatInputBar.swift */,
 				F9263FC2737FA209F3CD4B5E /* ChatSheet.swift */,
 				1D7A24EA7AB5379E0D5DC2B2 /* InlineBanner.swift */,
+				8C89CB8D3309FD5646E23434 /* LocalAttachment.swift */,
+				6726C3959F43F1B0F9C003A7 /* MarkdownMessageText.swift */,
 				086B3C207483BA0EBD27451F /* MessageBubble.swift */,
 			);
 			path = Chat;
@@ -1265,6 +1279,7 @@
 			packageProductDependencies = (
 				EE5F70FDF5F3A929496EC981 /* Supabase */,
 				7F7384A5D63B5A4A7371F923 /* Sentry */,
+				0C14DD43D1CA08BF7AAF0601 /* MarkdownUI */,
 			);
 			productName = SoloCompass;
 			productReference = 9945A4E03F4C75ED89674594 /* SoloCompass.app */;
@@ -1320,6 +1335,7 @@
 			packageReferences = (
 				D857C2B82381EF138F3812F2 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				9CED3AAE0D001036D45C96A4 /* XCRemoteSwiftPackageReference "supabase-swift" */,
+				131FB9C7398D6DD8F91ABE50 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 501EF6E4D08477F134FAED1E /* Products */;
@@ -1508,6 +1524,8 @@
 				371DDBAF4C385267248ABC83 /* AgentRouter.swift in Sources */,
 				1D8CCDA07285B75840FCF194 /* AppleSignInService.swift in Sources */,
 				4B4EE06B93E099D8EEDE6631 /* ApprovalQueueView.swift in Sources */,
+				9FDC9CE4E9D3B505758EDB7D /* AttachmentBubble.swift in Sources */,
+				AE7EF0304E8E72DAE72E90E7 /* AttachmentDraftStrip.swift in Sources */,
 				11A994FC5FFCF2618FBD7A3A /* AvatarStack.swift in Sources */,
 				FC5971A3C5E9DDB7F88E58E8 /* BestNowClock.swift in Sources */,
 				9A6B147D089D0942438D8972 /* BestTimesSignal.swift in Sources */,
@@ -1587,6 +1605,7 @@
 				98245881AB35CB7BB16688FC /* JoinRouteRequestSheet.swift in Sources */,
 				48DF93F42CDDB1329B038865 /* KeychainStore.swift in Sources */,
 				953C7BD48AF4AF55608145A6 /* LanguageService.swift in Sources */,
+				36E1316045802B2F642A9623 /* LocalAttachment.swift in Sources */,
 				D52FCC8C2C36D630A8845DA6 /* LocalRouteCompanionRemote.swift in Sources */,
 				23B40396E9D7B59CB71FBCD9 /* LocationCard.swift in Sources */,
 				2ADAF284E5182CF955D9641E /* LocationPickerSheet.swift in Sources */,
@@ -1597,6 +1616,7 @@
 				AF89A5DAA5BE9C3FC9DF1675 /* MapPinPickerView.swift in Sources */,
 				CE1A6A1D5EB25B2BEA5B29DA /* MapViewModel.swift in Sources */,
 				45A4E8EED0300F00253EC049 /* MarkdownExporter.swift in Sources */,
+				A94A887ACBF5222F85FE0FE2 /* MarkdownMessageText.swift in Sources */,
 				C2CCD06DDA37BF2F81E735E5 /* MarkdownShareSheet.swift in Sources */,
 				28E3EB1BFFB0A73A1C56FD54 /* MarkerIconView.swift in Sources */,
 				561418100F2F7D4D88DE1BC4 /* MessageBubble.swift in Sources */,
@@ -1973,6 +1993,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		131FB9C7398D6DD8F91ABE50 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.4.1;
+			};
+		};
 		9CED3AAE0D001036D45C96A4 /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/supabase/supabase-swift";
@@ -1992,6 +2020,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		0C14DD43D1CA08BF7AAF0601 /* MarkdownUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 131FB9C7398D6DD8F91ABE50 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
+			productName = MarkdownUI;
+		};
 		7F7384A5D63B5A4A7371F923 /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D857C2B82381EF138F3812F2 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;

--- a/apps/ios/SoloCompass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/ios/SoloCompass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "f426721f2a0daaf973b9d1e358d60db27442a4428b8b9c0cdc3cc1d54128f42a",
+  "originHash" : "7fd7e08a54601c363aa1523a400b1e3551db59633c3a1c4061f99022c2a72283",
   "pins" : [
+    {
+      "identity" : "networkimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "state" : {
+        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
+        "version" : "6.0.1"
+      }
+    },
     {
       "identity" : "sentry-cocoa",
       "kind" : "remoteSourceControl",
@@ -38,6 +47,15 @@
       }
     },
     {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
+        "version" : "0.8.0"
+      }
+    },
+    {
       "identity" : "swift-concurrency-extras",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
@@ -62,6 +80,15 @@
       "state" : {
         "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
         "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-markdown-ui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
+      "state" : {
+        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
+        "version" : "2.4.1"
       }
     },
     {

--- a/apps/ios/SoloCompass/Models/ChatMessage.swift
+++ b/apps/ios/SoloCompass/Models/ChatMessage.swift
@@ -10,6 +10,53 @@ public struct ChatMessageId: RawRepresentable, Codable, Hashable, Sendable {
     public init(rawValue: String) { self.rawValue = rawValue }
 }
 
+// MARK: - ChatAttachment
+
+/// A media or document attachment carried by a `ChatMessage`.
+///
+/// Mirrors `ChatAttachment` in `packages/core/src/companion.ts`. Synthesized
+/// Codable uses camelCase keys to round-trip the TS JSON payload verbatim.
+public struct ChatAttachment: Identifiable, Codable, Sendable, Equatable {
+    public let id: String
+    /// Discriminates a previewable image from an arbitrary file.
+    public let kind: Kind
+    public let fileName: String
+    public let mimeType: String
+    public let fileSizeBytes: Int
+    /// Path within the `chat-media` bucket: `{conversationId}/{messageId}/{attachmentId}-{fileName}`.
+    public let storagePath: String
+    /// Pixel width, image kind only.
+    public let width: Int?
+    /// Pixel height, image kind only.
+    public let height: Int?
+
+    /// Discriminates a previewable image from an arbitrary file.
+    public enum Kind: String, Codable, Sendable {
+        case image
+        case file
+    }
+
+    public init(
+        id: String,
+        kind: Kind,
+        fileName: String,
+        mimeType: String,
+        fileSizeBytes: Int,
+        storagePath: String,
+        width: Int? = nil,
+        height: Int? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.fileName = fileName
+        self.mimeType = mimeType
+        self.fileSizeBytes = fileSizeBytes
+        self.storagePath = storagePath
+        self.width = width
+        self.height = height
+    }
+}
+
 // MARK: - ChatMessage
 
 /// A single message sent within a Conversation, including its body and read receipt.
@@ -18,6 +65,8 @@ public struct ChatMessage: Identifiable, Codable, Sendable {
     public let conversationId: ConversationId
     public let senderId: String
     public let body: String
+    /// Attachments carried by this message. Nil/empty when text-only.
+    public let attachments: [ChatAttachment]?
     /// ISO 8601 UTC timestamp when the recipient read the message.
     public let readAt: String?
     /// ISO 8601 UTC timestamp.
@@ -28,6 +77,7 @@ public struct ChatMessage: Identifiable, Codable, Sendable {
         conversationId: ConversationId,
         senderId: String,
         body: String,
+        attachments: [ChatAttachment]? = nil,
         readAt: String? = nil,
         createdAt: String
     ) {
@@ -35,6 +85,7 @@ public struct ChatMessage: Identifiable, Codable, Sendable {
         self.conversationId = conversationId
         self.senderId = senderId
         self.body = body
+        self.attachments = attachments
         self.readAt = readAt
         self.createdAt = createdAt
     }

--- a/apps/ios/SoloCompass/Models/Experience.swift
+++ b/apps/ios/SoloCompass/Models/Experience.swift
@@ -95,6 +95,10 @@ public struct ExperienceLocation: Codable, Hashable {
     public let priceLevel: Double?     // 1–4 (1 = cheap, 4 = expensive)
     public let website: String?
     public let phone: String?
+    /// Photos attached to the place. User-created experiences populate this from
+    /// the photo picker; seed/OSM places leave it nil. Values are URL strings:
+    /// local `file://` paths until synced, then remote https URLs. Mirrors TS.
+    public let photoUrls: [String]?
 
     public var clCoordinate: CLLocationCoordinate2D? {
         guard coordinates.count >= 2 else { return nil }
@@ -111,7 +115,8 @@ public struct ExperienceLocation: Codable, Hashable {
         openingHours: String? = nil,
         priceLevel: Double? = nil,
         website: String? = nil,
-        phone: String? = nil
+        phone: String? = nil,
+        photoUrls: [String]? = nil
     ) {
         self.coordinates = coordinates
         self.cityCode = cityCode
@@ -123,6 +128,7 @@ public struct ExperienceLocation: Codable, Hashable {
         self.priceLevel = priceLevel
         self.website = website
         self.phone = phone
+        self.photoUrls = photoUrls
     }
 }
 
@@ -474,6 +480,87 @@ public struct Experience: Codable, Hashable, Identifiable {
     /// True when this entry was discovered via OpenStreetMap Explore
     /// (vs. a curated seed entry). Used to surface provenance in the UI.
     public var isFromOpenStreetMap: Bool { id.hasPrefix("exp_osm_") }
+
+    /// ID prefix for experiences a user creates by hand. Mirrors
+    /// `EXP_USER_ID_PREFIX` in packages/core/src/experience.ts.
+    public static let userIdPrefix = "exp_user_"
+
+    /// True when the user registered this place themselves. Drives a distinct
+    /// "unverified / user-created" marker and badge in the UI.
+    public var isUserCreated: Bool { id.hasPrefix(Self.userIdPrefix) }
+
+    /// Build a candidate `Experience` from raw user input. Trust-critical fields
+    /// are forced to safe, unverified defaults — the user never scores their own
+    /// place. Mirrors `createUserExperience` in packages/core/src/experience.ts.
+    ///
+    /// - Parameters:
+    ///   - uuid: caller-supplied unique id (e.g. `UUID().uuidString`).
+    ///   - now: creation timestamp; defaults to current date.
+    public static func userDraft(
+        uuid: String,
+        title: String,
+        oneLiner: String,
+        category: ExperienceCategory,
+        coordinates: [Double],
+        cityCode: String,
+        placeNameRomanized: String? = nil,
+        placeNameLocal: String? = nil,
+        addressHint: String? = nil,
+        description: String = "",
+        photoUrls: [String]? = nil,
+        userTags: [String]? = nil,
+        now: Date = Date()
+    ) -> Experience {
+        Experience(
+            id: "\(userIdPrefix)\(uuid)",
+            title: title,
+            oneLiner: oneLiner,
+            whyItMatters: description,
+            category: category,
+            location: ExperienceLocation(
+                coordinates: coordinates,
+                cityCode: cityCode,
+                addressHint: addressHint,
+                placeNameLocal: placeNameLocal,
+                placeNameRomanized: placeNameRomanized,
+                photoUrls: photoUrls
+            ),
+            bestTimes: [],
+            durationMinutes: DurationRange(min: 30, max: 60),
+            howTo: [],
+            realInconveniences: [],
+            soloScore: SoloScore(
+                overall: 5,
+                breakdown: SoloScore.Breakdown(
+                    seatingFriendly: 5,
+                    soloPatronRatio: 5,
+                    staffPressure: 5,
+                    soloPortioning: 5,
+                    ambianceFit: 5,
+                    safety: 5
+                ),
+                basedOnCount: 0
+            ),
+            sources: [InformationSource(type: .user, verifiedAt: now)],
+            confidence: Confidence(
+                level: 1,
+                lastVerifiedAt: now,
+                reason: "User-created, awaiting verification",
+                signals: Confidence.Signals(
+                    aiScrapeAgeDays: 0,
+                    passiveGpsHits30d: 0,
+                    activeReports30d: 0,
+                    trustedVerifications: 0
+                )
+            ),
+            nearbyExperienceIds: [],
+            stats: Stats(completionCount: 0, averageRating: 0),
+            status: .candidate,
+            createdAt: now,
+            updatedAt: now,
+            userTags: userTags
+        )
+    }
 
     /// True only when the entry actually went through AI synthesis. The
     /// `skeletonExperience` fallback (network/quota failure, missing key)

--- a/apps/ios/SoloCompass/Persistence/Models/ExperienceRecord.swift
+++ b/apps/ios/SoloCompass/Persistence/Models/ExperienceRecord.swift
@@ -80,6 +80,11 @@ public final class ExperienceRecord {
     /// as the empty array — see `asValue` below.
     public var userTagsBlob: Data?
 
+    /// Photos attached to a user-created place. JSON-encoded `[String]` of URL
+    /// strings (local `file://` then remote https after sync). Optional so rows
+    /// migrated from earlier schema versions decode as `nil`.
+    public var photoUrlsBlob: Data?
+
     public init(
         id: String,
         title: String,
@@ -110,7 +115,8 @@ public final class ExperienceRecord {
         confidenceBlob: Data,
         statsBlob: Data,
         nearbyExperienceIdsBlob: Data,
-        userTagsBlob: Data? = nil
+        userTagsBlob: Data? = nil,
+        photoUrlsBlob: Data? = nil
     ) {
         self.id = id
         self.title = title
@@ -142,10 +148,19 @@ public final class ExperienceRecord {
         self.statsBlob = statsBlob
         self.nearbyExperienceIdsBlob = nearbyExperienceIdsBlob
         self.userTagsBlob = userTagsBlob
+        self.photoUrlsBlob = photoUrlsBlob
     }
 }
 
 // MARK: - Two-way mapping
+
+/// Encode optional photo URLs to a JSON blob, or `nil` when there are none.
+/// Kept as a free function so the `init(from:)` call site stays a simple
+/// expression the Swift type-checker can resolve quickly.
+private func encodedPhotoUrls(_ urls: [String]?, encoder: JSONEncoder) -> Data? {
+    guard let urls else { return nil }
+    return try? encoder.encode(urls)
+}
 
 extension ExperienceRecord {
     /// Build a record from an `Experience` value. Encoding errors are
@@ -186,7 +201,8 @@ extension ExperienceRecord {
                 confidenceBlob: try encoder.encode(experience.confidence),
                 statsBlob: try encoder.encode(experience.stats),
                 nearbyExperienceIdsBlob: try encoder.encode(experience.nearbyExperienceIds),
-                userTagsBlob: try encoder.encode(experience.userTags ?? [])
+                userTagsBlob: try encoder.encode(experience.userTags ?? []),
+                photoUrlsBlob: encodedPhotoUrls(experience.location.photoUrls, encoder: encoder)
             )
         } catch {
             fatalError("Failed to encode Experience \(experience.id): \(error)")
@@ -215,7 +231,8 @@ extension ExperienceRecord {
                     openingHours: openingHours,
                     priceLevel: priceLevel,
                     website: website,
-                    phone: phone
+                    phone: phone,
+                    photoUrls: photoUrlsBlob.flatMap { try? decoder.decode([String].self, from: $0) }
                 ),
                 bestTimes: try decoder.decode([TimeWindow].self, from: bestTimesBlob),
                 durationMinutes: .init(min: durationMin, max: durationMax),

--- a/apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift
+++ b/apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift
@@ -68,12 +68,41 @@ public enum SoloCompassSchemaV1_1: VersionedSchema {
     }
 }
 
-/// Migration plan stitching v1.0 → v1.1. The only change is the addition of
-/// an optional `Data?` column on `ExperienceRecord`, which is a
-/// lightweight migration.
+/// Schema v1.2 — adds the optional `ExperienceRecord.photoUrlsBlob` column
+/// for user-created places. Like v1.1, this is a *lightweight* migration: the
+/// new column is `Data?`, so existing rows migrate with NULL and no data is
+/// rewritten. `asValue` treats a nil blob as `nil` photoUrls.
+// swiftlint:disable:next type_name
+public enum SoloCompassSchemaV1_2: VersionedSchema {
+    public static var versionIdentifier: Schema.Version { .init(1, 2, 0) }
+
+    public static var models: [any PersistentModel.Type] {
+        [
+            ExperienceRecord.self,
+            UserCompletionRecord.self,
+            UserFavoriteRecord.self,
+            MicroSurveyRecord.self,
+            PendingCheckInRecord.self,
+            ExploreCacheRecord.self,
+            AISynthesisCacheRecord.self,
+            DiscoveredCityRecord.self,
+            RecentExploreRegion.self,
+            AIUsageRecord.self,
+            PendingSyncRecord.self,
+            ItineraryRecord.self,
+            RouteRecord.self,
+            ConversationRecord.self,
+            WeatherCacheRecord.self,
+        ]
+    }
+}
+
+/// Migration plan stitching v1.0 → v1.1 → v1.2. Each change is the addition of
+/// an optional `Data?` column on `ExperienceRecord`, which is a lightweight
+/// migration.
 public enum SoloCompassMigrationPlan: SchemaMigrationPlan {
     public static var schemas: [any VersionedSchema.Type] {
-        [SoloCompassSchemaV1.self, SoloCompassSchemaV1_1.self]
+        [SoloCompassSchemaV1.self, SoloCompassSchemaV1_1.self, SoloCompassSchemaV1_2.self]
     }
 
     public static var stages: [MigrationStage] {
@@ -81,7 +110,11 @@ public enum SoloCompassMigrationPlan: SchemaMigrationPlan {
             .lightweight(
                 fromVersion: SoloCompassSchemaV1.self,
                 toVersion: SoloCompassSchemaV1_1.self
-            )
+            ),
+            .lightweight(
+                fromVersion: SoloCompassSchemaV1_1.self,
+                toVersion: SoloCompassSchemaV1_2.self
+            ),
         ]
     }
 }

--- a/apps/ios/SoloCompass/Resources/Info.plist
+++ b/apps/ios/SoloCompass/Resources/Info.plist
@@ -27,9 +27,11 @@
 	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
-	<!-- NSAppTransportSecurity: localhost exception is only exercised in DEBUG builds.
-	     Release builds with no SOLO_API_BASE_URL set short-circuit in ReviewsService
-	     before making any network request, so this entry is inert in production. -->
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>comgooglemaps</string>
+		<string>iosamap</string>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>
@@ -43,17 +45,16 @@
 			</dict>
 		</dict>
 	</dict>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>comgooglemaps</string>
-		<string>iosamap</string>
-	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Solo Compass uses the camera so you can photograph a place when you add it to the map.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>Solo Compass uses background location to alert you when you're near a place worth visiting — even when the app is closed.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Solo Compass uses your location to show experiences near you on the map.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Solo Compass uses the microphone for voice search.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Solo Compass needs access to your photos so you can attach an image to a place you add.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Solo Compass uses speech recognition so you can describe what you're looking for by voice.</string>
 	<key>UIBackgroundModes</key>

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1083,6 +1083,12 @@
 "companion.chat.error.title" = "Message error";
 "companion.chat.error.auth" = "Sign in to send messages.";
 "companion.chat.error.encode" = "Could not send message. Try again.";
+"companion.chat.attachment.backendNotReady" = "Attachments need the storage backend deployed — your message was sent without them.";
+"companion.chat.attachment.uploadFailed" = "Attachment upload failed (HTTP %d).";
+"companion.chat.attachment.tooLarge" = "That attachment is too large to send.";
+"companion.chat.attachment.rateLimited" = "Too many uploads right now — try again in a moment.";
+"companion.chat.attachment.notSignedIn" = "Sign in to send attachments.";
+"companion.chat.attachment.badResponse" = "The attachment service returned an unexpected response.";
 "companion.chat.bubble.me.a11y" = "You: %@, sent at %@";
 "companion.chat.bubble.them.a11y" = "Companion: %@, sent at %@";
 

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -184,11 +184,27 @@
 "common.close" = "Close";
 
 /* Add Experience (long-press flow) */
-"addExperience.confirm.title" = "Add an experience here?";
-"addExperience.confirm.message" = "Describe it with your voice.";
+"addExperience.confirm.title" = "Add a place here?";
+"addExperience.confirm.message" = "Fill in a few details, or describe it with your voice.";
 "addExperience.confirm.add" = "Add";
 "addExperience.record.title" = "Tell us about this place";
 "addExperience.record.hint" = "Hold the mic and describe what makes it worth a solo visit.";
+
+/* User-created place form (long-press → form) */
+"userLocation.create.title" = "Add a place";
+"userLocation.form.save" = "Save";
+"userLocation.form.name.label" = "Name";
+"userLocation.form.name.placeholder" = "Place name, e.g. Wat Suan Dok";
+"userLocation.form.nameLocal.placeholder" = "Local-language name (optional)";
+"userLocation.form.oneLiner.placeholder" = "One line: what makes it worth it (optional)";
+"userLocation.form.category.label" = "Category";
+"userLocation.form.notes.label" = "Notes";
+"userLocation.form.notes.placeholder" = "What's it like to be here alone?";
+"userLocation.form.photo.label" = "Photos";
+"userLocation.form.photo.library" = "Choose from library";
+"userLocation.form.photo.camera" = "Take a photo";
+"userLocation.form.useVoice" = "Describe with voice instead";
+"userLocation.form.unverifiedNote" = "Your place is added as unverified. It won't get a Solo Score until it's reviewed.";
 
 /* Marker accessibility */
 "marker.a11y.bestNow" = "best right now";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -107,11 +107,27 @@
 "common.cancel" = "取消";
 
 /* Add Experience (long-press flow) */
-"addExperience.confirm.title" = "在此处添加一个体验？";
-"addExperience.confirm.message" = "用语音描述它。";
+"addExperience.confirm.title" = "在此处添加一个地点？";
+"addExperience.confirm.message" = "填写几项信息，或用语音描述它。";
 "addExperience.confirm.add" = "添加";
 "addExperience.record.title" = "聊聊这个地方";
 "addExperience.record.hint" = "按住麦克风，描述它为何值得一人前来。";
+
+/* User-created place form (long-press → form) */
+"userLocation.create.title" = "添加地点";
+"userLocation.form.save" = "保存";
+"userLocation.form.name.label" = "名称";
+"userLocation.form.name.placeholder" = "地点名称，例如 Wat Suan Dok";
+"userLocation.form.nameLocal.placeholder" = "当地语言名称（可选）";
+"userLocation.form.oneLiner.placeholder" = "一句话：它为何值得（可选）";
+"userLocation.form.category.label" = "类别";
+"userLocation.form.notes.label" = "描述";
+"userLocation.form.notes.placeholder" = "一个人在这里是什么感受？";
+"userLocation.form.photo.label" = "照片";
+"userLocation.form.photo.library" = "从相册选择";
+"userLocation.form.photo.camera" = "拍照";
+"userLocation.form.useVoice" = "改用语音描述";
+"userLocation.form.unverifiedNote" = "你添加的地点为「待验证」。在通过审核前不会获得 Solo 评分。";
 
 /* Marker accessibility */
 "marker.a11y.bestNow" = "此刻最佳";

--- a/apps/ios/SoloCompass/Services/ChatAttachmentService.swift
+++ b/apps/ios/SoloCompass/Services/ChatAttachmentService.swift
@@ -1,0 +1,231 @@
+import Foundation
+
+/// Uploads draft attachments to Supabase Storage and resolves download URLs.
+///
+/// Mirrors the design doc §2.3. The protocol seam lets `ChatService` inject a
+/// mock in tests and lets the UI degrade gracefully when the storage backend
+/// (bucket `chat-media` + RLS) has not been deployed yet.
+@MainActor
+public protocol AttachmentUploading {
+    /// Upload one draft to the `chat-media` bucket and return the persisted
+    /// `ChatAttachment` metadata ready to write into a message row.
+    func upload(_ local: LocalAttachment, conversationId: String, messageId: String) async throws -> ChatAttachment
+    /// Resolve a short-lived (~1h) signed URL for downloading an attachment.
+    func signedURL(for attachment: ChatAttachment) async throws -> URL
+}
+
+/// Typed, user-presentable failures from the attachment pipeline.
+///
+/// `backendNotReady` is the critical case: the user has not deployed the
+/// Storage bucket / RLS migration yet, so any 400/401/403/404 from storage is
+/// surfaced as a clear "deploy the backend" message rather than a generic
+/// failure — the UI degrades by still sending the text-only message.
+public enum AttachmentError: Error, LocalizedError, Sendable {
+    case backendNotReady
+    case tooLarge
+    case rateLimited
+    case uploadFailed(Int)
+    case notSignedIn
+    case badResponse
+
+    public var errorDescription: String? {
+        switch self {
+        case .backendNotReady:
+            return NSLocalizedString(
+                "companion.chat.attachment.backendNotReady",
+                comment: "Attachments need the storage backend deployed"
+            )
+        case .tooLarge:
+            return NSLocalizedString(
+                "companion.chat.attachment.tooLarge",
+                comment: "Attachment is too large to upload"
+            )
+        case .rateLimited:
+            return NSLocalizedString(
+                "companion.chat.attachment.rateLimited",
+                comment: "Too many uploads — try again shortly"
+            )
+        case .uploadFailed(let status):
+            return String(
+                format: NSLocalizedString(
+                    "companion.chat.attachment.uploadFailed",
+                    comment: "Attachment upload failed (HTTP %d)"
+                ),
+                status
+            )
+        case .notSignedIn:
+            return NSLocalizedString(
+                "companion.chat.attachment.notSignedIn",
+                comment: "Sign in to send attachments"
+            )
+        case .badResponse:
+            return NSLocalizedString(
+                "companion.chat.attachment.badResponse",
+                comment: "Attachment service returned an unexpected response"
+            )
+        }
+    }
+}
+
+/// Real implementation backed by Supabase Storage's REST endpoints.
+///
+/// Hand-written URLSession to match `SupabaseClient`'s dependency-free REST
+/// style (the SDK's storage wrapper is intentionally not used). Config (base
+/// URL + anon key) is read the SAME way `SupabaseClient.loadConfig` does:
+/// env override → bundled `Secrets.plist` → build-time `GeneratedSecrets`.
+@MainActor
+public final class SupabaseAttachmentService: AttachmentUploading {
+
+    /// Storage bucket holding all chat media. Created by migration 0005.
+    private static let bucket = "chat-media"
+
+    private let client: SupabaseClientProtocol
+    private let urlSession: URLSession
+
+    public init(
+        client: SupabaseClientProtocol = SupabaseClient.shared,
+        urlSession: URLSession = .shared
+    ) {
+        self.client = client
+        self.urlSession = urlSession
+    }
+
+    // MARK: - Config (mirrors SupabaseClient.loadConfig)
+
+    private struct Config { let url: URL; let anonKey: String }
+
+    private func loadConfig() -> Config? {
+        let envURL = ProcessInfo.processInfo.environment["SUPABASE_URL"]
+        let envKey = ProcessInfo.processInfo.environment["SUPABASE_ANON_KEY"]
+            ?? ProcessInfo.processInfo.environment["SUPABASE_KEY"]
+        let urlStr = envURL ?? plistValue("SUPABASE_URL")
+            ?? (Secrets.supabaseURL.isEmpty ? nil : Secrets.supabaseURL)
+        let key = envKey ?? plistValue("SUPABASE_ANON_KEY") ?? plistValue("SUPABASE_KEY")
+            ?? (Secrets.supabaseAnonKey.isEmpty ? nil : Secrets.supabaseAnonKey)
+        guard let urlStr, let url = URL(string: urlStr), let key, !key.isEmpty else { return nil }
+        return Config(url: url, anonKey: key)
+    }
+
+    private func plistValue(_ key: String) -> String? {
+        guard let url = Bundle.main.url(forResource: "Secrets", withExtension: "plist"),
+              let data = try? Data(contentsOf: url),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        else { return nil }
+        return plist[key] as? String
+    }
+
+    // MARK: - Upload
+
+    public func upload(
+        _ local: LocalAttachment,
+        conversationId: String,
+        messageId: String
+    ) async throws -> ChatAttachment {
+        guard let cfg = loadConfig() else { throw AttachmentError.backendNotReady }
+        guard let token = client.currentSession?.accessToken else { throw AttachmentError.notSignedIn }
+
+        let attachmentId = UUID().uuidString
+        // Path convention from the design doc:
+        // "{conversationId}/{messageId}/{attachmentId}-{fileName}".
+        let path = "\(conversationId)/\(messageId)/\(attachmentId)-\(local.fileName)"
+        guard let objectURL = storageURL(base: cfg.url, suffix: "object/\(Self.bucket)/\(path)") else {
+            throw AttachmentError.badResponse
+        }
+
+        var req = URLRequest(url: objectURL)
+        req.httpMethod = "POST"
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.setValue(cfg.anonKey, forHTTPHeaderField: "apikey")
+        req.setValue(local.mimeType, forHTTPHeaderField: "Content-Type")
+        // Idempotent re-send on retry: overwrite rather than 409 on duplicate.
+        req.setValue("true", forHTTPHeaderField: "x-upsert")
+        req.httpBody = local.data
+
+        let status = try await send(req)
+        guard (200..<300).contains(status) else {
+            throw Self.mapStatus(status)
+        }
+
+        let width = local.image.map { Int($0.size.width) }
+        let height = local.image.map { Int($0.size.height) }
+        return ChatAttachment(
+            id: attachmentId,
+            kind: local.kind,
+            fileName: local.fileName,
+            mimeType: local.mimeType,
+            fileSizeBytes: local.data.count,
+            storagePath: path,
+            width: local.kind == .image ? width : nil,
+            height: local.kind == .image ? height : nil
+        )
+    }
+
+    // MARK: - Signed URL
+
+    public func signedURL(for attachment: ChatAttachment) async throws -> URL {
+        guard let cfg = loadConfig() else { throw AttachmentError.backendNotReady }
+        guard let token = client.currentSession?.accessToken else { throw AttachmentError.notSignedIn }
+        guard let signURL = storageURL(base: cfg.url, suffix: "object/sign/\(Self.bucket)/\(attachment.storagePath)") else {
+            throw AttachmentError.badResponse
+        }
+
+        var req = URLRequest(url: signURL)
+        req.httpMethod = "POST"
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.setValue(cfg.anonKey, forHTTPHeaderField: "apikey")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try? JSONSerialization.data(withJSONObject: ["expiresIn": 3600])
+
+        let (data, response) = try await urlSession.data(for: req)
+        guard let http = response as? HTTPURLResponse else { throw AttachmentError.badResponse }
+        guard (200..<300).contains(http.statusCode) else {
+            throw Self.mapStatus(http.statusCode)
+        }
+
+        struct SignResponse: Decodable { let signedURL: String }
+        guard let resp = try? JSONDecoder().decode(SignResponse.self, from: data) else {
+            throw AttachmentError.badResponse
+        }
+        // Supabase returns a relative path ("/storage/v1/...") — resolve it
+        // against the project base URL to get an absolute, fetchable URL.
+        let relative = resp.signedURL.hasPrefix("/") ? String(resp.signedURL.dropFirst()) : resp.signedURL
+        guard let absolute = URL(string: relative, relativeTo: cfg.url)?.absoluteURL else {
+            throw AttachmentError.badResponse
+        }
+        return absolute
+    }
+
+    // MARK: - Internals
+
+    /// Maps a non-2xx storage status to a user-meaningful error.
+    /// - 400/401/403/404 → `backendNotReady` (bucket / RLS not deployed yet — the
+    ///   dominant pre-deploy case; UI degrades to text-only).
+    /// - 413 → `tooLarge`, 429 → `rateLimited` (actionable user feedback rather
+    ///   than a bare HTTP code).
+    /// - anything else → `uploadFailed(status)`.
+    static func mapStatus(_ status: Int) -> AttachmentError {
+        switch status {
+        case 400, 401, 403, 404: return .backendNotReady
+        case 413:                return .tooLarge
+        case 429:                return .rateLimited
+        default:                 return .uploadFailed(status)
+        }
+    }
+
+    /// Builds a `/storage/v1/{suffix}` URL, percent-encoding path segments so
+    /// file names with spaces / unicode survive the round trip.
+    private func storageURL(base: URL, suffix: String) -> URL? {
+        let encoded = suffix
+            .split(separator: "/", omittingEmptySubsequences: false)
+            .map { $0.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? String($0) }
+            .joined(separator: "/")
+        return URL(string: "storage/v1/\(encoded)", relativeTo: base)?.absoluteURL
+    }
+
+    /// Performs the request and returns the HTTP status code.
+    private func send(_ request: URLRequest) async throws -> Int {
+        let (_, response) = try await urlSession.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw AttachmentError.badResponse }
+        return http.statusCode
+    }
+}

--- a/apps/ios/SoloCompass/Services/ChatService.swift
+++ b/apps/ios/SoloCompass/Services/ChatService.swift
@@ -88,8 +88,12 @@ public final class ChatService {
         let messageId = UUID().uuidString
         let now = ISO8601DateFormatter().string(from: Date())
 
+        // All-or-nothing upload: if ANY attachment fails, drop them ALL and keep
+        // only the text. Sending a message with a silent subset of attachments
+        // (e.g. 2 of 3, where #2 was too large) is a data-integrity trap — the
+        // recipient sees an incomplete set and the sender only sees one error.
         var uploaded: [ChatAttachment] = []
-        var degradedToTextOnly = false
+        var attachmentsDropped = false
         for local in attachments {
             do {
                 let attachment = try await attachmentService.upload(
@@ -98,22 +102,20 @@ public final class ChatService {
                     messageId: messageId
                 )
                 uploaded.append(attachment)
-            } catch AttachmentError.backendNotReady {
-                // Backend not deployed — drop attachments, keep the text.
-                degradedToTextOnly = true
+            } catch {
+                // Surface the specific reason (backendNotReady / tooLarge /
+                // rateLimited / uploadFailed) but treat every failure the same:
+                // abandon the whole attachment set, keep the text.
+                lastError = error.localizedDescription
+                attachmentsDropped = true
                 uploaded.removeAll()
                 break
-            } catch {
-                lastError = error.localizedDescription
             }
         }
 
-        if degradedToTextOnly {
-            lastError = NSLocalizedString(
-                "companion.chat.attachment.backendNotReady",
-                comment: "Attachments need the storage backend deployed"
-            )
-            // If there's no text to fall back on, there's nothing to send.
+        if attachmentsDropped {
+            // If there's no text to fall back on, there's nothing to send — the
+            // user must retry the attachments rather than receive an empty row.
             guard !trimmed.isEmpty else { return }
         }
 

--- a/apps/ios/SoloCompass/Services/ChatService.swift
+++ b/apps/ios/SoloCompass/Services/ChatService.swift
@@ -20,6 +20,9 @@ public final class ChatService {
 
     private let conversationId: ConversationId
     private let restClient: SupabaseClientProtocol
+    /// Uploads draft attachments to Storage before the message row is written.
+    /// Injectable so tests can supply a mock (and assert the degrade path).
+    private let attachmentService: AttachmentUploading
     private var sdkClient: Supabase.SupabaseClient?
     private var realtimeTask: Task<Void, Never>?
     /// ISO 8601 timestamp of the latest message received locally.
@@ -27,10 +30,12 @@ public final class ChatService {
 
     public init(
         conversationId: ConversationId,
-        client: SupabaseClientProtocol = SupabaseClient.shared
+        client: SupabaseClientProtocol = SupabaseClient.shared,
+        attachmentService: AttachmentUploading = SupabaseAttachmentService()
     ) {
         self.conversationId = conversationId
         self.restClient = client
+        self.attachmentService = attachmentService
     }
 
     // MARK: - Lifecycle
@@ -54,24 +59,70 @@ public final class ChatService {
     /// Send a plain-text message (≤1000 chars). Enforced client-side; RLS
     /// ensures only conversation participants can insert.
     public func send(_ text: String) async {
+        await send(text, attachments: [])
+    }
+
+    /// Send a message with optional attachments. Attachments are uploaded to
+    /// Storage first, then their metadata is written into the message's
+    /// `attachments` jsonb column.
+    ///
+    /// Degrade path: if the storage backend isn't deployed yet (any upload
+    /// throws `.backendNotReady`), we surface a clear error and STILL send the
+    /// text-only message so the user never loses their words.
+    public func send(_ text: String, attachments: [LocalAttachment]) async {
         guard FeatureFlags.companion else { return }
         guard let userId = restClient.currentSession?.userId else {
             lastError = NSLocalizedString("companion.chat.error.auth", comment: "Not signed in")
             return
         }
         let trimmed = String(text.prefix(1000))
-        guard !trimmed.isEmpty else { return }
+        // Allow attachment-only messages, but a fully empty send is a no-op.
+        guard !trimmed.isEmpty || !attachments.isEmpty else { return }
 
         isSending = true
         lastError = nil
         defer { isSending = false }
 
+        // Generate the messageId up front so uploaded objects can be keyed by
+        // it ("{conversationId}/{messageId}/...") before the row is written.
+        let messageId = UUID().uuidString
         let now = ISO8601DateFormatter().string(from: Date())
+
+        var uploaded: [ChatAttachment] = []
+        var degradedToTextOnly = false
+        for local in attachments {
+            do {
+                let attachment = try await attachmentService.upload(
+                    local,
+                    conversationId: conversationId.rawValue,
+                    messageId: messageId
+                )
+                uploaded.append(attachment)
+            } catch AttachmentError.backendNotReady {
+                // Backend not deployed — drop attachments, keep the text.
+                degradedToTextOnly = true
+                uploaded.removeAll()
+                break
+            } catch {
+                lastError = error.localizedDescription
+            }
+        }
+
+        if degradedToTextOnly {
+            lastError = NSLocalizedString(
+                "companion.chat.attachment.backendNotReady",
+                comment: "Attachments need the storage backend deployed"
+            )
+            // If there's no text to fall back on, there's nothing to send.
+            guard !trimmed.isEmpty else { return }
+        }
+
         let msg = ChatMessage(
-            id: ChatMessageId(rawValue: UUID().uuidString),
+            id: ChatMessageId(rawValue: messageId),
             conversationId: conversationId,
             senderId: userId,
             body: trimmed,
+            attachments: uploaded.isEmpty ? nil : uploaded,
             createdAt: now
         )
 
@@ -170,10 +221,24 @@ public final class ChatService {
             conversationId: ConversationId(rawValue: convIdStr),
             senderId: senderStr,
             body: bodyStr,
+            attachments: decodeAttachments(from: record["attachments"]),
             readAt: readAt,
             createdAt: createdStr
         )
         appendIfNew(msg)
+    }
+
+    /// Defensively decode the realtime record's `attachments` jsonb value into
+    /// `[ChatAttachment]`. Returns nil when the column is absent, null, or
+    /// malformed — never crashes. Re-encodes the `AnyJSON` value to bytes and
+    /// runs it through the same Codable path used for REST payloads.
+    private func decodeAttachments(from value: AnyJSON?) -> [ChatAttachment]? {
+        guard let value, case .array = value else { return nil }
+        guard let data = try? JSONEncoder().encode(value),
+              let attachments = try? JSONDecoder().decode([ChatAttachment].self, from: data),
+              !attachments.isEmpty
+        else { return nil }
+        return attachments
     }
 
     // MARK: - Helpers

--- a/apps/ios/SoloCompass/Services/ChatService.swift
+++ b/apps/ios/SoloCompass/Services/ChatService.swift
@@ -141,6 +141,14 @@ public final class ChatService {
         }
     }
 
+    /// Resolve a short-lived signed download URL for a persisted attachment,
+    /// delegating to the same injected `AttachmentUploading` service used for
+    /// upload. Returns `nil` (rather than throwing) so the UI degrades to a
+    /// placeholder when the storage backend isn't deployed yet.
+    public func resolveAttachmentURL(_ attachment: ChatAttachment) async -> URL? {
+        try? await attachmentService.signedURL(for: attachment)
+    }
+
     // MARK: - History fetch
 
     private func fetchHistory(since: String?) async {

--- a/apps/ios/SoloCompass/Services/PlacePhotoStore.swift
+++ b/apps/ios/SoloCompass/Services/PlacePhotoStore.swift
@@ -1,0 +1,53 @@
+import Foundation
+import UIKit
+
+/// Persists photos a user attaches to a place they create.
+///
+/// Phase 1 stores images in the app's Application Support directory and returns
+/// `file://` URLs, which go straight into `ExperienceLocation.photoUrls`. When
+/// Phase 2 adds upload sync, the same field is repopulated with remote https
+/// URLs and these local files can be cleaned up — the schema doesn't change.
+enum PlacePhotoStore {
+    /// Subdirectory under Application Support that holds user place photos.
+    private static let folderName = "UserPlacePhotos"
+
+    private static var folderURL: URL? {
+        guard
+            let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        else { return nil }
+        let dir = base.appendingPathComponent(folderName, isDirectory: true)
+        if !FileManager.default.fileExists(atPath: dir.path) {
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        return dir
+    }
+
+    /// Write a single image to disk as JPEG and return its `file://` URL string.
+    /// Returns nil when the image can't be encoded or the directory is missing.
+    ///
+    /// - Parameters:
+    ///   - image: the picked or captured image.
+    ///   - uuid: a caller-supplied unique id so filenames stay deterministic
+    ///           for tests (e.g. `UUID().uuidString`).
+    ///   - quality: JPEG compression quality (0–1). Defaults to 0.8.
+    static func save(_ image: UIImage, uuid: String, quality: CGFloat = 0.8) -> String? {
+        guard
+            let dir = folderURL,
+            let data = image.jpegData(compressionQuality: quality)
+        else { return nil }
+        let fileURL = dir.appendingPathComponent("photo_\(uuid).jpg")
+        do {
+            try data.write(to: fileURL, options: .atomic)
+            return fileURL.absoluteString
+        } catch {
+            return nil
+        }
+    }
+
+    /// Save several images, returning the `file://` URL strings that succeeded.
+    /// The `uuids` array must be at least as long as `images`; extra ids are
+    /// ignored. Indices are paired positionally so retries stay deterministic.
+    static func save(_ images: [UIImage], uuids: [String]) -> [String] {
+        zip(images, uuids).compactMap { save($0, uuid: $1) }
+    }
+}

--- a/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
@@ -52,6 +52,42 @@ public final class VoiceAgentOrchestrator: Identifiable {
 
     private var turnTask: Task<Void, Never>?
     private var isSeeded = false
+
+    // MARK: - Streaming throttle
+    //
+    // MarkdownMessageText re-parses the whole string on every `streamingContent`
+    // change. Publishing on every SSE token (often <5 chars) makes the markdown
+    // parser run dozens of times per second and stutters the bubble. We coalesce
+    // updates: a token is published only when ≥80ms has elapsed since the last
+    // publish OR ≥60 new chars have accumulated — whichever comes first. The
+    // final text always lands because callers call `publishStreaming(_, force:)`
+    // at end of stream, which forces the latest value through regardless of gate.
+    private static let streamThrottleInterval: TimeInterval = 0.08
+    private static let streamThrottleCharBudget = 60
+    private var lastStreamFlush = Date.distantPast
+    private var lastFlushedLength = 0
+
+    /// Throttled setter for `streamingContent` during token streaming.
+    /// Drops intermediate updates that arrive faster than the throttle window;
+    /// `force` (final message) bypasses the gate so the full text always shows.
+    private func publishStreaming(_ content: String, force: Bool = false) {
+        let now = Date()
+        let elapsed = now.timeIntervalSince(lastStreamFlush)
+        let grew = content.count - lastFlushedLength
+        guard force
+            || elapsed >= Self.streamThrottleInterval
+            || grew >= Self.streamThrottleCharBudget
+        else { return }
+        streamingContent = content
+        lastStreamFlush = now
+        lastFlushedLength = content.count
+    }
+
+    /// Reset the throttle window so the next stream starts fresh.
+    private func resetStreamThrottle() {
+        lastStreamFlush = .distantPast
+        lastFlushedLength = 0
+    }
     private let synthesizer = AVSpeechSynthesizer()
 
     public init(
@@ -312,6 +348,7 @@ public final class VoiceAgentOrchestrator: Identifiable {
     /// Returns false on unrecoverable error.
     private func sendToAIStreaming() async -> Bool {
         streamingContent = ""
+        resetStreamThrottle()
         var accumulatedContent = ""
         var pendingToolCalls: [(id: String, name: String, args: String)] = []
 
@@ -325,7 +362,8 @@ public final class VoiceAgentOrchestrator: Identifiable {
                 switch event {
                 case .contentDelta(let delta):
                     accumulatedContent += delta
-                    streamingContent = accumulatedContent
+                    // Throttled: coalesces rapid tokens to spare the markdown parser.
+                    publishStreaming(accumulatedContent)
                 case .toolCall(let id, let name, let args):
                     pendingToolCalls.append((id: id, name: name, args: args))
                     thinkingStep = thinkingStepLabel(for: name)
@@ -333,6 +371,10 @@ public final class VoiceAgentOrchestrator: Identifiable {
                     break
                 }
             }
+
+            // Force the final, complete text through the throttle gate so the
+            // full message always lands even if the last tokens were coalesced.
+            publishStreaming(accumulatedContent, force: true)
 
             let sessionCalls = pendingToolCalls.map {
                 VoiceAgentSession.ToolCall(id: $0.id, name: $0.name, argumentsJSON: $0.args)

--- a/apps/ios/SoloCompass/Tests/ChatAttachmentTests.swift
+++ b/apps/ios/SoloCompass/Tests/ChatAttachmentTests.swift
@@ -1,0 +1,337 @@
+import XCTest
+@testable import SoloCompass
+
+/// Covers the testable pure / injectable logic behind the chat-experience
+/// upgrade (design doc `docs/design/chat-experience-upgrade.md`):
+///
+/// 1. `SupabaseAttachmentService.mapStatus` — HTTP status → typed
+///    `AttachmentError` (the degrade-vs-actionable-error fork).
+/// 2. `ChatMessage` Codable round-trip with attachments, and decode from a
+///    hand-written camelCase JSON payload matching the TS `ChatMessage` shape.
+/// 3. Attachment-key absence (→ nil) and explicit null (→ nil) on decode.
+/// 4. `AttachmentUploading` degrade path: a mock that throws `.backendNotReady`
+///    drops attachments while the text-only `ChatMessage` is still produced.
+///
+/// User instruction (verbatim): "通过 Agent Team 优化聊天界面到满分"
+///
+/// `@MainActor` because `SupabaseAttachmentService.mapStatus` and the
+/// `AttachmentUploading` protocol are main-actor isolated.
+@MainActor
+final class ChatAttachmentTests: XCTestCase {
+
+    // MARK: - 1. mapStatus
+
+    // `AttachmentError` is intentionally not `Equatable` in production, so we
+    // pattern-match each case rather than use `XCTAssertEqual`.
+
+    /// `mapStatus` is `static` (internal) so `@testable import` reaches it.
+    /// 400/401/403/404 are the dominant pre-deploy signal (bucket / RLS not
+    /// shipped) → `.backendNotReady`, which the UI degrades to text-only.
+    func test_mapStatus_400_401_403_404_backendNotReady() {
+        for status in [400, 401, 403, 404] {
+            guard case .backendNotReady = SupabaseAttachmentService.mapStatus(status) else {
+                return XCTFail("HTTP \(status) must map to .backendNotReady (degrade to text-only)")
+            }
+        }
+    }
+
+    func test_mapStatus_413_tooLarge() {
+        guard case .tooLarge = SupabaseAttachmentService.mapStatus(413) else {
+            return XCTFail("HTTP 413 must map to .tooLarge")
+        }
+    }
+
+    func test_mapStatus_429_rateLimited() {
+        guard case .rateLimited = SupabaseAttachmentService.mapStatus(429) else {
+            return XCTFail("HTTP 429 must map to .rateLimited")
+        }
+    }
+
+    func test_mapStatus_500_uploadFailedCarriesStatus() {
+        // The status code must be carried through verbatim, not flattened.
+        guard case .uploadFailed(let s500) = SupabaseAttachmentService.mapStatus(500) else {
+            return XCTFail("HTTP 500 must map to .uploadFailed")
+        }
+        XCTAssertEqual(s500, 500)
+        guard case .uploadFailed(let s503) = SupabaseAttachmentService.mapStatus(503) else {
+            return XCTFail("HTTP 503 must map to .uploadFailed")
+        }
+        XCTAssertEqual(s503, 503)
+    }
+
+    // MARK: - 2. ChatMessage Codable round-trip WITH attachments
+
+    func test_chatMessage_roundTrip_withTwoAttachments_preservesAllFields() throws {
+        let image = ChatAttachment(
+            id: "att_img_1",
+            kind: .image,
+            fileName: "sunset.jpg",
+            mimeType: "image/jpeg",
+            fileSizeBytes: 204_800,
+            storagePath: "conv_1/cmsg_1/att_img_1-sunset.jpg",
+            width: 1024,
+            height: 768
+        )
+        let file = ChatAttachment(
+            id: "att_file_1",
+            kind: .file,
+            fileName: "itinerary.pdf",
+            mimeType: "application/pdf",
+            fileSizeBytes: 51_200,
+            storagePath: "conv_1/cmsg_1/att_file_1-itinerary.pdf"
+        )
+        let original = ChatMessage(
+            id: ChatMessageId(rawValue: "cmsg_1"),
+            conversationId: ConversationId(rawValue: "conv_1"),
+            senderId: "user_a",
+            body: "Here are the photos and the plan!",
+            attachments: [image, file],
+            readAt: "2026-06-06T10:05:00Z",
+            createdAt: "2026-06-06T10:00:00Z"
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ChatMessage.self, from: encoded)
+
+        XCTAssertEqual(decoded.id, original.id)
+        XCTAssertEqual(decoded.conversationId, original.conversationId)
+        XCTAssertEqual(decoded.senderId, original.senderId)
+        XCTAssertEqual(decoded.body, original.body)
+        XCTAssertEqual(decoded.readAt, original.readAt)
+        XCTAssertEqual(decoded.createdAt, original.createdAt)
+
+        // ChatAttachment is Equatable — every field (incl. width/height) compares.
+        XCTAssertEqual(decoded.attachments, original.attachments)
+        let attachments = try XCTUnwrap(decoded.attachments)
+        XCTAssertEqual(attachments.count, 2)
+        XCTAssertEqual(attachments[0].kind, .image)
+        XCTAssertEqual(attachments[0].width, 1024)
+        XCTAssertEqual(attachments[0].height, 768)
+        XCTAssertEqual(attachments[1].kind, .file)
+        // File kind carries no pixel dimensions.
+        XCTAssertNil(attachments[1].width)
+        XCTAssertNil(attachments[1].height)
+    }
+
+    /// The on-the-wire JSON keys must be camelCase to round-trip the TS payload
+    /// verbatim (`packages/core/src/companion.ts`). Assert the literal keys.
+    func test_chatMessage_encodesCamelCaseKeys() throws {
+        let message = ChatMessage(
+            id: ChatMessageId(rawValue: "cmsg_keys"),
+            conversationId: ConversationId(rawValue: "conv_keys"),
+            senderId: "user_a",
+            body: "hi",
+            attachments: [
+                ChatAttachment(
+                    id: "att_1",
+                    kind: .image,
+                    fileName: "a.jpg",
+                    mimeType: "image/jpeg",
+                    fileSizeBytes: 10,
+                    storagePath: "conv_keys/cmsg_keys/att_1-a.jpg",
+                    width: 2,
+                    height: 3
+                )
+            ],
+            createdAt: "2026-06-06T10:00:00Z"
+        )
+        let json = String(decoding: try JSONEncoder().encode(message), as: UTF8.self)
+
+        for key in ["conversationId", "senderId", "createdAt", "attachments",
+                    "fileName", "mimeType", "fileSizeBytes", "storagePath"] {
+            XCTAssertTrue(json.contains("\"\(key)\""), "Expected camelCase key \(key) in: \(json)")
+        }
+        // Snake_case must never leak into the encoded payload.
+        for snake in ["conversation_id", "sender_id", "created_at",
+                      "file_name", "file_size_bytes", "storage_path"] {
+            XCTAssertFalse(json.contains(snake), "Snake_case key \(snake) leaked into: \(json)")
+        }
+    }
+
+    /// Decode from a hand-written JSON string matching the TS camelCase shape
+    /// (branded ids serialise as bare strings via RawRepresentable Codable).
+    func test_chatMessage_decodesFromHandWrittenCamelCaseJSON() throws {
+        let json = """
+        {
+          "id": "cmsg_hand",
+          "conversationId": "conv_hand",
+          "senderId": "user_b",
+          "body": "look at this",
+          "attachments": [
+            {
+              "id": "att_img",
+              "kind": "image",
+              "fileName": "view.png",
+              "mimeType": "image/png",
+              "fileSizeBytes": 4096,
+              "storagePath": "conv_hand/cmsg_hand/att_img-view.png",
+              "width": 800,
+              "height": 600
+            },
+            {
+              "id": "att_doc",
+              "kind": "file",
+              "fileName": "notes.txt",
+              "mimeType": "text/plain",
+              "fileSizeBytes": 128,
+              "storagePath": "conv_hand/cmsg_hand/att_doc-notes.txt"
+            }
+          ],
+          "readAt": "2026-06-06T12:30:00Z",
+          "createdAt": "2026-06-06T12:00:00Z"
+        }
+        """
+        let decoded = try JSONDecoder().decode(ChatMessage.self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded.id, ChatMessageId(rawValue: "cmsg_hand"))
+        XCTAssertEqual(decoded.conversationId, ConversationId(rawValue: "conv_hand"))
+        XCTAssertEqual(decoded.senderId, "user_b")
+        XCTAssertEqual(decoded.body, "look at this")
+        XCTAssertEqual(decoded.readAt, "2026-06-06T12:30:00Z")
+        XCTAssertEqual(decoded.createdAt, "2026-06-06T12:00:00Z")
+
+        let attachments = try XCTUnwrap(decoded.attachments)
+        XCTAssertEqual(attachments.count, 2)
+        XCTAssertEqual(attachments[0], ChatAttachment(
+            id: "att_img", kind: .image, fileName: "view.png", mimeType: "image/png",
+            fileSizeBytes: 4096, storagePath: "conv_hand/cmsg_hand/att_img-view.png",
+            width: 800, height: 600
+        ))
+        XCTAssertEqual(attachments[1].kind, .file)
+        XCTAssertNil(attachments[1].width)
+        XCTAssertNil(attachments[1].height)
+    }
+
+    // MARK: - 3. attachments key absent / null → nil
+
+    func test_chatMessage_decodes_whenAttachmentsKeyAbsent_toNil() throws {
+        let json = """
+        {
+          "id": "cmsg_noatt",
+          "conversationId": "conv_noatt",
+          "senderId": "user_c",
+          "body": "text only",
+          "createdAt": "2026-06-06T13:00:00Z"
+        }
+        """
+        let decoded = try JSONDecoder().decode(ChatMessage.self, from: Data(json.utf8))
+        XCTAssertNil(decoded.attachments, "Absent attachments key must decode to nil")
+        XCTAssertNil(decoded.readAt, "Absent readAt key must decode to nil")
+        XCTAssertEqual(decoded.body, "text only")
+    }
+
+    func test_chatMessage_decodes_whenAttachmentsNull_toNil() throws {
+        let json = """
+        {
+          "id": "cmsg_nullatt",
+          "conversationId": "conv_nullatt",
+          "senderId": "user_d",
+          "body": "still text only",
+          "attachments": null,
+          "readAt": null,
+          "createdAt": "2026-06-06T14:00:00Z"
+        }
+        """
+        let decoded = try JSONDecoder().decode(ChatMessage.self, from: Data(json.utf8))
+        XCTAssertNil(decoded.attachments, "Explicit null attachments must decode to nil")
+        XCTAssertNil(decoded.readAt, "Explicit null readAt must decode to nil")
+        XCTAssertEqual(decoded.body, "still text only")
+    }
+
+    // MARK: - 4. Degrade path at the AttachmentUploading + ChatMessage layer
+
+    /// A mock uploader that always throws `.backendNotReady`, mirroring the
+    /// pre-deploy state where the Storage bucket / RLS migration (0005) is not
+    /// shipped yet.
+    @MainActor
+    final class BackendNotReadyUploader: AttachmentUploading {
+        private(set) var uploadCallCount = 0
+        func upload(_ local: LocalAttachment, conversationId: String, messageId: String) async throws -> ChatAttachment {
+            uploadCallCount += 1
+            throw AttachmentError.backendNotReady
+        }
+        func signedURL(for attachment: ChatAttachment) async throws -> URL {
+            throw AttachmentError.backendNotReady
+        }
+    }
+
+    /// Reproduces `ChatService.send`'s degrade fork (the lines that catch
+    /// `.backendNotReady` → drop attachments, keep the text) at the protocol +
+    /// model layer.
+    ///
+    /// LIMITATION (honest): `ChatService.send` itself is gated by
+    /// `FeatureFlags.companion`, which reads `FF_COMPANION` (default false in the
+    /// test environment, as documented in `CompanionPhase3Tests`). With the flag
+    /// off, `send` short-circuits before producing any message, so a true
+    /// end-to-end `ChatService.send(...)` assertion cannot run deterministically
+    /// in unit tests without mutating global feature-flag state. We therefore
+    /// exercise the same degrade logic the service implements — upload throws
+    /// `.backendNotReady` ⇒ attachments are dropped ⇒ a text-only `ChatMessage`
+    /// is still constructed — against the injected `AttachmentUploading` seam.
+    @MainActor
+    func test_degrade_backendNotReady_dropsAttachments_keepsTextOnlyMessage() async throws {
+        let uploader = BackendNotReadyUploader()
+        let oneImage = LocalAttachment(
+            kind: .image,
+            fileName: "photo.jpg",
+            mimeType: "image/jpeg",
+            data: Data([0xFF, 0xD8, 0xFF, 0xD9]) // synthetic 4-byte JPEG-ish blob
+        )
+
+        // Mirror ChatService.send's loop: attempt upload, catch backendNotReady,
+        // degrade to text-only.
+        var uploaded: [ChatAttachment] = []
+        var degradedToTextOnly = false
+        for local in [oneImage] {
+            do {
+                uploaded.append(try await uploader.upload(local, conversationId: "conv_x", messageId: "cmsg_x"))
+            } catch AttachmentError.backendNotReady {
+                degradedToTextOnly = true
+                uploaded.removeAll()
+                break
+            }
+        }
+
+        XCTAssertEqual(uploader.uploadCallCount, 1, "The uploader must have been attempted once")
+        XCTAssertTrue(degradedToTextOnly, "A .backendNotReady throw must trigger the degrade path")
+        XCTAssertTrue(uploaded.isEmpty, "Attachments must be dropped on degrade")
+
+        let trimmed = "hello"
+        let message = ChatMessage(
+            id: ChatMessageId(rawValue: "cmsg_x"),
+            conversationId: ConversationId(rawValue: "conv_x"),
+            senderId: "user_x",
+            body: trimmed,
+            attachments: uploaded.isEmpty ? nil : uploaded,
+            createdAt: "2026-06-06T15:00:00Z"
+        )
+
+        // The text-only message survives the degrade — the user never loses words.
+        XCTAssertEqual(message.body, "hello")
+        XCTAssertNil(message.attachments, "Degraded message carries no attachments")
+    }
+
+    /// Attachment-only degrade with empty text → nothing to send (matches the
+    /// `guard !trimmed.isEmpty` branch in `ChatService.send`).
+    @MainActor
+    func test_degrade_backendNotReady_withEmptyText_yieldsNothingToSend() async throws {
+        let uploader = BackendNotReadyUploader()
+        let onlyImage = LocalAttachment(
+            kind: .image, fileName: "x.jpg", mimeType: "image/jpeg", data: Data([0x00])
+        )
+
+        var uploaded: [ChatAttachment] = []
+        var degradedToTextOnly = false
+        do {
+            uploaded.append(try await uploader.upload(onlyImage, conversationId: "c", messageId: "m"))
+        } catch AttachmentError.backendNotReady {
+            degradedToTextOnly = true
+            uploaded.removeAll()
+        }
+
+        let trimmed = ""
+        let hasNothingToSend = degradedToTextOnly && trimmed.isEmpty
+        XCTAssertTrue(hasNothingToSend, "Empty text + degraded attachments ⇒ no message is sent")
+        XCTAssertTrue(uploaded.isEmpty)
+    }
+}

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -664,6 +664,9 @@ public final class MapViewModel {
     public var pendingAddCoordinate: CLLocationCoordinate2D?
     /// Set once the user confirms — drives the voice-input sheet.
     public var isRecordingNewExperience: Bool = false
+    /// Set once the user confirms — drives the structured create-place form
+    /// (the primary add path; voice is the secondary one).
+    public var isShowingCreateForm: Bool = false
     /// Candidate experiences added via long-press → voice → AI. Rendered with
     /// `.hidden` category and a distinct (dashed) marker.
     public var candidateExperiences: [Experience] = []
@@ -1225,6 +1228,7 @@ public final class MapViewModel {
     public func cancelAddExperience() {
         pendingAddCoordinate = nil
         isRecordingNewExperience = false
+        isShowingCreateForm = false
     }
 
     /// Confirm the long-pressed location and begin voice recording to describe
@@ -1232,6 +1236,45 @@ public final class MapViewModel {
     public func confirmAddExperience() {
         guard pendingAddCoordinate != nil else { return }
         isRecordingNewExperience = true
+    }
+
+    /// Confirm the long-pressed location and open the structured create-place
+    /// form (the primary add path). `pendingAddCoordinate` stays set so the
+    /// form knows where to anchor; it is cleared on save/cancel.
+    public func confirmAddExperienceWithForm() {
+        guard pendingAddCoordinate != nil else { return }
+        isShowingCreateForm = true
+    }
+
+    /// Persist a user-created place from the form, render it immediately, and
+    /// clear the add-experience flow. The candidate is built via
+    /// `Experience.userDraft`, which forces unverified trust defaults — the
+    /// user never scores their own place.
+    public func createUserExperience(from input: NewPlaceFormInput) {
+        defer { cancelAddExperience() }
+        let candidate = Experience.userDraft(
+            uuid: UUID().uuidString,
+            title: input.title,
+            oneLiner: input.oneLiner,
+            category: input.category,
+            coordinates: [input.coordinate.longitude, input.coordinate.latitude],
+            // No cityCode filtering for user pins — they belong to wherever the
+            // user dropped them, not a curated city set.
+            cityCode: selectedCity ?? "user",
+            placeNameRomanized: input.placeNameRomanized,
+            placeNameLocal: input.placeNameLocal,
+            description: input.description,
+            photoUrls: input.photoUrls
+        )
+        // Persist to SwiftData so it survives relaunch (idempotent by id).
+        _ = experienceService.appendGenerated([candidate])
+        // Render right away: keep it in the candidate layer (distinct marker)
+        // and surface it among visible experiences without a full reload.
+        candidateExperiences.append(candidate)
+        withAnimation(Self.markerSetAnimation) {
+            visibleExperiences.append(candidate)
+            nearbySoloCount = computeNearbySoloCount(in: visibleExperiences)
+        }
     }
 
     /// Use AIService to structure a free-form transcript into a candidate

--- a/apps/ios/SoloCompass/Views/Chat/AttachmentBubble.swift
+++ b/apps/ios/SoloCompass/Views/Chat/AttachmentBubble.swift
@@ -1,0 +1,306 @@
+import SwiftUI
+
+/// Renders the attachments carried by a *sent* message inside its bubble.
+///
+/// - Images: tappable rounded thumbnail; tap opens a full-screen zoom cover.
+/// - Files: a card (icon, name, size, open affordance) that opens the resolved
+///   URL via the share/quick-look path the host wires up.
+///
+/// URLs are resolved lazily through `resolveURL` — Phase D supplies real signed
+/// URLs from Supabase storage; until then it may return `nil`, in which case we
+/// show a spinner / placeholder rather than a broken image.
+@MainActor
+struct AttachmentBubble: View {
+    let attachments: [ChatAttachment]
+    /// Resolves a persisted attachment to a loadable URL (e.g. a signed URL).
+    /// Returns `nil` when the backend is not ready — UI degrades gracefully.
+    let resolveURL: (ChatAttachment) async -> URL?
+
+    /// 18pt continuous corners per contract §1.3.
+    private let corner: CGFloat = 18
+    private let thumbMax: CGFloat = 200
+
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var zoomURL: IdentifiedURL?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(attachments) { attachment in
+                switch attachment.kind {
+                case .image:
+                    imageCell(attachment)
+                case .file:
+                    fileCard(attachment)
+                }
+            }
+        }
+        .fullScreenCover(item: $zoomURL) { wrapped in
+            ZoomImageView(url: wrapped.url) { zoomURL = nil }
+        }
+    }
+
+    // MARK: - Image
+
+    private func imageCell(_ attachment: ChatAttachment) -> some View {
+        ResolvedThumbnail(
+            attachment: attachment,
+            resolveURL: resolveURL,
+            corner: corner,
+            maxSide: thumbMax,
+            borderColor: borderColor
+        ) { url in
+            zoomURL = IdentifiedURL(url: url)
+        }
+    }
+
+    // MARK: - File
+
+    private func fileCard(_ attachment: ChatAttachment) -> some View {
+        FileCard(
+            attachment: attachment,
+            resolveURL: resolveURL,
+            corner: corner,
+            fill: cardFill,
+            borderColor: borderColor
+        )
+    }
+
+    private var borderColor: Color {
+        colorScheme == .dark ? Color(.separator) : CT.borderSubtle
+    }
+
+    private var cardFill: Color {
+        colorScheme == .dark ? Color(.secondarySystemBackground) : CT.surfaceWhite
+    }
+}
+
+// MARK: - Resolved image thumbnail
+
+/// Resolves and loads an image attachment, showing a spinner until the URL and
+/// bytes arrive. Tappable to zoom once loaded.
+@MainActor
+private struct ResolvedThumbnail: View {
+    let attachment: ChatAttachment
+    let resolveURL: (ChatAttachment) async -> URL?
+    let corner: CGFloat
+    let maxSide: CGFloat
+    let borderColor: Color
+    let onTap: (URL) -> Void
+
+    @State private var url: URL?
+    @State private var resolving = true
+
+    var body: some View {
+        Group {
+            if let url {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .scaledToFill()
+                            .frame(maxWidth: maxSide, maxHeight: maxSide)
+                            .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
+                            .contentShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
+                            .onTapGesture { onTap(url) }
+                    case .failure:
+                        placeholder(systemImage: "exclamationmark.triangle")
+                    case .empty:
+                        loading
+                    @unknown default:
+                        loading
+                    }
+                }
+            } else if resolving {
+                loading
+            } else {
+                placeholder(systemImage: "photo")
+            }
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: corner, style: .continuous)
+                .strokeBorder(borderColor, lineWidth: 0.5)
+        )
+        .task { await resolve() }
+        .accessibilityLabel(Text(attachment.fileName))
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private func resolve() async {
+        resolving = true
+        url = await resolveURL(attachment)
+        resolving = false
+    }
+
+    private var loading: some View {
+        ZStack {
+            Color(.tertiarySystemBackground)
+            ProgressView()
+        }
+        .frame(width: 140, height: 140)
+        .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
+    }
+
+    private func placeholder(systemImage: String) -> some View {
+        ZStack {
+            Color(.tertiarySystemBackground)
+            Image(systemName: systemImage)
+                .font(.title2)
+                .foregroundStyle(.secondary)
+        }
+        .frame(width: 140, height: 140)
+        .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
+    }
+}
+
+// MARK: - File card
+
+@MainActor
+private struct FileCard: View {
+    let attachment: ChatAttachment
+    let resolveURL: (ChatAttachment) async -> URL?
+    let corner: CGFloat
+    let fill: Color
+    let borderColor: Color
+
+    @State private var url: URL?
+    @State private var resolving = true
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        Button {
+            if let url { openURL(url) }
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "doc.fill")
+                    .font(.title3)
+                    .foregroundStyle(CT.accent)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(attachment.fileName)
+                        .font(.subheadline.weight(.medium))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .foregroundStyle(.primary)
+                    Text(formattedSize)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 4)
+                if resolving {
+                    ProgressView().scaleEffect(0.7)
+                } else {
+                    Image(systemName: url == nil ? "arrow.down.circle" : "arrow.up.right.square")
+                        .font(.body)
+                        .foregroundStyle(url == nil ? Color.secondary : CT.accent)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .frame(maxWidth: 260, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: corner, style: .continuous)
+                    .fill(fill)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: corner, style: .continuous)
+                    .strokeBorder(borderColor, lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(url == nil)
+        .task { await resolve() }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text("\(attachment.fileName), \(formattedSize)"))
+    }
+
+    private var formattedSize: String {
+        ByteCountFormatter.string(fromByteCount: Int64(attachment.fileSizeBytes), countStyle: .file)
+    }
+
+    private func resolve() async {
+        resolving = true
+        url = await resolveURL(attachment)
+        resolving = false
+    }
+}
+
+// MARK: - Full-screen zoom
+
+@MainActor
+private struct ZoomImageView: View {
+    let url: URL
+    let onClose: () -> Void
+
+    @State private var scale: CGFloat = 1
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFit()
+                        .scaleEffect(scale)
+                        .gesture(
+                            MagnificationGesture()
+                                .onChanged { scale = max(1, $0) }
+                                .onEnded { _ in withAnimation(.spring) { scale = 1 } }
+                        )
+                case .failure:
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.largeTitle)
+                        .foregroundStyle(.white)
+                case .empty:
+                    ProgressView().tint(.white)
+                @unknown default:
+                    ProgressView().tint(.white)
+                }
+            }
+        }
+        .overlay(alignment: .topTrailing) {
+            Button(action: onClose) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title)
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(Color.white, Color.white.opacity(0.25))
+                    .padding()
+            }
+            .accessibilityLabel(Text(NSLocalizedString("chat.attachment.close.a11y", comment: "Close")))
+        }
+    }
+}
+
+/// Wraps a `URL` so it can drive an item-based `.fullScreenCover`.
+private struct IdentifiedURL: Identifiable {
+    let url: URL
+    var id: String { url.absoluteString }
+}
+
+#Preview("Sent attachments") {
+    let image = ChatAttachment(
+        id: "att_img_1",
+        kind: .image,
+        fileName: "harbor-view.jpg",
+        mimeType: "image/jpeg",
+        fileSizeBytes: 482_000,
+        storagePath: "conv/msg/att_img_1-harbor-view.jpg",
+        width: 1200,
+        height: 800
+    )
+    let file = ChatAttachment(
+        id: "att_file_1",
+        kind: .file,
+        fileName: "tokyo-7-day-itinerary.pdf",
+        mimeType: "application/pdf",
+        fileSizeBytes: 1_950_000,
+        storagePath: "conv/msg/att_file_1-tokyo-7-day-itinerary.pdf"
+    )
+    return AttachmentBubble(
+        attachments: [image, file],
+        // Phase D wires real signed URLs; preview returns nil → spinner/placeholder.
+        resolveURL: { _ in nil }
+    )
+    .padding()
+}

--- a/apps/ios/SoloCompass/Views/Chat/AttachmentBubble.swift
+++ b/apps/ios/SoloCompass/Views/Chat/AttachmentBubble.swift
@@ -114,7 +114,11 @@ private struct ResolvedThumbnail: View {
             } else if resolving {
                 loading
             } else {
-                placeholder(systemImage: "photo")
+                // Unresolved (backend not ready / transient failure): a tappable
+                // retry placeholder rather than a permanent broken thumbnail.
+                placeholder(systemImage: "arrow.clockwise")
+                    .contentShape(Rectangle())
+                    .onTapGesture { Task { await resolve() } }
             }
         }
         .overlay(
@@ -122,7 +126,7 @@ private struct ResolvedThumbnail: View {
                 .strokeBorder(borderColor, lineWidth: 0.5)
         )
         .task { await resolve() }
-        .accessibilityLabel(Text(attachment.fileName))
+        .accessibilityLabel(Text(url == nil ? "\(attachment.fileName), tap to retry" : attachment.fileName))
         .accessibilityAddTraits(.isButton)
     }
 
@@ -169,7 +173,13 @@ private struct FileCard: View {
 
     var body: some View {
         Button {
-            if let url { openURL(url) }
+            // Resolved → open the file. Unresolved (backend not ready / transient
+            // failure) → re-attempt resolution so the user isn't stuck.
+            if let url {
+                openURL(url)
+            } else if !resolving {
+                Task { await resolve() }
+            }
         } label: {
             HStack(spacing: 10) {
                 Image(systemName: "doc.fill")
@@ -179,7 +189,7 @@ private struct FileCard: View {
                     Text(attachment.fileName)
                         .font(.subheadline.weight(.medium))
                         .lineLimit(1)
-                        .truncationMode(.middle)
+                        .truncationMode(.tail)
                         .foregroundStyle(.primary)
                     Text(formattedSize)
                         .font(.caption2)
@@ -189,7 +199,9 @@ private struct FileCard: View {
                 if resolving {
                     ProgressView().scaleEffect(0.7)
                 } else {
-                    Image(systemName: url == nil ? "arrow.down.circle" : "arrow.up.right.square")
+                    // Resolved → open affordance; unresolved → a retry affordance
+                    // (NOT a download icon on a dead button, which reads as broken).
+                    Image(systemName: url == nil ? "arrow.clockwise.circle" : "arrow.up.right.square")
                         .font(.body)
                         .foregroundStyle(url == nil ? Color.secondary : CT.accent)
                 }
@@ -207,10 +219,13 @@ private struct FileCard: View {
             )
         }
         .buttonStyle(.plain)
-        .disabled(url == nil)
+        // Intentionally NOT .disabled when url == nil — the button doubles as a
+        // retry trigger so a transient resolve failure isn't a dead end.
         .task { await resolve() }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(Text("\(attachment.fileName), \(formattedSize)"))
+        .accessibilityLabel(Text(url == nil
+            ? "\(attachment.fileName), \(formattedSize), tap to retry"
+            : "\(attachment.fileName), \(formattedSize)"))
     }
 
     private var formattedSize: String {

--- a/apps/ios/SoloCompass/Views/Chat/AttachmentDraftStrip.swift
+++ b/apps/ios/SoloCompass/Views/Chat/AttachmentDraftStrip.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+/// Horizontal strip of draft attachments shown above the input row, Instagram-DM
+/// style: images render as rounded thumbnails, files as compact chips. Each item
+/// carries an "X" delete affordance in its top-trailing corner.
+///
+/// Pure presentation — owns no state. The parent (`ChatInputBar`) holds the
+/// `[LocalAttachment]` and supplies `onRemove` keyed by id.
+@MainActor
+struct AttachmentDraftStrip: View {
+    let attachments: [LocalAttachment]
+    /// Fires with the id of the draft the user tapped "X" on.
+    let onRemove: (UUID) -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    /// 18pt continuous corners + 0.5pt border per contract §1.3.
+    private let corner: CGFloat = 18
+    private let thumbSide: CGFloat = 64
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 10) {
+                ForEach(attachments) { attachment in
+                    cell(for: attachment)
+                }
+            }
+            .padding(.horizontal, 4)
+            .padding(.vertical, 2)
+        }
+        .frame(height: thumbSide + 8)
+    }
+
+    @ViewBuilder
+    private func cell(for attachment: LocalAttachment) -> some View {
+        content(for: attachment)
+            .overlay(alignment: .topTrailing) {
+                deleteButton(for: attachment.id)
+                    .offset(x: 6, y: -6)
+            }
+    }
+
+    @ViewBuilder
+    private func content(for attachment: LocalAttachment) -> some View {
+        switch attachment.kind {
+        case .image:
+            imageThumb(attachment)
+        case .file:
+            fileChip(attachment)
+        }
+    }
+
+    private func imageThumb(_ attachment: LocalAttachment) -> some View {
+        Group {
+            if let image = attachment.image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                ZStack {
+                    Color(.tertiarySystemBackground)
+                    Image(systemName: "photo")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .frame(width: thumbSide, height: thumbSide)
+        .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: corner, style: .continuous)
+                .strokeBorder(borderColor, lineWidth: 0.5)
+        )
+        .accessibilityLabel(Text(attachment.fileName))
+    }
+
+    private func fileChip(_ attachment: LocalAttachment) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "doc.fill")
+                .font(.body)
+                .foregroundStyle(CT.accent)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(attachment.fileName)
+                    .font(.footnote.weight(.medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .foregroundStyle(.primary)
+                Text(attachment.formattedSize)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal, 12)
+        .frame(maxWidth: 180, minHeight: thumbSide, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: corner, style: .continuous)
+                .fill(chipFill)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: corner, style: .continuous)
+                .strokeBorder(borderColor, lineWidth: 0.5)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text("\(attachment.fileName), \(attachment.formattedSize)"))
+    }
+
+    private func deleteButton(for id: UUID) -> some View {
+        Button {
+            onRemove(id)
+        } label: {
+            Image(systemName: "xmark.circle.fill")
+                .font(.body)
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(Color.white, Color.black.opacity(0.55))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text(NSLocalizedString("chat.attachment.remove.a11y", comment: "Remove attachment")))
+    }
+
+    private var borderColor: Color {
+        colorScheme == .dark ? Color(.separator) : CT.borderSubtle
+    }
+
+    private var chipFill: Color {
+        colorScheme == .dark ? Color(.secondarySystemBackground) : CT.chatInputBg
+    }
+}
+
+#Preview("Draft strip — image + file") {
+    let image = LocalAttachment(
+        kind: .image,
+        fileName: "sunset.jpg",
+        mimeType: "image/jpeg",
+        data: Data(count: 240_000),
+        image: UIImage(systemName: "photo.fill")
+    )
+    let file = LocalAttachment(
+        kind: .file,
+        fileName: "tokyo-itinerary-draft.pdf",
+        mimeType: "application/pdf",
+        data: Data(count: 1_400_000),
+        image: nil
+    )
+    return AttachmentDraftStrip(
+        attachments: [image, file],
+        onRemove: { _ in }
+    )
+    .padding()
+}

--- a/apps/ios/SoloCompass/Views/Chat/AttachmentInputBar.swift
+++ b/apps/ios/SoloCompass/Views/Chat/AttachmentInputBar.swift
@@ -156,7 +156,7 @@ struct AttachmentInputBar: View {
 
     private var textField: some View {
         TextField(placeholder, text: $draftText, axis: .vertical)
-            .lineLimit(1...5)
+            .lineLimit(1...4)  // matches ChatInputBar (Voice Agent) growth
             .textFieldStyle(.plain)
             .padding(.horizontal, 12)
             .padding(.vertical, 8)

--- a/apps/ios/SoloCompass/Views/Chat/AttachmentInputBar.swift
+++ b/apps/ios/SoloCompass/Views/Chat/AttachmentInputBar.swift
@@ -1,0 +1,313 @@
+import PhotosUI
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// Instagram-DM-style input bar for **human-to-human** chat (Companion DM).
+///
+/// Structurally mirrors the Voice-Agent `ChatInputBar` — a "+" attachment menu
+/// (Photo Library / Camera / Files), a rounded growing text field, and an inline
+/// send button — but deliberately drops the mic affordance: voice is a Voice-Agent
+/// concern only. Keeping the picker plumbing here (rather than duplicating it into
+/// `ChatView`) means both bars share one well-tested attachment ingestion path.
+///
+/// Camera capture reuses the existing internal `CameraPicker`
+/// (`Views/Experience/CreateExperienceSheet.swift`) so no camera type is
+/// redeclared (avoids colliding with `ChatCameraPicker` in `ChatInputBar.swift`).
+@MainActor
+struct AttachmentInputBar: View {
+    @Binding var draftText: String
+    /// Draft attachments staged for the next send. The parent owns the array;
+    /// this bar appends on pick and clears it after `onSend` runs.
+    @Binding var attachments: [LocalAttachment]
+    /// True while a send is in flight — disables the send button.
+    var isSending: Bool
+
+    /// Fires when the user taps send (or hits return) with a non-empty draft OR
+    /// at least one staged attachment. The trimmed text is passed in; the parent
+    /// reads `attachments` (still bound) inside the closure, then this bar clears
+    /// both `draftText` and `attachments`.
+    let onSend: (String) -> Void
+
+    let placeholder: String
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    // Attachment-picker presentation state.
+    @State private var showAttachmentDialog = false
+    @State private var photoSelections: [PhotosPickerItem] = []
+    @State private var showPhotosPicker = false
+    @State private var showCamera = false
+    @State private var showFileImporter = false
+
+    init(
+        draftText: Binding<String>,
+        attachments: Binding<[LocalAttachment]>,
+        isSending: Bool = false,
+        placeholder: String,
+        onSend: @escaping (String) -> Void
+    ) {
+        self._draftText = draftText
+        self._attachments = attachments
+        self.isSending = isSending
+        self.placeholder = placeholder
+        self.onSend = onSend
+    }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if !attachments.isEmpty {
+                AttachmentDraftStrip(attachments: attachments) { id in
+                    attachments.removeAll { $0.id == id }
+                }
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+
+            HStack(alignment: .bottom, spacing: 8) {
+                plusButton
+                textField
+                sendButton
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(alignment: .top) {
+            // Hairline top divider + opaque surface, matching ChatInputBar.
+            ZStack(alignment: .top) {
+                Color(.systemBackground)
+                Rectangle()
+                    .fill(CT.borderDefault)
+                    .frame(height: 0.5)
+            }
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.85), value: attachments)
+        .confirmationDialog(
+            NSLocalizedString("chat.attachment.add.title", comment: "Add attachment"),
+            isPresented: $showAttachmentDialog,
+            titleVisibility: .visible
+        ) {
+            Button(NSLocalizedString("chat.attachment.source.photos", comment: "Photo Library")) {
+                showPhotosPicker = true
+            }
+            if UIImagePickerController.isSourceTypeAvailable(.camera) {
+                Button(NSLocalizedString("chat.attachment.source.camera", comment: "Camera")) {
+                    showCamera = true
+                }
+            }
+            Button(NSLocalizedString("chat.attachment.source.files", comment: "Files")) {
+                showFileImporter = true
+            }
+            Button(NSLocalizedString("chat.attachment.source.cancel", comment: "Cancel"), role: .cancel) {}
+        }
+        .photosPicker(
+            isPresented: $showPhotosPicker,
+            selection: $photoSelections,
+            maxSelectionCount: 5,
+            matching: .images
+        )
+        .onChange(of: photoSelections) { _, items in
+            Task { await ingest(photoItems: items) }
+        }
+        .fullScreenCover(isPresented: $showCamera) {
+            CameraPicker { image in
+                if let image { appendCameraImage(image) }
+            }
+            .ignoresSafeArea()
+        }
+        .fileImporter(
+            isPresented: $showFileImporter,
+            allowedContentTypes: [.item],
+            allowsMultipleSelection: true
+        ) { result in
+            ingest(fileResult: result)
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var inputFieldFill: Color {
+        colorScheme == .dark ? Color(.secondarySystemBackground) : CT.chatInputBg
+    }
+
+    private var inputBorder: Color {
+        colorScheme == .dark ? Color(.separator) : CT.borderSubtle
+    }
+
+    /// Instagram-style "+" entry that surfaces the photo/camera/files menu.
+    private var plusButton: some View {
+        Button {
+            showAttachmentDialog = true
+        } label: {
+            Image(systemName: "plus")
+                .font(.body.weight(.semibold))
+                .foregroundStyle(CT.accent)
+                .frame(width: 40, height: 40)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(Color(.tertiarySystemBackground))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(CT.borderSubtle, lineWidth: 0.5)
+                )
+        }
+        .buttonStyle(PressableButtonStyle(pressedScale: 0.88))
+        .accessibilityLabel(Text(NSLocalizedString("chat.attachment.add.a11y", comment: "Add attachment")))
+    }
+
+    private var textField: some View {
+        TextField(placeholder, text: $draftText, axis: .vertical)
+            .lineLimit(1...5)
+            .textFieldStyle(.plain)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(inputFieldFill)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .strokeBorder(inputBorder, lineWidth: 0.5)
+            )
+            .submitLabel(.send)
+            .onSubmit(submitDraft)
+            .accessibilityLabel(Text(placeholder))
+    }
+
+    private var sendButton: some View {
+        let trimmed = draftText.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Enabled when there's text OR at least one staged attachment.
+        let canSend = (!trimmed.isEmpty || !attachments.isEmpty) && !isSending
+        return Button(action: submitDraft) {
+            Image(systemName: "arrow.up.circle.fill")
+                .font(.title2)
+                .foregroundStyle(canSend ? CT.accent : Color.secondary.opacity(0.5))
+        }
+        .buttonStyle(PressableButtonStyle(pressedScale: 0.88))
+        .disabled(!canSend)
+        .accessibilityLabel(Text(NSLocalizedString("chat.input.send.a11y", comment: "Send")))
+    }
+
+    private func submitDraft() {
+        let trimmed = draftText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard (!trimmed.isEmpty || !attachments.isEmpty) && !isSending else { return }
+        // Caller reads `attachments` (still bound) inside onSend, then we clear.
+        onSend(trimmed)
+        draftText = ""
+        attachments = []
+    }
+
+    // MARK: - Attachment ingestion
+
+    /// Decode picked photo-library items into image drafts.
+    private func ingest(photoItems: [PhotosPickerItem]) async {
+        var picked: [LocalAttachment] = []
+        for item in photoItems {
+            guard let data = try? await item.loadTransferable(type: Data.self) else { continue }
+            let image = UIImage(data: data)
+            let ext = item.supportedContentTypes.first?.preferredFilenameExtension ?? "jpg"
+            let mime = item.supportedContentTypes.first?.preferredMIMEType ?? "image/jpeg"
+            picked.append(
+                LocalAttachment(
+                    kind: .image,
+                    fileName: "image-\(UUID().uuidString.prefix(8)).\(ext)",
+                    mimeType: mime,
+                    data: data,
+                    image: image
+                )
+            )
+        }
+        if !picked.isEmpty {
+            attachments.append(contentsOf: picked)
+        }
+        photoSelections = []
+    }
+
+    /// Wrap a freshly captured camera photo as a JPEG image draft.
+    private func appendCameraImage(_ image: UIImage) {
+        guard let data = image.jpegData(compressionQuality: 0.9) else { return }
+        attachments.append(
+            LocalAttachment(
+                kind: .image,
+                fileName: "camera-\(UUID().uuidString.prefix(8)).jpg",
+                mimeType: "image/jpeg",
+                data: data,
+                image: image
+            )
+        )
+    }
+
+    /// Read security-scoped files chosen via the document picker into drafts.
+    private func ingest(fileResult: Result<[URL], Error>) {
+        guard case let .success(urls) = fileResult else { return }
+        var picked: [LocalAttachment] = []
+        for url in urls {
+            let scoped = url.startAccessingSecurityScopedResource()
+            defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+            guard let data = try? Data(contentsOf: url) else { continue }
+            let type = UTType(filenameExtension: url.pathExtension)
+            let isImage = type?.conforms(to: .image) ?? false
+            let mime = type?.preferredMIMEType ?? "application/octet-stream"
+            picked.append(
+                LocalAttachment(
+                    kind: isImage ? .image : .file,
+                    fileName: url.lastPathComponent,
+                    mimeType: mime,
+                    data: data,
+                    image: isImage ? UIImage(data: data) : nil
+                )
+            )
+        }
+        if !picked.isEmpty {
+            attachments.append(contentsOf: picked)
+        }
+    }
+}
+
+#Preview("Empty") {
+    StatefulAttachmentBarPreview(initial: "")
+}
+
+#Preview("With attachments") {
+    StatefulAttachmentBarPreview(
+        initial: "Check these out",
+        attachments: [
+            LocalAttachment(
+                kind: .image,
+                fileName: "photo.jpg",
+                mimeType: "image/jpeg",
+                data: Data(count: 120_000),
+                image: UIImage(systemName: "photo.fill")
+            ),
+            LocalAttachment(
+                kind: .file,
+                fileName: "notes.pdf",
+                mimeType: "application/pdf",
+                data: Data(count: 900_000),
+                image: nil
+            )
+        ]
+    )
+}
+
+/// Small helper so the previews can mutate `draftText` like the real parent.
+private struct StatefulAttachmentBarPreview: View {
+    @State var text: String
+    @State var attachments: [LocalAttachment]
+
+    init(initial: String, attachments: [LocalAttachment] = []) {
+        self._text = State(initialValue: initial)
+        self._attachments = State(initialValue: attachments)
+    }
+
+    var body: some View {
+        VStack {
+            Spacer()
+            AttachmentInputBar(
+                draftText: $text,
+                attachments: $attachments,
+                placeholder: "Message…",
+                onSend: { _ in }
+            )
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Views/Chat/ChatInputBar.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatInputBar.swift
@@ -1,4 +1,6 @@
+import PhotosUI
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Pinned bottom input bar for `ChatSheet`. Combines:
 ///  * a multi-line text field (1–4 lines of growth)
@@ -22,12 +24,18 @@ public struct ChatInputBar: View {
     }
 
     @Binding public var draftText: String
+    /// Draft attachments staged for the next send, Instagram-DM style. The
+    /// parent owns the array; the bar appends on pick and clears on send.
+    @Binding public var attachments: [LocalAttachment]
     public let micState: MicState
     public let errorMessage: String?
 
     /// Fires when the user taps the send button (or hits return) with a
     /// non-empty draft. The trimmed text is passed in; the input bar
     /// clears `draftText` after the closure runs.
+    ///
+    /// Attachments are delivered via the `attachments` binding: callers read
+    /// the staged drafts inside `onSend`; the bar clears them afterwards.
     public let onSend: (String) -> Void
 
     /// Tap-to-toggle voice mode (accessibility path). `true` requests start,
@@ -49,6 +57,36 @@ public struct ChatInputBar: View {
     /// Drives the soft pulse on the "Listening" status dot.
     @State private var listeningPulse: Bool = false
 
+    // Attachment-picker presentation state.
+    @State private var showAttachmentDialog = false
+    @State private var photoSelections: [PhotosPickerItem] = []
+    @State private var showPhotosPicker = false
+    @State private var showCamera = false
+    @State private var showFileImporter = false
+
+    /// Primary initializer — includes the draft `attachments` binding.
+    public init(
+        draftText: Binding<String>,
+        attachments: Binding<[LocalAttachment]>,
+        micState: MicState,
+        errorMessage: String?,
+        onSend: @escaping (String) -> Void,
+        onMicToggle: @escaping (Bool) -> Void,
+        onMicPress: @escaping (Bool) -> Void,
+        onRetry: @escaping () -> Void
+    ) {
+        self._draftText = draftText
+        self._attachments = attachments
+        self.micState = micState
+        self.errorMessage = errorMessage
+        self.onSend = onSend
+        self.onMicToggle = onMicToggle
+        self.onMicPress = onMicPress
+        self.onRetry = onRetry
+    }
+
+    /// Backward-compatible initializer for callers that don't (yet) stage
+    /// attachments. Binds `attachments` to a constant empty array.
     public init(
         draftText: Binding<String>,
         micState: MicState,
@@ -58,13 +96,16 @@ public struct ChatInputBar: View {
         onMicPress: @escaping (Bool) -> Void,
         onRetry: @escaping () -> Void
     ) {
-        self._draftText = draftText
-        self.micState = micState
-        self.errorMessage = errorMessage
-        self.onSend = onSend
-        self.onMicToggle = onMicToggle
-        self.onMicPress = onMicPress
-        self.onRetry = onRetry
+        self.init(
+            draftText: draftText,
+            attachments: .constant([]),
+            micState: micState,
+            errorMessage: errorMessage,
+            onSend: onSend,
+            onMicToggle: onMicToggle,
+            onMicPress: onMicPress,
+            onRetry: onRetry
+        )
     }
 
     public var body: some View {
@@ -80,7 +121,15 @@ public struct ChatInputBar: View {
 
             stateLabel
 
+            if !attachments.isEmpty {
+                AttachmentDraftStrip(attachments: attachments) { id in
+                    attachments.removeAll { $0.id == id }
+                }
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+
             HStack(alignment: .bottom, spacing: 8) {
+                plusButton
                 textField
                 sendButton
                 micButton
@@ -96,6 +145,47 @@ public struct ChatInputBar: View {
                     .fill(CT.borderDefault)
                     .frame(height: 0.5)
             }
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.85), value: attachments)
+        .confirmationDialog(
+            NSLocalizedString("chat.attachment.add.title", comment: "Add attachment"),
+            isPresented: $showAttachmentDialog,
+            titleVisibility: .visible
+        ) {
+            Button(NSLocalizedString("chat.attachment.source.photos", comment: "Photo Library")) {
+                showPhotosPicker = true
+            }
+            if UIImagePickerController.isSourceTypeAvailable(.camera) {
+                Button(NSLocalizedString("chat.attachment.source.camera", comment: "Camera")) {
+                    showCamera = true
+                }
+            }
+            Button(NSLocalizedString("chat.attachment.source.files", comment: "Files")) {
+                showFileImporter = true
+            }
+            Button(NSLocalizedString("chat.attachment.source.cancel", comment: "Cancel"), role: .cancel) {}
+        }
+        .photosPicker(
+            isPresented: $showPhotosPicker,
+            selection: $photoSelections,
+            maxSelectionCount: 5,
+            matching: .images
+        )
+        .onChange(of: photoSelections) { _, items in
+            Task { await ingest(photoItems: items) }
+        }
+        .fullScreenCover(isPresented: $showCamera) {
+            ChatCameraPicker { image in
+                appendCameraImage(image)
+            }
+            .ignoresSafeArea()
+        }
+        .fileImporter(
+            isPresented: $showFileImporter,
+            allowedContentTypes: [.item],
+            allowsMultipleSelection: true
+        ) { result in
+            ingest(fileResult: result)
         }
     }
 
@@ -150,6 +240,28 @@ public struct ChatInputBar: View {
         colorScheme == .dark ? Color(.separator) : CT.borderSubtle
     }
 
+    /// Instagram-style "+" entry that surfaces the photo/camera/files menu.
+    private var plusButton: some View {
+        Button {
+            showAttachmentDialog = true
+        } label: {
+            Image(systemName: "plus")
+                .font(.body.weight(.semibold))
+                .foregroundStyle(CT.accent)
+                .frame(width: 40, height: 40)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(Color(.tertiarySystemBackground))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(CT.borderSubtle, lineWidth: 0.5)
+                )
+        }
+        .buttonStyle(PressableButtonStyle(pressedScale: 0.88))
+        .accessibilityLabel(Text(NSLocalizedString("chat.attachment.add.a11y", comment: "Add attachment")))
+    }
+
     private var textField: some View {
         // Multi-line growth comes free with `axis: .vertical` + lineLimit range.
         TextField(
@@ -176,7 +288,8 @@ public struct ChatInputBar: View {
 
     private var sendButton: some View {
         let trimmed = draftText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let canSend = !trimmed.isEmpty
+        // Enabled when there's text OR at least one staged attachment.
+        let canSend = !trimmed.isEmpty || !attachments.isEmpty
         return Button(action: submitDraft) {
             Image(systemName: "arrow.up.circle.fill")
                 .font(.title2)
@@ -245,9 +358,117 @@ public struct ChatInputBar: View {
 
     private func submitDraft() {
         let trimmed = draftText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        // Allow sending an attachment-only message (no text).
+        guard !trimmed.isEmpty || !attachments.isEmpty else { return }
+        // Caller reads `attachments` (still bound) inside onSend, then we clear.
         onSend(trimmed)
         draftText = ""
+        attachments = []
+    }
+
+    // MARK: - Attachment ingestion
+
+    /// Decode picked photo-library items into image drafts.
+    private func ingest(photoItems: [PhotosPickerItem]) async {
+        var picked: [LocalAttachment] = []
+        for item in photoItems {
+            guard let data = try? await item.loadTransferable(type: Data.self) else { continue }
+            let image = UIImage(data: data)
+            let ext = (item.supportedContentTypes.first?.preferredFilenameExtension) ?? "jpg"
+            let mime = item.supportedContentTypes.first?.preferredMIMEType ?? "image/jpeg"
+            picked.append(
+                LocalAttachment(
+                    kind: .image,
+                    fileName: "image-\(UUID().uuidString.prefix(8)).\(ext)",
+                    mimeType: mime,
+                    data: data,
+                    image: image
+                )
+            )
+        }
+        if !picked.isEmpty {
+            attachments.append(contentsOf: picked)
+        }
+        photoSelections = []
+    }
+
+    /// Wrap a freshly captured camera photo as a JPEG image draft.
+    private func appendCameraImage(_ image: UIImage) {
+        guard let data = image.jpegData(compressionQuality: 0.9) else { return }
+        attachments.append(
+            LocalAttachment(
+                kind: .image,
+                fileName: "camera-\(UUID().uuidString.prefix(8)).jpg",
+                mimeType: "image/jpeg",
+                data: data,
+                image: image
+            )
+        )
+    }
+
+    /// Read security-scoped files chosen via the document picker into drafts.
+    private func ingest(fileResult: Result<[URL], Error>) {
+        guard case let .success(urls) = fileResult else { return }
+        var picked: [LocalAttachment] = []
+        for url in urls {
+            let scoped = url.startAccessingSecurityScopedResource()
+            defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+            guard let data = try? Data(contentsOf: url) else { continue }
+            let type = UTType(filenameExtension: url.pathExtension)
+            let isImage = type?.conforms(to: .image) ?? false
+            let mime = type?.preferredMIMEType ?? "application/octet-stream"
+            picked.append(
+                LocalAttachment(
+                    kind: isImage ? .image : .file,
+                    fileName: url.lastPathComponent,
+                    mimeType: mime,
+                    data: data,
+                    image: isImage ? UIImage(data: data) : nil
+                )
+            )
+        }
+        if !picked.isEmpty {
+            attachments.append(contentsOf: picked)
+        }
+    }
+}
+
+// MARK: - Camera picker bridge
+
+/// Minimal `UIImagePickerController` wrapper for in-app camera capture.
+/// Presented only when `.camera` source is available (guarded by the caller).
+private struct ChatCameraPicker: UIViewControllerRepresentable {
+    let onCapture: (UIImage) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let parent: ChatCameraPicker
+        init(_ parent: ChatCameraPicker) { self.parent = parent }
+
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            if let image = info[.originalImage] as? UIImage {
+                parent.onCapture(image)
+            }
+            parent.dismiss()
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            parent.dismiss()
+        }
     }
 }
 
@@ -271,14 +492,45 @@ public struct ChatInputBar: View {
     )
 }
 
+#Preview("With attachments") {
+    StatefulPreviewWrapper(
+        initial: "Check these out",
+        micState: .idle,
+        error: nil,
+        attachments: [
+            LocalAttachment(
+                kind: .image,
+                fileName: "photo.jpg",
+                mimeType: "image/jpeg",
+                data: Data(count: 120_000),
+                image: UIImage(systemName: "photo.fill")
+            ),
+            LocalAttachment(
+                kind: .file,
+                fileName: "notes.pdf",
+                mimeType: "application/pdf",
+                data: Data(count: 900_000),
+                image: nil
+            )
+        ]
+    )
+}
+
 /// Small helper so the previews can mutate `draftText` like the real parent.
 private struct StatefulPreviewWrapper: View {
     @State var text: String
+    @State var attachments: [LocalAttachment]
     let micState: ChatInputBar.MicState
     let error: String?
 
-    init(initial: String, micState: ChatInputBar.MicState, error: String?) {
+    init(
+        initial: String,
+        micState: ChatInputBar.MicState,
+        error: String?,
+        attachments: [LocalAttachment] = []
+    ) {
         self._text = State(initialValue: initial)
+        self._attachments = State(initialValue: attachments)
         self.micState = micState
         self.error = error
     }
@@ -288,6 +540,7 @@ private struct StatefulPreviewWrapper: View {
             Spacer()
             ChatInputBar(
                 draftText: $text,
+                attachments: $attachments,
                 micState: micState,
                 errorMessage: error,
                 onSend: { _ in },

--- a/apps/ios/SoloCompass/Views/Chat/LocalAttachment.swift
+++ b/apps/ios/SoloCompass/Views/Chat/LocalAttachment.swift
@@ -1,0 +1,48 @@
+import UIKit
+
+/// A draft attachment held by the input bar before the message is sent.
+///
+/// Distinct from `ChatAttachment` (the persisted, uploaded metadata): a
+/// `LocalAttachment` still carries the raw `data` (and, for images, a decoded
+/// `image` thumbnail) so the UI can preview it and the upload service can push
+/// the bytes to storage. Once uploaded it is replaced by a `ChatAttachment`.
+///
+/// Reuses `ChatAttachment.Kind` (see `Models/ChatMessage.swift`) so the draft
+/// and persisted layers share one discriminator. Equatable by `id` only — two
+/// drafts are the same iff they are literally the same picked item.
+public struct LocalAttachment: Identifiable, Equatable {
+    public let id: UUID
+    public let kind: ChatAttachment.Kind
+    public let fileName: String
+    public let mimeType: String
+    public let data: Data
+    /// Decoded preview thumbnail, present for `.image` kind. Nil for files.
+    public let image: UIImage?
+
+    public init(
+        id: UUID = UUID(),
+        kind: ChatAttachment.Kind,
+        fileName: String,
+        mimeType: String,
+        data: Data,
+        image: UIImage? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.fileName = fileName
+        self.mimeType = mimeType
+        self.data = data
+        self.image = image
+    }
+
+    /// Identity equality — `UIImage`/`Data` are intentionally excluded so the
+    /// strip can diff drafts cheaply by their stable id.
+    public static func == (lhs: LocalAttachment, rhs: LocalAttachment) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    /// Human-readable byte count for chip subtitles ("12 KB", "1.4 MB").
+    public var formattedSize: String {
+        ByteCountFormatter.string(fromByteCount: Int64(data.count), countStyle: .file)
+    }
+}

--- a/apps/ios/SoloCompass/Views/Chat/MarkdownMessageText.swift
+++ b/apps/ios/SoloCompass/Views/Chat/MarkdownMessageText.swift
@@ -113,20 +113,22 @@ struct MarkdownMessageText: View {
                     }
                     .markdownMargin(top: .em(0.25), bottom: .em(0.25))
             }
-            // Fenced code blocks: monospaced, inset background, horizontally
-            // scrollable so long lines don't blow out the bubble width.
+            // Fenced code blocks: render the raw `configuration.content` with our
+            // own monospaced `Text` rather than `configuration.label`. MarkdownUI's
+            // default code-block label wraps the lines in a container that renders
+            // blank under `ImageRenderer` (share cards / snapshots) — using the
+            // plain string guarantees the code is always visible and wraps inside
+            // the bubble instead of overflowing.
             .codeBlock { configuration in
-                ScrollView(.horizontal, showsIndicators: false) {
-                    configuration.label
-                        .markdownTextStyle {
-                            FontFamilyVariant(.monospaced)
-                            FontSize(.em(0.9))
-                            ForegroundColor(.primary)
-                        }
-                        .padding(10)
-                }
-                .background(codeBackground, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-                .markdownMargin(top: .em(0.3), bottom: .em(0.3))
+                Text(configuration.content)
+                    .font(.system(.callout, design: .monospaced))
+                    .foregroundStyle(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(codeBackground, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    .markdownMargin(top: .em(0.3), bottom: .em(0.3))
             }
     }
 }

--- a/apps/ios/SoloCompass/Views/Chat/MarkdownMessageText.swift
+++ b/apps/ios/SoloCompass/Views/Chat/MarkdownMessageText.swift
@@ -39,7 +39,7 @@ struct MarkdownMessageText: View {
     /// the code chip reads as inset without glaring.
     private var codeBackground: Color {
         colorScheme == .dark
-            ? Color.white.opacity(0.08)
+            ? Color.white.opacity(0.14)   // readable inset on the #28241E bubble
             : CT.surfaceSunken
     }
 
@@ -167,4 +167,30 @@ struct MarkdownMessageText: View {
             .padding()
     }
     .background(CT.bgWarm)
+}
+
+#Preview("Markdown Message — Dark") {
+    let sample = """
+    Here's a **bold** plan with *italic* nuance and inline `solo_score`.
+
+    ```swift
+    func recommend(_ city: String) -> [Experience] {
+        experiences.filter { $0.soloScore > 8.5 }
+    }
+    ```
+
+    > Travel light — the map is the home screen.
+
+    More at [Solo Compass](https://example.com).
+    """
+
+    ScrollView {
+        MarkdownMessageText(text: sample)
+            .padding(14)
+            .frame(maxWidth: 320, alignment: .leading)
+            .background(CT.chatAIBubbleBgDark, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .padding()
+    }
+    .background(Color.black)
+    .preferredColorScheme(.dark)
 }

--- a/apps/ios/SoloCompass/Views/Chat/MarkdownMessageText.swift
+++ b/apps/ios/SoloCompass/Views/Chat/MarkdownMessageText.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+import MarkdownUI
+
+// The app defines its own `Theme` protocol (Services/Themes/Theme.swift), which
+// shadows `MarkdownUI.Theme` when referenced unqualified. Alias the library type
+// so this file's chat theme builds against the correct concrete struct.
+private typealias MarkdownTheme = MarkdownUI.Theme
+
+/// Renders an LLM chat reply as Markdown inside a chat bubble.
+///
+/// Wraps `MarkdownUI`'s `Markdown(_:)` with a compact, chat-tuned theme that
+/// reuses the `CT` design tokens (no hardcoded colors) and adapts to light/dark
+/// via `@Environment(\.colorScheme)`. Headings/lists/quotes use modest margins
+/// because this lives inside a bubble — full document spacing would look loud.
+///
+/// Only the assistant bubble uses this; user bubbles stay plain `Text`.
+@MainActor
+struct MarkdownMessageText: View {
+    let text: String
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    init(text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        Markdown(text)
+            .markdownTheme(chatTheme)
+            // Body text matches the surrounding bubble: system body, primary fg.
+            .font(.body)
+            .foregroundStyle(.primary)
+    }
+
+    // MARK: - Theme
+
+    /// Subtle, dark-aware fill for inline code & code blocks. Sunken parchment
+    /// in light mode; a touch lighter than the dark bubble fill in dark mode so
+    /// the code chip reads as inset without glaring.
+    private var codeBackground: Color {
+        colorScheme == .dark
+            ? Color.white.opacity(0.08)
+            : CT.surfaceSunken
+    }
+
+    private var chatTheme: MarkdownTheme {
+        MarkdownTheme()
+            // Base text inherits the bubble's font/foreground.
+            .text {
+                FontSize(UIFont.preferredFont(forTextStyle: .body).pointSize)
+            }
+            // Inline `code`: monospaced, subtle inset background, readable fg.
+            .code {
+                FontFamilyVariant(.monospaced)
+                FontSize(.em(0.94))
+                ForegroundColor(.primary)
+                BackgroundColor(codeBackground)
+            }
+            // Links: accent-colored + underlined.
+            .link {
+                ForegroundColor(CT.accent)
+                UnderlineStyle(.single)
+            }
+            // Headings — modest margins so they don't dominate the bubble.
+            .heading1 { configuration in
+                configuration.label
+                    .markdownMargin(top: .em(0.5), bottom: .em(0.3))
+                    .markdownTextStyle {
+                        FontWeight(.bold)
+                        FontSize(.em(1.3))
+                    }
+            }
+            .heading2 { configuration in
+                configuration.label
+                    .markdownMargin(top: .em(0.45), bottom: .em(0.28))
+                    .markdownTextStyle {
+                        FontWeight(.bold)
+                        FontSize(.em(1.18))
+                    }
+            }
+            .heading3 { configuration in
+                configuration.label
+                    .markdownMargin(top: .em(0.4), bottom: .em(0.25))
+                    .markdownTextStyle {
+                        FontWeight(.semibold)
+                        FontSize(.em(1.08))
+                    }
+            }
+            // Paragraphs: tight vertical rhythm for chat density.
+            .paragraph { configuration in
+                configuration.label
+                    .markdownMargin(top: .em(0.2), bottom: .em(0.2))
+            }
+            // Ordered / unordered / task lists: modest indent + spacing.
+            .list { configuration in
+                configuration.label
+                    .markdownMargin(top: .em(0.2), bottom: .em(0.2))
+            }
+            .listItem { configuration in
+                configuration.label
+                    .markdownMargin(top: .em(0.08))
+            }
+            // Blockquote: accent left rule, muted fg, light inset.
+            .blockquote { configuration in
+                configuration.label
+                    .padding(.leading, 12)
+                    .padding(.vertical, 2)
+                    .foregroundStyle(.secondary)
+                    .overlay(alignment: .leading) {
+                        RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+                            .fill(CT.accentBorder)
+                            .frame(width: 3)
+                    }
+                    .markdownMargin(top: .em(0.25), bottom: .em(0.25))
+            }
+            // Fenced code blocks: monospaced, inset background, horizontally
+            // scrollable so long lines don't blow out the bubble width.
+            .codeBlock { configuration in
+                ScrollView(.horizontal, showsIndicators: false) {
+                    configuration.label
+                        .markdownTextStyle {
+                            FontFamilyVariant(.monospaced)
+                            FontSize(.em(0.9))
+                            ForegroundColor(.primary)
+                        }
+                        .padding(10)
+                }
+                .background(codeBackground, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .markdownMargin(top: .em(0.3), bottom: .em(0.3))
+            }
+    }
+}
+
+#Preview("Markdown Message") {
+    let sample = """
+    # Trip ideas
+    Here's a **bold** plan with some *italic* nuance and an inline `solo_score` tag.
+
+    ```swift
+    func recommend(_ city: String) -> [Experience] {
+        experiences.filter { $0.soloScore > 8.5 }
+    }
+    ```
+
+    Unordered:
+    - Quiet café with wifi
+    - Sunrise viewpoint
+    - Riverside walk
+
+    Ordered:
+    1. Coffee at Café Zenith
+    2. Walk to the old town
+    3. Sunset at the pier
+
+    > Travel light — the map is the home screen.
+
+    More at [Solo Compass](https://example.com).
+    """
+
+    ScrollView {
+        MarkdownMessageText(text: sample)
+            .padding(14)
+            .frame(maxWidth: 320, alignment: .leading)
+            .background(CT.surfaceWhite, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .padding()
+    }
+    .background(CT.bgWarm)
+}

--- a/apps/ios/SoloCompass/Views/Chat/MessageBubble.swift
+++ b/apps/ios/SoloCompass/Views/Chat/MessageBubble.swift
@@ -88,9 +88,10 @@ public struct MessageBubble: View {
         HStack(alignment: .top, spacing: 8) {
             AssistantAvatar()
             VStack(alignment: .leading, spacing: 0) {
-                Text(text.isEmpty ? " " : text)
-                    .font(.body)
-                    .foregroundStyle(.primary)
+                // Assistant replies render Markdown (code/lists/links/quotes).
+                // Streaming throttle (batched ~50–80 chars / ~80ms) lives in the
+                // orchestrator (Phase D) so this view re-renders smoothly.
+                MarkdownMessageText(text: text.isEmpty ? " " : text)
                     .padding(.horizontal, 14)
                     .padding(.vertical, 9)
                     // background{shape.fill.shadow} lets the soft shadow escape

--- a/apps/ios/SoloCompass/Views/Companion/ChatView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ChatView.swift
@@ -310,11 +310,18 @@ private struct ChatMessageRow: View {
             .fill(UserDirectory.color(forId: message.senderId))
             .frame(width: 22, height: 22)
             .overlay(
-                Text(String(message.senderId.prefix(1)).uppercased())
+                Text(avatarInitial)
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundStyle(.white)
             )
             .alignmentGuide(.bottom) { $0[.bottom] }
+    }
+
+    /// First letter of the sender id, falling back to "?" so an empty/unknown
+    /// id never renders a blank avatar.
+    private var avatarInitial: String {
+        let first = String(message.senderId.prefix(1)).uppercased()
+        return first.isEmpty ? "?" : first
     }
 
     private func formattedTime(_ iso: String) -> String {

--- a/apps/ios/SoloCompass/Views/Companion/ChatView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ChatView.swift
@@ -16,9 +16,10 @@ public struct ChatView: View {
     @Environment(\.modelContext) private var modelContext
     @State private var service: ChatService
     @State private var inputText = ""
+    /// Draft attachments staged in the Instagram-style input bar before send.
+    @State private var draftAttachments: [LocalAttachment] = []
     @State private var showingReportSheet = false
     @State private var pinnedRoute: Route?
-    @FocusState private var inputFocused: Bool
 
     private let currentUserId: String?
     /// The other participant's user ID (used for report/block in one-on-one).
@@ -136,7 +137,8 @@ public struct ChatView: View {
                         ChatMessageRow(
                             message: msg,
                             isFromMe: msg.senderId == currentUserId,
-                            isGroupRoute: isGroupRoute
+                            isGroupRoute: isGroupRoute,
+                            resolveURL: resolveAttachmentURL
                         )
                         .id(msg.id.rawValue)
                     }
@@ -154,49 +156,33 @@ public struct ChatView: View {
         }
     }
 
+    /// Instagram-DM-style input bar — "+" attachment menu (photos / camera /
+    /// files) + rounded text field + inline send. No mic (that's Voice Agent
+    /// only). Shared with the Voice-Agent bar's picker plumbing via
+    /// `AttachmentInputBar`; staged drafts live in `draftAttachments`.
     private var inputBar: some View {
-        HStack(alignment: .bottom, spacing: 8) {
-            TextField(
-                NSLocalizedString("companion.chat.input.placeholder", comment: "Message input placeholder"),
-                text: $inputText,
-                axis: .vertical
+        AttachmentInputBar(
+            draftText: $inputText,
+            attachments: $draftAttachments,
+            isSending: service.isSending,
+            placeholder: NSLocalizedString(
+                "companion.chat.input.placeholder",
+                comment: "Message input placeholder"
             )
-            .lineLimit(1...5)
-            .focused($inputFocused)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(
-                RoundedRectangle(cornerRadius: 20)
-                    .fill(Color(.secondarySystemBackground))
-            )
-            .accessibilityLabel(NSLocalizedString("companion.chat.input.a11y", comment: "Message input accessibility"))
-
-            Button {
-                Task { await submitMessage() }
-            } label: {
-                Image(systemName: "arrow.up.circle.fill")
-                    .font(.system(size: 30))
-                    .foregroundStyle(canSend ? Color.accentColor : Color.secondary)
-            }
-            .disabled(!canSend)
-            .accessibilityLabel(NSLocalizedString("companion.chat.send.a11y", comment: "Send message"))
+        ) { trimmed in
+            // Read staged drafts here (the bar clears them after this returns).
+            let staged = draftAttachments
+            Task { await service.send(trimmed, attachments: staged) }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(Color(.systemBackground))
     }
 
     // MARK: - Helpers
 
-    private var canSend: Bool {
-        !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !service.isSending
-    }
-
-    private func submitMessage() async {
-        let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty else { return }
-        inputText = ""
-        await service.send(text)
+    /// Resolve a persisted attachment to a signed download URL, delegating to
+    /// the conversation's `ChatService`. Returns `nil` (placeholder) when the
+    /// storage backend isn't deployed.
+    private func resolveAttachmentURL(_ attachment: ChatAttachment) async -> URL? {
+        await service.resolveAttachmentURL(attachment)
     }
 }
 
@@ -206,6 +192,10 @@ private struct ChatMessageRow: View {
     let message: ChatMessage
     let isFromMe: Bool
     var isGroupRoute: Bool = false
+    /// Resolves a persisted attachment to a signed download URL (Phase D).
+    let resolveURL: (ChatAttachment) async -> URL?
+
+    @Environment(\.colorScheme) private var colorScheme
 
     private static let timeFormatter: DateFormatter = {
         let f = DateFormatter()
@@ -216,6 +206,12 @@ private struct ChatMessageRow: View {
 
     private var showAvatar: Bool { isGroupRoute && !isFromMe }
 
+    private var hasText: Bool {
+        !message.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var attachments: [ChatAttachment] { message.attachments ?? [] }
+
     var body: some View {
         HStack(alignment: .bottom, spacing: 0) {
             if isFromMe { Spacer(minLength: 60) }
@@ -225,7 +221,7 @@ private struct ChatMessageRow: View {
                     .padding(.trailing, 6)
             }
 
-            VStack(alignment: isFromMe ? .trailing : .leading, spacing: 2) {
+            VStack(alignment: isFromMe ? .trailing : .leading, spacing: 4) {
                 if showAvatar {
                     Text(message.senderId)
                         .font(.caption2.weight(.medium))
@@ -234,15 +230,15 @@ private struct ChatMessageRow: View {
                         .padding(.horizontal, 4)
                 }
 
-                Text(message.body)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(
-                        RoundedRectangle(cornerRadius: 16)
-                            .fill(isFromMe ? Color.accentColor : Color(.secondarySystemBackground))
-                    )
-                    .foregroundStyle(isFromMe ? Color.white : Color.primary)
-                    .textSelection(.enabled)
+                // Text bubble — shown only when there's body text. Attachment-only
+                // messages skip the empty bubble and render just the media.
+                if hasText {
+                    textBubble
+                }
+
+                if !attachments.isEmpty {
+                    AttachmentBubble(attachments: attachments, resolveURL: resolveURL)
+                }
 
                 Text(formattedTime(message.createdAt))
                     .font(.caption2)
@@ -265,6 +261,47 @@ private struct ChatMessageRow: View {
                     message.body, formattedTime(message.createdAt)
                   )
         )
+    }
+
+    // MARK: - Bubble (unified Voice-Agent design language)
+
+    /// Plain-text bubble matching `MessageBubble`'s tokens: 18pt continuous
+    /// corners, 14×9 padding, CT.accent fill for my messages (white text) /
+    /// surface fill for others (dark-aware), 0.5pt border, soft shadow.
+    /// DM is human-to-human, so this stays plain `Text` (no Markdown).
+    private var textBubble: some View {
+        Text(message.body)
+            .font(.body)
+            .foregroundStyle(isFromMe ? Color.white : Color.primary)
+            .textSelection(.enabled)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+            .background(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(bubbleFill)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .strokeBorder(bubbleBorder, lineWidth: 0.5)
+            )
+            .shadow(
+                color: Color.black.opacity(isFromMe ? 0.10 : 0.06),
+                radius: isFromMe ? 6 : 4,
+                x: 0,
+                y: isFromMe ? 2 : 1
+            )
+    }
+
+    /// User bubble = warm accent; other = white (light) / dark AI fill (dark),
+    /// mirroring `MessageBubble.assistantFill`.
+    private var bubbleFill: Color {
+        if isFromMe { return CT.accent }
+        return colorScheme == .dark ? CT.chatAIBubbleBgDark : CT.surfaceWhite
+    }
+
+    private var bubbleBorder: Color {
+        if isFromMe { return CT.accentBorder }
+        return colorScheme == .dark ? Color(.separator) : CT.borderSubtle
     }
 
     @ViewBuilder
@@ -319,6 +356,23 @@ private struct ChatMessageRow: View {
             senderId: "user_preview",
             body: "Definitely. I have a few marked — let's compare notes.",
             createdAt: "2026-02-05T14:02:00Z"
+        ),
+        ChatMessage(
+            id: ChatMessageId(rawValue: "m4"),
+            conversationId: conv.id,
+            senderId: "user_preview",
+            body: "Here's my shortlist.",
+            attachments: [
+                ChatAttachment(
+                    id: "att_preview_1",
+                    kind: .file,
+                    fileName: "tokyo-coffee.pdf",
+                    mimeType: "application/pdf",
+                    fileSizeBytes: 820_000,
+                    storagePath: "conv/m4/att_preview_1-tokyo-coffee.pdf"
+                )
+            ],
+            createdAt: "2026-02-05T14:03:00Z"
         ),
     ]
     return NavigationStack {

--- a/apps/ios/SoloCompass/Views/Experience/CreateExperienceSheet.swift
+++ b/apps/ios/SoloCompass/Views/Experience/CreateExperienceSheet.swift
@@ -1,0 +1,299 @@
+import CoreLocation
+import PhotosUI
+import SwiftUI
+
+/// Form to register a new place at a long-pressed map coordinate.
+///
+/// This is the primary "add a place" path (the voice flow remains as a
+/// secondary entry point). The user supplies only honest, mechanical facts:
+/// name, category, a short description, and photos. Trust-critical fields
+/// (Solo Score, confidence) are NOT user-settable — `Experience.userDraft`
+/// fills them with safe, unverified defaults.
+public struct CreateExperienceSheet: View {
+    /// The map coordinate the user long-pressed. Photos and form text are
+    /// gathered here; the coordinate is fixed.
+    let coordinate: CLLocationCoordinate2D
+
+    /// Called with the assembled fields when the user taps Save. Photo URLs are
+    /// already-persisted `file://` strings.
+    var onSave: (_ input: NewPlaceFormInput) -> Void
+
+    /// Called when the user wants the secondary voice path instead of the form.
+    var onUseVoice: () -> Void
+
+    var onCancel: () -> Void
+
+    @State private var placeName: String = ""
+    @State private var placeNameLocal: String = ""
+    @State private var oneLiner: String = ""
+    @State private var description: String = ""
+    @State private var category: ExperienceCategory = .hidden
+
+    @State private var pickerItems: [PhotosPickerItem] = []
+    @State private var images: [UIImage] = []
+    @State private var isShowingCamera = false
+
+    @Environment(\.dismiss) private var dismiss
+
+    public init(
+        coordinate: CLLocationCoordinate2D,
+        onSave: @escaping (_ input: NewPlaceFormInput) -> Void,
+        onUseVoice: @escaping () -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.coordinate = coordinate
+        self.onSave = onSave
+        self.onUseVoice = onUseVoice
+        self.onCancel = onCancel
+    }
+
+    /// Save is meaningful only when there's at least a place name.
+    private var canSave: Bool {
+        !placeName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    public var body: some View {
+        NavigationStack {
+            Form {
+                nameSection
+                categorySection
+                descriptionSection
+                photosSection
+                voiceSection
+            }
+            .navigationTitle(NSLocalizedString("userLocation.create.title", comment: "Add a place"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(NSLocalizedString("common.cancel", comment: "Cancel")) {
+                        onCancel()
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(NSLocalizedString("userLocation.form.save", comment: "Save")) {
+                        submit()
+                    }
+                    .disabled(!canSave)
+                }
+            }
+            .sheet(isPresented: $isShowingCamera) {
+                CameraPicker { captured in
+                    if let captured { images.append(captured) }
+                }
+                .ignoresSafeArea()
+            }
+            .onChange(of: pickerItems) { _, newItems in
+                Task { await loadPickedImages(newItems) }
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var nameSection: some View {
+        Section {
+            TextField(
+                NSLocalizedString("userLocation.form.name.placeholder", comment: "Place name placeholder"),
+                text: $placeName
+            )
+            TextField(
+                NSLocalizedString("userLocation.form.nameLocal.placeholder", comment: "Local-language name placeholder"),
+                text: $placeNameLocal
+            )
+            TextField(
+                NSLocalizedString("userLocation.form.oneLiner.placeholder", comment: "One-line summary placeholder"),
+                text: $oneLiner
+            )
+        } header: {
+            Text(NSLocalizedString("userLocation.form.name.label", comment: "Place name section header"))
+        }
+    }
+
+    private var categorySection: some View {
+        Section {
+            Picker(
+                NSLocalizedString("userLocation.form.category.label", comment: "Category"),
+                selection: $category
+            ) {
+                ForEach(ExperienceCategory.allCases) { cat in
+                    Label(cat.localizedTitle, systemImage: cat.symbol).tag(cat)
+                }
+            }
+        }
+    }
+
+    private var descriptionSection: some View {
+        Section {
+            TextField(
+                NSLocalizedString("userLocation.form.notes.placeholder", comment: "Notes placeholder"),
+                text: $description,
+                axis: .vertical
+            )
+            .lineLimit(3...6)
+        } header: {
+            Text(NSLocalizedString("userLocation.form.notes.label", comment: "Notes section header"))
+        }
+    }
+
+    private var photosSection: some View {
+        Section {
+            if !images.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(Array(images.enumerated()), id: \.offset) { idx, img in
+                            Image(uiImage: img)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 72, height: 72)
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                                .overlay(alignment: .topTrailing) {
+                                    Button {
+                                        images.remove(at: idx)
+                                    } label: {
+                                        Image(systemName: "xmark.circle.fill")
+                                            .foregroundStyle(.white, .black.opacity(0.5))
+                                    }
+                                    .padding(2)
+                                }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            PhotosPicker(
+                selection: $pickerItems,
+                maxSelectionCount: 5,
+                matching: .images
+            ) {
+                Label(
+                    NSLocalizedString("userLocation.form.photo.library", comment: "Choose from library"),
+                    systemImage: "photo.on.rectangle"
+                )
+            }
+            Button {
+                isShowingCamera = true
+            } label: {
+                Label(
+                    NSLocalizedString("userLocation.form.photo.camera", comment: "Take a photo"),
+                    systemImage: "camera"
+                )
+            }
+        } header: {
+            Text(NSLocalizedString("userLocation.form.photo.label", comment: "Photos section header"))
+        }
+    }
+
+    private var voiceSection: some View {
+        Section {
+            Button {
+                onUseVoice()
+                dismiss()
+            } label: {
+                Label(
+                    NSLocalizedString("userLocation.form.useVoice", comment: "Describe with voice instead"),
+                    systemImage: "mic"
+                )
+            }
+        } footer: {
+            Text(NSLocalizedString("userLocation.form.unverifiedNote", comment: "Unverified note"))
+        }
+    }
+
+    // MARK: - Actions
+
+    private func loadPickedImages(_ items: [PhotosPickerItem]) async {
+        var loaded: [UIImage] = []
+        for item in items {
+            if let data = try? await item.loadTransferable(type: Data.self),
+               let img = UIImage(data: data) {
+                loaded.append(img)
+            }
+        }
+        await MainActor.run { images.append(contentsOf: loaded); pickerItems = [] }
+    }
+
+    private func submit() {
+        // Persist images to disk now so the form hands back ready-to-store URLs.
+        let urls = PlacePhotoStore.save(images, uuids: images.map { _ in UUID().uuidString })
+        let trimmedName = placeName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let input = NewPlaceFormInput(
+            coordinate: coordinate,
+            placeNameRomanized: trimmedName,
+            placeNameLocal: placeNameLocal.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+            // Title falls back to the place name when the user gives no one-liner action.
+            title: oneLiner.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? trimmedName,
+            oneLiner: oneLiner.trimmingCharacters(in: .whitespacesAndNewlines),
+            description: description.trimmingCharacters(in: .whitespacesAndNewlines),
+            category: category,
+            photoUrls: urls.isEmpty ? nil : urls
+        )
+        onSave(input)
+        dismiss()
+    }
+}
+
+/// The fields the create-place form hands back. Coordinate is fixed from the
+/// long-press; everything else is user-entered. Photo URLs are persisted
+/// `file://` strings ready for `ExperienceLocation.photoUrls`.
+public struct NewPlaceFormInput {
+    public let coordinate: CLLocationCoordinate2D
+    public let placeNameRomanized: String
+    public let placeNameLocal: String?
+    public let title: String
+    public let oneLiner: String
+    public let description: String
+    public let category: ExperienceCategory
+    public let photoUrls: [String]?
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
+}
+
+// MARK: - Camera picker (UIKit bridge)
+
+/// Minimal `UIImagePickerController` wrapper for taking a photo. SwiftUI has no
+/// native camera capture view, so we bridge UIKit. Library picking uses the
+/// native `PhotosPicker` in the form above.
+struct CameraPicker: UIViewControllerRepresentable {
+    var onCapture: (UIImage?) -> Void
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(onCapture: onCapture) }
+
+    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let onCapture: (UIImage?) -> Void
+        init(onCapture: @escaping (UIImage?) -> Void) { self.onCapture = onCapture }
+
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            onCapture(info[.originalImage] as? UIImage)
+            picker.dismiss(animated: true)
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            onCapture(nil)
+            picker.dismiss(animated: true)
+        }
+    }
+}
+
+#Preview {
+    CreateExperienceSheet(
+        coordinate: CLLocationCoordinate2D(latitude: 18.7877, longitude: 98.9938),
+        onSave: { _ in },
+        onUseVoice: {},
+        onCancel: {}
+    )
+}

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -388,11 +388,12 @@ struct CompassMapContentView: View {
                     viewModel.cancelAddExperience()
                 }
                 Button(NSLocalizedString("addExperience.confirm.add", comment: "Add")) {
-                    viewModel.confirmAddExperience()
+                    viewModel.confirmAddExperienceWithForm()
                 }
             } message: {
                 Text(NSLocalizedString("addExperience.confirm.message", comment: "Describe it with your voice"))
             }
+            .sheet(isPresented: createFormSheetBinding) { createFormSheetContent }
             .sheet(isPresented: recordExperienceSheetBinding) { recordExperienceSheetContent }
             .sheet(isPresented: detailSheetBinding) { detailSheetContent }
             .sheet(isPresented: $isShowingCityPicker) { cityPickerSheetContent }
@@ -740,8 +741,30 @@ struct CompassMapContentView: View {
 
     private var addExperienceAlertBinding: Binding<Bool> {
         Binding(
-            get: { (viewModel.pendingAddCoordinate != nil) && !viewModel.isRecordingNewExperience },
+            get: {
+                (viewModel.pendingAddCoordinate != nil)
+                    && !viewModel.isRecordingNewExperience
+                    && !viewModel.isShowingCreateForm
+            },
             set: { if !$0 { viewModel.cancelAddExperience() } }
+        )
+    }
+
+    /// Drives the structured create-place form. Presents only when the user
+    /// confirmed the long-press AND a coordinate is pending. On dismiss we only
+    /// tear down the add-flow if the user isn't switching to the voice path —
+    /// otherwise cancelling here would clear the pending coordinate before the
+    /// voice sheet could open.
+    private var createFormSheetBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.isShowingCreateForm && viewModel.pendingAddCoordinate != nil },
+            set: { presenting in
+                guard !presenting else { return }
+                viewModel.isShowingCreateForm = false
+                if !viewModel.isRecordingNewExperience {
+                    viewModel.cancelAddExperience()
+                }
+            }
         )
     }
 
@@ -810,6 +833,18 @@ struct CompassMapContentView: View {
             },
             onSkip: { surveyExperience = nil }
         )
+    }
+
+    @ViewBuilder
+    private var createFormSheetContent: some View {
+        if let coordinate = viewModel.pendingAddCoordinate {
+            CreateExperienceSheet(
+                coordinate: coordinate,
+                onSave: { input in viewModel.createUserExperience(from: input) },
+                onUseVoice: { viewModel.confirmAddExperience() },
+                onCancel: { viewModel.cancelAddExperience() }
+            )
+        }
     }
 
     @ViewBuilder

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -103,6 +103,8 @@ targets:
         product: Supabase
       - package: Sentry
         product: Sentry
+      - package: swift-markdown-ui
+        product: MarkdownUI
 
   SoloCompassTests:
     type: bundle.unit-test
@@ -136,6 +138,9 @@ packages:
   Sentry:
     url: https://github.com/getsentry/sentry-cocoa
     from: 8.36.0
+  swift-markdown-ui:
+    url: https://github.com/gonzalezreal/swift-markdown-ui
+    from: 2.4.1
 
 schemes:
   SoloCompass:

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -62,6 +62,8 @@ targets:
           - location
         NSSpeechRecognitionUsageDescription: "Solo Compass uses speech recognition so you can describe what you're looking for by voice."
         NSMicrophoneUsageDescription: "Solo Compass uses the microphone for voice search."
+        NSCameraUsageDescription: "Solo Compass uses the camera so you can photograph a place when you add it to the map."
+        NSPhotoLibraryUsageDescription: "Solo Compass needs access to your photos so you can attach an image to a place you add."
         LSApplicationQueriesSchemes:
           - comgooglemaps
           - iosamap

--- a/docs/design/chat-experience-upgrade.md
+++ b/docs/design/chat-experience-upgrade.md
@@ -13,12 +13,12 @@
 
 ## 0. 决策汇总(已与用户确认)
 
-| 维度 | 决策 |
-| --- | --- |
-| 范围 | 两套聊天都升级:LLM 对话(ChatSheet/MessageBubble/ChatInputBar)+ Companion DM(ChatView) |
-| Markdown | 引入 **swift-markdown-ui 2.4.1**(`from: "2.4.1"`,iOS 15+,项目 17.0 兼容) |
-| 附件 | **全链路含上传**;后端 SQL 迁移由 Claude 写,**用户负责部署到 Supabase** |
-| 输入栏 | 参考 Instagram DM:加号附件入口 + 相机 + 相册 + 文件,附件预览气泡 |
+| 维度     | 决策                                                                                  |
+| -------- | ------------------------------------------------------------------------------------- |
+| 范围     | 两套聊天都升级:LLM 对话(ChatSheet/MessageBubble/ChatInputBar)+ Companion DM(ChatView) |
+| Markdown | 引入 **swift-markdown-ui 2.4.1**(`from: "2.4.1"`,iOS 15+,项目 17.0 兼容)              |
+| 附件     | **全链路含上传**;后端 SQL 迁移由 Claude 写,**用户负责部署到 Supabase**                |
+| 输入栏   | 参考 Instagram DM:加号附件入口 + 相机 + 相册 + 文件,附件预览气泡                      |
 
 ## 0.1 现实约束(必须遵守)
 
@@ -32,13 +32,16 @@
 ## 1. 技术事实基线
 
 ### 1.1 MarkdownUI
+
 - 包:`https://github.com/gonzalezreal/swift-markdown-ui` `from: "2.4.1"`
 - 用法:`Markdown(text).markdownTheme(...)`;可 `.markdownTextStyle(.code){...}` 定制代码块字体/底色/前景。
 - 流式:逐字追加有渲染压力 → **批量节流(~每 50–80 字或每 80ms 刷新一次)**,避免每 token 重渲。
 - ImageRenderer 光栅化未官方保证 → 分享卡**不依赖 MarkdownUI**(沿用既有纯文本路径)。
 
 ### 1.2 设计 token(`Views/Shared/CompareTokens.swift` 的 `enum CT`)
+
 聊天相关 token(直接复用,不要硬编码颜色):
+
 - `CT.accent` #5D3000(用户气泡填充/发送按钮/流式光标)
 - `CT.surfaceWhite` #FFFFFF · `CT.chatAIBubbleBgDark` #28241E(AI 气泡亮/暗填充,见 `MessageBubble.assistantFill`)
 - `CT.borderSubtle` #EDE8DF · `CT.accentBorder` #E8DCCA(气泡边框)
@@ -47,6 +50,7 @@
 - 字体:聊天用系统字体;`CT.mono(_:)` = `.system(design:.monospaced)` 给代码块用。
 
 ### 1.3 现有数值(统一基线)
+
 - 气泡圆角 18pt(Voice)/ 16pt(Companion)→ **统一为 18pt continuous**
 - 气泡内边距 14×9;输入框内边距 12×8;输入框圆角 18pt
 - Avatar 32(Voice)/ 22(Companion);mic 按钮 40×40 圆角 12
@@ -59,6 +63,7 @@
 ### 2.1 附件数据模型(TS + Swift 同步)
 
 **`packages/core/src/companion.ts`** 新增:
+
 ```ts
 export interface ChatAttachment {
   readonly id: string;
@@ -66,9 +71,9 @@ export interface ChatAttachment {
   readonly fileName: string;
   readonly mimeType: string;
   readonly fileSizeBytes: number;
-  readonly storagePath: string;     // bucket 内路径:"{conversationId}/{messageId}/{attachmentId}-{fileName}"
-  readonly width?: number;          // image only
-  readonly height?: number;         // image only
+  readonly storagePath: string; // bucket 内路径:"{conversationId}/{messageId}/{attachmentId}-{fileName}"
+  readonly width?: number; // image only
+  readonly height?: number; // image only
 }
 
 export interface ChatMessage {
@@ -76,13 +81,14 @@ export interface ChatMessage {
   readonly conversationId: ConversationId;
   readonly senderId: UserId;
   readonly body: string;
-  readonly attachments?: readonly ChatAttachment[];   // ← 新增,可选,默认空
+  readonly attachments?: readonly ChatAttachment[]; // ← 新增,可选,默认空
   readonly readAt?: string;
   readonly createdAt: string;
 }
 ```
 
 **`apps/ios/.../Models/ChatMessage.swift`** 镜像:
+
 ```swift
 public struct ChatAttachment: Identifiable, Codable, Sendable, Equatable {
     public let id: String
@@ -101,12 +107,14 @@ public struct ChatAttachment: Identifiable, Codable, Sendable, Equatable {
 > parity:check 要求字段集合一致。`attachments` 在两侧都加。先跑 `pnpm parity:check` 看脚本对嵌套 ChatAttachment 的处理,再据报错调整。
 
 ### 2.2 后端迁移(`infra/supabase/migrations/0005_chat_attachments.sql`)
+
 - 在 `chat_messages` 加 `attachments jsonb`(选 JSON 列,避免连表;与 TS 的 `attachments?` 对齐)。
 - 创建 private bucket `chat-media`。
 - RLS:仅会话参与者可 upload(insert)到 `{conversationId}/...` 前缀、可 select(下载用 signed URL)。
 - 文件含完整可执行 SQL + 顶部注释「部署方式:supabase db push 或控制台 SQL editor」。
 
 ### 2.3 iOS 上传服务(`Services/ChatAttachmentService.swift`,新增)
+
 ```swift
 protocol AttachmentUploading {
     /// 上传到 chat-media bucket,返回可写入消息的 ChatAttachment 元数据。
@@ -115,10 +123,12 @@ protocol AttachmentUploading {
     func signedURL(for attachment: ChatAttachment) async throws -> URL
 }
 ```
+
 - 真实实现 `SupabaseAttachmentService`:`POST /storage/v1/object/chat-media/{path}` + `POST /storage/v1/object/sign/...`。
 - **后端未部署时**:upload 抛明确错误 → UI 显示「附件后端未就绪」,文本消息仍可发。
 
 ### 2.4 输入栏附件回调
+
 ```swift
 // 草稿态附件,发送前持有
 struct LocalAttachment: Identifiable, Equatable {
@@ -139,18 +149,21 @@ struct LocalAttachment: Identifiable, Equatable {
 ## 3. 文件清单与分工(并行批次)
 
 ### Batch A — 数据契约层(必须先做,其它依赖它)
+
 - `packages/core/src/companion.ts` [改] 加 ChatAttachment + ChatMessage.attachments
 - `apps/ios/.../Models/ChatMessage.swift` [改] 镜像
 - `infra/supabase/migrations/0005_chat_attachments.sql` [新] 迁移 + bucket + RLS
 - 验收:`pnpm parity:check` 绿
 
 ### Batch B — Markdown 渲染(依赖 A 完成 SwiftPM 接入)
+
 - `apps/ios/project.yml` [改] 加 swift-markdown-ui 依赖 → `xcodegen`
 - `apps/ios/.../Views/Chat/MarkdownMessageText.swift` [新] 封装 `Markdown(...)` + 聊天主题(代码块/inline code/链接/列表/引用样式,亮暗自适应,用 CT token)
 - `apps/ios/.../Views/Chat/MessageBubble.swift` [改] assistant 气泡文本改用 MarkdownMessageText;user 气泡保持纯文本;流式节流
 - 验收:构建绿;/tmp PNG 视觉验证 md(代码块/列表/加粗/链接/引用)
 
 ### Batch C — Instagram 风输入栏 + 附件 UI(依赖 A 的 LocalAttachment)
+
 - `apps/ios/.../Views/Chat/ChatInputBar.swift` [改] 加「+」附件菜单(相机/相册/文件)、PhotosPicker、.fileImporter、草稿附件预览条
 - `apps/ios/.../Views/Chat/AttachmentDraftStrip.swift` [新] 横向草稿附件缩略图 + 删除
 - `apps/ios/.../Views/Chat/AttachmentBubble.swift` [新] 已发消息里的附件渲染(图片缩略图点开大图 / 文件卡片)
@@ -158,6 +171,7 @@ struct LocalAttachment: Identifiable, Equatable {
 - 验收:构建绿;选图/选文件/预览/删除可用;视觉对齐 Instagram DM
 
 ### Batch D — 服务/数据流(依赖 A、C)
+
 - `apps/ios/.../Services/ChatAttachmentService.swift` [新] AttachmentUploading + Supabase 实现 + 未部署降级
 - `apps/ios/.../Services/SupabaseClient.swift` [改] 加 storage upload/sign 方法
 - `apps/ios/.../Services/ChatService.swift` [改] send 接收 attachments:先上传 → 写入 message.attachments;handleInsert 解析 attachments
@@ -165,11 +179,13 @@ struct LocalAttachment: Identifiable, Equatable {
 - 验收:构建绿;mock 上传单测;parity 绿
 
 ### Batch E — 气泡视觉统一打磨(依赖 B、C)
+
 - 两套气泡统一 18pt continuous、CT token、阴影/边框基线;时间戳/已读/sender 名排版精修
 - `#Preview` 覆盖:user/assistant/含 md/含图片/含文件/流式
 - 验收:/tmp PNG 全场景视觉验收
 
 ### Batch F — 测试 + 本地化 + 验证
+
 - `Tests/MarkdownMessageTextTests.swift`、`Tests/ChatAttachmentServiceTests.swift`、`Tests/ChatMessageAttachmentParsingTests.swift`
 - `Resources/en.lproj/Localizable.strings` 新 key(附件入口/错误/占位)
 - `xcodegen` → build → test(`Executed N>0`);`pnpm parity:check`

--- a/docs/design/chat-experience-upgrade.md
+++ b/docs/design/chat-experience-upgrade.md
@@ -1,0 +1,197 @@
+# 聊天体验升级 — 实现计划与接口契约
+
+> Markdown 渲染 + Instagram 风输入栏 + 全链路附件 + 两套气泡视觉统一。
+> 本文是所有实现 agent 的**单一事实源**:接口契约一旦写定,各层按此并行实现,保证对齐。
+
+- **作者**: Claude (Agent Team 交付)
+- **日期**: 2026-06-06
+- **分支**: `feat/chat-experience-upgrade`
+- **状态**: 实现中
+- **关联**: 兼容 `docs/PRD/prd-post-pro-chat-rebuild-v1.md`(本文是其未覆盖部分的补充,不冲突)
+
+---
+
+## 0. 决策汇总(已与用户确认)
+
+| 维度 | 决策 |
+| --- | --- |
+| 范围 | 两套聊天都升级:LLM 对话(ChatSheet/MessageBubble/ChatInputBar)+ Companion DM(ChatView) |
+| Markdown | 引入 **swift-markdown-ui 2.4.1**(`from: "2.4.1"`,iOS 15+,项目 17.0 兼容) |
+| 附件 | **全链路含上传**;后端 SQL 迁移由 Claude 写,**用户负责部署到 Supabase** |
+| 输入栏 | 参考 Instagram DM:加号附件入口 + 相机 + 相册 + 文件,附件预览气泡 |
+
+## 0.1 现实约束(必须遵守)
+
+- Supabase **Storage bucket / RLS 当前不存在**。Claude 交付迁移 SQL,但**无法替用户部署到生产**(权限边界)。未部署前 iOS 上传会 403/404 → UI 必须优雅降级,不能假装发送成功。
+- 改 `ChatMessage` 字段触发 `pnpm parity:check`(CI 阻断)。**TS core 与 Swift 模型必须同步改**,字段名/类型/可选性一致。
+- 现有 `SupabaseClient.swift` REST 层**未封装 Storage**,需新增 storage upload/signed-url 方法(URLSession 手写,与现有 REST 风格一致)。
+- **PRD 既有约束**:所有 AI 调用走 `chat-proxy` Edge function(不引第二条路);复用 `MessageBubble` 玻璃态风格。本次升级不违背。
+
+---
+
+## 1. 技术事实基线
+
+### 1.1 MarkdownUI
+- 包:`https://github.com/gonzalezreal/swift-markdown-ui` `from: "2.4.1"`
+- 用法:`Markdown(text).markdownTheme(...)`;可 `.markdownTextStyle(.code){...}` 定制代码块字体/底色/前景。
+- 流式:逐字追加有渲染压力 → **批量节流(~每 50–80 字或每 80ms 刷新一次)**,避免每 token 重渲。
+- ImageRenderer 光栅化未官方保证 → 分享卡**不依赖 MarkdownUI**(沿用既有纯文本路径)。
+
+### 1.2 设计 token(`Views/Shared/CompareTokens.swift` 的 `enum CT`)
+聊天相关 token(直接复用,不要硬编码颜色):
+- `CT.accent` #5D3000(用户气泡填充/发送按钮/流式光标)
+- `CT.surfaceWhite` #FFFFFF · `CT.chatAIBubbleBgDark` #28241E(AI 气泡亮/暗填充,见 `MessageBubble.assistantFill`)
+- `CT.borderSubtle` #EDE8DF · `CT.accentBorder` #E8DCCA(气泡边框)
+- `CT.chatInputBg` #F5F0EB(输入框亮色填充)· `CT.borderDefault` #D6CEC0(输入栏顶分隔)
+- `CT.sunGold/sunGoldDeep/sunGoldSoft`(语音态)· `CT.bannerError` #C03B1E
+- 字体:聊天用系统字体;`CT.mono(_:)` = `.system(design:.monospaced)` 给代码块用。
+
+### 1.3 现有数值(统一基线)
+- 气泡圆角 18pt(Voice)/ 16pt(Companion)→ **统一为 18pt continuous**
+- 气泡内边距 14×9;输入框内边距 12×8;输入框圆角 18pt
+- Avatar 32(Voice)/ 22(Companion);mic 按钮 40×40 圆角 12
+- 边框 0.5pt;阴影 user(r6,y2)/ ai(r4,y1)
+
+---
+
+## 2. 接口契约(各层必须严格一致)
+
+### 2.1 附件数据模型(TS + Swift 同步)
+
+**`packages/core/src/companion.ts`** 新增:
+```ts
+export interface ChatAttachment {
+  readonly id: string;
+  readonly kind: "image" | "file";
+  readonly fileName: string;
+  readonly mimeType: string;
+  readonly fileSizeBytes: number;
+  readonly storagePath: string;     // bucket 内路径:"{conversationId}/{messageId}/{attachmentId}-{fileName}"
+  readonly width?: number;          // image only
+  readonly height?: number;         // image only
+}
+
+export interface ChatMessage {
+  readonly id: ChatMessageId;
+  readonly conversationId: ConversationId;
+  readonly senderId: UserId;
+  readonly body: string;
+  readonly attachments?: readonly ChatAttachment[];   // ← 新增,可选,默认空
+  readonly readAt?: string;
+  readonly createdAt: string;
+}
+```
+
+**`apps/ios/.../Models/ChatMessage.swift`** 镜像:
+```swift
+public struct ChatAttachment: Identifiable, Codable, Sendable, Equatable {
+    public let id: String
+    public let kind: Kind            // image | file (String raw)
+    public let fileName: String
+    public let mimeType: String
+    public let fileSizeBytes: Int
+    public let storagePath: String
+    public let width: Int?
+    public let height: Int?
+    public enum Kind: String, Codable, Sendable { case image, file }
+}
+// ChatMessage 加 `public let attachments: [ChatAttachment]?`
+```
+
+> parity:check 要求字段集合一致。`attachments` 在两侧都加。先跑 `pnpm parity:check` 看脚本对嵌套 ChatAttachment 的处理,再据报错调整。
+
+### 2.2 后端迁移(`infra/supabase/migrations/0005_chat_attachments.sql`)
+- 在 `chat_messages` 加 `attachments jsonb`(选 JSON 列,避免连表;与 TS 的 `attachments?` 对齐)。
+- 创建 private bucket `chat-media`。
+- RLS:仅会话参与者可 upload(insert)到 `{conversationId}/...` 前缀、可 select(下载用 signed URL)。
+- 文件含完整可执行 SQL + 顶部注释「部署方式:supabase db push 或控制台 SQL editor」。
+
+### 2.3 iOS 上传服务(`Services/ChatAttachmentService.swift`,新增)
+```swift
+protocol AttachmentUploading {
+    /// 上传到 chat-media bucket,返回可写入消息的 ChatAttachment 元数据。
+    func upload(_ local: LocalAttachment, conversationId: String, messageId: String) async throws -> ChatAttachment
+    /// 取下载用 signed URL(有效期 ~1h)。
+    func signedURL(for attachment: ChatAttachment) async throws -> URL
+}
+```
+- 真实实现 `SupabaseAttachmentService`:`POST /storage/v1/object/chat-media/{path}` + `POST /storage/v1/object/sign/...`。
+- **后端未部署时**:upload 抛明确错误 → UI 显示「附件后端未就绪」,文本消息仍可发。
+
+### 2.4 输入栏附件回调
+```swift
+// 草稿态附件,发送前持有
+struct LocalAttachment: Identifiable, Equatable {
+    let id: UUID
+    let kind: ChatAttachment.Kind
+    let fileName: String
+    let mimeType: String
+    let data: Data
+    let image: UIImage?    // 预览缩略图(image kind)
+}
+// 输入栏新增:
+//   @Binding var attachments: [LocalAttachment]
+//   内置 PhotosPicker + .fileImporter + 相机入口;发送时把 attachments 一并交给 onSend
+```
+
+---
+
+## 3. 文件清单与分工(并行批次)
+
+### Batch A — 数据契约层(必须先做,其它依赖它)
+- `packages/core/src/companion.ts` [改] 加 ChatAttachment + ChatMessage.attachments
+- `apps/ios/.../Models/ChatMessage.swift` [改] 镜像
+- `infra/supabase/migrations/0005_chat_attachments.sql` [新] 迁移 + bucket + RLS
+- 验收:`pnpm parity:check` 绿
+
+### Batch B — Markdown 渲染(依赖 A 完成 SwiftPM 接入)
+- `apps/ios/project.yml` [改] 加 swift-markdown-ui 依赖 → `xcodegen`
+- `apps/ios/.../Views/Chat/MarkdownMessageText.swift` [新] 封装 `Markdown(...)` + 聊天主题(代码块/inline code/链接/列表/引用样式,亮暗自适应,用 CT token)
+- `apps/ios/.../Views/Chat/MessageBubble.swift` [改] assistant 气泡文本改用 MarkdownMessageText;user 气泡保持纯文本;流式节流
+- 验收:构建绿;/tmp PNG 视觉验证 md(代码块/列表/加粗/链接/引用)
+
+### Batch C — Instagram 风输入栏 + 附件 UI(依赖 A 的 LocalAttachment)
+- `apps/ios/.../Views/Chat/ChatInputBar.swift` [改] 加「+」附件菜单(相机/相册/文件)、PhotosPicker、.fileImporter、草稿附件预览条
+- `apps/ios/.../Views/Chat/AttachmentDraftStrip.swift` [新] 横向草稿附件缩略图 + 删除
+- `apps/ios/.../Views/Chat/AttachmentBubble.swift` [新] 已发消息里的附件渲染(图片缩略图点开大图 / 文件卡片)
+- `apps/ios/.../Views/Companion/ChatView.swift` [改] inputBar 同款附件入口 + 气泡渲染 attachments
+- 验收:构建绿;选图/选文件/预览/删除可用;视觉对齐 Instagram DM
+
+### Batch D — 服务/数据流(依赖 A、C)
+- `apps/ios/.../Services/ChatAttachmentService.swift` [新] AttachmentUploading + Supabase 实现 + 未部署降级
+- `apps/ios/.../Services/SupabaseClient.swift` [改] 加 storage upload/sign 方法
+- `apps/ios/.../Services/ChatService.swift` [改] send 接收 attachments:先上传 → 写入 message.attachments;handleInsert 解析 attachments
+- Voice Agent 侧附件本期**只做 UI 展示**(LLM 多模态接入留接口);**重点跑通 Companion DM 全链路**
+- 验收:构建绿;mock 上传单测;parity 绿
+
+### Batch E — 气泡视觉统一打磨(依赖 B、C)
+- 两套气泡统一 18pt continuous、CT token、阴影/边框基线;时间戳/已读/sender 名排版精修
+- `#Preview` 覆盖:user/assistant/含 md/含图片/含文件/流式
+- 验收:/tmp PNG 全场景视觉验收
+
+### Batch F — 测试 + 本地化 + 验证
+- `Tests/MarkdownMessageTextTests.swift`、`Tests/ChatAttachmentServiceTests.swift`、`Tests/ChatMessageAttachmentParsingTests.swift`
+- `Resources/en.lproj/Localizable.strings` 新 key(附件入口/错误/占位)
+- `xcodegen` → build → test(`Executed N>0`);`pnpm parity:check`
+
+---
+
+## 4. 验收标准(满分清单)
+
+- [ ] LLM 回复 Markdown 优雅渲染:代码块(等宽+底色)、有序/无序/任务列表、加粗斜体、行内代码、链接、引用块、标题 —— 亮暗模式都正确。
+- [ ] 流式回复时 Markdown 平滑增量渲染,不卡顿(节流生效)。
+- [ ] 输入栏 Instagram 风:文本 + 「+」附件菜单(相机/相册/文件),草稿附件横向预览可删。
+- [ ] 选图(PhotosPicker)/ 选文件(.fileImporter)可用;附件随消息发送(后端就绪时真上传,未就绪时明确降级提示且文本仍可发)。
+- [ ] 收到的消息正确渲染附件:图片缩略图可点开、文件显示卡片。
+- [ ] 两套气泡视觉统一、精致(圆角/内边距/阴影/边框/配色用 CT token)。
+- [ ] `xcodebuild build` 绿;聊天相关 XCTest 绿(真实 Executed N>0);`pnpm parity:check` 绿。
+- [ ] 交付 SQL 迁移文件 + 部署说明给用户;明确标注「后端需用户部署」。
+- [ ] 关键路径 /tmp PNG 肉眼验证出片质量。
+
+## 5. 风险登记
+
+- MarkdownUI 在 ImageRenderer/流式下的性能 → 节流 + 分享卡不走 md。
+- parity:check 对嵌套 ChatAttachment 的处理未知 → A 批先跑 parity 看报错再定形。
+- Storage RLS 写错会导致全员可读他人附件 → RLS 用会话参与者校验,迁移里写测试注释。
+- 后端未部署 → 全链路「最后一公里」不在 Claude 手里,UI 必须优雅降级,不能假装发成功。
+- supabase-swift storage vs 手写 URLSession → 优先手写(SupabaseClient 已是手写 REST 风格,一致)。

--- a/infra/supabase/migrations/0005_chat_attachments.sql
+++ b/infra/supabase/migrations/0005_chat_attachments.sql
@@ -1,0 +1,63 @@
+-- Solo Compass — Chat Attachments (chat-experience-upgrade Batch A)
+--
+-- Adds full-chain attachment support to companion DMs and LLM chat:
+--   1. `chat_messages.attachments` jsonb column — mirrors TS `ChatMessage.attachments`
+--      (array of ChatAttachment; avoids a join table, aligns with `attachments?`).
+--   2. Private storage bucket `chat-media` for the binary payloads.
+--   3. storage.objects RLS so ONLY conversation participants can upload (insert)
+--      and download (select) objects under their conversation prefix.
+--
+-- Object path convention: `{conversationId}/{messageId}/{attachmentId}-{fileName}`,
+-- so `(storage.foldername(name))[1]` is the conversationId.
+--
+-- DEPLOYMENT: run via `supabase db push` or paste into the Supabase SQL editor.
+-- Claude cannot deploy this — the user must. The `chat-media` bucket can
+-- alternatively be created in the Supabase dashboard (Storage → New bucket,
+-- name `chat-media`, public = off); the RLS policies below still apply.
+
+begin;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 1. chat_messages.attachments
+-- ──────────────────────────────────────────────────────────────────────────────
+
+alter table public.chat_messages
+  add column if not exists attachments jsonb;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 2. Private storage bucket `chat-media`
+-- ──────────────────────────────────────────────────────────────────────────────
+
+insert into storage.buckets (id, name, public)
+values ('chat-media', 'chat-media', false)
+on conflict (id) do nothing;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 3. storage.objects RLS — conversation participants only
+--
+-- The first path segment is the conversationId. A user may read/write an object
+-- only when they are a participant of that conversation. This prevents one user
+-- from reading another user's attachments.
+-- ──────────────────────────────────────────────────────────────────────────────
+
+create policy "chat-media participant-insert" on storage.objects
+  for insert with check (
+    bucket_id = 'chat-media'
+    and exists (
+      select 1 from public.conversations c
+      where c.id = (storage.foldername(name))[1]
+        and c.participant_ids @> to_jsonb(auth.uid()::text)
+    )
+  );
+
+create policy "chat-media participant-select" on storage.objects
+  for select using (
+    bucket_id = 'chat-media'
+    and exists (
+      select 1 from public.conversations c
+      where c.id = (storage.foldername(name))[1]
+        and c.participant_ids @> to_jsonb(auth.uid()::text)
+    )
+  );
+
+commit;

--- a/packages/core/src/companion.ts
+++ b/packages/core/src/companion.ts
@@ -126,11 +126,29 @@ export interface Conversation {
   readonly updatedAt: string;
 }
 
+/** A media or document attachment carried by a {@link ChatMessage}. */
+export interface ChatAttachment {
+  readonly id: string;
+  /** Discriminates a previewable image from an arbitrary file. */
+  readonly kind: "image" | "file";
+  readonly fileName: string;
+  readonly mimeType: string;
+  readonly fileSizeBytes: number;
+  /** Path within the `chat-media` bucket: `{conversationId}/{messageId}/{attachmentId}-{fileName}`. */
+  readonly storagePath: string;
+  /** Pixel width, image kind only. */
+  readonly width?: number;
+  /** Pixel height, image kind only. */
+  readonly height?: number;
+}
+
 export interface ChatMessage {
   readonly id: ChatMessageId;
   readonly conversationId: ConversationId;
   readonly senderId: UserId;
   readonly body: string;
+  /** Attachments carried by this message. Omitted/empty when text-only. */
+  readonly attachments?: readonly ChatAttachment[];
   /** ISO 8601 UTC timestamp when the recipient read the message. */
   readonly readAt?: string;
   /** ISO 8601 UTC timestamp. */

--- a/packages/core/src/experience.ts
+++ b/packages/core/src/experience.ts
@@ -82,6 +82,11 @@ export interface ExperienceLocation {
   readonly priceLevel?: number; // 1–4 (1 = cheap, 4 = expensive)
   readonly website?: string;
   readonly phone?: string;
+  // Photos attached to the place. User-created experiences populate this from
+  // the photo picker; seed/OSM places leave it undefined. Values are URLs:
+  // local `file://` paths until the place is synced, then remote https URLs.
+  // Mirrors the `photoUrls` convention in user.ts.
+  readonly photoUrls?: readonly string[];
 }
 
 /**
@@ -223,4 +228,110 @@ export interface DiscoveredCity {
  */
 export function isCandidateExperience(exp: Experience): exp is CandidateExperience {
   return exp.status === "candidate";
+}
+
+/**
+ * ID prefix for experiences a user creates by hand (long-press the map → fill
+ * the form). Like `exp_osm_*`, these start at `confidence.level === 1`
+ * (unverified) and never carry a self-assigned Solo Score — the trust fields
+ * are placeholders until the AI synthesis / verification pipeline fills them.
+ *
+ * Format: `exp_user_<uuid>` (e.g. `exp_user_550e8400-e29b-41d4-a716-446655440000`).
+ */
+export const EXP_USER_ID_PREFIX = "exp_user_" as const;
+
+/**
+ * The handful of fields a user can honestly supply when registering a new place.
+ * Everything else on `Experience` (Solo Score, confidence, nearby links, stats)
+ * is system-owned and must NOT be user-settable — that is the product's trust moat.
+ */
+export interface UserExperienceInput {
+  /** Action-oriented title. Falls back to the place name if the user only gives a name. */
+  readonly title: string;
+  readonly oneLiner: string;
+  readonly category: ExperienceCategory;
+  readonly coordinates: Coordinates;
+  readonly cityCode: string;
+  /** The full place name the user enters, e.g. "Wat Suan Dok". */
+  readonly placeNameRomanized?: string;
+  /** Optional local-language name, e.g. "วัดสวนดอก". */
+  readonly placeNameLocal?: string;
+  readonly addressHint?: string;
+  /** Free-form description; stored as `whyItMatters`. */
+  readonly description?: string;
+  /** Photo URLs (local `file://` in Phase 1, remote https after sync). */
+  readonly photoUrls?: readonly string[];
+  readonly userTags?: readonly string[];
+}
+
+/**
+ * Build a `CandidateExperience` from raw user input.
+ *
+ * Trust-critical fields are forced to safe, unverified defaults:
+ *   - `status: "candidate"` — never enters the public pool until promoted.
+ *   - `confidence.level: 1` — unverified; hidden from top recommendations.
+ *   - `soloScore`: neutral 5.0 placeholder with `basedOnCount: 0`. The user
+ *     does NOT score their own place; the synthesis pipeline overwrites this.
+ *   - `sources: [{ type: "user" }]` — provenance is always visible.
+ *
+ * @param input    The user-supplied fields.
+ * @param ids       Injected non-deterministic values (uuid + nowIso) so this
+ *                  function stays pure and testable.
+ */
+export function createUserExperience(
+  input: UserExperienceInput,
+  ids: { readonly uuid: string; readonly nowIso: string },
+): CandidateExperience {
+  const { uuid, nowIso } = ids;
+  const neutralBreakdown = {
+    seatingFriendly: 5,
+    soloPatronRatio: 5,
+    staffPressure: 5,
+    soloPortioning: 5,
+    ambianceFit: 5,
+    safety: 5,
+  } as const;
+
+  return {
+    id: `${EXP_USER_ID_PREFIX}${uuid}` as ExperienceId,
+    title: input.title,
+    oneLiner: input.oneLiner,
+    whyItMatters: input.description ?? "",
+    category: input.category,
+    location: {
+      coordinates: input.coordinates,
+      cityCode: input.cityCode,
+      addressHint: input.addressHint,
+      placeNameLocal: input.placeNameLocal,
+      placeNameRomanized: input.placeNameRomanized,
+      photoUrls: input.photoUrls,
+    },
+    bestTimes: [], // empty = anytime; user can refine later
+    durationMinutes: { min: 30, max: 60 },
+    howTo: [],
+    realInconveniences: [],
+    soloScore: {
+      overall: 5,
+      breakdown: neutralBreakdown,
+      basedOnCount: 0,
+    },
+    sources: [{ type: "user", verifiedAt: nowIso }],
+    confidence: {
+      level: 1,
+      lastVerifiedAt: nowIso,
+      reason: "User-created, awaiting verification",
+      signals: {
+        aiScrapeAgeDays: 0,
+        passiveGpsHits30d: 0,
+        activeReports30d: 0,
+        trustedVerifications: 0,
+      },
+    },
+    nearbyExperienceIds: [],
+    stats: { completionCount: 0, averageRating: 0 },
+    status: "candidate",
+    createdAt: nowIso,
+    updatedAt: nowIso,
+    userTags: input.userTags,
+  };
 }


### PR DESCRIPTION
通过 Agent Team 五阶段编排(数据契约 → Markdown+UI → 服务 → DM统一 → 对抗式评审)实现的聊天体验升级。

## 三大能力

### 1. Markdown 优雅渲染(LLM 回复)
- 引入 `swift-markdown-ui 2.4.1`,`MarkdownMessageText` 聊天专用主题
- 标题/加粗/斜体/有序·无序·任务列表/行内代码/**代码块(等宽+底色+换行)**/引用块/链接
- 亮/暗模式自适应(暗色代码块对比度经评审调优 0.08→0.14)
- 流式回复节流(≥80ms 或 ≥60 字才重渲,不卡顿)
- 修复关键 bug:代码块原本在 ImageRenderer 下渲染为空(LLM 代码会消失)→ 改用 `configuration.content` 自渲染

### 2. Instagram 风输入栏 + 全链路附件
- 两套聊天(Voice Agent + Companion DM)统一:`+`菜单(相册/相机/文件)、草稿附件预览条、附件气泡(图片放大/文件卡片)
- `ChatAttachmentService`:Supabase Storage 上传 + signed URL 下载,配置来自 GeneratedSecrets(无硬编码密钥)
- 优雅降级:后端未部署时文本永不丢失;400/401/403/404→backendNotReady,413→tooLarge,429→rateLimited
- **全有或全无上传**(评审修复):任一附件失败则全部丢弃保文本,杜绝静默部分发送

### 3. 气泡视觉统一
- Companion DM 对齐 Voice Agent 设计语言:18pt continuous、CT design token、统一阴影/边框

## ⚠️ 需要部署后端(权限边界)

附件全链路依赖 Supabase Storage,迁移已写好但**需 reviewer 部署**:

```bash
supabase db push   # 或把 infra/supabase/migrations/0005_chat_attachments.sql 贴进 SQL editor
```

创建 `chat-media` private bucket + `chat_messages.attachments` jsonb 列 + 参与者鉴权 RLS。**部署前**文本消息正常、附件走降级提示;**部署后**附件真上传/下载。

## 对抗式评审

2 个 reviewer(正确性 + UI/边界)找出并修复:
- HIGH:多附件部分失败静默丢失 → 全有或全无
- HIGH:文件卡禁用却显示下载图标 → 改可点重试
- HIGH:图片缩略图卡 spinner → 可点重试 placeholder
- MEDIUM:暗色代码块对比度、两输入栏 lineLimit 统一、暗色 preview
- 最终复查:3 个 HIGH 全修,无回归,无残留

## 测试
- `xcodebuild build` 绿
- `pnpm parity:check` 四维度绿(ChatMessage.attachments 对齐)
- `ChatAttachmentTests` 11 个绿:mapStatus / ChatMessage Codable 往返 / 附件解析降级
- Markdown 亮·暗模式 PNG 肉眼验证

## 设计文档
`docs/design/chat-experience-upgrade.md` — 接口契约 + 分批计划

🤖 Generated with [Claude Code](https://claude.com/claude-code)