### PR TITLE
feat(chat): 路线仅在 Now + 内嵌卡片 + chat 体验升级 + 历史持久化

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		352247C1FBF4C8F901D17F32 /* ApprovalTrustSignalTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804618047547A9D7F3F8EAAA /* ApprovalTrustSignalTest.swift */; };
 		36E1316045802B2F642A9623 /* LocalAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C89CB8D3309FD5646E23434 /* LocalAttachment.swift */; };
 		371DDBAF4C385267248ABC83 /* AgentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38E5736BF6DF5644D687637 /* AgentRouter.swift */; };
+		378B1344A5EE8001D033035F /* ChatMessageRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50C2F35BCC11F93944A83B9 /* ChatMessageRecord.swift */; };
 		37D5A0FD622C9649308BD14D /* FavoriteFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA17ED8FE9ABA2F5CC1D557E /* FavoriteFilterTests.swift */; };
 		3889A861FFD32BE4EEE4F19F /* ActiveRouteOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CEA4BFADFDB1575F6655E48 /* ActiveRouteOverlay.swift */; };
 		391D6B5C48997AD74F367C0C /* GeneratedSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5642EDC714993C8EE0ECDD83 /* GeneratedSecrets.swift */; };
@@ -96,6 +97,8 @@
 		48DF01972A1FB107BFFF0684 /* QueryAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06086F5F9463C18F486E5694 /* QueryAgent.swift */; };
 		48DF93F42CDDB1329B038865 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6556C23BF1B228BF686C5500 /* KeychainStore.swift */; };
 		49C48BE7027B3D172A0BD9B1 /* ReviewsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6F9AAA8749FA23B91F7C93 /* ReviewsServiceTests.swift */; };
+		49DE5F0AC0458584B67F3E78 /* ChatHistoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFAB38A4600C667B8D7CD2B /* ChatHistoryListView.swift */; };
+		49E7F4783C47BB3872F0F816 /* ChatHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1F20B36F8441905A909DC2 /* ChatHistoryStore.swift */; };
 		4A32BD98962770BAAB48B504 /* RouteCardStopStripTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAFD5561863516F6E60AEDE3 /* RouteCardStopStripTest.swift */; };
 		4B4EE06B93E099D8EEDE6631 /* ApprovalQueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8964F4628C43BB7311B48D38 /* ApprovalQueueView.swift */; };
 		4C16F9056859D3AFA88B3355 /* ConversationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E575898B14533C58035EFC79 /* ConversationStore.swift */; };
@@ -267,6 +270,7 @@
 		C7E95C61D88390B3324AC5D4 /* GeohashUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18AAA718024540127A95A827 /* GeohashUtils.swift */; };
 		C7F4A9BD252AC60BDBD74585 /* MicroSurveyRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23043E51C493093CF7244629 /* MicroSurveyRecord.swift */; };
 		C81007F6A39364D0872736B2 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C660F7996B1E4387C37720B3 /* OnboardingView.swift */; };
+		C885F9EB7C15E42D9AF6C13E /* ChatSessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7AE422ACCFA23FCA7DF90D /* ChatSessionRecord.swift */; };
 		C985528978123590367E30EB /* WeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78404BD902D3A518F5C8730D /* WeatherService.swift */; };
 		C9DAF262896CB6CFBA6F97D3 /* IOS18AvailabilityGuardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFF9ECB175F4D2219406952 /* IOS18AvailabilityGuardTest.swift */; };
 		CA06289D4E0D0C24C2079B40 /* VoiceWaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0CBFD5114CC6728D6AA876 /* VoiceWaveformView.swift */; };
@@ -432,6 +436,7 @@
 		3AF871B84DDAAD8453B8258D /* RouteStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteStoreTests.swift; sourceTree = "<group>"; };
 		3B0C9228AD213C6D5FE01FCE /* RoutePolylineShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutePolylineShape.swift; sourceTree = "<group>"; };
 		3C9A1F22AAE512199548C269 /* FilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarView.swift; sourceTree = "<group>"; };
+		3DFAB38A4600C667B8D7CD2B /* ChatHistoryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryListView.swift; sourceTree = "<group>"; };
 		3E7AFBAAF6E42AE8043F476D /* VoiceInterruptionToastTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInterruptionToastTest.swift; sourceTree = "<group>"; };
 		402644EEDBCD7DD3658E6DD5 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		405A56207920EA0DDADF8FC5 /* CompanionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionRequest.swift; sourceTree = "<group>"; };
@@ -450,6 +455,7 @@
 		4C93A2F826BD75AF124C1210 /* NowScoreOfflineDegradeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowScoreOfflineDegradeTest.swift; sourceTree = "<group>"; };
 		4D557D1D0D224C725834A08D /* SoloScoreRadarChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloScoreRadarChart.swift; sourceTree = "<group>"; };
 		4EAB2E028C69B7C63DCAF860 /* RouteCardRecruitMiniTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCardRecruitMiniTest.swift; sourceTree = "<group>"; };
+		4F7AE422ACCFA23FCA7DF90D /* ChatSessionRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSessionRecord.swift; sourceTree = "<group>"; };
 		4FE945F792AFD68B33B7E8B5 /* UserDirectoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDirectoryTests.swift; sourceTree = "<group>"; };
 		520EDA3B7A8A6136FB0355A4 /* SupabaseRouteCompanionRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseRouteCompanionRemote.swift; sourceTree = "<group>"; };
 		535B5FA4ADF216CEC74FE056 /* RouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteTests.swift; sourceTree = "<group>"; };
@@ -542,6 +548,7 @@
 		8D0CBFD5114CC6728D6AA876 /* VoiceWaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceWaveformView.swift; sourceTree = "<group>"; };
 		8D41862432A45DC023C96B8D /* FilterNowMapAnimationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterNowMapAnimationTest.swift; sourceTree = "<group>"; };
 		8E055BAC372B75F743428920 /* MyHostedRoutesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyHostedRoutesListView.swift; sourceTree = "<group>"; };
+		8F1F20B36F8441905A909DC2 /* ChatHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryStore.swift; sourceTree = "<group>"; };
 		8FDFA5F3503B8ABC4B5CB086 /* SoloCompassTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SoloCompassTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9055347887EF473171916120 /* AttachmentBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentBubble.swift; sourceTree = "<group>"; };
 		907EA19EC9B84B93AB110C70 /* ColdStartExperienceLoadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColdStartExperienceLoadTests.swift; sourceTree = "<group>"; };
@@ -669,6 +676,7 @@
 		F1D68F42114231582501CB90 /* NowCountCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowCountCacheTests.swift; sourceTree = "<group>"; };
 		F336099C48E0B04CD7612E4C /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		F4814DBCEAB5975B6338558D /* AIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIService.swift; sourceTree = "<group>"; };
+		F50C2F35BCC11F93944A83B9 /* ChatMessageRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageRecord.swift; sourceTree = "<group>"; };
 		F63FDD874A8F533F0717132A /* UserPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPreferences.swift; sourceTree = "<group>"; };
 		F7FB43528F45882868CCC203 /* NavigationLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLauncherTests.swift; sourceTree = "<group>"; };
 		F8547EB44AE47A5D653D3994 /* FavoritesBounceAvailabilityTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesBounceAvailabilityTest.swift; sourceTree = "<group>"; };
@@ -986,6 +994,8 @@
 			children = (
 				E7E69F3EF6F0100CFA47DAFE /* AISynthesisCacheRecord.swift */,
 				001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */,
+				F50C2F35BCC11F93944A83B9 /* ChatMessageRecord.swift */,
+				4F7AE422ACCFA23FCA7DF90D /* ChatSessionRecord.swift */,
 				C12888843433B2A00D7CAB18 /* ConversationRecord.swift */,
 				CE05EF69960CBB73431A6F2F /* DiscoveredCityRecord.swift */,
 				E03076AD221F78BBDE981C3A /* ExperienceRecord.swift */,
@@ -1105,6 +1115,7 @@
 				98A9885BEB8D9686F5384BEC /* AttachmentInputBar.swift */,
 				D91E024770F8793AB27EF247 /* ChatCardStack.swift */,
 				7989FA184B0EFCE68C961241 /* ChatCardViews.swift */,
+				3DFAB38A4600C667B8D7CD2B /* ChatHistoryListView.swift */,
 				B88D9F377D7AF634DAE07A3E /* ChatInputBar.swift */,
 				F9263FC2737FA209F3CD4B5E /* ChatSheet.swift */,
 				1D7A24EA7AB5379E0D5DC2B2 /* InlineBanner.swift */,
@@ -1132,6 +1143,7 @@
 		7E2FB1BFAED4DC291176B347 /* Persistence */ = {
 			isa = PBXGroup;
 			children = (
+				8F1F20B36F8441905A909DC2 /* ChatHistoryStore.swift */,
 				E575898B14533C58035EFC79 /* ConversationStore.swift */,
 				A250916F91C8EF0BE90DF763 /* ExperienceRepository.swift */,
 				397E1B23A9CF2D6470C7C954 /* ItineraryStore.swift */,
@@ -1560,9 +1572,13 @@
 				BECD282A85E9DA084B84D546 /* ChatCard.swift in Sources */,
 				96454A8DFA4F596AAD8B790E /* ChatCardStack.swift in Sources */,
 				99E3055C98F6477EF46D260C /* ChatCardViews.swift in Sources */,
+				49DE5F0AC0458584B67F3E78 /* ChatHistoryListView.swift in Sources */,
+				49E7F4783C47BB3872F0F816 /* ChatHistoryStore.swift in Sources */,
 				BA0DD7D5C46016E81A23B2B4 /* ChatInputBar.swift in Sources */,
 				96A79D8DD36F5B67B3146998 /* ChatMessage.swift in Sources */,
+				378B1344A5EE8001D033035F /* ChatMessageRecord.swift in Sources */,
 				31DAB367EE76F147742B2B3E /* ChatService.swift in Sources */,
+				C885F9EB7C15E42D9AF6C13E /* ChatSessionRecord.swift in Sources */,
 				B7366111257111EC98F4A0C4 /* ChatSheet.swift in Sources */,
 				3AA7B0463C3B8084D954C3AA /* ChatStateModifier.swift in Sources */,
 				9D81327AE55FA8142F9E5B8D /* ChatUIState.swift in Sources */,

--- a/apps/ios/SoloCompass/Persistence/ChatHistoryStore.swift
+++ b/apps/ios/SoloCompass/Persistence/ChatHistoryStore.swift
@@ -1,0 +1,163 @@
+import Foundation
+import SwiftData
+
+/// SwiftData-backed persistence for chat conversations so history survives app
+/// restarts and the user can reopen a past conversation.
+///
+/// `@MainActor` because SwiftData's `ModelContext` is single-actor, matching
+/// `RouteStore` / `ItineraryStore`. A conversation is stored as one
+/// `ChatSessionRecord` plus N `ChatMessageRecord` rows linked by `sessionId`.
+/// `saveSession` is an idempotent upsert: it replaces the session's existing
+/// message rows so the latest snapshot always wins (a turn-by-turn save just
+/// overwrites the prior partial conversation under the same id).
+@MainActor
+public final class ChatHistoryStore {
+    /// Posted after any successful mutation so observers can refresh the
+    /// history list without holding a strong reference to the store.
+    public static let didChange = Notification.Name("SoloCompass.ChatHistoryStore.didChange")
+
+    let context: ModelContext
+
+    public init(context: ModelContext) {
+        self.context = context
+    }
+
+    /// Convenience init using the shared on-disk container.
+    public convenience init() {
+        self.init(context: ModelContext(SoloCompassModelContainer.shared))
+    }
+
+    private static func nowISO() -> String {
+        ISO8601DateFormatter().string(from: Date())
+    }
+
+    // MARK: - Save
+
+    /// Persist (upsert) a whole conversation under `sessionId`. Skips sessions
+    /// that have no real user content yet so an opened-but-unused chat doesn't
+    /// litter history. Returns true when something was written.
+    @discardableResult
+    public func saveSession(
+        id sessionId: String,
+        messages: [VoiceAgentSession.Message],
+        scopedExperienceId: String?,
+        createdAt: String? = nil
+    ) -> Bool {
+        // Only persist conversations the user actually had — at least one user
+        // message present.
+        let conversational = messages.filter { $0.role == .user || $0.role == .assistant }
+        guard conversational.contains(where: { $0.role == .user }) else { return false }
+
+        let now = Self.nowISO()
+        let created = createdAt ?? existingSession(sessionId)?.createdAt ?? now
+
+        // Replace any prior rows for this session (idempotent upsert).
+        deleteRows(sessionId: sessionId)
+
+        let title = Self.deriveTitle(from: messages)
+        let session = ChatSessionRecord(
+            id: sessionId,
+            scopedExperienceId: scopedExperienceId,
+            title: title,
+            createdAt: created,
+            updatedAt: now,
+            messageCount: conversational.count
+        )
+        context.insert(session)
+
+        for (index, message) in messages.enumerated() {
+            // Don't persist the system prompt — it's rebuilt fresh on restore
+            // and would otherwise bloat every stored conversation.
+            guard message.role != .system else { continue }
+            context.insert(
+                ChatMessageRecord.fromMessage(
+                    message,
+                    sessionId: sessionId,
+                    orderIndex: index,
+                    createdAt: now
+                )
+            )
+        }
+
+        do {
+            try context.save()
+        } catch {
+            assertionFailure("ChatHistoryStore.saveSession failed: \(error)")
+            return false
+        }
+        postChange()
+        return true
+    }
+
+    // MARK: - Fetch
+
+    /// Saved sessions, most-recently-updated first, capped at `limit`.
+    public func recentSessions(limit: Int = 30) -> [ChatSessionRecord] {
+        guard limit > 0 else { return [] }
+        var descriptor = FetchDescriptor<ChatSessionRecord>(
+            sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]
+        )
+        descriptor.fetchLimit = limit
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    /// All non-system messages for a session, in stored order, as domain values
+    /// ready to seed back into a `VoiceAgentSession`.
+    public func messages(sessionId: String) -> [VoiceAgentSession.Message] {
+        let descriptor = FetchDescriptor<ChatMessageRecord>(
+            predicate: #Predicate { $0.sessionId == sessionId },
+            sortBy: [SortDescriptor(\.orderIndex)]
+        )
+        return (try? context.fetch(descriptor))?.map(\.asMessage) ?? []
+    }
+
+    // MARK: - Delete
+
+    /// Delete one session and all of its messages. No-op if not found.
+    public func delete(sessionId: String) {
+        deleteRows(sessionId: sessionId)
+        if let session = existingSession(sessionId) {
+            context.delete(session)
+        }
+        do {
+            try context.save()
+        } catch {
+            assertionFailure("ChatHistoryStore.delete failed: \(error)")
+        }
+        postChange()
+    }
+
+    // MARK: - Private helpers
+
+    private func existingSession(_ id: String) -> ChatSessionRecord? {
+        let descriptor = FetchDescriptor<ChatSessionRecord>(
+            predicate: #Predicate { $0.id == id }
+        )
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    private func deleteRows(sessionId: String) {
+        let descriptor = FetchDescriptor<ChatMessageRecord>(
+            predicate: #Predicate { $0.sessionId == sessionId }
+        )
+        let rows = (try? context.fetch(descriptor)) ?? []
+        for row in rows { context.delete(row) }
+    }
+
+    private func postChange() {
+        NotificationCenter.default.post(name: ChatHistoryStore.didChange, object: self)
+    }
+
+    /// Derive a short title from the first user message (trimmed to one line,
+    /// capped). Falls back to nil so the list can show a default.
+    static func deriveTitle(from messages: [VoiceAgentSession.Message]) -> String? {
+        guard let firstUser = messages.first(where: { $0.role == .user })?.content else {
+            return nil
+        }
+        let oneLine = firstUser
+            .replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !oneLine.isEmpty else { return nil }
+        return oneLine.count > 40 ? String(oneLine.prefix(40)) + "…" : oneLine
+    }
+}

--- a/apps/ios/SoloCompass/Persistence/Models/ChatMessageRecord.swift
+++ b/apps/ios/SoloCompass/Persistence/Models/ChatMessageRecord.swift
@@ -1,0 +1,128 @@
+import Foundation
+import SwiftData
+
+/// SwiftData representation of one persisted chat message inside a saved
+/// conversation. Mirrors `RouteRecord`'s strategy: scalar fields stored
+/// natively, the tool-call array stored as a JSON `Data` blob, branded/UUID
+/// ids stored as `String`, and timestamps stored as ISO 8601 UTC strings.
+///
+/// One `ChatMessageRecord` maps to one `VoiceAgentSession.Message`. The link
+/// to its owning conversation is a plain `sessionId` foreign key (no
+/// `@Relationship`) to stay consistent with the rest of the persistence layer.
+@Model
+public final class ChatMessageRecord {
+    @Attribute(.unique) public var id: String
+
+    /// Foreign key → `ChatSessionRecord.id`.
+    public var sessionId: String
+    /// Raw value of `VoiceAgentSession.Role` (system|user|assistant|tool).
+    public var role: String
+    public var content: String?
+    /// Position within the conversation, ascending. Lets the fetch restore the
+    /// exact order regardless of how SwiftData lays rows out on disk.
+    public var orderIndex: Int
+    /// ISO 8601 UTC creation timestamp.
+    public var createdAt: String
+
+    /// JSON-encoded `[CodableToolCall]` — nil for non-assistant rows or
+    /// assistant rows that carried no tool calls.
+    public var toolCallsBlob: Data?
+    /// For tool rows: the `tool_call_id` this result answers.
+    public var toolCallId: String?
+    /// For tool rows: the name of the tool that produced this result.
+    public var toolName: String?
+
+    public init(
+        id: String,
+        sessionId: String,
+        role: String,
+        content: String?,
+        orderIndex: Int,
+        createdAt: String,
+        toolCallsBlob: Data?,
+        toolCallId: String?,
+        toolName: String?
+    ) {
+        self.id = id
+        self.sessionId = sessionId
+        self.role = role
+        self.content = content
+        self.orderIndex = orderIndex
+        self.createdAt = createdAt
+        self.toolCallsBlob = toolCallsBlob
+        self.toolCallId = toolCallId
+        self.toolName = toolName
+    }
+}
+
+/// Codable mirror of `VoiceAgentSession.ToolCall` (which is intentionally not
+/// Codable in the domain layer). Used solely to (de)serialize the tool-call
+/// blob on a `ChatMessageRecord`.
+public struct CodableToolCall: Codable, Equatable, Sendable {
+    public let id: String
+    public let name: String
+    public let argumentsJSON: String
+
+    public init(id: String, name: String, argumentsJSON: String) {
+        self.id = id
+        self.name = name
+        self.argumentsJSON = argumentsJSON
+    }
+}
+
+// MARK: - Two-way mapping
+
+extension ChatMessageRecord {
+    /// Build a record from a session message. `sessionId` and `orderIndex` are
+    /// supplied by the store since they describe the message's place in a
+    /// conversation, not the message itself.
+    static func fromMessage(
+        _ message: VoiceAgentSession.Message,
+        sessionId: String,
+        orderIndex: Int,
+        createdAt: String
+    ) -> ChatMessageRecord {
+        let toolCallsBlob: Data?
+        if message.toolCalls.isEmpty {
+            toolCallsBlob = nil
+        } else {
+            let dtos = message.toolCalls.map {
+                CodableToolCall(id: $0.id, name: $0.name, argumentsJSON: $0.argumentsJSON)
+            }
+            toolCallsBlob = try? JSONEncoder().encode(dtos)
+        }
+        return ChatMessageRecord(
+            id: message.id.uuidString,
+            sessionId: sessionId,
+            role: message.role.rawValue,
+            content: message.content,
+            orderIndex: orderIndex,
+            createdAt: createdAt,
+            toolCallsBlob: toolCallsBlob,
+            toolCallId: message.toolCallId,
+            toolName: message.name
+        )
+    }
+
+    /// Reconstruct a domain `Message`. Falls back to a fresh UUID if the stored
+    /// id isn't a valid UUID string (shouldn't happen, but keeps decode total).
+    var asMessage: VoiceAgentSession.Message {
+        let decodedCalls: [VoiceAgentSession.ToolCall]
+        if let blob = toolCallsBlob,
+           let dtos = try? JSONDecoder().decode([CodableToolCall].self, from: blob) {
+            decodedCalls = dtos.map {
+                VoiceAgentSession.ToolCall(id: $0.id, name: $0.name, argumentsJSON: $0.argumentsJSON)
+            }
+        } else {
+            decodedCalls = []
+        }
+        return VoiceAgentSession.Message(
+            id: UUID(uuidString: id) ?? UUID(),
+            role: VoiceAgentSession.Role(rawValue: role) ?? .assistant,
+            content: content,
+            toolCalls: decodedCalls,
+            toolCallId: toolCallId,
+            name: toolName
+        )
+    }
+}

--- a/apps/ios/SoloCompass/Persistence/Models/ChatSessionRecord.swift
+++ b/apps/ios/SoloCompass/Persistence/Models/ChatSessionRecord.swift
@@ -1,0 +1,44 @@
+import Foundation
+import SwiftData
+
+/// SwiftData representation of one saved chat conversation (a session the user
+/// can reopen from history). Holds only conversation-level metadata; the actual
+/// messages live in `ChatMessageRecord` rows linked by `sessionId`.
+///
+/// Consistent with the rest of the persistence layer: branded/UUID ids stored
+/// as `String`, timestamps as ISO 8601 UTC strings, no `@Relationship`.
+@Model
+public final class ChatSessionRecord {
+    @Attribute(.unique) public var id: String
+
+    /// `Experience.id` this conversation was scoped to (per-place chat), or nil
+    /// for the global "+ button" chat.
+    public var scopedExperienceId: String?
+    /// Short title for the history list — derived from the first user message.
+    /// Optional so a session that only ever held a greeting still saves.
+    public var title: String?
+    /// ISO 8601 UTC — when the conversation started.
+    public var createdAt: String
+    /// ISO 8601 UTC — last time a message was appended. Drives history ordering
+    /// (most-recent first) so the list reads like a messaging app.
+    public var updatedAt: String
+    /// Cached count of user+assistant messages, for the history subtitle without
+    /// fetching every message row.
+    public var messageCount: Int
+
+    public init(
+        id: String,
+        scopedExperienceId: String?,
+        title: String?,
+        createdAt: String,
+        updatedAt: String,
+        messageCount: Int
+    ) {
+        self.id = id
+        self.scopedExperienceId = scopedExperienceId
+        self.title = title
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.messageCount = messageCount
+    }
+}

--- a/apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift
+++ b/apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift
@@ -93,6 +93,11 @@ public enum SoloCompassSchemaV1_2: VersionedSchema {
             RouteRecord.self,
             ConversationRecord.self,
             WeatherCacheRecord.self,
+            // Chat history (saved conversations). New @Model tables are an
+            // additive, lightweight migration — existing stores just gain two
+            // empty tables, no data is rewritten.
+            ChatSessionRecord.self,
+            ChatMessageRecord.self,
         ]
     }
 }
@@ -157,6 +162,8 @@ public enum SoloCompassModelContainer {
                 RouteRecord.self,
                 ConversationRecord.self,
                 WeatherCacheRecord.self,
+                ChatSessionRecord.self,
+                ChatMessageRecord.self,
                 configurations: config
             )
         } catch {
@@ -190,6 +197,8 @@ public enum SoloCompassModelContainer {
                 RouteRecord.self,
                 ConversationRecord.self,
                 WeatherCacheRecord.self,
+                ChatSessionRecord.self,
+                ChatMessageRecord.self,
                 configurations: config
             )
         } catch {

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1465,3 +1465,11 @@
 "nowscore.sunset.before_min" = "Sunset in %d min";
 "nowscore.sunset.blue_hour" = "%d min after sunset · blue hour";
 "nowscore.sunset.after_min" = "Sunset was %d min ago";
+
+/* Chat history (saved conversations) */
+"chat.history.title" = "History";
+"chat.history.untitled" = "Untitled chat";
+"chat.history.messageCount" = "%d messages";
+"chat.history.empty" = "No saved conversations yet";
+"chat.history.open.a11y" = "Open chat history";
+"common.done" = "Done";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1462,3 +1462,11 @@
 "solo.staff.desc" = "店员不打扰你 — 不盯着、不追问“还有别人来吗”、不催促服务。";
 "solo.weakest" = "注意：%@";
 "solo.weakest.a11y" = "注意：%@ 是该地点最弱的维度。";
+
+/* Chat history (saved conversations) */
+"chat.history.title" = "历史记录";
+"chat.history.untitled" = "未命名对话";
+"chat.history.messageCount" = "%d 条消息";
+"chat.history.empty" = "还没有保存的对话";
+"chat.history.open.a11y" = "打开聊天历史";
+"common.done" = "完成";

--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -225,6 +225,15 @@ public final class AIService {
         let routeId = RouteId(rawValue: "ai-\(UUID().uuidString.prefix(8))")
         let validIds = Set(candidates.map(\.id))
 
+        // An AI-built route is composed for the CURRENT moment (the user asked
+        // to "plan tonight" / "string these together now", and reasonNow speaks
+        // to right now). Anchor its best-now window to the current hour so that,
+        // once adopted, it immediately surfaces in the "此刻 / Now" section —
+        // otherwise bestStartHour stays nil, isBestNow() is always false, and the
+        // route the user just created never appears in Now. Same RouteStore, same
+        // table; this is the field that gates Now visibility.
+        let nowHour = Double(Calendar.current.component(.hour, from: now))
+
         do {
             let prompt = Self.routeGenerationPrompt(candidates: candidates, cityCode: cityCode)
             let raw = try await sendMessage(prompt: prompt, kind: .synthesis)
@@ -246,6 +255,7 @@ public final class AIService {
                 pace: .relaxed,
                 tags: plan.tags ?? Self.tags(from: ordered),
                 source: .aiGenerated,
+                bestStartHour: nowHour,
                 reasonNow: plan.reasonNow?.isEmpty == false ? plan.reasonNow : nil
             )
         } catch {
@@ -268,7 +278,8 @@ public final class AIService {
                 cityCode: cityCode,
                 pace: .relaxed,
                 tags: Self.tags(from: ordered),
-                source: .aiGenerated
+                source: .aiGenerated,
+                bestStartHour: nowHour
             )
         }
     }
@@ -532,11 +543,21 @@ public final class AIService {
     /// Serialise the conversation as the array DeepSeek wants. We map
     /// each Role / Message field by hand so the wire shape stays
     /// decoupled from the in-memory model.
+    /// Wrap user content in `<user_input>` tags at API-serialization time so the
+    /// model always treats it as untrusted input — WITHOUT polluting the stored
+    /// message (which the chat UI renders verbatim). Session history keeps the
+    /// raw text; only the bytes sent to the model carry the tags.
+    static func wrapUserContentForAPI(_ content: String) -> String {
+        "<user_input>\(content)</user_input>"
+    }
+
     static func serializeAgentMessages(_ messages: [VoiceAgentSession.Message]) -> [[String: Any]] {
         messages.map { msg -> [String: Any] in
             var row: [String: Any] = ["role": msg.role.rawValue]
             if let content = msg.content {
-                row["content"] = content
+                // User turns get wrapped here (not in the stored message) so the
+                // <user_input> guard never leaks into the chat bubble.
+                row["content"] = msg.role == .user ? wrapUserContentForAPI(content) : content
             } else {
                 // OpenAI requires "content" key even when null on assistant
                 // tool-call rows. NSNull renders as JSON null.

--- a/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
@@ -18,6 +18,17 @@ public final class VoiceAgentOrchestrator: Identifiable {
     private let voiceService: VoiceService
     private let toolRouter: VoiceAgentToolRouter
     private weak var mapViewModel: MapViewModel?
+    /// Optional persistence for chat history. When wired, each completed turn
+    /// upserts the conversation so it survives the sheet closing / app restart.
+    private let historyStore: ChatHistoryStore?
+
+    /// Stable id for THIS conversation in the history store. A fresh UUID per
+    /// orchestrator session; reused across turns so saves upsert rather than
+    /// pile up. Replaced by `restoreConversation` when reopening from history.
+    public private(set) var persistedConversationId: String = UUID().uuidString
+    /// ISO 8601 UTC creation stamp for the persisted conversation, set on first
+    /// save and preserved across upserts.
+    private var persistedConversationCreatedAt: String?
     /// US-023: optional ContextManager — when set, snapshot JSON is injected
     /// into the system prompt before each session starts.
     private let contextManager: (any ContextManager)?
@@ -107,18 +118,74 @@ public final class VoiceAgentOrchestrator: Identifiable {
         voiceService: VoiceService,
         mapViewModel: MapViewModel,
         preferences: UserPreferences,
-        contextManager: (any ContextManager)? = nil
+        contextManager: (any ContextManager)? = nil,
+        historyStore: ChatHistoryStore? = nil
     ) {
         self.aiService = aiService
         self.voiceService = voiceService
         self.mapViewModel = mapViewModel
         self.contextManager = contextManager
+        self.historyStore = historyStore
         self.toolRouter = VoiceAgentToolRouter(
             mapViewModel: mapViewModel,
             preferences: preferences,
             // Wire the AI service so `build_route` can string a walk together.
             aiService: aiService
         )
+    }
+
+    /// Persist the current conversation snapshot (no-op when no store is wired
+    /// or there's nothing meaningful yet). Idempotent upsert under
+    /// `persistedConversationId`. Called after each completed turn and on close.
+    public func persistConversation() {
+        guard let historyStore else { return }
+        let wrote = historyStore.saveSession(
+            id: persistedConversationId,
+            messages: session.messages,
+            scopedExperienceId: scopedExperience?.id,
+            createdAt: persistedConversationCreatedAt
+        )
+        if wrote, persistedConversationCreatedAt == nil {
+            // Capture the created stamp from the just-written record so later
+            // upserts preserve it.
+            persistedConversationCreatedAt = historyStore
+                .recentSessions(limit: 1)
+                .first(where: { $0.id == persistedConversationId })?
+                .createdAt
+        }
+    }
+
+    /// Reopen a saved conversation: cancel any in-flight turn, re-seed a fresh
+    /// system prompt, adopt the saved conversation's id (so further turns upsert
+    /// the same record), then replay the stored messages into the session.
+    /// Safe to call while running; leaves the orchestrator ready for new turns.
+    public func restoreConversation(id: String, messages restored: [VoiceAgentSession.Message]) {
+        turnTask?.cancel()
+        turnTask = nil
+        synthesizer.stopSpeaking(at: .immediate)
+        didRequestImmediateSpeechStop = true
+
+        streamingContent = ""
+        thinkingStep = ""
+        isExecutingTool = false
+        errorMessage = nil
+        cardsByMessageId = [:]
+        reasoningTrace = []
+
+        persistedConversationId = id
+        persistedConversationCreatedAt = nil
+
+        Task {
+            let prompt = await buildSystemPrompt(experience: scopedExperience)
+            currentSystemPrompt = prompt
+            // Fresh system prompt first, then replay the saved history on top so
+            // ordering is [system, ...restored].
+            session.reseedSystem(prompt)
+            session.restoreHistory(restored)
+            isSeeded = true
+            isRunning = true
+            uiState = .listening
+        }
     }
 
     // MARK: - Public API
@@ -290,8 +357,12 @@ public final class VoiceAgentOrchestrator: Identifiable {
 
     // MARK: - Prompt-injection guard
 
-    /// Strips common prompt-injection control sequences and wraps the result
-    /// in <user_input> tags so the model always treats the text as user content.
+    /// Strips common prompt-injection control sequences from raw user text.
+    ///
+    /// The result is the text that gets STORED in the session and rendered in
+    /// the chat bubble — so it must stay clean and tag-free. The `<user_input>`
+    /// safety wrapper is applied separately, only when serializing for the API
+    /// (`AIService.wrapUserContentForAPI`), so the guard never leaks into the UI.
     static func sanitizeUserInput(_ text: String) -> String {
         var sanitized = text
         // Strip sequences that try to override the system prompt.
@@ -315,7 +386,9 @@ public final class VoiceAgentOrchestrator: Identifiable {
         }
         // Collapse runs of newlines that could smuggle fake role headers.
         sanitized = sanitized.replacingOccurrences(of: "\n{3,}", with: "\n\n", options: .regularExpression)
-        return "<user_input>\(sanitized)</user_input>"
+        // NOTE: no <user_input> wrapping here — that happens at API serialization
+        // time so the stored/displayed text stays clean. See doc comment above.
+        return sanitized
     }
 
     // MARK: - Turn loop
@@ -350,12 +423,19 @@ public final class VoiceAgentOrchestrator: Identifiable {
                     uiState = .processing
                     shouldContinue = true
                 } else {
-                    let finalText = streamingContent
+                    // Read the final text from the committed assistant message,
+                    // not from `streamingContent` — the latter is now cleared in
+                    // sendToAIStreaming() once the text lands in `messages` (so it
+                    // can't be rendered as a duplicate bubble).
+                    let finalText = session.lastAssistantText ?? ""
                     uiState = .responding(finalText)
                     session.finishSpeakingTurn()
                     thinkingStep = ""
                     shouldContinue = false
                     speakResponse(finalText)
+                    // Turn complete — persist the conversation so it survives the
+                    // sheet closing and shows up in history.
+                    persistConversation()
                 }
 
                 if Date().timeIntervalSince(turnStart) > VoiceAgentSession.turnTimeoutSeconds {
@@ -404,9 +484,12 @@ public final class VoiceAgentOrchestrator: Identifiable {
             }
             let content = accumulatedContent.isEmpty ? nil : accumulatedContent
             session.appendAssistantTurn(content: content, toolCalls: sessionCalls)
-            if sessionCalls.isEmpty {
-                streamingContent = ""
-            }
+            // The text is now committed to `messages` and rendered from there.
+            // Always clear the live streaming buffer so it isn't ALSO rendered
+            // as a second, duplicate bubble — this previously only happened when
+            // there were no tool calls, so a tool-call turn's opening line (e.g.
+            // "Let me look around you first…") showed up twice.
+            streamingContent = ""
             return true
 
         } catch {
@@ -426,9 +509,10 @@ public final class VoiceAgentOrchestrator: Identifiable {
                 content: response.content,
                 toolCalls: response.toolCalls
             )
-            if let content = response.content {
-                streamingContent = content
-            }
+            // Mirror the streaming path: the text is committed to `messages`, so
+            // clear the live buffer to avoid a duplicate bubble. The final reply
+            // is read back via `session.lastAssistantText` in runTurn.
+            streamingContent = ""
             return true
         } catch {
             errorMessage = error.localizedDescription
@@ -497,7 +581,9 @@ public final class VoiceAgentOrchestrator: Identifiable {
     private func sendForceText(prompt: String) async {
         session.appendSystemContinuation(prompt)
         _ = await sendToAIFallback()
-        let finalText = streamingContent
+        // Read the committed reply, not the live buffer (now cleared after commit).
+        let finalText = session.lastAssistantText ?? ""
+        uiState = .responding(finalText)
         session.finishSpeakingTurn()
         thinkingStep = ""
         speakResponse(finalText)
@@ -575,12 +661,12 @@ public final class VoiceAgentOrchestrator: Identifiable {
         \(visibleSummary)
 
         TOOLS AVAILABLE:
-        1. explore_nearby(latitude, longitude, radius_meters) — Fetch real OSM POIs near a coordinate and enrich with AI. Use when the user wants new places or is in an unfamiliar area. Surfaced places appear to the user as tappable cards.
+        1. explore_nearby(latitude, longitude, radius_meters) — Fetch real OSM POIs near a coordinate and enrich with AI. Use when the user wants new places or is in an unfamiliar area. Surfaced places appear to the user as tappable cards. If the first ring is empty this tool AUTOMATICALLY widens the search (5 → 10 → 25 → 100 km) until it finds something or runs out of range — you do NOT need to call expand_radius yourself. The result reports `auto_expanded_stages` and `search_exhausted`.
         2. filter_by_category(category) — Filter the map to one category. Values: culture|nature|food|coffee|work|wellness|nightlife|hidden
         3. show_details(experience_id) — Present ONE place to the user as an inline card they can tap. Does NOT seize the map. MUST use an ID from CURRENT VISIBLE EXPERIENCES.
         4. save_to_favorites(experience_id) — Toggle favorite status for an experience.
         5. dismiss_recommendation(experience_id) — Hide an experience from the current view. Ephemeral — it can return after refresh.
-        6. search_places(query, latitude, longitude, radius_meters) — Search for a specific type or named place (e.g. "ramen", "7-Eleven", "rooftop bar"). Returns newly discovered experiences as cards.
+        6. search_places(query, latitude, longitude, radius_meters) — Search for a specific type or named place (e.g. "ramen", "7-Eleven", "rooftop bar"). Returns newly discovered experiences as cards. Like explore_nearby, it AUTOMATICALLY widens the radius when the first ring is empty, so don't give up early.
         7. navigate_to(experience_id) — Open the user's preferred map app with walking directions. ONLY when the user explicitly asks to go / get directions.
         8. build_route(experience_ids?) — String nearby places into ONE walkable route, ordered into a sensible walk, with a "why now" line reflecting the time, weather, and which places the user has or hasn't visited. The route appears as a card the user can adopt — it is NOT saved until they tap adopt. Use when the user asks you to plan a walk or string places together.
 
@@ -594,6 +680,7 @@ public final class VoiceAgentOrchestrator: Identifiable {
         - When the user wants a walk, an itinerary, or to "string these together", call build_route and let them adopt the proposed route.
         - Personalize using the CONTEXT SNAPSHOT (time, weather, location, visited history) — prefer places that fit the current moment and that the user hasn't seen yet, and say why in one short phrase.
         - When the user wants somewhere specific, use filter_by_category or search_places first.
+        - NEVER reply "there's nothing nearby" off a single empty search. explore_nearby / search_places already auto-widen the radius for you. Only acknowledge an empty area if the result has `search_exhausted: true` (the ladder reached its 100 km limit and still found nothing); otherwise work with what the search surfaced.
         - NEVER invent experience IDs — only use IDs from CURRENT VISIBLE EXPERIENCES or from explore_nearby/search_places results.
         - Detect the user's language from their input and reply in the same language.
         - If the user's request is unclear, ask exactly ONE clarifying question.

--- a/apps/ios/SoloCompass/Services/VoiceAgentSession.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentSession.swift
@@ -169,6 +169,20 @@ public final class VoiceAgentSession {
         messages.append(Message(role: .system, content: prompt))
     }
 
+    /// Seed a restored conversation's history after the system prompt has been
+    /// seeded. Appends the stored (non-system) messages in order so the chat
+    /// reopens exactly where it left off. `turnCount` is bumped to the number of
+    /// restored user turns so compaction/limits behave sensibly going forward.
+    public func restoreHistory(_ restored: [Message]) {
+        let nonSystem = restored.filter { $0.role != .system }
+        guard !nonSystem.isEmpty else { return }
+        messages.append(contentsOf: nonSystem)
+        turnCount = nonSystem.filter { $0.role == .user }.count
+        recursionDepth = 0
+        state = .idle
+        compactIfNeeded()
+    }
+
     /// Transition .idle → .listening. Caller is the long-press gesture.
     public func beginListening() {
         guard endReason == nil else { return }
@@ -266,6 +280,17 @@ public final class VoiceAgentSession {
 
     /// True when the session has ended for any reason.
     public var isEnded: Bool { endReason != nil }
+
+    /// Text of the most recently committed assistant message, if any. The
+    /// orchestrator reads this for the final spoken/displayed reply instead of
+    /// relying on the live `streamingContent` buffer (which is cleared as soon
+    /// as the text lands here, to avoid a duplicate bubble).
+    public var lastAssistantText: String? {
+        for msg in messages.reversed() where msg.role == .assistant {
+            if let content = msg.content, !content.isEmpty { return content }
+        }
+        return nil
+    }
 
     // MARK: - History compaction (PRD §5.2)
 

--- a/apps/ios/SoloCompass/Services/VoiceAgentToolRouter.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentToolRouter.swift
@@ -306,11 +306,26 @@ public final class VoiceAgentToolRouter {
         } else {
             await vm.exploreNearby(at: coord, radiusMeters: radius, category: category)
         }
+        // If the first ring came up empty, don't surrender — widen the search
+        // automatically (the agent should compile the wider surroundings rather
+        // than reply "found nothing"). Only meaningful on the progressive path,
+        // which owns the ring ladder.
+        var stagesExpanded = 0
+        var ladderExhausted = false
+        if useProgressive {
+            let outcome = await autoExpandUntilResults(vm: vm)
+            stagesExpanded = outcome.stagesExpanded
+            ladderExhausted = outcome.exhausted
+        }
+        // Re-diff against the original snapshot so cards reflect everything the
+        // auto-expansion surfaced, not just the (empty) first ring.
         recordAddedEffect(before: before, vm: vm)
         return Self.successJSON([
             "added_count": vm.lastExploreAddedCount,
             "radius_meters": radius,
             "progressive": useProgressive,
+            "auto_expanded_stages": stagesExpanded,
+            "search_exhausted": ladderExhausted,
         ])
     }
 
@@ -327,6 +342,31 @@ public final class VoiceAgentToolRouter {
     /// Max places surfaced as cards from a single explore/search so the chat
     /// rail stays scannable rather than dumping 30 cards.
     private static let maxCardExperiences = 6
+
+    /// Hard ceiling on automatic radius expansions per explore/search call so a
+    /// genuinely empty area can't loop forever. The ring ladder tops out at
+    /// 100 km in a handful of stages, so this comfortably covers the full ladder.
+    private static let maxAutoExpandStages = 6
+
+    /// When the initial explore/search found nothing new, keep widening the
+    /// search ring (5 → 10 → 25 → 100 km) automatically until SOMETHING new
+    /// turns up or the ladder is exhausted — so the agent compiles the
+    /// surrounding area on its own instead of giving up and going silent.
+    ///
+    /// Returns how many stages it expanded (0 when the first ring already had
+    /// results) and whether the ladder was exhausted, for the tool reply so the
+    /// agent can tell the user how far it had to look.
+    private func autoExpandUntilResults(vm: MapViewModel) async -> (stagesExpanded: Int, exhausted: Bool) {
+        var stages = 0
+        while vm.lastExploreAddedCount == 0, stages < Self.maxAutoExpandStages {
+            // nil = a wider ring was launched; non-nil reason = already at max.
+            if await vm.expandOneStage() != nil {
+                return (stages, true)
+            }
+            stages += 1
+        }
+        return (stages, false)
+    }
 
     private struct FilterByCategoryArgs: Decodable {
         let category: String
@@ -430,12 +470,24 @@ public final class VoiceAgentToolRouter {
         } else {
             await vm.exploreNearby(at: coord, radiusMeters: radius, category: category)
         }
+        // Same auto-widen behavior as explore_nearby: a query that found nothing
+        // in the first ring keeps expanding instead of returning an empty result
+        // and stalling the agent.
+        var stagesExpanded = 0
+        var ladderExhausted = false
+        if useProgressive {
+            let outcome = await autoExpandUntilResults(vm: vm)
+            stagesExpanded = outcome.stagesExpanded
+            ladderExhausted = outcome.exhausted
+        }
         recordAddedEffect(before: before, vm: vm)
         return Self.successJSON([
             "query": parsed.query,
             "added_count": vm.lastExploreAddedCount,
             "radius_meters": radius,
             "progressive": useProgressive,
+            "auto_expanded_stages": stagesExpanded,
+            "search_exhausted": ladderExhausted,
         ])
     }
 

--- a/apps/ios/SoloCompass/Tests/ChatCardRenderVisualTest.swift
+++ b/apps/ios/SoloCompass/Tests/ChatCardRenderVisualTest.swift
@@ -83,4 +83,28 @@ final class ChatCardRenderVisualTest: XCTestCase {
         )
         try write(render(stack), "chatcard_experience_rail")
     }
+
+    // MARK: - B-batch redesign (#6 bubbles)
+
+    /// Renders a representative conversation so the avatar-free, warm-parchment
+    /// assistant bubble + accent user bubble can be eyeballed against the old
+    /// white-card-with-compass-avatar look.
+    func testRedesignedBubbleConversationRenders() throws {
+        let convo = VStack(alignment: .leading, spacing: 10) {
+            MessageBubble(role: .user, text: "帮我计划今晚的行程")
+            MessageBubble(
+                role: .assistant,
+                text: "好的！现在是晚上，我来看看你附近有哪些适合夜晚的好去处。先看看你周围有什么："
+            )
+            MessageBubble(role: .tool, text: "{}", toolName: "explore_nearby")
+            MessageBubble(
+                role: .assistant,
+                text: "找到 3 个不错的地方，**河畔夜市**离你最近，灯火很热闹，适合一个人慢慢逛。"
+            )
+            TypingIndicatorBubble(label: "🧭 正在串联路线…")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 12)
+        try write(render(convo), "bubbles_redesigned_light")
+    }
 }

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -3801,6 +3801,14 @@ final class SoloCompassTests: XCTestCase {
                                     "a walk needs at least two stops")
         XCTAssertEqual(proposal.route.experienceIds, proposal.stops.map(\.id),
                        "resolved stops must match the route's ordered ids")
+        // #5 regression: an AI-built route is composed for the current moment,
+        // so it must read as "best now" immediately — otherwise, once adopted,
+        // it would never surface in the 此刻/Now section (bestStartHour was nil
+        // before, making isBestNow() permanently false).
+        XCTAssertNotNil(proposal.route.bestStartHour,
+                        "AI route must anchor a best-now window so it shows in Now")
+        XCTAssertTrue(proposal.route.isBestNow(),
+                      "a freshly built AI route must be best-now at creation time")
     }
 
     /// build_route must NOT save the route — adoption is the user's explicit
@@ -5364,11 +5372,33 @@ final class VoiceAgentOrchestratorUnconfiguredTests: XCTestCase {
 
     // MARK: - US-017 Prompt-injection sanitizer
 
-    func testSanitizeUserInput_wrapsCleanTextInTags() {
+    func testSanitizeUserInput_keepsCleanTextTagFreeForUI() {
+        // The sanitizer now returns the text that gets STORED and DISPLAYED —
+        // so it must NOT contain the <user_input> wrapper (that leaked into the
+        // chat bubble before). The wrapper is applied only at API serialization.
         let result = VoiceAgentOrchestrator.sanitizeUserInput("Find me a coffee shop")
-        XCTAssertTrue(result.hasPrefix("<user_input>"), "output must start with <user_input> tag")
-        XCTAssertTrue(result.hasSuffix("</user_input>"), "output must end with </user_input> tag")
-        XCTAssertTrue(result.contains("Find me a coffee shop"), "clean text must be preserved inside tags")
+        XCTAssertEqual(result, "Find me a coffee shop", "clean text must pass through untouched, no tags")
+        XCTAssertFalse(result.contains("<user_input>"), "no <user_input> tag may leak into stored/displayed text")
+        XCTAssertFalse(result.contains("</user_input>"), "no closing tag may leak into stored/displayed text")
+    }
+
+    func testWrapUserContentForAPI_addsTagsForModelOnly() {
+        let wrapped = AIService.wrapUserContentForAPI("Find me a coffee shop")
+        XCTAssertEqual(wrapped, "<user_input>Find me a coffee shop</user_input>",
+                       "API serialization must wrap user content in the safety tags")
+    }
+
+    func testSerializeAgentMessages_wrapsUserRoleOnly() {
+        let messages: [VoiceAgentSession.Message] = [
+            .init(role: .system, content: "system prompt"),
+            .init(role: .user, content: "hello there"),
+            .init(role: .assistant, content: "hi!"),
+        ]
+        let rows = AIService.serializeAgentMessages(messages)
+        XCTAssertEqual(rows[0]["content"] as? String, "system prompt", "system content stays raw")
+        XCTAssertEqual(rows[1]["content"] as? String, "<user_input>hello there</user_input>",
+                       "user content is wrapped for the API")
+        XCTAssertEqual(rows[2]["content"] as? String, "hi!", "assistant content stays raw")
     }
 
     func testSanitizeUserInput_stripsIgnorePreviousInstructions() {
@@ -5403,8 +5433,8 @@ final class VoiceAgentOrchestratorUnconfiguredTests: XCTestCase {
     func testSanitizeUserInput_preservesNormalConversation() {
         let normal = "Can you recommend a quiet café near the museum?"
         let result = VoiceAgentOrchestrator.sanitizeUserInput(normal)
-        XCTAssertEqual(result, "<user_input>Can you recommend a quiet café near the museum?</user_input>",
-                       "normal user input must pass through unchanged inside tags")
+        XCTAssertEqual(result, "Can you recommend a quiet café near the museum?",
+                       "normal user input must pass through unchanged, tag-free")
     }
 
     // MARK: - US-021 TTS stops immediately on stop()
@@ -6988,5 +7018,104 @@ final class MinutesLeftInBestWindowTests: XCTestCase {
         let at = Calendar.current.date(from: c)!
         let result = exp.minutesLeftInBestWindow(at: at)
         XCTAssertEqual(result, 1)
+    }
+}
+
+// MARK: - #8 Chat history persistence
+
+@MainActor
+final class ChatHistoryStoreTests: XCTestCase {
+
+    private func makeStore() -> ChatHistoryStore {
+        ChatHistoryStore(context: ModelContext(SoloCompassModelContainer.makeInMemory()))
+    }
+
+    private func userMsg(_ text: String) -> VoiceAgentSession.Message {
+        .init(role: .user, content: text)
+    }
+
+    private func assistantMsg(_ text: String) -> VoiceAgentSession.Message {
+        .init(role: .assistant, content: text)
+    }
+
+    func testSaveAndRestoreRoundTrips() {
+        let store = makeStore()
+        let id = UUID().uuidString
+        let messages: [VoiceAgentSession.Message] = [
+            .init(role: .system, content: "system prompt"),
+            userMsg("帮我找咖啡馆"),
+            assistantMsg("好的，附近有几家不错的。"),
+        ]
+        let wrote = store.saveSession(id: id, messages: messages, scopedExperienceId: nil)
+        XCTAssertTrue(wrote, "a conversation with a user turn must persist")
+
+        let restored = store.messages(sessionId: id)
+        // System prompt is intentionally dropped on save (rebuilt on restore).
+        XCTAssertEqual(restored.map(\.role), [.user, .assistant])
+        XCTAssertEqual(restored.first?.content, "帮我找咖啡馆")
+        XCTAssertEqual(restored.last?.content, "好的，附近有几家不错的。")
+    }
+
+    func testEmptyConversationIsNotPersisted() {
+        let store = makeStore()
+        let id = UUID().uuidString
+        // No user message → nothing meaningful to save.
+        let wrote = store.saveSession(
+            id: id,
+            messages: [.init(role: .system, content: "system prompt")],
+            scopedExperienceId: nil
+        )
+        XCTAssertFalse(wrote, "a conversation with no user turn must be skipped")
+        XCTAssertTrue(store.recentSessions().isEmpty)
+    }
+
+    func testUpsertReplacesPriorSnapshot() {
+        let store = makeStore()
+        let id = UUID().uuidString
+        store.saveSession(id: id, messages: [userMsg("hi")], scopedExperienceId: nil)
+        store.saveSession(
+            id: id,
+            messages: [userMsg("hi"), assistantMsg("hello"), userMsg("more")],
+            scopedExperienceId: nil
+        )
+        // Same id → one session, latest snapshot only (no piled-up duplicates).
+        XCTAssertEqual(store.recentSessions().count, 1)
+        XCTAssertEqual(store.messages(sessionId: id).count, 3)
+    }
+
+    func testDeleteRemovesSessionAndMessages() {
+        let store = makeStore()
+        let id = UUID().uuidString
+        store.saveSession(id: id, messages: [userMsg("hi"), assistantMsg("yo")], scopedExperienceId: nil)
+        store.delete(sessionId: id)
+        XCTAssertTrue(store.recentSessions().isEmpty)
+        XCTAssertTrue(store.messages(sessionId: id).isEmpty)
+    }
+
+    func testTitleDerivedFromFirstUserMessage() {
+        let title = ChatHistoryStore.deriveTitle(from: [
+            .init(role: .system, content: "ignored"),
+            VoiceAgentSession.Message(role: .user, content: "找一家安静的咖啡馆"),
+        ])
+        XCTAssertEqual(title, "找一家安静的咖啡馆")
+    }
+
+    func testToolCallsSurviveRoundTrip() {
+        let store = makeStore()
+        let id = UUID().uuidString
+        let assistantWithTool = VoiceAgentSession.Message(
+            role: .assistant,
+            content: "let me look",
+            toolCalls: [.init(id: "c1", name: "explore_nearby", argumentsJSON: #"{"radius_meters":3000}"#)]
+        )
+        store.saveSession(
+            id: id,
+            messages: [userMsg("find cafes"), assistantWithTool],
+            scopedExperienceId: nil
+        )
+        let restored = store.messages(sessionId: id)
+        let toolCall = restored.first(where: { $0.role == .assistant })?.toolCalls.first
+        XCTAssertEqual(toolCall?.name, "explore_nearby")
+        XCTAssertEqual(toolCall?.argumentsJSON, #"{"radius_meters":3000}"#)
     }
 }

--- a/apps/ios/SoloCompass/Views/Chat/ChatHistoryListView.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatHistoryListView.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+/// History of saved chat conversations. Presented from the chat header's clock
+/// button; tapping a row reopens that conversation, swipe deletes it. Reads from
+/// `ChatHistoryStore` and refreshes on appear.
+@MainActor
+public struct ChatHistoryListView: View {
+    let store: ChatHistoryStore
+    /// Called with a chosen session's id + restored messages so the host can
+    /// rebind the live orchestrator to that conversation.
+    let onSelect: (_ sessionId: String, _ messages: [VoiceAgentSession.Message]) -> Void
+    let onDismiss: () -> Void
+
+    @State private var sessions: [ChatSessionRecord] = []
+    @Environment(\.colorScheme) private var colorScheme
+
+    public init(
+        store: ChatHistoryStore,
+        onSelect: @escaping (_ sessionId: String, _ messages: [VoiceAgentSession.Message]) -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.store = store
+        self.onSelect = onSelect
+        self.onDismiss = onDismiss
+    }
+
+    public var body: some View {
+        NavigationStack {
+            Group {
+                if sessions.isEmpty {
+                    emptyState
+                } else {
+                    list
+                }
+            }
+            .navigationTitle(Text(NSLocalizedString("chat.history.title", comment: "History")))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(NSLocalizedString("common.done", comment: "Done"), action: onDismiss)
+                }
+            }
+            .background(backgroundColor)
+        }
+        .onAppear(perform: reload)
+    }
+
+    private var list: some View {
+        List {
+            ForEach(sessions, id: \.id) { session in
+                Button {
+                    let restored = store.messages(sessionId: session.id)
+                    onSelect(session.id, restored)
+                } label: {
+                    row(for: session)
+                }
+                .listRowBackground(rowBackground)
+            }
+            .onDelete(perform: deleteRows)
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+
+    private func row(for session: ChatSessionRecord) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(session.title ?? NSLocalizedString("chat.history.untitled", comment: "Untitled chat"))
+                .font(.body.weight(.medium))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+            HStack(spacing: 8) {
+                Text(Self.relativeDate(session.updatedAt))
+                Text("·")
+                Text(String(
+                    format: NSLocalizedString("chat.history.messageCount", comment: "%d messages"),
+                    session.messageCount
+                ))
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.title.weight(.semibold))
+                .foregroundStyle(CT.fgSubtle)
+            Text(NSLocalizedString("chat.history.empty", comment: "No saved conversations yet"))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(32)
+    }
+
+    // MARK: - Actions
+
+    private func reload() {
+        sessions = store.recentSessions()
+    }
+
+    private func deleteRows(_ offsets: IndexSet) {
+        let ids = offsets.map { sessions[$0].id }
+        for id in ids { store.delete(sessionId: id) }
+        reload()
+    }
+
+    // MARK: - Helpers
+
+    private var backgroundColor: Color {
+        colorScheme == .dark ? Color(.systemBackground) : CT.bgWarm
+    }
+
+    private var rowBackground: Color {
+        colorScheme == .dark ? Color(.secondarySystemBackground) : CT.surfaceWhite
+    }
+
+    /// Format an ISO 8601 stamp as a short relative description ("2h ago").
+    /// Falls back to the raw date if parsing fails.
+    static func relativeDate(_ iso: String) -> String {
+        guard let date = ISO8601DateFormatter().date(from: iso) else { return iso }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}

--- a/apps/ios/SoloCompass/Views/Chat/ChatInputBar.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatInputBar.swift
@@ -131,9 +131,12 @@ public struct ChatInputBar: View {
             HStack(alignment: .bottom, spacing: 8) {
                 plusButton
                 textField
-                sendButton
-                micButton
+                // WeChat-style trailing affordance: an empty draft shows the mic;
+                // as soon as the user types, it morphs into the send button. No
+                // permanently-docked send key sitting low next to the mic.
+                trailingButton
             }
+            .animation(.spring(response: 0.28, dampingFraction: 0.8), value: hasSendableDraft)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
@@ -286,17 +289,42 @@ public struct ChatInputBar: View {
         .accessibilityLabel(Text(NSLocalizedString("chat.input.placeholder", comment: "Type a message…")))
     }
 
+    /// True when there is something to send: trimmed text OR a staged attachment.
+    private var hasSendableDraft: Bool {
+        !draftText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !attachments.isEmpty
+    }
+
+    /// WeChat-style single trailing slot: mic when the draft is empty, send when
+    /// the user has typed (or staged an attachment). Morphs in place with a
+    /// quick scale/opacity so it reads as one control changing mode, not two
+    /// buttons swapping.
+    @ViewBuilder
+    private var trailingButton: some View {
+        if hasSendableDraft {
+            sendButton
+                .transition(.scale(scale: 0.7).combined(with: .opacity))
+        } else {
+            micButton
+                .transition(.scale(scale: 0.7).combined(with: .opacity))
+        }
+    }
+
+    /// Filled-circle send key, sized to match the 40×40 plus/mic buttons so the
+    /// row stays on one baseline (the old `.title2` glyph sat low). Only shown
+    /// when there's a sendable draft, so it's always enabled.
     private var sendButton: some View {
-        let trimmed = draftText.trimmingCharacters(in: .whitespacesAndNewlines)
-        // Enabled when there's text OR at least one staged attachment.
-        let canSend = !trimmed.isEmpty || !attachments.isEmpty
-        return Button(action: submitDraft) {
-            Image(systemName: "arrow.up.circle.fill")
-                .font(.title2)
-                .foregroundStyle(canSend ? CT.accent : Color.secondary.opacity(0.5))
+        Button(action: submitDraft) {
+            ZStack {
+                Circle()
+                    .fill(CT.accent)
+                    .frame(width: 40, height: 40)
+                Image(systemName: "arrow.up")
+                    .font(.body.weight(.bold))
+                    .foregroundStyle(.white)
+            }
         }
         .buttonStyle(PressableButtonStyle(pressedScale: 0.88))
-        .disabled(!canSend)
         .accessibilityLabel(Text(NSLocalizedString("chat.input.send.a11y", comment: "Send")))
     }
 

--- a/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
@@ -26,7 +26,18 @@ public struct ChatSheet: View {
     /// User tapped "采用这条路线" on a proposed-route card — persist + open it.
     public let onAdoptRoute: (RouteProposal) -> Void
 
+    /// Optional binding to the host sheet's selected detent. When provided, the
+    /// sheet auto-expands to `.large` as soon as the agent starts working so the
+    /// reply has room to render, instead of being squeezed into a half-sheet.
+    /// Defaults to a throwaway constant so previews/tests need not supply one.
+    @Binding private var detent: PresentationDetent
+
+    /// Optional history store. When wired, the header shows a clock button that
+    /// opens saved conversations the user can reopen.
+    private let historyStore: ChatHistoryStore?
+
     @State private var draftText: String = ""
+    @State private var showHistory: Bool = false
     @State private var liveTranscript: String = ""
     @State private var voiceStreamTask: Task<Void, Never>? = nil
     @State private var permissionDenied: Bool = false
@@ -69,7 +80,9 @@ public struct ChatSheet: View {
         startInVoiceMode: Bool,
         onDismiss: @escaping () -> Void,
         onSelectExperience: @escaping (Experience) -> Void = { _ in },
-        onAdoptRoute: @escaping (RouteProposal) -> Void = { _ in }
+        onAdoptRoute: @escaping (RouteProposal) -> Void = { _ in },
+        detent: Binding<PresentationDetent> = .constant(.large),
+        historyStore: ChatHistoryStore? = nil
     ) {
         self.orchestrator = orchestrator
         self.voiceService = voiceService
@@ -77,6 +90,8 @@ public struct ChatSheet: View {
         self.onDismiss = onDismiss
         self.onSelectExperience = onSelectExperience
         self.onAdoptRoute = onAdoptRoute
+        self._detent = detent
+        self.historyStore = historyStore
     }
 
     public var body: some View {
@@ -99,6 +114,46 @@ public struct ChatSheet: View {
         .onDisappear { teardownVoiceStream() }
         .onChange(of: orchestrator.session.messages.count) { _, _ in
             handleMessageCountChange()
+        }
+        .onChange(of: orchestrator.uiState) { _, newState in
+            expandSheetWhileWorking(newState)
+        }
+        .sheet(isPresented: $showHistory) {
+            if let historyStore {
+                ChatHistoryListView(
+                    store: historyStore,
+                    onSelect: { sessionId, messages in
+                        restoreConversation(id: sessionId, messages: messages)
+                    },
+                    onDismiss: { showHistory = false }
+                )
+            }
+        }
+    }
+
+    /// Reopen a saved conversation in the live orchestrator, then close the
+    /// history sheet. Persist the current (possibly in-progress) conversation
+    /// first so switching away doesn't lose it. The orchestrator owns the
+    /// re-seed + replay so ordering stays [system, ...restored].
+    private func restoreConversation(id: String, messages: [VoiceAgentSession.Message]) {
+        orchestrator.persistConversation()
+        orchestrator.restoreConversation(id: id, messages: messages)
+        showHistory = false
+        showVoiceSurface = false
+    }
+
+    /// While the agent is thinking or streaming a reply, lift the sheet to full
+    /// height so the response renders in a roomy, focused surface — the most
+    /// readable state. The user can still drag it back down afterward; we only
+    /// drive the expansion, never force it closed.
+    private func expandSheetWhileWorking(_ state: ChatUIState) {
+        switch state {
+        case .processing, .responding:
+            if detent != .large {
+                withAnimation(.easeInOut(duration: 0.3)) { detent = .large }
+            }
+        default:
+            break
         }
     }
 
@@ -178,10 +233,21 @@ public struct ChatSheet: View {
     // MARK: - Subviews
 
     private var header: some View {
-        HStack {
+        HStack(spacing: 12) {
             Text(NSLocalizedString("chat.title", comment: "Chat title — Solo Compass"))
                 .font(.headline)
             Spacer()
+            if historyStore != nil {
+                Button { showHistory = true } label: {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 28, height: 28)
+                        .background(closeButtonFill, in: Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Text(NSLocalizedString("chat.history.open.a11y", comment: "Open chat history")))
+            }
             Button(action: closeSheet) {
                 Image(systemName: "xmark")
                     .font(.footnote.weight(.semibold))

--- a/apps/ios/SoloCompass/Views/Chat/MessageBubble.swift
+++ b/apps/ios/SoloCompass/Views/Chat/MessageBubble.swift
@@ -85,42 +85,39 @@ public struct MessageBubble: View {
     }
 
     private var assistantBubble: some View {
-        HStack(alignment: .top, spacing: 8) {
-            AssistantAvatar()
-            VStack(alignment: .leading, spacing: 0) {
-                // Assistant replies render Markdown (code/lists/links/quotes).
-                // Streaming throttle (batched ~50–80 chars / ~80ms) lives in the
-                // orchestrator (Phase D) so this view re-renders smoothly.
-                MarkdownMessageText(text: text.isEmpty ? " " : text)
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 9)
-                    // background{shape.fill.shadow} lets the soft shadow escape
-                    // the rounded clip instead of being chopped by it.
-                    .background {
-                        bubbleShape
-                            .fill(MessageBubble.assistantFill(colorScheme))
-                            .shadow(color: .black.opacity(0.06), radius: 4, y: 1)
+        // No per-message avatar — the compass mark used to repeat on every
+        // single reply, which read as generic "AI assistant" chrome. The reply
+        // simply sits left-aligned in a warm, low-contrast bubble that belongs
+        // to the app's parchment palette rather than a stark white card.
+        HStack(spacing: 0) {
+            // Assistant replies render Markdown (code/lists/links/quotes).
+            // Streaming throttle (batched ~50–80 chars / ~80ms) lives in the
+            // orchestrator (Phase D) so this view re-renders smoothly.
+            MarkdownMessageText(text: text.isEmpty ? " " : text)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background {
+                    bubbleShape.fill(MessageBubble.assistantFill(colorScheme))
+                }
+                .overlay(bubbleShape.strokeBorder(CT.borderSubtle, lineWidth: 0.5))
+                .overlay(alignment: .trailing) {
+                    if isStreaming {
+                        StreamingCursor()
+                            .padding(.trailing, 10)
                     }
-                    .overlay(bubbleShape.strokeBorder(CT.borderSubtle, lineWidth: 0.5))
-                    .overlay(alignment: .trailing) {
-                        if isStreaming {
-                            StreamingCursor()
-                                .padding(.trailing, 10)
+                }
+                .contextMenu {
+                    if !text.isEmpty && !isStreaming {
+                        Button {
+                            copyText()
+                        } label: {
+                            Label(
+                                NSLocalizedString("chat.bubble.copy", comment: "Copy bubble text"),
+                                systemImage: "doc.on.doc"
+                            )
                         }
                     }
-                    .contextMenu {
-                        if !text.isEmpty && !isStreaming {
-                            Button {
-                                copyText()
-                            } label: {
-                                Label(
-                                    NSLocalizedString("chat.bubble.copy", comment: "Copy bubble text"),
-                                    systemImage: "doc.on.doc"
-                                )
-                            }
-                        }
-                    }
-            }
+                }
             Spacer(minLength: 48)
         }
         .accessibilityLabel(Text(String(
@@ -132,10 +129,11 @@ public struct MessageBubble: View {
         }
     }
 
-    /// AI bubble fill: warm white in light mode, the dark token in dark mode so
-    /// the parchment surface doesn't glare on a near-black background.
+    /// AI bubble fill: a warm, low-contrast parchment tint in light mode (not
+    /// stark white — that read as a generic chat card glued onto the map), and
+    /// the dark token in dark mode so it doesn't glare on a near-black sheet.
     static func assistantFill(_ scheme: ColorScheme) -> Color {
-        scheme == .dark ? CT.chatAIBubbleBgDark : CT.surfaceWhite
+        scheme == .dark ? CT.chatAIBubbleBgDark : CT.surfaceSunken
     }
 
     private var toolIndicator: some View {
@@ -246,8 +244,9 @@ public struct TypingIndicatorBubble: View {
     }
 
     public var body: some View {
-        HStack(alignment: .top, spacing: 8) {
-            AssistantAvatar()
+        // Avatar-free to match `MessageBubble.assistantBubble` — the typing
+        // bubble sits left-aligned in the same warm parchment fill.
+        HStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 6) {
                 HStack(spacing: 5) {
                     ForEach(0..<3, id: \.self) { index in
@@ -259,7 +258,6 @@ public struct TypingIndicatorBubble: View {
                 .background {
                     RoundedRectangle(cornerRadius: 18, style: .continuous)
                         .fill(MessageBubble.assistantFill(colorScheme))
-                        .shadow(color: .black.opacity(0.06), radius: 4, y: 1)
                 }
                 .overlay(
                     RoundedRectangle(cornerRadius: 18, style: .continuous)

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -122,6 +122,11 @@ struct CompassMapContentView: View {
     @State private var surveyExperience: Experience? = nil
     @State private var isShowingFavorites: Bool = false
     @State private var voiceOrchestrator: VoiceAgentOrchestrator? = nil
+    /// Selected detent for the chat sheet. Bound into `presentationDetents` so
+    /// the sheet can auto-expand to `.large` while the agent is working (see
+    /// `ChatSheet`), giving the reply room to breathe instead of being read in a
+    /// cramped half-sheet.
+    @State private var chatDetent: PresentationDetent = .medium
 
     // US-017: Companion map layer (default off)
     @State private var isCompanionLayerOn: Bool = false
@@ -129,6 +134,9 @@ struct CompassMapContentView: View {
 
     // US-025: Routes section in BottomInfoSheet
     @State private var routeStore = RouteStore()
+    /// Persists chat conversations so history survives the sheet closing / app
+    /// restart and the user can reopen them from the chat header.
+    @State private var chatHistoryStore = ChatHistoryStore()
     @State private var nearbyRoutes: [Route] = []
     // Single source of truth for the route detail / create-route sheets. Two
     // separate `.sheet(isPresented:)` modifiers on the same view silently
@@ -1099,7 +1107,8 @@ struct CompassMapContentView: View {
             aiService: aiService,
             voiceService: voiceService,
             mapViewModel: vm,
-            preferences: preferences
+            preferences: preferences,
+            historyStore: chatHistoryStore
         )
         orch.start()
         voiceOrchestrator = orch
@@ -1129,7 +1138,12 @@ struct CompassMapContentView: View {
             startInVoiceMode: chatStartMode == .voice,
             // The in-view "X" routes through the same binding setter so its
             // teardown matches swipe-to-dismiss exactly.
-            onDismiss: { chatOrchestratorBinding.wrappedValue = nil },
+            onDismiss: {
+                // Persist the conversation before tearing the orchestrator down
+                // so it lands in history even if the user only closed the sheet.
+                orch.persistConversation()
+                chatOrchestratorBinding.wrappedValue = nil
+            },
             // Tapping a chat place card reveals it on the map (the agent never
             // jumps there on its own — this is the user's explicit action).
             onSelectExperience: { exp in
@@ -1142,9 +1156,13 @@ struct CompassMapContentView: View {
                 routeStore.save(proposal.route)
                 refreshNearbyRoutes(cityCode: viewModel.selectedCity)
                 routeSheet = .detail(proposal.route)
-            }
+            },
+            // Bound detent lets the sheet auto-expand to full height while the
+            // agent is thinking, then the user can still drag it back down.
+            detent: $chatDetent,
+            historyStore: chatHistoryStore
         )
-        .presentationDetents([.medium, .large])
+        .presentationDetents([.medium, .large], selection: $chatDetent)
         .presentationDragIndicator(.visible)
         .presentationBackgroundInteraction(.enabled(upThrough: .medium))
     }


### PR DESCRIPTION
## 概述

围绕地图内 AI chat 的两批工作：上个 commit 的「路线仅在 Now + 推荐卡片化 + reasoning trace」，加上本次根据体验截图反馈做的 **8 项修复/打磨**。

## 本次 8 项修复（commit `91e7a41`）

| # | 问题 | 修复 |
|---|------|------|
| 🔴1 | 气泡显示 `<user_input>` 标签 | 注入防护包装移到 API 序列化层（仅 `.user` 角色），session 存/渲染干净原文 |
| 🔴2 | 第一条回复重复显示 | 带工具调用的开场白被双渲染；commit 后统一清流式缓冲，finalText 读 `lastAssistantText` |
| 🟠3 | 发送键多余/偏下 | 微信式：输入框空→麦克风，有字→40×40 发送键，morph 切换 |
| 🟠4 | 搜不到就放弃回复 | `explore_nearby`/`search_places` 空结果自动逐环扩张 5→10→25→100km，prompt 禁止轻易放弃 |
| 🟠5 | AI 路线不进 Now | 同一 RouteStore，真因 `generateRoute` 没传 `bestStartHour`→`isBestNow()` 恒假；锚到当前小时 |
| 🟡6 | 气泡太丑 | 去重复罗盘头像、白底→暖米色、扁平阴影 |
| 🟡7 | 等待不升全屏 | agent 工作时 sheet 自动升 `.large` |
| 🟢8 | 无历史记录 | SwiftData 持久化（ChatSessionRecord/ChatMessageRecord/ChatHistoryStore）+ header 历史入口 + 会话恢复 |

## 测试

- `xcodebuild build` ✅
- 单测全绿：sanitizer/序列化(5)、build_route Now 窗口(2)、ExpandOneStage(3)、ChatHistoryStore round-trip/upsert/restore(6)、气泡渲染(1)

## 验收提示

- **#2 不重复** 与 **#7 升全屏** 是流式渲染行为，需真实 AI 对话在 Simulator 肉眼确认（逻辑已坐实 + 单测覆盖）。
- **#6 气泡** 已有 ImageRenderer PNG 确认暖色调 + 去头像。
- **#8 历史 UI** 是标准 SwiftUI List，核心逻辑单测全覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)