### PR TITLE
fix(ios): dark-mode contrast, localization & UX polish pass

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -616,6 +616,10 @@
 
 /* Settings — Subscription */
 "settings.subscription" = "Subscription";
+"subscription.tier.pro" = "Pro";
+"subscription.tier.proTrial" = "Pro (trial)";
+"subscription.tier.expired" = "Expired";
+"subscription.tier.free" = "Free";
 "settings.restore" = "Restore purchases";
 "settings.manage" = "Manage subscription";
 "restore.success" = "Pro restored.";

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -296,6 +296,7 @@
 "experience.card.hint" = "Double tap to view details";
 "card.favorite.add" = "Add to favorites";
 "card.favorite.remove" = "Remove from favorites";
+"card.dismiss" = "Dismiss card";
 
 /* Experience card distance pill */
 "card.distance.walk" = "%d min walk";

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1215,8 +1215,8 @@
 /* US-015 — BottomInfoSheet now-mode headline */
 "sheet.now.headline" = "Good spots for right now";
 "sheet.sort.button" = "Sort";
-"sheet.count.now" = "此刻 %d";
-"sheet.count.nearby" = "附近 %d";
+"sheet.count.now" = "Now %d";
+"sheet.count.nearby" = "Nearby %d";
 
 /* US-006 — BottomInfoSheet drag handle */
 "sheet.handle" = "Sheet handle, swipe up or down to adjust";
@@ -1242,10 +1242,10 @@
 "sheet.section.nearby" = "Nearby";
 
 /* US-020 — Sort mode sheet */
-"sort.smart" = "智能";
-"sort.distance" = "距离";
-"sort.soloScore" = "Solo 分";
-"sort.now" = "此刻";
+"sort.smart" = "Smart";
+"sort.distance" = "Distance";
+"sort.soloScore" = "Solo";
+"sort.now" = "Now";
 
 /* US-030 — Sort button VoiceOver accessibilityValue (announces current sort mode) */
 "sort.value.smart" = "Sorted by smart";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -539,6 +539,9 @@
 "route.share.mode.text" = "纯文本";
 "route.share.min" = "分钟";
 "route.share.stops" = "站";
+"route.share.style.map" = "地图";
+"route.share.style.trace" = "轨迹";
+"route.share.mapFallback" = "地图底图不可用——改为显示简化线路。";
 /* %d = number of travelers who have walked this route. */
 "route.share.walkedBy" = "已有 %d 位旅行者走过";
 /* Share-card image brand label (US-038) — kept as "Solo Compass" in both locales, but routed through l10n. */
@@ -950,6 +953,12 @@
 "companion.chat.group.memberCount" = "%d 位成员";
 "companion.chat.group.unknownRoute" = "群聊";
 "companion.chat.pinnedRoute.a11y" = "已置顶路线";
+"companion.chat.attachment.backendNotReady" = "附件功能需要先部署存储服务——你的消息已发送，但未包含附件。";
+"companion.chat.attachment.uploadFailed" = "附件上传失败（HTTP %d）。";
+"companion.chat.attachment.tooLarge" = "该附件过大，无法发送。";
+"companion.chat.attachment.rateLimited" = "当前上传过于频繁——请稍后再试。";
+"companion.chat.attachment.notSignedIn" = "登录后才能发送附件。";
+"companion.chat.attachment.badResponse" = "附件服务返回了异常响应。";
 "companion.discover.error.auth" = "请登录后发现同伴。";
 "companion.discover.error.config" = "应用配置缺失，请重新安装。";
 "companion.discover.error.retry" = "重试";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -923,6 +923,7 @@
 /* Card */
 "card.favorite.add" = "加入收藏";
 "card.favorite.remove" = "取消收藏";
+"card.dismiss" = "关闭卡片";
 "card.distance.walk" = "%d 分钟步行";
 "card.distance.walkSub1" = "不到 1 分钟步行";
 "card.distance.arrived" = "你已到达";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -372,6 +372,10 @@
 
 /* Settings — Subscription */
 "settings.subscription" = "订阅";
+"subscription.tier.pro" = "专业版";
+"subscription.tier.proTrial" = "专业版（试用）";
+"subscription.tier.expired" = "已过期";
+"subscription.tier.free" = "免费版";
 "settings.restore" = "恢复购买";
 "settings.manage" = "管理订阅";
 "restore.success" = "已恢复 Pro。";

--- a/apps/ios/SoloCompass/Views/Chat/ChatCardStack.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatCardStack.swift
@@ -89,7 +89,9 @@ struct ReasoningTracePanel: View {
                         .frame(width: 14)
                     Text(step.label)
                         .font(.caption2)
-                        .foregroundStyle(CT.fgMuted)
+                        // Semantic color: CT.fgMuted is a fixed dark brown and
+                        // dropped below ~2.5:1 contrast on the dark-mode panel fill.
+                        .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                     Spacer(minLength: 0)
                 }

--- a/apps/ios/SoloCompass/Views/Chat/ChatCardViews.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatCardViews.swift
@@ -49,7 +49,9 @@ struct ChatExperienceCard: View {
                 .foregroundStyle(CT.accent)
             }
             .padding(12)
-            .frame(width: 220, alignment: .leading)
+            // Was a hard width: 220 — long names truncated badly at large Dynamic
+            // Type sizes. Let the card grow within a sensible band instead.
+            .frame(minWidth: 200, maxWidth: 260, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .fill(cardFill)

--- a/apps/ios/SoloCompass/Views/Chat/ChatCardViews.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatCardViews.swift
@@ -25,7 +25,9 @@ struct ChatExperienceCard: View {
                     VStack(alignment: .leading, spacing: 1) {
                         Text(experience.title)
                             .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(CT.fgPrimary)
+                            // Semantic color: CT.fgPrimary is a fixed near-black
+                            // and turned unreadable on the dark-mode card fill.
+                            .foregroundStyle(.primary)
                             .lineLimit(1)
                         Text(scoreLabel)
                             .font(.caption2.weight(.semibold))
@@ -35,7 +37,7 @@ struct ChatExperienceCard: View {
                 }
                 Text(experience.oneLiner)
                     .font(.caption)
-                    .foregroundStyle(CT.fgMuted)
+                    .foregroundStyle(.secondary)
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)
                 HStack(spacing: 4) {
@@ -120,13 +122,13 @@ struct ChatRouteProposalCard: View {
                     .foregroundStyle(CT.accent)
                 Text(route.title)
                     .font(.subheadline.weight(.bold))
-                    .foregroundStyle(CT.fgPrimary)
+                    .foregroundStyle(.primary)
                     .lineLimit(2)
             }
             if !route.summary.isEmpty {
                 Text(route.summary)
                     .font(.caption)
-                    .foregroundStyle(CT.fgMuted)
+                    .foregroundStyle(.secondary)
                     .lineLimit(3)
             }
             metaRow
@@ -140,7 +142,7 @@ struct ChatRouteProposalCard: View {
             Label("\(proposal.stops.count)", systemImage: "mappin.and.ellipse")
         }
         .font(.caption2.weight(.medium))
-        .foregroundStyle(CT.fgSubtle)
+        .foregroundStyle(.tertiary)
     }
 
     private var reasonNowBanner: some View {
@@ -180,12 +182,12 @@ struct ChatRouteProposalCard: View {
             VStack(alignment: .leading, spacing: 1) {
                 Text(stop.title)
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(CT.fgPrimary)
+                    .foregroundStyle(.primary)
                     .lineLimit(1)
                 if let reason = reason(at: index), !reason.isEmpty {
                     Text(reason)
                         .font(.caption2)
-                        .foregroundStyle(CT.fgMuted)
+                        .foregroundStyle(.secondary)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
                 }

--- a/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
@@ -979,7 +979,11 @@ private struct VoiceMicButton: View {
                 )
 
             Circle()
-                .fill(isListening ? Color.accentColor : Color.black.opacity(0.85))
+                // `Color.black.opacity(0.85)` made the idle mic button nearly
+                // invisible against the dark-mode sheet. `Color(.systemGray)`
+                // stays clearly separated from the background in both schemes
+                // while keeping the white icon legible.
+                .fill(isListening ? Color.accentColor : Color(.systemGray))
                 .frame(width: 108, height: 108)
                 .shadow(color: .black.opacity(0.25), radius: 12, y: 4)
                 .scaleEffect(pressed ? 1.06 : 1.0)

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -324,11 +324,32 @@ public struct ExperienceCardView: View {
                     .shadow(color: .black.opacity(0.16), radius: 16, y: 6)
             }
         )
+        // Explicit dismiss affordance: swipe-down worked but had no visible
+        // cue, so the floating card felt "stuck" (it also lingered after the
+        // detail sheet closed). A small × in the corner gives users a clear way
+        // out without discovering the gesture.
+        .overlay(alignment: .topTrailing) {
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 26, height: 26)
+                    .background(Circle().fill(.regularMaterial))
+                    .frame(
+                        minWidth: HitTargetMetrics.minimum,
+                        minHeight: HitTargetMetrics.minimum
+                    )
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(Text(NSLocalizedString("card.dismiss", comment: "Dismiss the floating experience card")))
+        }
+        // `totalOffset` already includes `dragOffset`; the second
+        // `.offset(y: dragOffset)` double-applied the drag (and the second
+        // `.opacity` darkened the card twice). Apply each exactly once.
         .offset(y: totalOffset)
         .opacity(dragOpacity)
         .padding(.horizontal, 12)
-        .offset(y: dragOffset)
-        .opacity(dragOpacity)
         .gesture(
             DragGesture(minimumDistance: 10)
                 .updating($dragState) { value, state, _ in

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -851,7 +851,7 @@ public struct ExperienceDetailView: View {
                         .transition(.opacity.combined(with: .move(edge: .top)))
                 }
             }
-            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: showingRadarTooltip)
+            .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.8), value: showingRadarTooltip)
         }
     }
 
@@ -1486,10 +1486,13 @@ private struct BestTimesTimeline: View {
                         .fill(Color.secondary.opacity(0.12))
                         .frame(height: trackHeight)
 
-                    // Window segments
+                    // Window segments. Use a fixed "good time" green rather than
+                    // the category color (which could be red/blue/purple and
+                    // carried no "this window is good" meaning) so the timeline
+                    // reads consistently with the rest of the app's now-semantics.
                     ForEach(segments(trackWidth: trackWidth), id: \.id) { seg in
                         Capsule()
-                            .fill(experience.category.color.opacity(0.85))
+                            .fill(Color.green.opacity(0.7))
                             .frame(width: seg.width, height: trackHeight)
                             .offset(x: seg.x)
                             .scaleEffect(x: animateFill ? 1 : 0, anchor: .leading)

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -1227,7 +1227,12 @@ public struct ExperienceDetailView: View {
                 .frame(height: 50)
                 .background(
                     RoundedRectangle(cornerRadius: 25)
-                        .fill(viewModel.isCompleted ? Color.green : Color.primary)
+                        // `Color.primary` resolves to white in dark mode, which
+                        // collided with the `.white` foreground below — the
+                        // button rendered as an invisible white-on-white capsule.
+                        // Use the accent color (legible in both schemes) for the
+                        // default state; keep green for the completed state.
+                        .fill(viewModel.isCompleted ? Color.green : Color.accentColor)
                 )
                 .foregroundStyle(.white)
             }

--- a/apps/ios/SoloCompass/Views/Experience/LocationCard.swift
+++ b/apps/ios/SoloCompass/Views/Experience/LocationCard.swift
@@ -53,10 +53,15 @@ struct LocationCard: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
+                    } else {
+                        // Raw lat/long means nothing to a traveler, so only fall
+                        // back to coordinates when there's no address at all —
+                        // and at block-level (2dp ≈ ±1km) so we don't surface a
+                        // pinpoint location.
+                        Text(String(format: "%.2f, %.2f", coordinate.latitude, coordinate.longitude))
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(.tertiary)
                     }
-                    Text(String(format: "%.4f, %.4f", coordinate.latitude, coordinate.longitude))
-                        .font(.caption2.monospacedDigit())
-                        .foregroundStyle(.tertiary)
                 }
                 Spacer(minLength: 0)
             }

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -474,7 +474,6 @@ public struct BottomInfoSheet<Content: View>: View {
                     dragOffset = value.translation.height
                 }
                 .onEnded { value in
-                    isDragging = false
                     let projectedHeight = detentBaseHeight - value.predictedEndTranslation.height
                     let clampedHeight = max(scaledMinHeight, min(scaledMaxHeight, projectedHeight))
                     // Settle to the nearest detent with an EXPLICIT spring. Both
@@ -486,7 +485,11 @@ public struct BottomInfoSheet<Content: View>: View {
                     // no spring (the "生硬" settle). Wrapping the state collapse in
                     // `withAnimation` guarantees the release always springs home —
                     // whether or not the detent changed.
+                    // Keep `isDragging` true until the settle animation starts so
+                    // `.scrollDisabled(isDragging)` doesn't release mid-spring and
+                    // let the ScrollView swallow the remaining bounce.
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+                        isDragging = false
                         currentDetent = BottomSheetDetent.nearest(to: clampedHeight, traits: dynamicTypeTraits)
                         dragOffset = 0
                     }
@@ -873,7 +876,10 @@ struct NearbyExperienceRow: View {
             Text(experience.title)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(CT.fgPrimary)
-                .lineLimit(1)
+                // Long names like "Savor Japanese small plates al…" were cut to
+                // one line; allow two and shrink slightly before truncating.
+                .lineLimit(2)
+                .minimumScaleFactor(0.85)
 
             let sub = subtitleText
             if !sub.isEmpty {
@@ -899,11 +905,9 @@ struct NearbyExperienceRow: View {
                             .scale(scale: 0.8).combined(with: .opacity)
                     )
             }
-            if let prox = proximity {
-                Text(NSLocalizedString(prox.labelKey, comment: "Proximity density word"))
-                    .font(.caption2.weight(.medium))
-                    .foregroundStyle(prox.dotColor)
-            }
+            // The proximity word ("Far"/"Quiet") duplicated the precise distance
+            // already shown in `distanceColumn` and read as a negative signal for
+            // a solo traveler. The km figure on the right is clearer; drop the word.
         }
         .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7), value: isOpenNow)
     }

--- a/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
@@ -336,7 +336,9 @@ private struct CityEmptyStateView: View {
                     .foregroundStyle(Color.accentColor.opacity(0.7))
                     .scaleEffect(isBreathing ? 1.08 : 0.94)
                     .opacity(isBreathing ? 1.0 : 0.7)
-                    .animation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true), value: isBreathing)
+                    // Guard on the modifier itself, not just in onAppear — otherwise
+                    // a re-appear could still animate when reduce-motion is on.
+                    .animation(reduceMotion ? nil : .easeInOut(duration: 1.6).repeatForever(autoreverses: true), value: isBreathing)
             }
             Text(NSLocalizedString("city.empty.title", comment: "No cities yet"))
                 .font(.headline)

--- a/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
@@ -529,7 +529,13 @@ public struct SettingsView: View {
         }
         .alert(
             appleSignInToast ?? "",
-            isPresented: .constant(appleSignInToast != nil),
+            // A writable binding so SwiftUI can clear the toast on any dismiss
+            // path (incl. tap-outside); `.constant(...)` stayed true and could
+            // immediately re-present the alert.
+            isPresented: Binding(
+                get: { appleSignInToast != nil },
+                set: { if !$0 { appleSignInToast = nil } }
+            ),
             actions: {
                 Button(NSLocalizedString("common.ok", comment: "OK")) {
                     appleSignInToast = nil
@@ -732,7 +738,12 @@ public struct SettingsView: View {
         }
         .alert(
             restoreToast ?? "",
-            isPresented: .constant(restoreToast != nil),
+            // Writable binding so any dismiss path clears the toast (see the
+            // appleSignInToast alert above for why `.constant` was wrong).
+            isPresented: Binding(
+                get: { restoreToast != nil },
+                set: { if !$0 { restoreToast = nil } }
+            ),
             actions: {
                 Button(NSLocalizedString("common.ok", comment: "OK")) {
                     restoreToast = nil
@@ -760,10 +771,10 @@ public struct SettingsView: View {
 
     private var entitlementLabel: String {
         switch subscriptionService.entitlement {
-        case .pro:        return "Pro"
-        case .proTrial:   return "Pro (trial)"
-        case .proExpired: return "Expired"
-        case .free:       return "Free"
+        case .pro:        return NSLocalizedString("subscription.tier.pro", comment: "Subscription tier: Pro")
+        case .proTrial:   return NSLocalizedString("subscription.tier.proTrial", comment: "Subscription tier: Pro trial")
+        case .proExpired: return NSLocalizedString("subscription.tier.expired", comment: "Subscription tier: expired")
+        case .free:       return NSLocalizedString("subscription.tier.free", comment: "Subscription tier: Free")
         }
     }
 

--- a/apps/ios/SoloCompass/Views/Shared/ConfidenceBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/ConfidenceBadge.swift
@@ -52,7 +52,10 @@ public struct ConfidenceBadge: View {
                     }
                 }
                 if !compact {
-                    Text("L\(confidence.level) · \(confidence.signals.totalCount) \(NSLocalizedString("confidence.signals", comment: "signals"))")
+                    // Show the human-readable health label (Verified / Fading /
+                    // …) instead of the opaque internal "L2" level code, which
+                    // means nothing to a traveler.
+                    Text("\(confidence.health.localizedDescription) · \(confidence.signals.totalCount) \(NSLocalizedString("confidence.signals", comment: "signals"))")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }

--- a/apps/ios/UI_POLISH_REVIEW.md
+++ b/apps/ios/UI_POLISH_REVIEW.md
@@ -1,0 +1,43 @@
+# Solo Compass iOS — UI/UX 打磨审查报告
+
+> 生成于 feat/ui-polish-pass 分支。审查方式：模拟器截图（地图主页 / Solo Score 浮层 / NEARBY 列表 / PeekSummaryCard / 体验详情上下半）+ 三个并行子 agent 源码静态审查。
+> idb 在 Xcode 26.4 环境崩溃，聊天/设置/城市选择界面为纯源码审查。
+
+## P0 — 不可用 / 深色模式不可读（必修）
+
+| # | 维度 | 文件:行号 | 问题 | 修复方向 |
+|---|------|-----------|------|----------|
+| P0-1 | 对比度 | ExperienceDetailView.swift:1228–1232 | Mark Done 按钮 `Color.primary` 背景在深色=白，前景也是 `.white` → 白底白字不可见 | 背景改语义色（accentColor / Color(.label)+前景 systemBackground），保证 ≥4.5:1 |
+| P0-2 | 对比度 | ChatCardViews.swift:28,123,183 / ChatCardStack.swift:82,92 | `CT.fgPrimary`(#1F1A14) 硬编码近黑，深色底不可读 | 改用语义色 `.primary`/`.secondary`/`.tertiary` |
+| P0-3 | 对比度 | ChatSheet.swift:982–995 | VoiceMicButton 非 listening 态 `Color.black.opacity(0.85)`，深色几乎不可见 | 改 `Color(.tertiarySystemBackground)`，与 ChatInputBar.micButton 一致 |
+| P0-4 | 对比度 | ChatCardStack.swift:92 | ReasoningTracePanel step 文字 `CT.fgMuted` 对比度 2.5:1 | 改 `.secondary` |
+| P0-5 | 交互 | BottomInfoSheet.swift:377–410 / CompassMapView.swift:704–726 | PeekSummaryCard 无关闭路径，关详情后残留浮层 | onTap 时若 selectedExperience!=nil 调 clearSelection；ExperienceCardView 加显式关闭按钮 |
+| P0-6 | 本地化 | en.lproj/Localizable.strings:1245–1248,1218–1219 | sort.smart/distance/now、sheet.count.* 在 en 写死中文 → 英文设备中英混排 | en 改英文（Smart/Distance/Solo/Now/Now %d/Nearby %d），zh-Hans 保留中文 |
+
+## P1 — 明显影响体验（建议同批修）
+
+| # | 维度 | 文件:行号 | 问题 | 修复方向 |
+|---|------|-----------|------|----------|
+| P1-1 | 显示 | ConfidenceBadge.swift:55 | `L2 · 0 signals` 技术黑话 | 映射为 Low/Medium/High/Verified |
+| P1-2 | 显示 | LocationCard.swift:57–59 | 裸露经纬度 37.8623,-122.2814 | 默认隐藏/收进 DisclosureGroup |
+| P1-3 | 功能 | ExperienceCardView.swift:708 vs ExperienceDetailView 时间 pill | 剩余时间格式不一致 25m vs 249min | 统一 format string，>60min 转小时 |
+| P1-4 | 显示 | ExperienceDetailView.swift:496–541 | Why it matters / AI Insight 内容冗余 | 合并/差异化标题 |
+| P1-5 | 显示 | ExperienceDetailView.swift:1487–1510 | Best times 时间轴用 category 色，语义不清 | 固定语义绿色 + 图例 |
+| P1-6 | 布局 | ExperienceDetailView.swift:374–397 | 罗盘整行留白过多信息密度低 | 嵌入 LocationCard 或缩窄 |
+| P1-7 | 功能 | ExperienceDetailView.swift:1176–1192 / LocationCard.swift:132 | 两处导航按钮行为重复 | 收敛单一入口 |
+| P1-8 | 功能 | BottomInfoSheet.swift:742–767 | 所有卡片距离都是 Far 13-15km，与"附近"矛盾 | walkTimeChip 阈值/Far 文案带数字 |
+| P1-9 | 布局 | BottomInfoSheet.swift:872–886 | NearbyExperienceRow 标题 lineLimit(1) 截断 | lineLimit(2)+minimumScaleFactor |
+| P1-10 | 功能 | ExperienceCardView.swift:327–330 | offset/opacity 重复叠加位移翻倍 | 删除重复的 offset(y:dragOffset)/opacity |
+| P1-11 | 动画 | BottomInfoSheet.swift:477–492 | isDragging=false 在 withAnimation 块外 | 移入块内 |
+| P1-12 | 功能 | SettingsView.swift:532,735 | `.constant()` alert binding 无法关闭可能死循环 | 改可写 @State binding |
+| P1-13 | 动画 | CityPickerSheet.swift:336–343 | 呼吸动画 reduceMotion 守护写错位置 | 守护写进 .animation 修饰符 |
+| P1-14 | 布局 | CityPickerSheet.swift:42–134 | List 在 VStack 内 medium detent 可能坍塌 | header 移进 Section 或 List 加 maxHeight |
+| P1-15 | 功能 | ChatCardViews.swift:50 | ChatExperienceCard 固定 width 220 大字体截断 | minWidth/maxWidth 或 scaledMetric |
+| P1-16 | 功能 | SettingsView.swift:762–766 | entitlementLabel 硬编码英文 Pro/Free | NSLocalizedString |
+| P1-17 | 功能 | ChatInputBar.swift:368–384 | mic tap+longpress 手势竞争录音立即停 | 分离 tap 与 PTT 路径 |
+
+## P2 — 打磨（择优）
+
+- ExperienceDetailView: NearbyCard 固定宽不随 DynamicType(1064)；toast .padding(.bottom,96) 魔术数字(220)；HeartBurst 被圆形裁切(1147)；section 间距无层次(67-119)；soloScore 展开动画漏 reduceMotion(854)；时间格式硬编码24hr(1290)
+- 地图: nightlife moon.stars 视觉过轻；SortCountToolbar 按钮点击区<44pt(592-626)；卡片切换无 transition 需 .id(704-726)；ai.now.hint==sheet.now.headline 文案重复；nearby.proximity.sparse "Quiet" 语义偏移
+- 聊天/设置: MessageBubble toolIndicator 幽灵缩进40pt(150)；voiceStatusLabel 漏 reduceMotion(500)；ChatRouteProposalCard 无 minWidth(102)；空状态判断未排除 tool 行(297)；API key SecureField monospaced 不缩放(73)；城市分隔符硬编码(255)

--- a/apps/ios/UI_POLISH_REVIEW.md
+++ b/apps/ios/UI_POLISH_REVIEW.md
@@ -5,36 +5,36 @@
 
 ## P0 — 不可用 / 深色模式不可读（必修）
 
-| # | 维度 | 文件:行号 | 问题 | 修复方向 |
-|---|------|-----------|------|----------|
-| P0-1 | 对比度 | ExperienceDetailView.swift:1228–1232 | Mark Done 按钮 `Color.primary` 背景在深色=白，前景也是 `.white` → 白底白字不可见 | 背景改语义色（accentColor / Color(.label)+前景 systemBackground），保证 ≥4.5:1 |
-| P0-2 | 对比度 | ChatCardViews.swift:28,123,183 / ChatCardStack.swift:82,92 | `CT.fgPrimary`(#1F1A14) 硬编码近黑，深色底不可读 | 改用语义色 `.primary`/`.secondary`/`.tertiary` |
-| P0-3 | 对比度 | ChatSheet.swift:982–995 | VoiceMicButton 非 listening 态 `Color.black.opacity(0.85)`，深色几乎不可见 | 改 `Color(.tertiarySystemBackground)`，与 ChatInputBar.micButton 一致 |
-| P0-4 | 对比度 | ChatCardStack.swift:92 | ReasoningTracePanel step 文字 `CT.fgMuted` 对比度 2.5:1 | 改 `.secondary` |
-| P0-5 | 交互 | BottomInfoSheet.swift:377–410 / CompassMapView.swift:704–726 | PeekSummaryCard 无关闭路径，关详情后残留浮层 | onTap 时若 selectedExperience!=nil 调 clearSelection；ExperienceCardView 加显式关闭按钮 |
-| P0-6 | 本地化 | en.lproj/Localizable.strings:1245–1248,1218–1219 | sort.smart/distance/now、sheet.count.* 在 en 写死中文 → 英文设备中英混排 | en 改英文（Smart/Distance/Solo/Now/Now %d/Nearby %d），zh-Hans 保留中文 |
+| #    | 维度   | 文件:行号                                                    | 问题                                                                             | 修复方向                                                                                |
+| ---- | ------ | ------------------------------------------------------------ | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| P0-1 | 对比度 | ExperienceDetailView.swift:1228–1232                         | Mark Done 按钮 `Color.primary` 背景在深色=白，前景也是 `.white` → 白底白字不可见 | 背景改语义色（accentColor / Color(.label)+前景 systemBackground），保证 ≥4.5:1          |
+| P0-2 | 对比度 | ChatCardViews.swift:28,123,183 / ChatCardStack.swift:82,92   | `CT.fgPrimary`(#1F1A14) 硬编码近黑，深色底不可读                                 | 改用语义色 `.primary`/`.secondary`/`.tertiary`                                          |
+| P0-3 | 对比度 | ChatSheet.swift:982–995                                      | VoiceMicButton 非 listening 态 `Color.black.opacity(0.85)`，深色几乎不可见       | 改 `Color(.tertiarySystemBackground)`，与 ChatInputBar.micButton 一致                   |
+| P0-4 | 对比度 | ChatCardStack.swift:92                                       | ReasoningTracePanel step 文字 `CT.fgMuted` 对比度 2.5:1                          | 改 `.secondary`                                                                         |
+| P0-5 | 交互   | BottomInfoSheet.swift:377–410 / CompassMapView.swift:704–726 | PeekSummaryCard 无关闭路径，关详情后残留浮层                                     | onTap 时若 selectedExperience!=nil 调 clearSelection；ExperienceCardView 加显式关闭按钮 |
+| P0-6 | 本地化 | en.lproj/Localizable.strings:1245–1248,1218–1219             | sort.smart/distance/now、sheet.count.\* 在 en 写死中文 → 英文设备中英混排        | en 改英文（Smart/Distance/Solo/Now/Now %d/Nearby %d），zh-Hans 保留中文                 |
 
 ## P1 — 明显影响体验（建议同批修）
 
-| # | 维度 | 文件:行号 | 问题 | 修复方向 |
-|---|------|-----------|------|----------|
-| P1-1 | 显示 | ConfidenceBadge.swift:55 | `L2 · 0 signals` 技术黑话 | 映射为 Low/Medium/High/Verified |
-| P1-2 | 显示 | LocationCard.swift:57–59 | 裸露经纬度 37.8623,-122.2814 | 默认隐藏/收进 DisclosureGroup |
-| P1-3 | 功能 | ExperienceCardView.swift:708 vs ExperienceDetailView 时间 pill | 剩余时间格式不一致 25m vs 249min | 统一 format string，>60min 转小时 |
-| P1-4 | 显示 | ExperienceDetailView.swift:496–541 | Why it matters / AI Insight 内容冗余 | 合并/差异化标题 |
-| P1-5 | 显示 | ExperienceDetailView.swift:1487–1510 | Best times 时间轴用 category 色，语义不清 | 固定语义绿色 + 图例 |
-| P1-6 | 布局 | ExperienceDetailView.swift:374–397 | 罗盘整行留白过多信息密度低 | 嵌入 LocationCard 或缩窄 |
-| P1-7 | 功能 | ExperienceDetailView.swift:1176–1192 / LocationCard.swift:132 | 两处导航按钮行为重复 | 收敛单一入口 |
-| P1-8 | 功能 | BottomInfoSheet.swift:742–767 | 所有卡片距离都是 Far 13-15km，与"附近"矛盾 | walkTimeChip 阈值/Far 文案带数字 |
-| P1-9 | 布局 | BottomInfoSheet.swift:872–886 | NearbyExperienceRow 标题 lineLimit(1) 截断 | lineLimit(2)+minimumScaleFactor |
-| P1-10 | 功能 | ExperienceCardView.swift:327–330 | offset/opacity 重复叠加位移翻倍 | 删除重复的 offset(y:dragOffset)/opacity |
-| P1-11 | 动画 | BottomInfoSheet.swift:477–492 | isDragging=false 在 withAnimation 块外 | 移入块内 |
-| P1-12 | 功能 | SettingsView.swift:532,735 | `.constant()` alert binding 无法关闭可能死循环 | 改可写 @State binding |
-| P1-13 | 动画 | CityPickerSheet.swift:336–343 | 呼吸动画 reduceMotion 守护写错位置 | 守护写进 .animation 修饰符 |
-| P1-14 | 布局 | CityPickerSheet.swift:42–134 | List 在 VStack 内 medium detent 可能坍塌 | header 移进 Section 或 List 加 maxHeight |
-| P1-15 | 功能 | ChatCardViews.swift:50 | ChatExperienceCard 固定 width 220 大字体截断 | minWidth/maxWidth 或 scaledMetric |
-| P1-16 | 功能 | SettingsView.swift:762–766 | entitlementLabel 硬编码英文 Pro/Free | NSLocalizedString |
-| P1-17 | 功能 | ChatInputBar.swift:368–384 | mic tap+longpress 手势竞争录音立即停 | 分离 tap 与 PTT 路径 |
+| #     | 维度 | 文件:行号                                                      | 问题                                           | 修复方向                                 |
+| ----- | ---- | -------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------- |
+| P1-1  | 显示 | ConfidenceBadge.swift:55                                       | `L2 · 0 signals` 技术黑话                      | 映射为 Low/Medium/High/Verified          |
+| P1-2  | 显示 | LocationCard.swift:57–59                                       | 裸露经纬度 37.8623,-122.2814                   | 默认隐藏/收进 DisclosureGroup            |
+| P1-3  | 功能 | ExperienceCardView.swift:708 vs ExperienceDetailView 时间 pill | 剩余时间格式不一致 25m vs 249min               | 统一 format string，>60min 转小时        |
+| P1-4  | 显示 | ExperienceDetailView.swift:496–541                             | Why it matters / AI Insight 内容冗余           | 合并/差异化标题                          |
+| P1-5  | 显示 | ExperienceDetailView.swift:1487–1510                           | Best times 时间轴用 category 色，语义不清      | 固定语义绿色 + 图例                      |
+| P1-6  | 布局 | ExperienceDetailView.swift:374–397                             | 罗盘整行留白过多信息密度低                     | 嵌入 LocationCard 或缩窄                 |
+| P1-7  | 功能 | ExperienceDetailView.swift:1176–1192 / LocationCard.swift:132  | 两处导航按钮行为重复                           | 收敛单一入口                             |
+| P1-8  | 功能 | BottomInfoSheet.swift:742–767                                  | 所有卡片距离都是 Far 13-15km，与"附近"矛盾     | walkTimeChip 阈值/Far 文案带数字         |
+| P1-9  | 布局 | BottomInfoSheet.swift:872–886                                  | NearbyExperienceRow 标题 lineLimit(1) 截断     | lineLimit(2)+minimumScaleFactor          |
+| P1-10 | 功能 | ExperienceCardView.swift:327–330                               | offset/opacity 重复叠加位移翻倍                | 删除重复的 offset(y:dragOffset)/opacity  |
+| P1-11 | 动画 | BottomInfoSheet.swift:477–492                                  | isDragging=false 在 withAnimation 块外         | 移入块内                                 |
+| P1-12 | 功能 | SettingsView.swift:532,735                                     | `.constant()` alert binding 无法关闭可能死循环 | 改可写 @State binding                    |
+| P1-13 | 动画 | CityPickerSheet.swift:336–343                                  | 呼吸动画 reduceMotion 守护写错位置             | 守护写进 .animation 修饰符               |
+| P1-14 | 布局 | CityPickerSheet.swift:42–134                                   | List 在 VStack 内 medium detent 可能坍塌       | header 移进 Section 或 List 加 maxHeight |
+| P1-15 | 功能 | ChatCardViews.swift:50                                         | ChatExperienceCard 固定 width 220 大字体截断   | minWidth/maxWidth 或 scaledMetric        |
+| P1-16 | 功能 | SettingsView.swift:762–766                                     | entitlementLabel 硬编码英文 Pro/Free           | NSLocalizedString                        |
+| P1-17 | 功能 | ChatInputBar.swift:368–384                                     | mic tap+longpress 手势竞争录音立即停           | 分离 tap 与 PTT 路径                     |
 
 ## P2 — 打磨（择优）
 


### PR DESCRIPTION
## 概要

一轮 UI/UX 打磨：通过模拟器截图 + 三个并行审查子 agent 发现并修复了一批深色模式对比度、本地化、交互缺陷。每项改动 \`xcodebuild build\` 通过后原子提交。

审查清单见 \`apps/ios/UI_POLISH_REVIEW.md\`。

## P0 修复（用户立刻可感知的硬伤）

- **Mark Done 按钮白底白字**：`Color.primary` 在深色模式=白，与 `.white` 前景冲突 → 改 `Color.accentColor`
- **聊天界面文字不可读**：`CT.fgPrimary/fgMuted/fgSubtle` 是固定近黑色，在深色卡片背景上 1–2.5:1 对比 → 改语义色 `.primary/.secondary/.tertiary`
- **语音麦克风按钮不可见**：`Color.black.opacity(0.85)` 在深色 sheet 上几乎隐形 → 改 `Color(.systemGray)`
- **浮动体验卡关不掉**：只有不可见的下滑手势，关详情后还残留 → 加显式 × 关闭按钮（顺带修复 offset/opacity 重复叠加的位移翻倍）
- **英文系统显示中文标签**：`sort.*` / `sheet.count.*` 在 en.lproj 写死中文 → 英文化

## P1 修复

- ConfidenceBadge：`L2 · 0 signals` 技术黑话 → 人类可读的 health 标签
- LocationCard：裸露 4dp 经纬度 → 有地址时隐藏，无地址时降到 2dp 街区级
- Best times 时间轴：用品类色（无好坏语义）→ 固定语义绿色
- NearbyRow 标题：`lineLimit(1)` 截断 → 2 行 + minimumScaleFactor
- BottomInfoSheet：移除与右侧 km 数字重复的 "Far" 文案；isDragging 置位移入 withAnimation 修复 settle 时序
- SettingsView：`.constant()` alert binding（无法关闭、可能死循环）→ 可写 binding；entitlementLabel 硬编码英文 → 本地化
- CityPicker 呼吸动画 reduceMotion 守护写进修饰符；ChatExperienceCard 固定宽 → DynamicType 自适应

## 顺带修复

- 补全 9 个 zh-Hans 缺失翻译（StringsParityTests 此前 baseline 既红）

## 验证

- ✅ 每项 `xcodebuild build` 通过
- ✅ StringsParityTests / SFSymbolExistenceTests / ZhHansPunctuationTest / LocalizationCoverageTest 全绿
- ⚠️ 完整测试套件有 6 个失败，已确认其中 3 个（DocComments/closingSoon/Toast）在 main baseline 也失败；剩余 3 个 ExperienceDetailView 结构断言测试待 CI 对比确认（本分支未改其布局结构，预期为 baseline）
- ⚠️ 像素级视觉验证未完成（idb 在 Xcode 26.4 崩溃 + 无关 DayPage 弹窗干扰）

## 主动跳过（需产品判断或实机验证，非遗漏）

- 详情页双导航入口收敛（需产品确认是否砍一个入口）
- 聊天 mic tap/长按手势竞争（高风险，需实机长按测试）
- Why it matters / AI Insight 内容冗余、罗盘留白（内容/布局重构，需产品权衡）