### PR TITLE
feat(ios): tap card opens detail, long-press floats preview

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		045740DB5060EBE8D6D2EEA0 /* PendingCheckInBannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26F2087E12E63A73B812D7E /* PendingCheckInBannerTests.swift */; };
 		066FE809A43C937B7EFA7609 /* VoiceToastA11yTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A3AF5B9538F583142315C2 /* VoiceToastA11yTests.swift */; };
 		0A830B26D4A18948D16F3A42 /* Experience.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C97F8159A6FA7953D28DAB /* Experience.swift */; };
+		0A9FB49B7459777E59EDA55A /* LongPressCardModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA7F7C7168AB78E23C3AB0 /* LongPressCardModifier.swift */; };
 		0B7CC2BD1359B8AB3E4A590D /* HapticServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4609B3C2E77F98A59871C26E /* HapticServiceTests.swift */; };
 		0C0580E1BF61F5C02C2EE640 /* BottomSheetUnifiedScrollGuardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E41DCA29798B5D8E49B7CA /* BottomSheetUnifiedScrollGuardTest.swift */; };
 		0DE8ECCE242F2FDFFD69C199 /* VoiceInterruptionToastTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E7AFBAAF6E42AE8043F476D /* VoiceInterruptionToastTest.swift */; };
@@ -592,6 +593,7 @@
 		A98E594C5575B41E32382209 /* MyRequestsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRequestsListView.swift; sourceTree = "<group>"; };
 		AA17ED8FE9ABA2F5CC1D557E /* FavoriteFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteFilterTests.swift; sourceTree = "<group>"; };
 		AA96BC45388A8EC99F3B29ED /* ChatAttachmentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentService.swift; sourceTree = "<group>"; };
+		AAAA7F7C7168AB78E23C3AB0 /* LongPressCardModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongPressCardModifier.swift; sourceTree = "<group>"; };
 		AB46D6F6F8942CD390A5CCF4 /* SoloCompass.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SoloCompass.entitlements; sourceTree = "<group>"; };
 		AF007DB5F72E30021CADA555 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		B14FE2118ED82DD0593F5C3C /* StringsParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringsParityTests.swift; sourceTree = "<group>"; };
@@ -726,6 +728,7 @@
 				5933575E731D8AC09356AB9F /* GlassmorphismCapsule.swift */,
 				295A9108AFAF3BEE4EFF7524 /* HeartBurstView.swift */,
 				D22A9156A8CA2E798375C5C9 /* HitTargetMetrics.swift */,
+				AAAA7F7C7168AB78E23C3AB0 /* LongPressCardModifier.swift */,
 				5C62D0EFA5859698D9C70B7D /* OfflineBanner.swift */,
 				130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */,
 				A744E7B767BDEC07E9C58F4D /* PressableButtonStyle.swift */,
@@ -1660,6 +1663,7 @@
 				3C5AB28556912D115AEC4AEC /* LocationPickerState.swift in Sources */,
 				DF438C3AEBB3163AA522BAC1 /* LocationSearchService.swift in Sources */,
 				31F9538643C362D7EEF64C6B /* LocationService.swift in Sources */,
+				0A9FB49B7459777E59EDA55A /* LongPressCardModifier.swift in Sources */,
 				A75EEA586481D5A86B7FCFDA /* MapKitPOIService.swift in Sources */,
 				AF89A5DAA5BE9C3FC9DF1675 /* MapPinPickerView.swift in Sources */,
 				CE1A6A1D5EB25B2BEA5B29DA /* MapViewModel.swift in Sources */,

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -294,6 +294,7 @@
 
 /* Experience card accessibility */
 "experience.card.hint" = "Double tap to view details";
+"experience.card.preview.a11y" = "Show quick preview";
 "card.favorite.add" = "Add to favorites";
 "card.favorite.remove" = "Remove from favorites";
 "card.dismiss" = "Dismiss card";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -188,6 +188,7 @@
 
 /* Experience card accessibility */
 "experience.card.hint" = "双击查看详情";
+"experience.card.preview.a11y" = "显示快速预览";
 
 /* Voice recognition error alert */
 "voice.error.title" = "语音识别错误";

--- a/apps/ios/SoloCompass/Tests/PreviewCardLifecycleTests.swift
+++ b/apps/ios/SoloCompass/Tests/PreviewCardLifecycleTests.swift
@@ -7,20 +7,21 @@ import XCTest
 ///
 ///     selectedExperience != nil && !isShowingDetail
 ///
-/// Unified-preview model (all entry points behave the same):
-///   • selecting an experience (map pin, Nearby row, favorites) floats the
-///     preview card — it does NOT jump straight to detail;
-///   • the card's expand action opens the detail sheet (isShowingDetail = true);
+/// Tap-vs-long-press model (all card/pin entry points behave the same):
+///   • TAP a card/pin (`openExperienceDetail`) jumps straight to the detail
+///     sheet — `selectedExperience` is set AND `isShowingDetail = true`;
+///   • LONG-PRESS a card/pin (`selectExperience`) floats the quick preview card
+///     instead — it does NOT open detail;
+///   • the preview card's expand action opens the detail sheet
+///     (isShowingDetail = true);
 ///   • backing out of detail (dismissDetail) FALLS BACK to the preview card —
 ///     selection is retained, because detail is a layer above the preview;
 ///   • the card's own dismiss (clearSelection) is the only thing that returns
 ///     to the bare map.
 ///
-/// Regression guard for the "退出详情后悬窗残留" report: the original surprise
-/// was that a list row skipped the card on the way in but the card popped up on
-/// the way out. Now the card is consistently present on both legs, so the
-/// return is expected rather than jarring — and `clearSelection` gives a clean
-/// exit.
+/// Regression guard for the "退出详情后悬窗残留" report: backing out of detail
+/// lands on the preview card (selection retained), and `clearSelection` gives a
+/// clean exit to the bare map.
 @MainActor
 final class PreviewCardLifecycleTests: XCTestCase {
 
@@ -43,18 +44,46 @@ final class PreviewCardLifecycleTests: XCTestCase {
         try XCTUnwrap(vm.visibleExperiences.first, "seed expected ≥1 experience")
     }
 
-    // MARK: - Unified entry: selecting floats the card, never auto-opens detail
+    // MARK: - Long-press path: selectExperience floats the card, never opens detail
 
     func testSelectExperienceFloatsCardWithoutOpeningDetail() throws {
         let vm = makeViewModel()
         let exp = try firstExperience(vm)
 
-        vm.selectExperience(exp)
+        vm.selectExperience(exp)             // long-press path
         XCTAssertTrue(cardIsFloating(vm),
-                      "selecting an experience must float the preview card")
+                      "long-pressing an experience must float the preview card")
         XCTAssertFalse(vm.isShowingDetail,
-                       "selecting must NOT auto-open the detail sheet — "
-                       + "every entry point previews first")
+                       "long-press must NOT open the detail sheet — it previews")
+    }
+
+    // MARK: - Tap path: openExperienceDetail jumps straight to detail
+
+    func testOpenExperienceDetailJumpsStraightToDetail() throws {
+        let vm = makeViewModel()
+        let exp = try firstExperience(vm)
+
+        vm.openExperienceDetail(exp)         // tap path
+        XCTAssertEqual(vm.selectedExperience?.id, exp.id,
+                       "tapping must set the selection so back-out lands on the card")
+        XCTAssertTrue(vm.isShowingDetail,
+                      "tapping a card/pin must open the detail sheet directly")
+        XCTAssertFalse(cardIsFloating(vm),
+                       "the preview card must NOT float on a tap — detail is up")
+    }
+
+    // MARK: - Tap → back-out falls back to the preview card
+
+    func testOpenDetailThenDismissFallsBackToCard() throws {
+        let vm = makeViewModel()
+        let exp = try firstExperience(vm)
+
+        vm.openExperienceDetail(exp)         // tap → detail
+        vm.dismissDetail()                   // back out of detail
+        XCTAssertTrue(cardIsFloating(vm),
+                      "backing out of a tapped detail still lands on the card")
+        XCTAssertEqual(vm.selectedExperience?.id, exp.id,
+                       "selection retained after dismissing a tapped detail")
     }
 
     // MARK: - Card → detail → back lands on the card again

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -985,10 +985,26 @@ public final class MapViewModel {
         updateBottomInfo()
     }
 
-    /// Select a map pin to surface its preview card and pan the camera to frame it.
+    /// Select an experience to surface its floating preview card (without opening
+    /// the full detail sheet) and pan the camera to frame it. This is the
+    /// *long-press* path: a quick peek that the user can expand into the detail
+    /// sheet via the card's own expand action. Tapping a card/pin instead routes
+    /// through `openExperienceDetail` for a direct jump to the detail sheet.
     public func selectExperience(_ experience: Experience) {
         selectedExperience = experience
         // isShowingDetail stays false — card shows first, detail sheet on expand
+        focusOnExperience(experience)
+    }
+
+    /// Open an experience's full detail sheet directly, skipping the floating
+    /// preview card. This is the *tap* path: tapping a Nearby/favorite card or a
+    /// map pin jumps straight to the detail content. `selectedExperience` is still
+    /// set so backing out of the detail lands on the preview card (see
+    /// `dismissDetail`), and the camera reframes the same way `selectExperience`
+    /// does. Long-pressing the same card/pin floats the preview card instead.
+    public func openExperienceDetail(_ experience: Experience) {
+        selectedExperience = experience
+        isShowingDetail = true
         focusOnExperience(experience)
     }
 

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -726,7 +726,11 @@ struct NearbyExperienceRow: View {
     let distanceMeters: Double?
     /// True when the experience's bestTimes include the current clock hour (Now sort mode only).
     let isOpenNow: Bool
+    /// Tapping the card jumps straight to the detail sheet.
     let onTap: () -> Void
+    /// Long-pressing the card floats the quick preview card instead. Optional so
+    /// existing callers that only want a tap action keep compiling.
+    var onLongPress: (() -> Void)? = nil
 
     @State private var pressed = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -851,9 +855,16 @@ struct NearbyExperienceRow: View {
         }
         .buttonStyle(.plain)
         .scaleEffect(pressed ? 0.97 : 1.0)
+        // Long-press floats the quick preview card; the tap (above) opens detail.
+        // Attached only when a handler is provided so non-long-press callers are
+        // unaffected.
+        .modifier(LongPressCardModifier(onLongPress: onLongPress))
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint(Text(NSLocalizedString("experience.card.hint", comment: "Double tap to view details")))
+        .accessibilityAction(named: Text(NSLocalizedString("experience.card.preview.a11y", comment: "Preview action: float the quick preview card"))) {
+            onLongPress?()
+        }
     }
 
     // MARK: - Sub-views
@@ -1166,7 +1177,11 @@ struct NearbySection: View {
     /// Reference coordinate for distance calculation (user location or map center).
     let referenceCoordinate: CLLocationCoordinate2D?
     let sortMode: SortMode
+    /// Tapping a row jumps straight to the detail sheet.
     let onSelectExperience: (Experience) -> Void
+    /// Long-pressing a row floats the quick preview card instead. Optional so
+    /// callers that only wire a tap keep compiling.
+    let onLongPressExperience: ((Experience) -> Void)?
     /// When non-nil, passed through to EmptySheetListView to render the
     /// 'Explore another area' CTA that zooms the map out.
     let onExploreElsewhere: (() -> Void)?
@@ -1180,7 +1195,8 @@ struct NearbySection: View {
         sortMode: SortMode = .smart,
         showsSectionDivider: Bool = false,
         onExploreElsewhere: (() -> Void)? = nil,
-        onSelectExperience: @escaping (Experience) -> Void
+        onSelectExperience: @escaping (Experience) -> Void,
+        onLongPressExperience: ((Experience) -> Void)? = nil
     ) {
         self.experiences = experiences
         self.smartPickIds = smartPickIds
@@ -1189,6 +1205,7 @@ struct NearbySection: View {
         self.showsSectionDivider = showsSectionDivider
         self.onExploreElsewhere = onExploreElsewhere
         self.onSelectExperience = onSelectExperience
+        self.onLongPressExperience = onLongPressExperience
     }
 
     /// US-036: When true, the Nearby header is preceded by an inset divider so a
@@ -1225,7 +1242,8 @@ struct NearbySection: View {
                             isSmartPick: sortMode == .smart && smartPickIds.contains(exp.id),
                             distanceMeters: distance(to: exp),
                             isOpenNow: sortMode == .now && isOpenNow(exp),
-                            onTap: { onSelectExperience(exp) }
+                            onTap: { onSelectExperience(exp) },
+                            onLongPress: onLongPressExperience.map { handler in { handler(exp) } }
                         )
                     }
                 }

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -667,15 +667,21 @@ struct CompassMapContentView: View {
                                         }
                                     },
                                     onSelectExperience: { exp in
-                                        // Unified preview path: every entry
-                                        // point floats the preview card first
-                                        // (no longer jumps straight to detail),
-                                        // so the list row and a map-pin tap
-                                        // feel identical and backing out of the
-                                        // detail lands on the same card.
-                                        // withAnimation drives the card's
-                                        // move+fade transition for a layered
-                                        // reveal instead of a hard cut.
+                                        // Tap → jump straight to the detail sheet.
+                                        // (Long-press floats the preview card via
+                                        // onLongPressExperience below.) The list
+                                        // row and a map-pin tap stay consistent:
+                                        // both open detail on tap, both peek on
+                                        // long-press. withAnimation drives the
+                                        // detail content transition.
+                                        withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                                            viewModel.openExperienceDetail(exp)
+                                        }
+                                    },
+                                    onLongPressExperience: { exp in
+                                        // Long-press → float the quick preview
+                                        // card (the former tap behavior). Backing
+                                        // out of detail still lands on this card.
                                         withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
                                             viewModel.selectExperience(exp)
                                         }
@@ -960,8 +966,14 @@ struct CompassMapContentView: View {
         FavoritesListView(
             onSelectExperience: { exp in
                 isShowingFavorites = false
-                // Unified preview path (see Nearby onSelectExperience): float
-                // the preview card rather than jumping straight to detail.
+                // Tap → open the detail sheet directly (long-press peeks instead).
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                    viewModel.openExperienceDetail(exp)
+                }
+            },
+            onLongPressExperience: { exp in
+                isShowingFavorites = false
+                // Long-press → float the quick preview card (former tap behavior).
                 withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
                     viewModel.selectExperience(exp)
                 }
@@ -1205,7 +1217,8 @@ struct CompassMapContentView: View {
                         // accessibilityLabel below instead.
                         Annotation("", coordinate: coord) {
                             Button {
-                                viewModel.selectExperience(exp)
+                                // Tap → open the detail sheet directly.
+                                viewModel.openExperienceDetail(exp)
                                 HapticService.shared.impact(style: .light)
                             } label: {
                                 VStack(spacing: 2) {
@@ -1233,8 +1246,16 @@ struct CompassMapContentView: View {
                                 .transition(.scale.combined(with: .opacity))
                             }
                             .buttonStyle(.plain)
+                            // Long-press a pin → float the quick preview card
+                            // (former tap behavior) instead of opening detail.
+                            .modifier(LongPressCardModifier(onLongPress: {
+                                viewModel.selectExperience(exp)
+                            }))
                             .transition(.scale.combined(with: .opacity))
                             .accessibilityLabel(Text(exp.title))
+                            .accessibilityAction(named: Text(NSLocalizedString("experience.card.preview.a11y", comment: "Preview action: float the quick preview card"))) {
+                                viewModel.selectExperience(exp)
+                            }
                         }
                     }
                 }
@@ -1741,14 +1762,22 @@ private struct MapOverlayView: View {
                     .accessibilityElement(children: .ignore)
                     .accessibilityLabel(Text(a11yText))
                     .accessibilityAddTraits(.isButton)
+                    // Tap → open detail directly (openExperienceDetail reframes
+                    // the camera itself, so no separate focusOnExperience call).
                     .accessibilityAction {
                         UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                        viewModel.focusOnExperience(tickedNext.experience)
+                        viewModel.openExperienceDetail(tickedNext.experience)
+                    }
+                    // Long-press → float the quick preview card (former behavior).
+                    .accessibilityAction(named: Text(NSLocalizedString("experience.card.preview.a11y", comment: "Preview action: float the quick preview card"))) {
                         viewModel.selectExperience(tickedNext.experience)
                     }
                     .onTapGesture {
                         UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                        viewModel.focusOnExperience(tickedNext.experience)
+                        viewModel.openExperienceDetail(tickedNext.experience)
+                    }
+                    .onLongPressGesture(minimumDuration: 0.4) {
+                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                         viewModel.selectExperience(tickedNext.experience)
                     }
                 }

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -12,7 +12,10 @@ public struct FavoritesListView: View {
     @Environment(BestNowClock.self) private var bestNowClock
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.accessibilityVoiceOverEnabled) private var voiceOverOn
+    /// Tapping a favorite jumps straight to the detail sheet.
     let onSelectExperience: (Experience) -> Void
+    /// Long-pressing a favorite floats the quick preview card instead.
+    var onLongPressExperience: ((Experience) -> Void)? = nil
     var onExplore: (() -> Void)? = nil
 
     @State private var lastUnfavorited: (id: String, title: String, date: Date)?
@@ -1153,7 +1156,7 @@ private extension FavoritesListView {
         let bestHint = (!isDone && !goodNow) ? exp.bestTimeHint() : nil
         Button {
             Haptics.selection()
-            onSelectExperience(exp)
+            onSelectExperience(exp)   // tap → open detail directly
         } label: {
             HStack(spacing: 12) {
                 ZStack {
@@ -1253,6 +1256,13 @@ private extension FavoritesListView {
             .contentShape(Rectangle())
         }
         .buttonStyle(PressableRowStyle(reduceMotion: reduceMotion))
+        // Long-press floats the quick preview card; the tap opens detail. Inside a
+        // List row, a high-priority long-press gesture coexists with the row's
+        // tap without being swallowed by scroll or swipe-action recognizers.
+        .modifier(LongPressCardModifier(onLongPress: onLongPressExperience.map { handler in { handler(exp) } }))
+        .accessibilityAction(named: Text(NSLocalizedString("experience.card.preview.a11y", comment: "Preview action: float the quick preview card"))) {
+            onLongPressExperience?(exp)
+        }
         .accessibilityLabel({
             let doneWord = isDone ? ", \(NSLocalizedString("favorites.row.done.a11y", comment: "Completed row suffix"))" : ""
             let timingWord: String = {

--- a/apps/ios/SoloCompass/Views/Shared/LongPressCardModifier.swift
+++ b/apps/ios/SoloCompass/Views/Shared/LongPressCardModifier.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+// MARK: - LongPressCardModifier
+
+/// Attaches a long-press gesture to a card/pin so the *tap* and the *long-press*
+/// can drive two different destinations:
+///
+///   • tap          → open the full detail sheet (the card's own `Button`/`onTap`)
+///   • long-press   → float the quick preview card (`onLongPress`)
+///
+/// The gesture is attached only when a non-nil handler is supplied, so callers
+/// that want a plain tap-only card are completely unaffected (no gesture is
+/// installed, the underlying `Button` keeps its normal hit-testing).
+///
+/// `.onLongPressGesture` coexists with a `Button`'s tap on iOS: a quick tap fires
+/// the button, a sustained press (≥ `minimumDuration`) fires the long-press and
+/// suppresses the tap. A medium impact haptic confirms the long-press landed.
+struct LongPressCardModifier: ViewModifier {
+    let onLongPress: (() -> Void)?
+
+    /// 0.4s matches the system default for context-menu style long-presses —
+    /// short enough to feel responsive, long enough not to fire on a scroll.
+    private let minimumDuration = 0.4
+
+    func body(content: Content) -> some View {
+        if let onLongPress {
+            content.onLongPressGesture(minimumDuration: minimumDuration) {
+                #if canImport(UIKit)
+                Haptics.impact(.medium)
+                #endif
+                onLongPress()
+            }
+        } else {
+            content
+        }
+    }
+}


### PR DESCRIPTION
## Summary

反转了地图所有卡片入口的交互层级：

- **点击卡片 → 直接进详情页**（原来是先浮预览卡，再点一次才进详情）
- **长按卡片 → 浮出快速预览卡**（原来的点击行为，保留为快速 peek）

**机制**
- `MapViewModel.openExperienceDetail()` 新方法 = 点击路径（设 selection + isShowingDetail）。`selectExperience()` 行为不变，现为长按路径。退出详情仍回落到预览卡。
- `LongPressCardModifier`（新共享文件）= 仅在提供 handler 时附加 0.4s 长按手势，tap-only 调用方不受影响，Button 的点击命中保持原样。带中等强度触觉反馈。
- 接入 Nearby 列表卡、收藏列表卡、地图图钉、BestNow tick 提示卡。

**不动的入口（语义不同）**
- 路线站点（本就直达详情）、详情页内 nearby 切换、chat 地点卡（语义是"在地图显示位置"）

## Test Coverage

PreviewCardLifecycleTests 套件:
- `testSelectExperienceFloatsCardWithoutOpeningDetail`（长按路径）
- `testOpenExperienceDetailJumpsStraightToDetail`（新增 — 点击直达详情）
- `testOpenDetailThenDismissFallsBackToCard`（新增 — 点击进详情后退出回落预览卡）
- 既有 3 个生命周期测试仍成立

`xcodebuild test -only-testing:SoloCompassTests/PreviewCardLifecycleTests` → Executed 6 tests, 0 failures.

## Pre-Landing Review

No issues found. 纯 UI 交互改动:无 SQL/数据安全、无 LLM trust boundary。`LongPressCardModifier` 向后兼容(仅在有 handler 时附加手势),`openExperienceDetail` 纯新增,`selectExperience` 行为未变。

## Design Review

无视觉布局改动 — 仅交互手势路由。VoiceOver 新增 "Show quick preview"（显示快速预览）action，中英文本地化齐全。

## Accessibility

每个改造入口都加了 `.accessibilityAction("Show quick preview")`,VoiceOver 用户用 rotor action 触发预览卡(替代长按)。

## Test plan
- [x] xcodebuild build 通过（iPhone 17 Pro 模拟器）
- [x] PreviewCardLifecycleTests 6 个测试全过
- [x] 模拟器截图确认列表卡渲染完好

⚠️ 注：点击/长按手势用 simctl 无法可靠自动触发，交互行为靠单元测试断言 ViewModel 状态验证。真机需手动确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)