### PR TITLE
auto: Consistent emoji avatars across the Friends list rows

### DIFF
--- a/apps/ios/SoloCompass/Views/Friends/FriendsListView.swift
+++ b/apps/ios/SoloCompass/Views/Friends/FriendsListView.swift
@@ -411,9 +411,10 @@ private struct IncomingRequestRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 8) {
-                Image(systemName: "person.circle.fill")
-                    .font(.title2)
-                    .foregroundStyle(.secondary)
+                Text(AvatarEmoji.emoji(for: request.requesterId))
+                    .font(.system(size: 24))
+                    .frame(width: 40, height: 40)
+                    .background(Circle().fill(Color.accentColor.opacity(0.12)))
                     .accessibilityHidden(true)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(NSLocalizedString("friends.list.request.from", comment: "Request from label"))
@@ -466,9 +467,10 @@ private struct FriendRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            Image(systemName: "person.crop.circle.fill")
-                .font(.title2)
-                .foregroundStyle(Color.accentColor)
+            Text(AvatarEmoji.emoji(for: userId))
+                .font(.system(size: 22))
+                .frame(width: 36, height: 36)
+                .background(Circle().fill(Color.accentColor.opacity(0.12)))
                 .accessibilityHidden(true)
             Text(userId)
                 .font(.body)


### PR DESCRIPTION
## Consistent emoji avatars across the Friends list rows

The friends avatar strip already renders a stable per-user emoji via AvatarEmoji, but the list rows (FriendRow) and incoming-request rows fall back to a generic SF Symbol person glyph — so the same friend reads as two different identities on one screen. This unifies identity by giving every row the same deterministic emoji avatar inside a tinted circle, matching the strip.

### Acceptance
A friend shown in the horizontal avatar strip and in the list below renders the identical emoji; incoming request rows show the requester's emoji avatar instead of a generic glyph. The 'With friends + requests' and 'Empty' previews still compile and render. VoiceOver labels are unchanged (avatar marked accessibilityHidden, row label still reads the user id). `xcodebuild build` succeeds and existing SoloCompassTests pass.