### PR TITLE
auto: Voice recording: show a 'Xs left' countdown in the final 10 seconds and fix the silent auto-stop announcement

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -346,6 +346,8 @@
 /* Voice recording auto-stop at 60s system limit */
 "voice.recording.maxReached" = "Maximum length reached";
 "voice.recording.maxReached.a11y" = "Maximum recording length reached — transcript saved";
+/* Countdown pill shown in the final 10 s of a recording (%d = seconds remaining) */
+"voice.recording.secondsLeft" = "%ds left";
 
 /* Voice recognition error alert */
 "voice.error.title" = "Voice recognition error";

--- a/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
+++ b/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
@@ -113,20 +113,25 @@ public struct VoiceButton: View {
             Text(recognitionError ?? "")
         }
         .overlay(alignment: .top) {
-            if isRecording {
+            if isRecording || autoStopMessage != nil {
+                let secondsRemaining = Int(maxRecordingDuration) - Int(elapsed)
+                let inCountdown = elapsed >= 50 && !didAutoStop
                 VStack(spacing: 4) {
                     if let message = autoStopMessage {
                         Text(message)
                             .font(.caption.monospacedDigit())
                             .foregroundStyle(AnyShapeStyle(Color.orange))
                             .accessibilityHidden(true)
+                    } else if inCountdown {
+                        Text(String(format: NSLocalizedString("voice.recording.secondsLeft", comment: "%ds left countdown"), secondsRemaining))
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(AnyShapeStyle(Color.orange))
+                            .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: secondsRemaining)
+                            .accessibilityHidden(true)
                     } else {
                         Text(formattedElapsed)
                             .font(.caption.monospacedDigit())
-                            .foregroundStyle(elapsed >= 50
-                                ? AnyShapeStyle(Color.orange)
-                                : AnyShapeStyle(Color.secondary))
-                            .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: elapsed >= 50)
+                            .foregroundStyle(AnyShapeStyle(Color.secondary))
                             .accessibilityHidden(true)
                     }
 
@@ -145,7 +150,9 @@ public struct VoiceButton: View {
                 }
                 .offset(y: -62)
                 .accessibilityElement(children: .combine)
-                .accessibilityLabel(Text(String(format: NSLocalizedString("voice.recording.timer.a11y", comment: ""), Int(elapsed))))
+                .accessibilityLabel(Text(inCountdown
+                    ? String(format: NSLocalizedString("voice.recording.secondsLeft", comment: ""), secondsRemaining)
+                    : String(format: NSLocalizedString("voice.recording.timer.a11y", comment: ""), Int(elapsed))))
             }
         }
     }
@@ -208,12 +215,12 @@ public struct VoiceButton: View {
         }
     }
 
-    private func stopRecording() {
+    private func stopRecording(suppressStoppedAnnouncement: Bool = false) {
         voiceService.stopListening()
         isRecording = false
         pulse = false
         stopElapsedTimer()
-        if UIAccessibility.isVoiceOverRunning {
+        if UIAccessibility.isVoiceOverRunning && !suppressStoppedAnnouncement {
             UIAccessibility.post(notification: .announcement,
                 argument: NSLocalizedString("voice.announcement.stopped", comment: "Recording stopped"))
         }
@@ -242,7 +249,19 @@ public struct VoiceButton: View {
                 if elapsed >= maxRecordingDuration && !didAutoStop {
                     didAutoStop = true
                     autoStopMessage = NSLocalizedString("voice.recording.maxReached", comment: "Maximum recording length reached")
-                    stopRecording()
+                    if UIAccessibility.isVoiceOverRunning {
+                        UIAccessibility.post(notification: .announcement,
+                            argument: NSLocalizedString("voice.recording.maxReached.a11y", comment: "Maximum recording length reached — transcript saved"))
+                    }
+                    stopRecording(suppressStoppedAnnouncement: true)
+                    // Keep the pill visible briefly before the timer resets it.
+                    let capturedMessage = autoStopMessage
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .seconds(1.2))
+                        if autoStopMessage == capturedMessage {
+                            autoStopMessage = nil
+                        }
+                    }
                     break
                 }
             }
@@ -253,7 +272,9 @@ public struct VoiceButton: View {
         timerTask?.cancel()
         timerTask = nil
         elapsed = 0
-        autoStopMessage = nil
+        // autoStopMessage is intentionally NOT cleared here; the auto-stop path
+        // keeps it visible for ~1.2s via a delayed Task before nilling it out.
+        // Manual stops don't set autoStopMessage, so it stays nil.
         ringPulse = false
     }
 }


### PR DESCRIPTION
## Voice recording: show a 'Xs left' countdown in the final 10 seconds and fix the silent auto-stop announcement

VoiceButton caps recordings at 60s and turns the ring/timer orange at 50s, but never tells the user how many seconds remain before the hard cut-off, and the 'Maximum length reached' notice is set inside stopRecording() right before stopElapsedTimer() nils it out — so it flashes for a frame at most and the existing voice.recording.maxReached.a11y VoiceOver string is dead code. This adds an explicit '10s left'…'1s left' countdown pill during the final stretch and makes the auto-stop confirmation actually appear and announce.

### Acceptance
During a recording, once elapsed reaches 50s a 'Xs left' countdown (10→1) shows in orange and counts down each second; VoiceOver announces remaining time in the final window. When the 60s cap hits, the 'Maximum length reached' pill remains visible for ~1.2s before the button returns to idle, VoiceOver speaks the maxReached.a11y string, and the captured transcript still fires via onTranscript. Reduce Motion suppresses pulsing but the countdown text still updates. Builds clean with xcodebuild and existing VoiceButton previews render.