### PR TITLE
auto: Add a gentle invitational pulse to the map empty-state icon

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/PeekSummaryCard.swift
+++ b/apps/ios/SoloCompass/Views/Map/PeekSummaryCard.swift
@@ -251,15 +251,20 @@ struct PeekSummaryCard: View {
 
 // MARK: - PeekEmptyCard
 
-/// Peek-state placeholder shown when no experiences are visible. A calm, single
-/// horizontal row (no breathing animation, unlike the mid-list empty state) that
-/// nudges the traveler to pan the map.
+/// Peek-state placeholder shown when no experiences are visible. The mappin.slash
+/// icon pulses gently (scale + opacity) to invite the traveler to pan the map.
+/// Pulse is suppressed when Reduce Motion is on.
 struct PeekEmptyCard: View {
+    @State private var isPulsing = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         HStack(spacing: 10) {
             Image(systemName: "mappin.slash")
                 .font(.system(size: 16, weight: .medium))
                 .foregroundStyle(CT.fgSubtle)
+                .scaleEffect(isPulsing ? 1.08 : 0.94)
+                .opacity(isPulsing ? 1.0 : 0.6)
             Text(NSLocalizedString("peek.empty.hint", comment: "Move the map to discover nearby spots"))
                 .font(.subheadline)
                 .foregroundStyle(CT.fgMuted)
@@ -279,6 +284,21 @@ struct PeekEmptyCard: View {
         )
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(NSLocalizedString("peek.empty.hint", comment: "Move the map to discover nearby spots")))
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true)) {
+                isPulsing = true
+            }
+        }
+        .onChange(of: reduceMotion) { _, reduced in
+            if reduced {
+                withAnimation(.default) { isPulsing = false }
+            } else {
+                withAnimation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true)) {
+                    isPulsing = true
+                }
+            }
+        }
     }
 }
 
@@ -311,4 +331,14 @@ struct PeekEmptyCard: View {
     }
     .environment(LocationService.shared)
     .environment(BestNowClock.shared)
+}
+
+#Preview("Empty Pulse") {
+    ZStack {
+        Color(.systemGroupedBackground).ignoresSafeArea()
+        VStack(spacing: 16) {
+            PeekEmptyCard()
+        }
+        .padding(16)
+    }
 }


### PR DESCRIPTION
## Add a gentle invitational pulse to the map empty-state icon

PeekEmptyCard and the nearby-list empty state show a static 'mappin.slash' icon that does nothing to invite the traveler to pan the map. Add a subtle, Reduce-Motion-aware breathing pulse on the icon (scale + opacity) so the empty state feels alive and nudges discovery, matching the polish of OfflineBanner's pulsing wifi icon. This is the home-screen empty state — the first thing a new user sees before any experiences load.

### Acceptance
PeekEmptyCard's mappin.slash icon gently pulses (scale 0.94→1.08, opacity 0.6→1.0) on a 1.6s loop when Reduce Motion is off; the icon is fully static when Reduce Motion is on. xcodebuild build succeeds, the existing #Preview still renders, and no new force-unwraps or schema/@Model files are touched.