### PR TITLE
auto: Add opt-in haptic feedback to the shared PressableButtonStyle

### DIFF
--- a/apps/ios/SoloCompass/Tests/PressableButtonStyleHapticTest.swift
+++ b/apps/ios/SoloCompass/Tests/PressableButtonStyleHapticTest.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import SoloCompass
+
+/// Source-level guard that `PressableButtonStyle` wires up haptic feedback
+/// correctly and respects the accessibility Reduce Motion setting.
+///
+/// SwiftUI `ButtonStyle` bodies can't be exercised from XCTest without a full
+/// host window, so — mirroring the sibling *TappableGuardTest pattern — we
+/// scan the source file for the structural invariants that keep the haptic
+/// behaviour correct and accessible.
+final class PressableButtonStyleHapticTest: XCTestCase {
+
+    private var source: String {
+        get throws {
+            let url = Self.sourceRoot()
+                .appendingPathComponent("Views/Shared/PressableButtonStyle.swift")
+            return try String(contentsOf: url, encoding: .utf8)
+        }
+    }
+
+    /// Invariant 1: `Haptics.selection()` must be called inside `makeBody` so
+    /// every press-down fires a light selection haptic.
+    func testHapticsSelectionIsCalled() throws {
+        XCTAssertTrue(
+            try source.contains("Haptics.selection()"),
+            "PressableButtonStyle must call `Haptics.selection()` on press-down "
+                + "to provide consistent tactile feedback across all tappable surfaces."
+        )
+    }
+
+    /// Invariant 2: the call must be guarded by `accessibilityReduceMotion` so
+    /// haptics are suppressed when the user has enabled Reduce Motion.
+    func testReduceMotionGuardIsPresent() throws {
+        XCTAssertTrue(
+            try source.contains("accessibilityReduceMotion"),
+            "PressableButtonStyle must read `accessibilityReduceMotion` and skip "
+                + "the haptic when Reduce Motion is enabled."
+        )
+    }
+
+    /// Invariant 3: the haptic call must be wrapped in a `#if canImport(UIKit)`
+    /// guard so the style compiles on macOS / watchOS targets that lack UIKit.
+    func testUIKitGuardIsPresent() throws {
+        XCTAssertTrue(
+            try source.contains("#if canImport(UIKit)"),
+            "PressableButtonStyle must wrap `Haptics.selection()` in "
+                + "`#if canImport(UIKit)` so the file compiles on non-UIKit platforms."
+        )
+    }
+
+    /// Invariant 4: the `haptic` parameter must default to `true` so existing
+    /// call sites gain haptic feedback without any modification.
+    func testHapticParameterDefaultsToTrue() throws {
+        XCTAssertTrue(
+            try source.contains("haptic: Bool = true"),
+            "PressableButtonStyle.init must declare `haptic: Bool = true` so "
+                + "all existing call sites compile without modification."
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// `apps/ios/SoloCompass/` — derived from this test file's compile-time path
+    /// (`…/SoloCompass/Tests/PressableButtonStyleHapticTest.swift`).
+    private static func sourceRoot(file: StaticString = #filePath) -> URL {
+        URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // SoloCompass/
+    }
+}

--- a/apps/ios/SoloCompass/Views/Shared/PressableButtonStyle.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PressableButtonStyle.swift
@@ -7,14 +7,46 @@ public struct PressableButtonStyle: ButtonStyle {
     /// Press-down scale. Default 0.92 matches the filter pills; the send button
     /// passes a slightly punchier value.
     private let pressedScale: CGFloat
+    /// When true, fires a light selection haptic on press-down (default).
+    /// Set to false on surfaces that provide their own haptic feedback.
+    private let haptic: Bool
 
-    public init(pressedScale: CGFloat = 0.92) {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    public init(pressedScale: CGFloat = 0.92, haptic: Bool = true) {
         self.pressedScale = pressedScale
+        self.haptic = haptic
     }
 
     public func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .scaleEffect(configuration.isPressed ? pressedScale : 1.0)
             .animation(.spring(response: 0.25, dampingFraction: 0.6), value: configuration.isPressed)
+            .onChange(of: configuration.isPressed) { _, isPressed in
+                if isPressed && haptic && !reduceMotion {
+                    #if canImport(UIKit)
+                    Haptics.selection()
+                    #endif
+                }
+            }
     }
+}
+
+// MARK: - Preview
+
+#Preview("Tappable Pill") {
+    VStack(spacing: 20) {
+        Button("Filter Pill") {}
+            .buttonStyle(PressableButtonStyle())
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(Capsule().fill(Color.accentColor.opacity(0.15)))
+
+        Button("No Haptic") {}
+            .buttonStyle(PressableButtonStyle(haptic: false))
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(Capsule().fill(Color.secondary.opacity(0.15)))
+    }
+    .padding()
 }


### PR DESCRIPTION
## Add opt-in haptic feedback to the shared PressableButtonStyle

PressableButtonStyle drives press-scale animation on 15+ tappable surfaces (filter pills, chat input/cards, route cards) but fires no haptic, unlike the rest of the app where tappable controls trigger Haptics.selection(). Add an opt-in `haptic` parameter (default on) that fires a light selection haptic on press-down, respecting Reduce Motion, so tactile feedback is consistent app-wide.

### Acceptance
Tapping any filter pill or chat send button produces a light selection haptic on press-down on a physical device; no haptic fires when Reduce Motion is enabled. The press-scale animation is unchanged. All existing call sites compile without modification. `xcodebuild build` succeeds and the new guard test passes under `xcodebuild test`.