### PR TITLE
auto: Add an actionable CTA to the empty Friends state

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1553,6 +1553,7 @@
 "friends.list.empty.friends" = "No friends yet.";
 "friends.list.empty.title" = "No friends yet";
 "friends.list.empty.description" = "When you meet fellow travelers and add them, they'll show up here.";
+"friends.list.empty.cta" = "Add a friend";
 "friends.list.error.title" = "Couldn't load friends";
 "friends.list.error.retry" = "Try Again";
 

--- a/apps/ios/SoloCompass/Views/Friends/FriendsListView.swift
+++ b/apps/ios/SoloCompass/Views/Friends/FriendsListView.swift
@@ -45,7 +45,7 @@ public struct FriendsListView: View {
             } else if let error = service.lastError {
                 errorView(message: error)
             } else if service.friends.isEmpty && service.incomingRequests.isEmpty {
-                EmptyFriendsView()
+                EmptyFriendsView(onAddFriend: { showAddFriend = true })
             } else {
                 friendsList
             }
@@ -486,6 +486,8 @@ private struct FriendRow: View {
 // MARK: - EmptyFriendsView
 
 private struct EmptyFriendsView: View {
+    var onAddFriend: (() -> Void)? = nil
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isBreathing = false
 
@@ -511,6 +513,17 @@ private struct EmptyFriendsView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
+            if let onAddFriend {
+                Button {
+                    Haptics.selection()
+                    onAddFriend()
+                } label: {
+                    Label(NSLocalizedString("friends.list.empty.cta", comment: "Add a friend button in empty friends state"), systemImage: "person.badge.plus")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+                .padding(.top, 4)
+            }
         }
         .padding(32)
         .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Add an actionable CTA to the empty Friends state

The Friends list empty state (EmptyFriendsView) is a dead end — a breathing icon and static description with no way forward — while the parallel EmptyFavoritesView offers an 'Explore the map' button. This adds an 'Add a friend' button that opens the existing AddFriendSheet (already wired via showAddFriend), turning a passive empty screen into a conversion point for the social graph.

### Acceptance
When the user has no friends and no incoming requests, the Friends list shows a prominent 'Add a friend' button beneath the empty-state copy; tapping it presents AddFriendSheet (the same sheet as the toolbar person.badge.plus button) and fires a selection haptic. The button is absent when onAddFriend is nil (preview/test path). Build passes `xcodebuild build` and the new string key resolves (no raw key shown). reduceMotion still disables the icon breathing.