### PR TITLE
auto: Add VoiceOver Audio Graph (AXChartDescriptor) to the Solo Score radar chart

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -70,6 +70,7 @@
 "solo.radar.weakest.a11y" = "Note: %@ is the weakest dimension — expect it to be a tradeoff.";
 "solo.radar.strongest" = "Great for solo %@";
 "solo.radar.strongest.a11y" = "Great for solo %@.";
+"solo.radar.axis.dimension" = "Dimension";
 "solo.basedOn.early" = "Based on %d early reports";
 "solo.estimate.pill" = "AI estimate";
 "solo.section.estimate" = "Solo Score (AI estimate)";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1211,6 +1211,7 @@
 "solo.radar.weakest.a11y" = "注意：%@ 是最弱的维度 — 这是一个权衡点。";
 "solo.radar.strongest" = "独行最佳：%@";
 "solo.radar.strongest.a11y" = "独行最佳：%@。";
+"solo.radar.axis.dimension" = "维度";
 
 /* Sort */
 "sort.smart" = "智能";

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Accessibility
 
 /// Radar chart visualising the six SoloScore dimensions.
 /// Falls back to highlighted progress bars when dimension variance < 0.5.
@@ -232,6 +233,9 @@ public struct SoloScoreRadarChart: View {
             }
         }
         .aspectRatio(1, contentMode: .fit)
+        .accessibilityChartDescriptor(RadarChartDescriptor(
+            values: Self.axes.map { ($0.label, score.breakdown[keyPath: $0.keyPath]) }
+        ))
         .onTapGesture {
             guard !reduceMotion, !isReplaying else { return }
             replay()
@@ -425,6 +429,43 @@ public struct SoloScoreRadarChart: View {
             }
         }
     }
+}
+
+// MARK: - AXChartDescriptor
+
+private struct RadarChartDescriptor: AXChartDescriptorRepresentable {
+    let values: [(label: String, value: Double)]
+
+    func makeChartDescriptor() -> AXChartDescriptor {
+        let categoryAxis = AXCategoricalDataAxisDescriptor(
+            title: NSLocalizedString("solo.radar.axis.dimension", comment: ""),
+            categoryOrder: values.map(\.label)
+        )
+        let valueAxis = AXNumericDataAxisDescriptor(
+            title: NSLocalizedString("solo.scoreTitle", comment: ""),
+            range: 0...10,
+            gridlinePositions: [0, 5, 10]
+        ) { value in "\(Int(value))" }
+
+        let dataPoints = values.map { pair in
+            AXDataPoint(x: .category(pair.label), y: .number(pair.value))
+        }
+        let series = AXDataSeriesDescriptor(
+            name: NSLocalizedString("solo.scoreTitle", comment: ""),
+            isContinuous: false,
+            dataPoints: dataPoints
+        )
+        return AXChartDescriptor(
+            title: NSLocalizedString("solo.scoreTitle", comment: ""),
+            summary: nil,
+            xAxis: categoryAxis,
+            yAxis: valueAxis,
+            additionalAxes: [],
+            series: [series]
+        )
+    }
+
+    func updateChartDescriptor(_ descriptor: AXChartDescriptor) {}
 }
 
 // MARK: - Axis tooltip


### PR DESCRIPTION
## Add VoiceOver Audio Graph (AXChartDescriptor) to the Solo Score radar chart

The SoloScoreRadarChart has rich VoiceOver summary labels but no AXChartDescriptor, so VoiceOver users can't open the rotor's 'Audio Graph' to hear the six Solo Score dimensions sonified or step through them individually — the Apple-recommended affordance for chart accessibility. This adds an AXChartDescriptor conformance that exposes the six dimensions as a data series on a 0–10 scale, making the chart's actual data reachable rather than just a flat text summary.

### Acceptance
xcodebuild build succeeds for the SoloCompass scheme. With VoiceOver on, focusing the radar chart and opening the rotor exposes an 'Audio Graph' / 'Describe Chart' option that plays the six Solo Score dimensions in the same order as the visual axes, each announced with its 0–10 value; the existing summary accessibilityLabel/Value and replay action are unchanged. No SwiftData/@Model files touched and no new localization keys required (existing solo.* dimension keys reused).