### PR TITLE
auto: Polish the Friends hub empty state with ContentUnavailableView

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -260,6 +260,9 @@
 "me.friends.incoming" = "Friend Requests";
 "me.friends.list" = "Friends";
 "me.friends.empty" = "No friends yet";
+"me.friends.empty.title" = "No friends yet";
+"me.friends.empty.description" = "Add a fellow traveler by sharing your friend code or scanning theirs.";
+"me.friends.empty.cta" = "Add a friend";
 "me.avatar.a11y" = "Open your personal hub";
 "me.avatar.a11y.pending" = "You have pending friend requests";
 

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1509,6 +1509,11 @@
 "friend.discover.error.lowTrust" = "暂时无法添加这位旅行者。";
 "friend.discover.error.rateLimited" = "你最近添加的人有点多，请稍后再试。";
 
+/* Friends hub empty state (MeSheet) */
+"me.friends.empty.title" = "还没有好友";
+"me.friends.empty.description" = "分享你的好友码或扫描对方的码，添加旅伴。";
+"me.friends.empty.cta" = "添加好友";
+
 /* US-017: 统一会话列表（我 ▸ 消息） */
 "messages.empty" = "暂无会话";
 "messages.preview.empty" = "暂无消息";

--- a/apps/ios/SoloCompass/Views/Me/MeSheet.swift
+++ b/apps/ios/SoloCompass/Views/Me/MeSheet.swift
@@ -143,8 +143,44 @@ private struct ProfileHeader: View {
 /// later FRD. Kept self-contained so US-007 wires the entry point end-to-end.
 private struct FriendsHubView: View {
     @State private var service = FriendService.shared
+    @State private var showingAddFriend = false
 
     var body: some View {
+        Group {
+            if service.friends.isEmpty && service.incomingRequests.isEmpty {
+                emptyState
+            } else {
+                friendList
+            }
+        }
+        .navigationTitle(NSLocalizedString("me.friends", comment: "Friends"))
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await service.refresh() }
+        .sheet(isPresented: $showingAddFriend) {
+            AddFriendSheet()
+        }
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label(
+                NSLocalizedString("me.friends.empty.title", comment: "Friends empty state title"),
+                systemImage: "person.2.slash"
+            )
+        } description: {
+            Text(NSLocalizedString("me.friends.empty.description", comment: "Friends empty state description"))
+        } actions: {
+            Button {
+                Haptics.impact(.light)
+                showingAddFriend = true
+            } label: {
+                Text(NSLocalizedString("me.friends.empty.cta", comment: "Add a friend CTA"))
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+
+    private var friendList: some View {
         List {
             if !service.incomingRequests.isEmpty {
                 Section(NSLocalizedString("me.friends.incoming", comment: "Incoming friend requests")) {
@@ -156,22 +192,21 @@ private struct FriendsHubView: View {
                 }
             }
             Section(NSLocalizedString("me.friends.list", comment: "Friends list")) {
-                if service.friends.isEmpty {
-                    Text(NSLocalizedString("me.friends.empty", comment: "No friends yet"))
+                ForEach(service.friends, id: \.id) { friendship in
+                    Text(friendship.userHighId)
                         .font(.subheadline)
-                        .foregroundStyle(CT.fgSubtle)
-                } else {
-                    ForEach(service.friends, id: \.id) { friendship in
-                        Text(friendship.userHighId)
-                            .font(.subheadline)
-                            .foregroundStyle(CT.fgPrimary)
-                    }
+                        .foregroundStyle(CT.fgPrimary)
                 }
             }
         }
-        .navigationTitle(NSLocalizedString("me.friends", comment: "Friends"))
-        .navigationBarTitleDisplayMode(.inline)
-        .task { await service.refresh() }
+    }
+}
+
+// MARK: - FriendsHubView Preview
+
+#Preview("Friends empty state") {
+    NavigationStack {
+        FriendsHubView()
     }
 }
 


### PR DESCRIPTION
## Polish the Friends hub empty state with ContentUnavailableView

The FriendsHubView in MeSheet.swift renders its empty friends list as a single flat gray Text line, inconsistent with every other list in the app (DiscoverListView, etc.) which uses a proper ContentUnavailableView with an icon, title, description, and a CTA. This replaces the bare text with a polished empty state that includes a 'person.2.slash' icon, an explanatory description, and an 'Add a friend' button that surfaces the existing AddFriendSheet, plus a light haptic on tap — making the most personal screen feel finished and giving users a discoverable path out of the empty state.

### Acceptance
FriendsHubView shows an icon + title + description + 'Add a friend' button when the user has no friends and no incoming requests, matching the app's ContentUnavailableView pattern; tapping the button presents AddFriendSheet with a light haptic; non-empty states are unchanged; `pnpm` is N/A but `xcodebuild build` and `xcodebuild test` (including StringsParityTests) pass, and the new #Preview renders the empty state.