### PR TITLE
auto: Polished directional slide transitions + haptic-shim parity for onboarding steps

### DIFF
--- a/apps/ios/SoloCompass/Views/Onboarding/OnboardingView.swift
+++ b/apps/ios/SoloCompass/Views/Onboarding/OnboardingView.swift
@@ -26,18 +26,33 @@ enum OnboardingA11ySortPriority {
 public struct OnboardingView: View {
     @Environment(LocationService.self) private var locationService
     @Environment(UserPreferences.self) private var preferences
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let onComplete: () -> Void
 
     @State private var step: Int = 0
+
+    private var slideTransition: AnyTransition {
+        reduceMotion
+            ? .opacity
+            : .asymmetric(
+                insertion: .move(edge: .trailing).combined(with: .opacity),
+                removal: .move(edge: .leading).combined(with: .opacity)
+            )
+    }
 
     public var body: some View {
         ZStack {
             Color(.systemBackground).ignoresSafeArea()
 
             switch step {
-            case 0: welcomeStep
-            case 1: styleStep
-            default: welcomeStep
+            case 0:
+                welcomeStep
+                    .transition(slideTransition)
+                    .id(0)
+            default:
+                styleStep
+                    .transition(slideTransition)
+                    .id(1)
             }
         }
         .overlay(alignment: .topTrailing) {
@@ -213,7 +228,7 @@ public struct OnboardingView: View {
     private func styleRow(_ style: UserPreferences.SoloTravelStyle) -> some View {
         let selected = preferences.soloTravelStyle == style
         Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            Haptics.selection()
             preferences.soloTravelStyle = style
         } label: {
             HStack(spacing: 14) {


### PR DESCRIPTION
## Polished directional slide transitions + haptic-shim parity for onboarding steps

The first-run onboarding flow currently swaps between its two steps with only a blunt container-level cross-fade, and the travel-style picker fires a raw UIImpactFeedbackGenerator that bypasses the app's HapticService shim (ignoring the user's hapticsEnabled and Reduce Motion settings). This adds a directional slide-plus-fade transition so advancing feels like moving forward, and routes the style-selection haptic through the shared Haptics.selection() shim for full settings parity.

### Acceptance
Advancing from the welcome step to the style step slides content in from the right while the prior step slides out left (fade-only when Reduce Motion is on); selecting a travel style produces a selection haptic only when haptics are enabled in settings; xcodebuild build and xcodebuild test both pass; #Preview renders both steps; no force-unwraps introduced and all strings remain via NSLocalizedString.