### PR TITLE
auto: Highlight the strongest Solo Score dimension in the breakdown popover

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -238,6 +238,8 @@
 "solo.dim.safety" = "Safety";
 "solo.weakest" = "Watch: %@";
 "solo.weakest.a11y" = "Watch out: %@ is the weakest dimension for this place.";
+"solo.strongest" = "Great for: %@";
+"solo.strongest.a11y" = "Strongest dimension: %@";
 
 /* Empty filter banner (below FilterBarView) */
 "filter.empty.title" = "No matches";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1493,6 +1493,8 @@
 "solo.staff.desc" = "店员不打扰你 — 不盯着、不追问“还有别人来吗”、不催促服务。";
 "solo.weakest" = "注意：%@";
 "solo.weakest.a11y" = "注意：%@ 是该地点最弱的维度。";
+"solo.strongest" = "亮点：%@";
+"solo.strongest.a11y" = "最强维度：%@";
 
 /* Chat history (saved conversations) */
 "chat.history.title" = "历史记录";

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -203,6 +203,8 @@ private struct SoloScorePopoverContent: View {
         ]
     }
 
+    private let strongestThreshold: Double = 7.5
+
     private var weakestIndex: Int {
         dimensions.enumerated().min(by: { $0.element.value < $1.element.value })?.offset ?? 0
     }
@@ -213,6 +215,18 @@ private struct SoloScorePopoverContent: View {
 
     private var showWeakestCaption: Bool {
         dimensions[weakestIndex].value < weakestThreshold
+    }
+
+    private var strongestIndex: Int {
+        dimensions.enumerated().max(by: { $0.element.value < $1.element.value })?.offset ?? 0
+    }
+
+    private var strongestLabel: String {
+        NSLocalizedString(dimensions[strongestIndex].labelKey, comment: "")
+    }
+
+    private var showStrongestCaption: Bool {
+        dimensions[strongestIndex].value >= strongestThreshold && strongestIndex != weakestIndex
     }
 
     var body: some View {
@@ -231,6 +245,20 @@ private struct SoloScorePopoverContent: View {
                 Text(hint)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+            }
+
+            if showStrongestCaption {
+                HStack(spacing: 4) {
+                    Image(systemName: "star.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.green)
+                        .accessibilityHidden(true)
+                    Text(String(format: NSLocalizedString("solo.strongest", comment: ""), strongestLabel))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(Text(String(format: NSLocalizedString("solo.strongest.a11y", comment: ""), strongestLabel)))
             }
 
             if showWeakestCaption {
@@ -254,7 +282,8 @@ private struct SoloScorePopoverContent: View {
                     label: NSLocalizedString(row.labelKey, comment: ""),
                     value: row.value,
                     index: index,
-                    isWeakest: index == weakestIndex && showWeakestCaption
+                    isWeakest: index == weakestIndex && showWeakestCaption,
+                    isStrongest: index == strongestIndex && showStrongestCaption && index != weakestIndex
                 )
             }
 
@@ -309,9 +338,9 @@ private struct SoloScorePopoverContent: View {
         }
     }
 
-    private func dimensionRow(label: String, value: Double, index: Int, isWeakest: Bool) -> some View {
+    private func dimensionRow(label: String, value: Double, index: Int, isWeakest: Bool, isStrongest: Bool = false) -> some View {
         let clamped = max(0, min(10, value))
-        let barColor: Color = isWeakest ? .orange.opacity(0.8) : score.scoreColor.opacity(0.8)
+        let barColor: Color = isWeakest ? .orange.opacity(0.8) : isStrongest ? .green.opacity(0.8) : score.scoreColor.opacity(0.8)
         return VStack(alignment: .leading, spacing: 3) {
             HStack {
                 if isWeakest {
@@ -319,10 +348,15 @@ private struct SoloScorePopoverContent: View {
                         .font(.system(size: 9))
                         .foregroundStyle(.orange)
                         .accessibilityHidden(true)
+                } else if isStrongest {
+                    Image(systemName: "star.fill")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.green)
+                        .accessibilityHidden(true)
                 }
                 Text(label)
-                    .font(isWeakest ? .caption.bold() : .caption)
-                    .foregroundStyle(isWeakest ? .primary : .secondary)
+                    .font(isWeakest || isStrongest ? .caption.bold() : .caption)
+                    .foregroundStyle(isWeakest || isStrongest ? .primary : .secondary)
                 Spacer()
                 Text(String(format: "%.1f", value))
                     .font(.caption.weight(.medium))


### PR DESCRIPTION
## Highlight the strongest Solo Score dimension in the breakdown popover

The Solo Score breakdown popover already flags the weakest dimension (when below 5.0) with an orange warning, but never surfaces what a place is *best* at for solo travelers — the key positive decision signal (e.g. 'Great for: Seating'). This adds a green strongest-dimension caption and a subtle star marker on the top bar, giving the popover symmetry and making the 'why eat here alone' answer scannable in one glance.

### Acceptance
Open any experience detail and tap the Solo pill: the popover shows a green 'Great for: <dimension>' caption when the top dimension is >= 7.5 and distinct from the weakest, with the corresponding bar tinted green and a star marker on its label. Low/flat-score places (e.g. cautionScore preview, all dims < 7.5) show no strongest caption. VoiceOver reads 'Strongest dimension: <name>'. `xcodebuild build` succeeds and `StringsParityTests` passes with the two new keys present in en.lproj.