### PR TITLE
auto: Smooth traveling-wave animation for the voice 'thinking' dots

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/VoiceProcessingToast.swift
+++ b/apps/ios/SoloCompass/Views/Map/VoiceProcessingToast.swift
@@ -62,31 +62,49 @@ struct VoiceProcessingToast: View {
 /// Three dots that animate as a continuous left-to-right traveling wave,
 /// each dot peaking in scale and opacity in sequence with overlapping easing.
 private struct ThinkingDots: View {
-    @State private var animate = false
-
     private let dotSize: CGFloat = 4
     private let dotCount = 3
-    private let waveDuration = 0.6
-    private let dotDelay = 0.15
 
     var body: some View {
         HStack(spacing: 3) {
             ForEach(0..<dotCount, id: \.self) { index in
-                Circle()
-                    .fill(.secondary)
-                    .frame(width: dotSize, height: dotSize)
-                    .scaleEffect(animate ? 1.4 : 1.0)
-                    .opacity(animate ? 1.0 : 0.4)
-                    .animation(
-                        .easeInOut(duration: waveDuration)
-                            .repeatForever(autoreverses: true)
-                            .delay(Double(index) * dotDelay),
-                        value: animate
-                    )
+                WaveDot(dotSize: dotSize, index: index)
             }
         }
         .accessibilityHidden(true)
-        .onAppear { animate = true }
+    }
+}
+
+/// A single dot whose scale/opacity loop independently using a per-dot timer,
+/// producing a true traveling-wave effect across all three dots.
+private struct WaveDot: View {
+    let dotSize: CGFloat
+    let index: Int
+
+    @State private var scale: CGFloat = 1.0
+    @State private var opacity: Double = 0.4
+
+    private let waveDuration = 0.6
+    private let dotDelay = 0.15
+
+    var body: some View {
+        Circle()
+            .fill(.secondary)
+            .frame(width: dotSize, height: dotSize)
+            .scaleEffect(scale)
+            .opacity(opacity)
+            .onAppear {
+                let delay = Double(index) * dotDelay
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                    withAnimation(
+                        .easeInOut(duration: waveDuration)
+                            .repeatForever(autoreverses: true)
+                    ) {
+                        scale = 1.4
+                        opacity = 1.0
+                    }
+                }
+            }
     }
 }
 

--- a/apps/ios/SoloCompass/Views/Map/VoiceProcessingToast.swift
+++ b/apps/ios/SoloCompass/Views/Map/VoiceProcessingToast.swift
@@ -59,13 +59,15 @@ struct VoiceProcessingToast: View {
     }
 }
 
-/// Three sequential dots that animate one at a time to suggest AI deliberation.
+/// Three dots that animate as a continuous left-to-right traveling wave,
+/// each dot peaking in scale and opacity in sequence with overlapping easing.
 private struct ThinkingDots: View {
-    @State private var phase: Int = 0
-    @State private var advanceTask: Task<Void, Never>?
+    @State private var animate = false
 
     private let dotSize: CGFloat = 4
     private let dotCount = 3
+    private let waveDuration = 0.6
+    private let dotDelay = 0.15
 
     var body: some View {
         HStack(spacing: 3) {
@@ -73,35 +75,30 @@ private struct ThinkingDots: View {
                 Circle()
                     .fill(.secondary)
                     .frame(width: dotSize, height: dotSize)
-                    .scaleEffect(phase == index ? 1.4 : 1.0)
-                    .opacity(phase == index ? 1.0 : 0.4)
-                    .animation(.easeInOut(duration: 0.4), value: phase)
+                    .scaleEffect(animate ? 1.4 : 1.0)
+                    .opacity(animate ? 1.0 : 0.4)
+                    .animation(
+                        .easeInOut(duration: waveDuration)
+                            .repeatForever(autoreverses: true)
+                            .delay(Double(index) * dotDelay),
+                        value: animate
+                    )
             }
         }
         .accessibilityHidden(true)
-        .onAppear {
-            advanceTask = Task { @MainActor in
-                await advancePhase()
-            }
-        }
-        .onDisappear {
-            advanceTask?.cancel()
-            advanceTask = nil
-        }
-    }
-
-    @MainActor
-    private func advancePhase() async {
-        while !Task.isCancelled {
-            try? await Task.sleep(for: .milliseconds(500))
-            guard !Task.isCancelled else { return }
-            phase = (phase + 1) % dotCount
-        }
+        .onAppear { animate = true }
     }
 }
 
-#Preview("Animated") {
+#Preview("Animated — traveling wave") {
     VoiceProcessingToast(text: "Thinking about \"coffee near me\"…")
+        .padding()
+}
+
+#Preview("Wave dots only") {
+    ThinkingDots()
+        .padding()
+        .background(.thinMaterial, in: Capsule())
         .padding()
 }
 


### PR DESCRIPTION
## Smooth traveling-wave animation for the voice 'thinking' dots

The ThinkingDots indicator in VoiceProcessingToast currently animates a single dot at a time (phase == index), producing a stepped, mechanical hop that reads as low-fidelity next to the rest of the app's polish. Replace it with a continuously phased traveling wave where each dot eases through overlapping scale+opacity offsets, giving the 'AI is thinking' toast a smoother, premium feel that matches HeartBurstView and CompletionCelebrationView. Reduce Motion already swaps in a static ProgressView, so the change is fully gated.

### Acceptance
Build succeeds (xcodebuild build, iPhone 17 Pro sim). With Reduce Motion OFF, the three dots animate as a continuous overlapping wave (no single-dot hop, no visible stutter at loop boundary). With Reduce Motion ON, the static ProgressView branch is unchanged. No manual Task/sleep loop remains in ThinkingDots. Existing accessibility (updatesFrequently trait, announcement on appear/change) is preserved. Change is confined to VoiceProcessingToast.swift and under 100 lines.