### PR TITLE
auto: Add success/error haptics to share & export copy actions

### DIFF
--- a/apps/ios/SoloCompass/Views/Experience/MarkdownShareSheet.swift
+++ b/apps/ios/SoloCompass/Views/Experience/MarkdownShareSheet.swift
@@ -38,6 +38,7 @@ struct MarkdownShareSheet: View {
                 VStack(spacing: 12) {
                     Button {
                         UIPasteboard.general.string = markdown
+                        Haptics.notify(.success)
                         dismiss()
                     } label: {
                         Label(

--- a/apps/ios/SoloCompass/Views/Experience/Share/ShareSheet.swift
+++ b/apps/ios/SoloCompass/Views/Experience/Share/ShareSheet.swift
@@ -269,6 +269,7 @@ struct ShareSheet: View {
     }
 
     private func flashStatus(_ message: String, error: Bool) {
+        Haptics.notify(error ? .error : .success)
         withAnimation { statusMessage = message; statusIsError = error }
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
             withAnimation { statusMessage = nil }


### PR DESCRIPTION
## Add success/error haptics to share & export copy actions

The ShareSheet and MarkdownShareSheet copy/render confirmations (Copy Image, Copy Markdown, render-failed) flash a green/red status label but fire no haptic — the only meaningful success/failure actions in the app that are silent to the touch, breaking the consistent tactile vocabulary used everywhere else (Haptics.selection/impact). Route copy/share successes through Haptics.notify(.success) and render failures through Haptics.notify(.error), so confirmation is felt as well as seen. Goes through HapticService, so it automatically respects the user's haptics opt-out, Reduce Motion, and preview suppression.

### Acceptance
Build succeeds (xcodebuild build, iPhone 17 Pro sim). On a device/sim with haptics enabled: tapping 'Copy Image' or 'Copy Markdown' in ShareSheet produces a success haptic alongside the existing green status text; a forced render failure produces an error haptic with the red status text; tapping 'Copy Markdown' in MarkdownShareSheet produces a success haptic as the sheet dismisses. With haptics disabled in settings or Reduce Motion on, no haptic fires (verified via HapticService gating) and all visual behavior is unchanged. Existing ShareSheet/MarkdownShareSheet previews still render.