### PR TITLE
auto: Tap-to-explain dimension rows in the Solo Score breakdown popover

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -181,6 +181,7 @@ private struct SoloScorePopoverContent: View {
     let score: SoloScore
     @State private var appeared = false
     @State private var barsFilled = false
+    @State private var expandedIndex: Int? = nil
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let weakestThreshold: Double = 5.0
@@ -189,17 +190,18 @@ private struct SoloScorePopoverContent: View {
 
     private struct DimensionRow {
         let labelKey: String
+        let descKey: String
         let value: Double
     }
 
     private var dimensions: [DimensionRow] {
         [
-            DimensionRow(labelKey: "solo.dim.seating",    value: score.breakdown.seatingFriendly),
-            DimensionRow(labelKey: "solo.dim.ratio",      value: score.breakdown.soloPatronRatio),
-            DimensionRow(labelKey: "solo.dim.pressure",   value: score.breakdown.staffPressure),
-            DimensionRow(labelKey: "solo.dim.portioning", value: score.breakdown.soloPortioning),
-            DimensionRow(labelKey: "solo.dim.ambiance",   value: score.breakdown.ambianceFit),
-            DimensionRow(labelKey: "solo.dim.safety",     value: score.breakdown.safety),
+            DimensionRow(labelKey: "solo.dim.seating",    descKey: "solo.seating.desc",   value: score.breakdown.seatingFriendly),
+            DimensionRow(labelKey: "solo.dim.ratio",      descKey: "solo.patrons.desc",   value: score.breakdown.soloPatronRatio),
+            DimensionRow(labelKey: "solo.dim.pressure",   descKey: "solo.staff.desc",     value: score.breakdown.staffPressure),
+            DimensionRow(labelKey: "solo.dim.portioning", descKey: "solo.portioning.desc", value: score.breakdown.soloPortioning),
+            DimensionRow(labelKey: "solo.dim.ambiance",   descKey: "solo.ambiance.desc",  value: score.breakdown.ambianceFit),
+            DimensionRow(labelKey: "solo.dim.safety",     descKey: "solo.safety.desc",    value: score.breakdown.safety),
         ]
     }
 
@@ -280,6 +282,7 @@ private struct SoloScorePopoverContent: View {
             ForEach(Array(dimensions.enumerated()), id: \.offset) { index, row in
                 dimensionRow(
                     label: NSLocalizedString(row.labelKey, comment: ""),
+                    desc: NSLocalizedString(row.descKey, comment: ""),
                     value: row.value,
                     index: index,
                     isWeakest: index == weakestIndex && showWeakestCaption,
@@ -338,49 +341,70 @@ private struct SoloScorePopoverContent: View {
         }
     }
 
-    private func dimensionRow(label: String, value: Double, index: Int, isWeakest: Bool, isStrongest: Bool = false) -> some View {
+    private func dimensionRow(label: String, desc: String, value: Double, index: Int, isWeakest: Bool, isStrongest: Bool = false) -> some View {
         let clamped = max(0, min(10, value))
         let barColor: Color = isWeakest ? .orange.opacity(0.8) : isStrongest ? .green.opacity(0.8) : score.scoreColor.opacity(0.8)
-        return VStack(alignment: .leading, spacing: 3) {
-            HStack {
-                if isWeakest {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.system(size: 9))
-                        .foregroundStyle(.orange)
-                        .accessibilityHidden(true)
-                } else if isStrongest {
-                    Image(systemName: "star.fill")
-                        .font(.system(size: 9))
-                        .foregroundStyle(.green)
+        let isExpanded = expandedIndex == index
+        return Button {
+            withAnimation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.8)) {
+                expandedIndex = isExpanded ? nil : index
+            }
+            Haptics.selection()
+        } label: {
+            VStack(alignment: .leading, spacing: 3) {
+                HStack {
+                    if isWeakest {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 9))
+                            .foregroundStyle(.orange)
+                            .accessibilityHidden(true)
+                    } else if isStrongest {
+                        Image(systemName: "star.fill")
+                            .font(.system(size: 9))
+                            .foregroundStyle(.green)
+                            .accessibilityHidden(true)
+                    }
+                    Text(label)
+                        .font(isWeakest || isStrongest ? .caption.bold() : .caption)
+                        .foregroundStyle(isWeakest || isStrongest ? .primary : .secondary)
+                    Spacer()
+                    Text(String(format: "%.1f", value))
+                        .font(.caption.weight(.medium))
+                        .monospacedDigit()
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(.tertiary)
                         .accessibilityHidden(true)
                 }
-                Text(label)
-                    .font(isWeakest || isStrongest ? .caption.bold() : .caption)
-                    .foregroundStyle(isWeakest || isStrongest ? .primary : .secondary)
-                Spacer()
-                Text(String(format: "%.1f", value))
-                    .font(.caption.weight(.medium))
-                    .monospacedDigit()
+                GeometryReader { geo in
+                    Capsule()
+                        .fill(Color.secondary.opacity(0.2))
+                        .overlay(alignment: .leading) {
+                            Capsule()
+                                .fill(barColor)
+                                .frame(width: barsFilled ? geo.size.width * CGFloat(clamped / 10) : 0)
+                                .animation(
+                                    reduceMotion ? nil : .spring(response: 0.5, dampingFraction: 0.8)
+                                        .delay(Double(index) * 0.05),
+                                    value: barsFilled
+                                )
+                        }
+                }
+                .frame(height: 4)
+                if isExpanded {
+                    Text(desc)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .transition(reduceMotion ? .opacity : .scale(scale: 0.95).combined(with: .opacity))
+                }
             }
-            GeometryReader { geo in
-                Capsule()
-                    .fill(Color.secondary.opacity(0.2))
-                    .overlay(alignment: .leading) {
-                        Capsule()
-                            .fill(barColor)
-                            .frame(width: barsFilled ? geo.size.width * CGFloat(clamped / 10) : 0)
-                            .animation(
-                                reduceMotion ? nil : .spring(response: 0.5, dampingFraction: 0.8)
-                                    .delay(Double(index) * 0.05),
-                                value: barsFilled
-                            )
-                    }
-            }
-            .frame(height: 4)
         }
+        .buttonStyle(.plain)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(label))
-        .accessibilityValue(Text(String(format: "%.1f", value)))
+        .accessibilityValue(Text(isExpanded ? "\(String(format: "%.1f", value)), \(desc)" : String(format: "%.1f", value)))
+        .accessibilityHint(Text(NSLocalizedString("solo.axis.tap.hint", comment: "")))
     }
 }
 


### PR DESCRIPTION
## Tap-to-explain dimension rows in the Solo Score breakdown popover

The SoloScorePopoverContent bar list shows six Solo Score dimensions but offers no way to learn what each one means, unlike the radar chart whose axes reveal plain-language tooltips on tap. This adds a tappable disclosure to each dimension row that expands an inline plain-language explanation (reusing the existing solo.*.desc localized strings), with a chevron affordance, haptic feedback, smooth expand/collapse, Reduce Motion support, and a VoiceOver hint — making the breakdown self-explanatory for first-time and assistive-tech users.

### Acceptance
Building the SoloCompass scheme succeeds (xcodebuild build). Opening the Solo Score breakdown popover and tapping any dimension row expands a one-line plain-language explanation for that dimension and collapses the previously expanded one; a chevron indicates expand/collapse state; tapping triggers a selection haptic; the animation is suppressed under Reduce Motion (verified via the 'Score Breakdown Popover' #Preview with Reduce Motion on); VoiceOver reports the dimension hint and reads the explanation when a row is expanded; no new entries are required in Localizable.strings (existing solo.*.desc keys are reused).