### PR TITLE
auto: Milestone pulses on the Favorites journey progress bar

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -574,6 +574,8 @@
 
 /* Favorites journey halfway milestone VoiceOver announcement */
 "favorites.journey.halfway" = "Halfway there — %1$d of %2$d explored";
+/* Favorites journey progress bar — milestone pulse VoiceOver announcement (%d = percent, e.g. 25) */
+"favorites.journey.milestone.a11y" = "%d%% of your favorites explored";
 
 /* Favorites journey header — closest pill (shown when nearbyCount == 0) */
 "favorites.journey.closest" = "%1$@ · %2$@";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -726,6 +726,8 @@ private struct JourneyProgressBar: View {
     @State private var fillScaleY: CGFloat = 1
     @State private var didHalfwayPulse = false
     @State private var tickPulse = false
+    @State private var lastMilestone: Int = 0
+    @State private var glowOpacity: CGFloat = 0
 
     private var targetFraction: CGFloat {
         total > 0 ? CGFloat(completed) / CGFloat(total) : 0
@@ -754,6 +756,28 @@ private struct JourneyProgressBar: View {
                 fillScaleY = 1
             }
             tickPulse = false
+        }
+    }
+
+    private func currentMilestone() -> Int {
+        Int(targetFraction * 4)
+    }
+
+    private func handleMilestoneCheck() {
+        let newMilestone = currentMilestone()
+        guard newMilestone > lastMilestone, completed < total else { return }
+        lastMilestone = newMilestone
+        Haptics.impact(.light)
+        let pct = newMilestone * 25
+        let announcement = String(
+            format: NSLocalizedString("favorites.journey.milestone.a11y", comment: "VoiceOver milestone announcement in journey progress bar"),
+            pct
+        )
+        UIAccessibility.post(notification: .announcement, argument: announcement)
+        guard !reduceMotion else { return }
+        withAnimation(.easeOut(duration: 0.15)) { glowOpacity = 0.6 }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            withAnimation(.easeIn(duration: 0.35)) { glowOpacity = 0 }
         }
     }
 
@@ -804,10 +828,18 @@ private struct JourneyProgressBar: View {
                         }
                     }
                     .clipShape(Capsule())
+                if glowOpacity > 0 {
+                    Capsule()
+                        .fill(Color.green.opacity(glowOpacity))
+                        .frame(width: geo.size.width * animatedFraction, height: 4)
+                        .blur(radius: 3)
+                        .allowsHitTesting(false)
+                }
             }
         }
         .frame(height: 4)
         .onAppear {
+            lastMilestone = currentMilestone()
             if reduceMotion {
                 animatedFraction = targetFraction
             } else {
@@ -838,6 +870,7 @@ private struct JourneyProgressBar: View {
             } else {
                 didHalfwayPulse = false
             }
+            handleMilestoneCheck()
         }
     }
 

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -776,7 +776,8 @@ private struct JourneyProgressBar: View {
         UIAccessibility.post(notification: .announcement, argument: announcement)
         guard !reduceMotion else { return }
         withAnimation(.easeOut(duration: 0.15)) { glowOpacity = 0.6 }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+        Task {
+            try? await Task.sleep(nanoseconds: 150_000_000)
             withAnimation(.easeIn(duration: 0.35)) { glowOpacity = 0 }
         }
     }
@@ -871,6 +872,15 @@ private struct JourneyProgressBar: View {
                 didHalfwayPulse = false
             }
             handleMilestoneCheck()
+        }
+        .onChange(of: total) { _, _ in
+            if reduceMotion {
+                animatedFraction = targetFraction
+            } else {
+                withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
+                    animatedFraction = targetFraction
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Milestone pulses on the Favorites journey progress bar

The FavoritesJourneyHeader's JourneyProgressBar currently animates its fill but gives no feedback when a traveler crosses a meaningful milestone (25/50/75%). Add a one-shot glow pulse plus a light haptic the moment the fill crosses each quarter threshold, so solo travelers feel momentum as they complete saved experiences. This complements the existing all-done CompletionRing celebration with lightweight intermediate reward moments.

### Acceptance
Building apps/ios with xcodebuild succeeds. Marking a favorite as visited that pushes completion across 25/50/75% triggers a single green glow pulse on the journey bar and a light haptic; crossing 100% does NOT fire the milestone pulse (the existing CompletionRing celebration handles that). Re-opening the Favorites sheet with pre-existing progress shows the filled bar with no replayed pulses. With Reduce Motion on, no glow animates but the haptic and a VoiceOver 'X% explored' announcement still occur. Existing FavoritesListView previews and tests still pass.