### PR TITLE
auto: Imminence progress ring on the 'Now · upcoming' badge

### DIFF
--- a/apps/ios/SoloCompass/Tests/ImminenceProgressTests.swift
+++ b/apps/ios/SoloCompass/Tests/ImminenceProgressTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import SoloCompass
+
+/// Verifies the `CompassMapView.imminenceProgress(minutesUntil:windowMinutes:)` helper
+/// used to fill the gold progress ring in the 'Now · upcoming' badge.
+///
+/// Run with:
+///   xcodebuild test -only-testing:SoloCompassTests/ImminenceProgressTests
+final class ImminenceProgressTests: XCTestCase {
+
+    func testAtWindowBoundaryReturnsZero() {
+        XCTAssertEqual(CompassMapView.imminenceProgress(minutesUntil: 120), 0.0, accuracy: 1e-9)
+    }
+
+    func testAtHalfwayReturnsFiftyPercent() {
+        XCTAssertEqual(CompassMapView.imminenceProgress(minutesUntil: 60), 0.5, accuracy: 1e-9)
+    }
+
+    func testAtZeroMinutesReturnsFull() {
+        XCTAssertEqual(CompassMapView.imminenceProgress(minutesUntil: 0), 1.0, accuracy: 1e-9)
+    }
+
+    func testBeyondWindowClampsToZero() {
+        XCTAssertEqual(CompassMapView.imminenceProgress(minutesUntil: 200), 0.0, accuracy: 1e-9)
+    }
+
+    func testNegativeMinutesClampsToOne() {
+        XCTAssertEqual(CompassMapView.imminenceProgress(minutesUntil: -5), 1.0, accuracy: 1e-9)
+    }
+}

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -1785,6 +1785,7 @@ private struct MapOverlayView: View {
                 TimelineView(.periodic(from: .now, by: 60)) { context in
                     let tickedNext = viewModel.nextBestExperience(now: context.date) ?? next
                     let minutesUntil = tickedNext.minutesUntil
+                    let progress = Self.imminenceProgress(minutesUntil: minutesUntil)
                     let idleText = NSLocalizedString("filter.now.empty.idle", comment: "Nothing's at its best now")
                     let upcomingText = String(
                         format: NSLocalizedString("filter.now.empty.upcoming", comment: "%@ in %dm"),
@@ -1802,9 +1803,19 @@ private struct MapOverlayView: View {
                         shadowY: 3
                     ) {
                         HStack(spacing: 6) {
-                            Circle()
-                                .fill(accentGold)
-                                .frame(width: 8, height: 8)
+                            ZStack {
+                                Circle()
+                                    .stroke(accentGold.opacity(0.25), lineWidth: 2)
+                                Circle()
+                                    .trim(from: 0, to: progress)
+                                    .stroke(accentGold, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                                    .rotationEffect(.degrees(-90))
+                                    .animation(reduceMotion ? nil : .easeInOut, value: progress)
+                                Circle()
+                                    .fill(accentGold)
+                                    .frame(width: 8, height: 8)
+                            }
+                            .frame(width: 14, height: 14)
                             Text(idleText)
                                 .font(.caption.weight(.medium))
                                 .foregroundStyle(.primary)
@@ -1908,6 +1919,12 @@ private struct MapOverlayView: View {
             .animation(.spring(response: 0.3, dampingFraction: 0.8), value: count)
             .accessibilityLabel(Text(countText))
         }
+    }
+
+    /// Returns how full the imminence ring should be: 0.0 at `windowMinutes` out, 1.0 at 0m.
+    /// Clamped to [0, 1].
+    static func imminenceProgress(minutesUntil: Int, windowMinutes: Int = 120) -> Double {
+        max(0, min(1, 1 - Double(minutesUntil) / Double(windowMinutes)))
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Imminence progress ring on the 'Now · upcoming' badge

When the 'Now' filter is active and nothing is at its best yet, the map shows a badge like 'Nothing's at its best · Coffee Lab in 23m', but the only cue to how soon is the raw number — 'in 5m' and 'in 95m' look identical at a glance. This adds a thin gold progress ring around the existing gold dot that fills as the golden window approaches (empty at 120m out, nearly full near 0m), making imminence glanceable and reinforcing the existing gold-dot 'Now' motif without adding any new UI chrome.

### Acceptance
1) When the 'Now' filter yields zero current matches but a next-best experience is within 120m, the badge shows a gold ring around the dot whose fill fraction equals 1 - minutesUntil/120 (e.g. ~80% full at 24m out, near-empty at ~115m out). 2) The ring advances every minute via the existing TimelineView tick and animates smoothly when reduceMotion is off, with no animation when reduceMotion is on. 3) `imminenceProgress` clamps to [0,1] (verified by a unit test in SoloCompassTests covering minutesUntil=120→0.0, 60→0.5, 0→1.0, and an out-of-range 200→0.0). 4) Tap and long-press behavior, layout, and VoiceOver label of the badge are unchanged; `xcodebuild build` and the test target pass.