### PR TITLE
auto: Add a Haptic Feedback toggle to Settings (wire up the existing opt-out)

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -894,6 +894,8 @@
 /* Theme picker (US-039) */
 "settings.appearance" = "Appearance";
 "settings.theme" = "Theme";
+"settings.haptics" = "Haptic Feedback";
+"settings.haptics.footer" = "When on, Solo Compass taps your device on favorites, check-ins, filter changes, and map peeks.";
 
 /* Map preview in exports (US-020) */
 "settings.exportMapPreview" = "Include map preview in exports";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -574,6 +574,8 @@
 /* Theme picker (US-039) */
 "settings.appearance" = "外观";
 "settings.theme" = "主题";
+"settings.haptics" = "触感反馈";
+"settings.haptics.footer" = "开启后，Solo Compass 会在收藏、打卡、筛选和地图预览等操作时振动提示。";
 
 /* Map preview in exports (US-020) */
 "settings.exportMapPreview" = "导出时包含地图预览";

--- a/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
@@ -809,8 +809,29 @@ public struct SettingsView: View {
                 }
             }
             .pickerStyle(.segmented)
+
+            Toggle(isOn: Binding(
+                get: { HapticService.shared.isEnabled },
+                set: { newValue in
+                    HapticService.shared.isEnabled = newValue
+                    if newValue {
+                        HapticService.shared.impact(style: .light)
+                    }
+                }
+            )) {
+                HStack(spacing: 10) {
+                    Image(systemName: "hand.tap.fill")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(.white)
+                        .frame(width: 30, height: 30)
+                        .background(Color.pink, in: RoundedRectangle(cornerRadius: 7))
+                    Text(NSLocalizedString("settings.haptics", comment: "Haptic Feedback"))
+                }
+            }
         } header: {
             settingsSectionHeader("paintpalette", label: NSLocalizedString("settings.appearance", comment: "Appearance"))
+        } footer: {
+            Text(NSLocalizedString("settings.haptics.footer", comment: "Haptic feedback footer"))
         }
     }
 


### PR DESCRIPTION
## Add a Haptic Feedback toggle to Settings (wire up the existing opt-out)

HapticService already supports a full per-user opt-out via UserDefaults (`hapticsEnabled`, exposed as `HapticService.shared.isEnabled`), and every haptic call site respects it — but there is no UI anywhere in the app to turn haptics off. Solo Compass fires haptics on favoriting, check-ins, filter changes, and map peeks, with zero way to disable them. This adds a visible 'Haptic Feedback' toggle to the Appearance section of SettingsView, completing a feature that is half-built but unreachable.

### Acceptance
Settings > Appearance shows a 'Haptic Feedback' toggle (default ON) with a pink hand.tap.fill icon and an explanatory footer. Toggling OFF makes all subsequent haptics (favorite, check-in, filter, peek) silent; toggling back ON restores them and fires a confirming light tap. The state survives app relaunch (UserDefaults-backed). Strings render in both English and Simplified Chinese. `xcodebuild build -scheme SoloCompass` succeeds; existing HapticServiceTests still pass.