### PR TITLE
auto: Add press feedback and haptic to the BottomInfoSheet sort button

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -594,6 +594,9 @@ struct SortCountToolbar: View {
 
     private var sortButton: some View {
         Button {
+            #if canImport(UIKit)
+            Haptics.selection()
+            #endif
             showSortSheet = true
         } label: {
             HStack(spacing: 4) {
@@ -607,7 +610,7 @@ struct SortCountToolbar: View {
             .padding(.vertical, 5)
             .background(Capsule().fill(.regularMaterial))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(SortRowButtonStyle())
         .accessibilityLabel(Text(NSLocalizedString("sheet.sort.button", comment: "Sort")))
         .accessibilityValue(Text(sortMode.accessibilityValue))
     }


### PR DESCRIPTION
## Add press feedback and haptic to the BottomInfoSheet sort button

The sort-mode button in `SortCountToolbar` opens the sort sheet with no press-scale animation and no haptic, making it feel dead compared to every other tappable control in the app (filter pills, nearby cards, sort rows all scale-on-press). Apply the existing `SortRowButtonStyle` (already defined in the same file) and fire a selection haptic on tap so the button matches the app's established tactile language.

### Acceptance
Tapping the sort pill in the bottom sheet visibly scales it down ~4% with a spring and fires one selection haptic before the sort sheet presents; the control's feel now matches FilterBarView pills and the SortModeSheet rows. `xcodebuild build` succeeds and existing `SoloCompassTests` pass; no force-unwraps or schema files touched; change is under ~10 lines in one file.