### PR TITLE
auto: Add a 'good now' nudge to the empty-search results in Favorites

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -502,6 +502,8 @@
 "favorites.search.noResults.hint" = "Try a different word, or clear your search.";
 "favorites.search.clear" = "Clear search";
 "favorites.search.clear.hint" = "Clears the search field and shows all favorites";
+"favorites.search.goodNow.cta" = "%d great right now";
+"favorites.search.goodNow.cta.a11y" = "%d favorites are great to visit right now";
 "favorites.search.prompt" = "Search favorites";
 "favorites.sort.label" = "Sort";
 "favorites.sort.nearest" = "Nearest";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1057,6 +1057,8 @@
 "favorites.row.distance.a11y" = "%@外";
 "favorites.search.clear" = "清空搜索";
 "favorites.search.clear.hint" = "清空搜索框并显示所有收藏";
+"favorites.search.goodNow.cta" = "%d 个此刻很适合";
+"favorites.search.goodNow.cta.a11y" = "%d 个收藏此刻很适合前往";
 "favorites.search.noResults" = "没有\"%@\"的匹配结果";
 "favorites.search.noResults.hint" = "换个词试试，或清空搜索。";
 "favorites.search.prompt" = "搜索收藏";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -236,8 +236,16 @@ public struct FavoritesListView: View {
                     })
                     .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
                 } else if filteredFavorites.isEmpty {
-                    NoSearchResultsView(query: searchText, onClear: { searchText = "" })
-                        .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
+                    NoSearchResultsView(
+                        query: searchText,
+                        onClear: { searchText = "" },
+                        goodNowCount: goodNowCount,
+                        onShowGoodNow: goodNowCount > 0 ? {
+                            searchText = ""
+                            prioritizeGoodNow = true
+                        } : nil
+                    )
+                    .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
                 } else {
                     VStack(spacing: 0) {
                         if sortedFavorites.count > 0 {
@@ -959,6 +967,8 @@ private struct AllRemainingDoneView: View {
 private struct NoSearchResultsView: View {
     let query: String
     let onClear: () -> Void
+    var goodNowCount: Int = 0
+    var onShowGoodNow: (() -> Void)? = nil
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var appeared = false
@@ -985,6 +995,23 @@ private struct NoSearchResultsView: View {
             .buttonStyle(.bordered)
             .controlSize(.small)
             .accessibilityHint(NSLocalizedString("favorites.search.clear.hint", comment: "Clears the search field and shows all favorites"))
+            if goodNowCount > 0, let onShowGoodNow {
+                Button {
+                    Haptics.selection()
+                    withAnimation(reduceMotion ? nil : .easeInOut) {
+                        onShowGoodNow()
+                    }
+                } label: {
+                    Label(
+                        String(format: NSLocalizedString("favorites.search.goodNow.cta", comment: "Good-now CTA in no-results view: N great right now"), goodNowCount),
+                        systemImage: "clock.badge.checkmark"
+                    )
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .accessibilityLabel(String(format: NSLocalizedString("favorites.search.goodNow.cta.a11y", comment: "Good-now CTA accessibility label: N favorites great right now"), goodNowCount))
+                .accessibilityHint(NSLocalizedString("favorites.journey.goodNow.hint", comment: "Good now nudge sorts those favorites to the top of the list"))
+            }
         }
         .padding(32)
         .scaleEffect(appeared ? 1 : 0.85)


### PR DESCRIPTION
## Add a 'good now' nudge to the empty-search results in Favorites

When a Favorites search returns no matches, the NoSearchResultsView is a dead end. If the user has favorites that are great to do right now, surface a one-tap 'X are great right now' button that clears the search and prioritizes those — turning a frustrating empty state into a useful next action.

### Acceptance
Searching favorites for a non-matching term shows the no-results view; if any favorites are good-now, a 'N great right now' button appears and, when tapped, clears the search and reorders the list with those favorites on top. iOS target builds clean (xcodebuild build) and existing FavoritesListView tests still pass. Button is hidden when goodNowCount is 0, and the new strings have entries in en.lproj/Localizable.strings.