### PR TITLE
auto: Polish the empty-favorites tip carousel: tap-to-advance, progress dots, and VoiceOver announcements

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -489,6 +489,7 @@
 "favorites.empty.tip2" = "Saved spots show a green dot when they're walkable right now.";
 "favorites.empty.tip3" = "Favorites sort by what's good to do at this hour.";
 "favorites.empty.tip4" = "Swipe left on a saved spot to remove it — tap Undo to bring it back.";
+"favorites.empty.tip.hint" = "Double tap for the next tip";
 "favorites.undo" = "Removed — Undo";
 "favorites.undo.named" = "Removed \"%@\"";
 /* Plural forms handled by Localizable.stringsdict */

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -307,6 +307,7 @@
 "favorites.title" = "收藏";
 "favorites.empty.title" = "还没有收藏";
 "favorites.empty.hint" = "点击任意体验上的爱心即可保存到这里。";
+"favorites.empty.tip.hint" = "双击查看下一条提示";
 "favorites.undo.named" = "已移除\"%@\"";
 
 /* Generic actions */

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -844,6 +844,7 @@ private struct EmptyFavoritesView: View {
     var onExplore: (() -> Void)? = nil
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityVoiceOverEnabled) private var voiceOverOn
     @State private var isBreathing = false
     @State private var tipIndex = 0
     @State private var rotateTask: Task<Void, Never>?
@@ -855,6 +856,12 @@ private struct EmptyFavoritesView: View {
             NSLocalizedString("favorites.empty.tip3", comment: "Empty favorites tip 3"),
             NSLocalizedString("favorites.empty.tip4", comment: "Empty favorites tip 4"),
         ]
+    }
+
+    private func advanceTip() {
+        tipIndex = (tipIndex + 1) % tips.count
+        Haptics.selection()
+        UIAccessibility.post(notification: .announcement, argument: tips[tipIndex])
     }
 
     var body: some View {
@@ -869,17 +876,34 @@ private struct EmptyFavoritesView: View {
                     .scaleEffect(isBreathing ? 1.08 : 0.94)
                     .opacity(isBreathing ? 1.0 : 0.7)
                     .animation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true), value: isBreathing)
+                    .accessibilityHidden(true)
             }
             Text(NSLocalizedString("favorites.empty.title", comment: "No favorites yet"))
                 .font(.headline)
-            Text(tips[tipIndex])
-                .id(tipIndex)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(minHeight: 36)
-                .transition(.opacity)
-                .animation(reduceMotion ? nil : .easeInOut(duration: 0.4), value: tipIndex)
+            Button {
+                advanceTip()
+            } label: {
+                Text(tips[tipIndex])
+                    .id(tipIndex)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(minHeight: 36)
+                    .transition(.opacity)
+                    .animation(reduceMotion ? nil : .easeInOut(duration: 0.4), value: tipIndex)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(tips[tipIndex])
+            .accessibilityHint(NSLocalizedString("favorites.empty.tip.hint", comment: "Hint to advance to the next tip"))
+            HStack(spacing: 6) {
+                ForEach(0..<tips.count, id: \.self) { index in
+                    Circle()
+                        .fill(index == tipIndex ? Color.primary : Color.primary.opacity(0.2))
+                        .frame(width: 6, height: 6)
+                        .animation(reduceMotion ? nil : .easeInOut, value: tipIndex)
+                }
+            }
+            .accessibilityHidden(true)
             if let onExplore {
                 Button {
                     Haptics.selection()
@@ -902,7 +926,9 @@ private struct EmptyFavoritesView: View {
                     try? await Task.sleep(for: .seconds(4))
                     guard !Task.isCancelled else { return }
                     await MainActor.run {
+                        guard !voiceOverOn else { return }
                         withAnimation { tipIndex = (tipIndex + 1) % tips.count }
+                        UIAccessibility.post(notification: .announcement, argument: tips[tipIndex])
                     }
                 }
             }


### PR DESCRIPTION
## Polish the empty-favorites tip carousel: tap-to-advance, progress dots, and VoiceOver announcements

The EmptyFavoritesView rotates four tips on a silent 4-second timer — VoiceOver users never hear a tip change, there's no way to advance manually, and no indication that more tips exist. This adds tappable tip-progress dots, tap-to-advance on the tip text, and a VoiceOver announcement when the tip rotates, matching the accessibility rigor of the surrounding views (PendingCheckInBanner, OfflineBanner).

### Acceptance
1) `xcodebuild build -project apps/ios/SoloCompass.xcodeproj -scheme SoloCompass -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest'` succeeds. 2) In Simulator with zero favorites, tapping the tip text advances to the next tip with a haptic and updates the highlighted progress dot. 3) Progress dots show 4 dots with the current one filled; reduce-motion disables the dot transition. 4) With VoiceOver on, the tip carousel does not auto-rotate, the tip is one focusable element announcing only title + current tip (heart hidden), and manually advancing announces the new tip. 5) New `favorites.empty.tip.hint` key present in both en.lproj and zh-Hans.lproj Localizable.strings.