### PR TITLE
auto: Animate the Pending Check-In banner's countdown bar to fade to a hairline when paused

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
@@ -19,6 +19,28 @@ public struct PendingCheckInBanner: View {
     @State private var autoDismissTask: Task<Void, Never>?
     private let dismissThreshold: CGFloat = 80
 
+    public init(
+        experienceTitle: String,
+        onConfirm: @escaping () -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.experienceTitle = experienceTitle
+        self.onConfirm = onConfirm
+        self.onDismiss = onDismiss
+    }
+
+    fileprivate init(
+        experienceTitle: String,
+        onConfirm: @escaping () -> Void,
+        onDismiss: @escaping () -> Void,
+        isInteracting: Bool
+    ) {
+        self.experienceTitle = experienceTitle
+        self.onConfirm = onConfirm
+        self.onDismiss = onDismiss
+        self._isInteracting = State(initialValue: isInteracting)
+    }
+
     // Pause/resume interaction tracking
     @State private var isInteracting = false
     /// Snapshot of countdownProgress taken when interaction begins; 1 = full bar.
@@ -108,9 +130,11 @@ public struct PendingCheckInBanner: View {
             if !reduceMotion {
                 GeometryReader { geo in
                     Capsule()
-                        .fill(isExpiringSoon ? Color.orange : Color.blue)
+                        .fill(isInteracting ? Color.gray : (isExpiringSoon ? Color.orange : Color.blue))
                         .frame(width: geo.size.width * countdownProgress, height: 2)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        .opacity(isInteracting ? 0.4 : 1.0)
+                        .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: isInteracting)
                 }
                 .frame(height: 2)
                 .padding(.horizontal, 2)
@@ -272,5 +296,18 @@ public struct PendingCheckInBanner: View {
         // Settings → Accessibility → Motion → Reduce Motion. The previous
         // `.environment(\.accessibilityReduceMotion, true)` broke the build
         // (KeyPath is not a WritableKeyPath).
+    }
+}
+
+#Preview("Paused state") {
+    ZStack(alignment: .bottom) {
+        Color(.systemGroupedBackground).ignoresSafeArea()
+        PendingCheckInBanner(
+            experienceTitle: "Watch the monks collect alms at dawn",
+            onConfirm: {},
+            onDismiss: {},
+            isInteracting: true
+        )
+        .padding(.bottom, 40)
     }
 }

--- a/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
@@ -43,8 +43,12 @@ public struct PendingCheckInBanner: View {
 
     // Pause/resume interaction tracking
     @State private var isInteracting = false
-    /// Snapshot of countdownProgress taken when interaction begins; 1 = full bar.
+    /// Remaining fraction [0,1] computed from elapsed time when interaction begins.
     @State private var progressAtPause: CGFloat = 1
+    /// Wall-clock instant when the current countdown animation started; nil before first start.
+    @State private var countdownStartDate: Date? = nil
+    /// The remainingFraction value that was passed into the most recent startCountdown call.
+    @State private var countdownStartFraction: CGFloat = 1
     /// Guards pauseCountdown() so it fires only on the first-touch, not every drag event.
     @State private var wasPaused = false
     /// True when ~2 s remain; drives amber color shift on the bar and Yes button.
@@ -134,7 +138,7 @@ public struct PendingCheckInBanner: View {
                         .frame(width: geo.size.width * countdownProgress, height: 2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .opacity(isInteracting ? 0.4 : 1.0)
-                        .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: isInteracting)
+                        .animation(.easeInOut(duration: 0.2), value: isInteracting)
                 }
                 .frame(height: 2)
                 .padding(.horizontal, 2)
@@ -221,6 +225,8 @@ public struct PendingCheckInBanner: View {
     /// `remainingFraction` is in [0, 1] where 1 means full duration remaining.
     private func startCountdown(remainingFraction: CGFloat) {
         isExpiringSoon = false
+        countdownStartDate = Date()
+        countdownStartFraction = remainingFraction
         guard !voiceOverOn else {
             // VoiceOver: no bar, just arm the dismiss task.
             scheduleAutoDismiss(remainingFraction: remainingFraction)
@@ -238,9 +244,17 @@ public struct PendingCheckInBanner: View {
         autoDismissTask?.cancel()
         autoDismissTask = nil
         isExpiringSoon = false
-        // Snapshot the current progress fraction so resume can animate from here.
-        progressAtPause = countdownProgress
-        // Stop the running animation by re-asserting the current value with zero duration.
+        // Compute remaining fraction from elapsed wall-clock time, not the state variable
+        // (which holds the animation TARGET 0, not the in-flight rendered position).
+        if let start = countdownStartDate {
+            let totalSeconds = autoDismissSeconds * Double(countdownStartFraction)
+            let elapsed = Date().timeIntervalSince(start)
+            let remaining = max(0, totalSeconds - elapsed)
+            progressAtPause = CGFloat(remaining / autoDismissSeconds)
+        } else {
+            progressAtPause = countdownStartFraction
+        }
+        // Freeze the bar at the computed position.
         withAnimation(.linear(duration: 0)) {
             countdownProgress = progressAtPause
         }


### PR DESCRIPTION
## Animate the Pending Check-In banner's countdown bar to fade to a hairline when paused

When the user touches the PendingCheckInBanner to drag it, the auto-dismiss countdown pauses, but the progress bar gives no visual cue that time is frozen — it just stops, which reads as a stutter. This adds a subtle opacity dip and a brief 'paused' tint on the countdown bar while the user is interacting, so the freeze feels intentional rather than buggy, matching the existing amber 'expiring soon' affordance already in the file.

### Acceptance
Touching the banner to begin a drag dims the countdown bar to a neutral gray hairline and freezes it; releasing without dismissing restores the bar to full-opacity blue (or amber if expiring soon) and resumes the animation from where it paused. Under Reduce Motion the bar is absent so no regression. xcodebuild build and the existing SoloCompassTests pass, and all three #Previews render.