### PR TITLE
auto: Animated empty-state illustration for the companion Discover list

### DIFF
--- a/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
@@ -140,29 +140,7 @@ public struct DiscoverListView: View {
     }
 
     private var emptyStateView: some View {
-        ContentUnavailableView {
-            Label(
-                NSLocalizedString("companion.discover.empty.title", comment: "No companions found title"),
-                systemImage: "person.2.slash"
-            )
-        } description: {
-            Text(NSLocalizedString("companion.discover.empty.description", comment: "No companions found description"))
-        } actions: {
-            VStack(spacing: 16) {
-                Text(NSLocalizedString("companion.discover.coldstart.tip", comment: "Cold start tip"))
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                Button {
-                    Haptics.impact(.light)
-                    showPostSheet = true
-                } label: {
-                    Text(NSLocalizedString("companion.discover.empty.cta", comment: "Post your availability CTA"))
-                }
-                .buttonStyle(.borderedProminent)
-                .accessibilityHint(NSLocalizedString("companion.discover.empty.cta.hint", comment: "Post your availability accessibility hint"))
-            }
-        }
+        EmptyCompanionState(onPostTapped: { showPostSheet = true })
     }
 
     private var postList: some View {
@@ -242,6 +220,79 @@ public struct DiscoverListView: View {
                 errorMessage = nil
             }
         }
+    }
+}
+
+// MARK: - EmptyCompanionState
+
+private struct EmptyCompanionState: View {
+    let onPostTapped: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var pulse = false
+    @State private var appeared = false
+
+    var body: some View {
+        VStack(spacing: 24) {
+            ZStack {
+                Circle()
+                    .fill(Color.accentColor.opacity(pulse ? 0.6 : 0.35))
+                    .frame(width: 80, height: 80)
+                    .scaleEffect(pulse ? 1.08 : 0.9)
+
+                Image(systemName: "person.2.slash")
+                    .font(.system(size: 36, weight: .medium))
+                    .foregroundStyle(Color.accentColor)
+            }
+            .onAppear {
+                if reduceMotion {
+                    pulse = true
+                    appeared = true
+                } else {
+                    withAnimation(.easeInOut(duration: 1.8).repeatForever(autoreverses: true)) {
+                        pulse = true
+                    }
+                    withAnimation(.easeOut(duration: 0.4)) {
+                        appeared = true
+                    }
+                }
+            }
+
+            VStack(spacing: 8) {
+                Text(NSLocalizedString("companion.discover.empty.title", comment: "No companions found title"))
+                    .font(.title3.weight(.semibold))
+                    .multilineTextAlignment(.center)
+
+                Text(NSLocalizedString("companion.discover.empty.description", comment: "No companions found description"))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .opacity(appeared ? 1 : 0)
+                    .offset(y: appeared ? 0 : 6)
+                    .animation(reduceMotion ? .none : .easeOut(duration: 0.4).delay(0.1), value: appeared)
+            }
+
+            VStack(spacing: 12) {
+                Text(NSLocalizedString("companion.discover.coldstart.tip", comment: "Cold start tip"))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                Button {
+                    Haptics.impact(.light)
+                    onPostTapped()
+                } label: {
+                    Text(NSLocalizedString("companion.discover.empty.cta", comment: "Post your availability CTA"))
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityHint(NSLocalizedString("companion.discover.empty.cta.hint", comment: "Post your availability accessibility hint"))
+            }
+            .opacity(appeared ? 1 : 0)
+            .offset(y: appeared ? 0 : 6)
+            .animation(reduceMotion ? .none : .easeOut(duration: 0.4).delay(0.2), value: appeared)
+        }
+        .padding(.horizontal, 32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 


### PR DESCRIPTION
## Animated empty-state illustration for the companion Discover list

The Discover list's empty state currently shows a static SF Symbol via ContentUnavailableView, which reads as flat and lifeless on the most common cold-start screen. This adds a gentle breathing/pulse animation to the illustration plus a soft staggered fade-in for the supporting text and CTA, making the empty state feel intentional rather than broken. The animation respects Reduce Motion (renders fully static) and reuses the existing Haptics and animation idioms already established across the codebase.

### Acceptance
Build succeeds (`xcodebuild build -scheme SoloCompass`). The DiscoverListView 'Empty state' #Preview shows the halo gently breathing and the CTA fading in on appear. Enabling Reduce Motion (Environment override) renders the empty state fully static with no animation. The 'Post your availability' CTA still opens OpenForCompanionsSheet and fires the light haptic. No schema/@Model files touched; existing localized strings reused unchanged.