### PR TITLE
auto: Richer chat-history empty state + delete haptic

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1531,7 +1531,8 @@
 "chat.history.title" = "History";
 "chat.history.untitled" = "Untitled chat";
 "chat.history.messageCount" = "%d messages";
-"chat.history.empty" = "No saved conversations yet";
+"chat.history.empty.title" = "No conversations yet";
+"chat.history.empty" = "Your saved chats will appear here.";
 "chat.history.open.a11y" = "Open chat history";
 "common.done" = "Done";
 

--- a/apps/ios/SoloCompass/Views/Chat/ChatHistoryListView.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatHistoryListView.swift
@@ -85,9 +85,13 @@ public struct ChatHistoryListView: View {
     private var emptyState: some View {
         VStack(spacing: 12) {
             Image(systemName: "clock.arrow.circlepath")
-                .font(.title.weight(.semibold))
-                .foregroundStyle(CT.fgSubtle)
-            Text(NSLocalizedString("chat.history.empty", comment: "No saved conversations yet"))
+                .font(.title2.weight(.medium))
+                .foregroundStyle(.secondary)
+            Text(NSLocalizedString("chat.history.empty.title", comment: "No conversations yet"))
+                .font(.headline)
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.center)
+            Text(NSLocalizedString("chat.history.empty", comment: "Hint to start a conversation"))
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -106,6 +110,9 @@ public struct ChatHistoryListView: View {
         let ids = offsets.map { sessions[$0].id }
         for id in ids { store.delete(sessionId: id) }
         reload()
+        #if canImport(UIKit)
+        Haptics.impact(.soft)
+        #endif
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Richer chat-history empty state + delete haptic

The chat history list shows a bare icon-and-text empty state and deletes conversations with no tactile feedback. Add a friendlier empty state with a clear call-to-action subtitle, and fire a soft impact haptic on swipe-delete so the destructive action feels confirmed — matching the haptic-rich feel of the rest of the app.

### Acceptance
Build succeeds via `xcodebuild build`. Opening chat history with no saved sessions shows the new title + hint subtitle, centered. Swiping to delete a conversation removes the row and fires a soft haptic. All strings resolve through Localizable.strings (no hardcoded literals). Reduce Motion / hapticsEnabled=off suppresses the haptic via existing HapticService guards.