### PR TITLE
auto: Attention-nudge the 'No matches' empty-filter capsule so users notice the Clear affordance

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -1521,6 +1521,7 @@ private struct MapOverlayView: View {
     var onTapAvatar: () -> Void = {}
 
     @State private var checkInCelebrationTrigger = 0
+    @State private var noMatchPop = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var isFilterActive: Bool {
@@ -1882,9 +1883,11 @@ private struct MapOverlayView: View {
                                 .font(.caption.weight(.semibold))
                                 .foregroundStyle(dotColor)
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(PressableButtonStyle(haptic: false))
                     }
                 }
+                .scaleEffect(noMatchPop ? 1.06 : 1.0)
+                .animation(.spring(response: 0.3, dampingFraction: 0.5), value: noMatchPop)
                 .contentTransition(.opacity)
                 .animation(.spring(response: 0.3, dampingFraction: 0.8), value: count)
                 .accessibilityElement(children: .ignore)
@@ -1893,6 +1896,16 @@ private struct MapOverlayView: View {
                 .accessibilityAction {
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                     viewModel.clearFilters()
+                }
+                .onChange(of: count) { _, newCount in
+                    guard newCount == 0 else { return }
+                    UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                    guard !reduceMotion else { return }
+                    noMatchPop = true
+                    Task {
+                        try? await Task.sleep(nanoseconds: 450_000_000)
+                        noMatchPop = false
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
## Attention-nudge the 'No matches' empty-filter capsule so users notice the Clear affordance

When an active filter drops the visible experience count to zero, the 'No matches · Clear filter' capsule in CompassMapView appears statically with no motion drawing the eye to the recovery action, and its 'Clear filter' button lacks the PressableButtonStyle tactile feedback every other tappable surface in the app uses. This adds a one-shot spring 'pop' on the capsule plus a light warning haptic the moment results transition to zero, and routes the Clear button through the shared PressableButtonStyle — making the dead-end state legible and recoverable. Fully respects Reduce Motion (haptic only, no scale).

### Acceptance
Build passes (xcodebuild build, iPhone 17 Pro sim). When a category/tag filter narrows the map to zero experiences, the 'No matches · Clear filter' capsule does one spring pulse and a warning haptic fires; with Reduce Motion ON only the haptic fires (no scale). The Clear button scales down ~8% on press like other pills and still calls viewModel.clearFilters(). VoiceOver label/announcement behavior and all localized strings are unchanged. Existing EmptyStateAnnouncementTest and FilterBar tests still pass.