### PR TITLE
auto: Add commit haptics to the chat send & mic-toggle buttons

### DIFF
--- a/apps/ios/SoloCompass/Views/Chat/ChatInputBar.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatInputBar.swift
@@ -375,6 +375,7 @@ public struct ChatInputBar: View {
         )
         .simultaneousGesture(
             TapGesture().onEnded {
+                Haptics.selection()
                 let isStarting = micState != .listening
                 onMicToggle(isStarting)
             }
@@ -388,6 +389,7 @@ public struct ChatInputBar: View {
         let trimmed = draftText.trimmingCharacters(in: .whitespacesAndNewlines)
         // Allow sending an attachment-only message (no text).
         guard !trimmed.isEmpty || !attachments.isEmpty else { return }
+        Haptics.impact(.light)
         // Caller reads `attachments` (still bound) inside onSend, then we clear.
         onSend(trimmed)
         draftText = ""


### PR DESCRIPTION
## Add commit haptics to the chat send & mic-toggle buttons

The chat input bar's send button and tap-to-toggle mic fire no haptic feedback on commit, unlike every other commit gesture in the app (favorites swipe, score badge tap, completion ring all call Haptics). Adding a light impact on send and a selection tick on mic toggle closes a tactile inconsistency on the single most-used commit gesture in the companion chat.

### Acceptance
Build succeeds (xcodebuild build, iPhone 17 Pro sim). In the companion chat: tapping send with a non-empty draft (or a staged attachment) produces a light impact; tapping the mic to toggle voice mode produces a selection tick; tapping send with an empty draft produces no haptic (guard still rejects). Existing ChatInputBar previews render unchanged. Haptics remain suppressed when hapticsEnabled is off or Reduce Motion is on, since the call routes through HapticService.