### PR TITLE
auto: Haptic confirmation on first speech detection in VoiceButton

### DIFF
--- a/apps/ios/SoloCompass/Tests/VoiceButtonHapticTests.swift
+++ b/apps/ios/SoloCompass/Tests/VoiceButtonHapticTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import SoloCompass
+
+final class VoiceButtonHapticTests: XCTestCase {
+
+    // MARK: - shouldFireSpeechHaptic
+
+    func testFiresWhenNotYetFiredAndTranscriptNonBlank() {
+        XCTAssertTrue(VoiceButton.shouldFireSpeechHaptic(alreadyFired: false, transcript: "hello"))
+    }
+
+    func testDoesNotFireWhenAlreadyFired() {
+        XCTAssertFalse(VoiceButton.shouldFireSpeechHaptic(alreadyFired: true, transcript: "hello"))
+    }
+
+    func testDoesNotFireWhenTranscriptIsEmpty() {
+        XCTAssertFalse(VoiceButton.shouldFireSpeechHaptic(alreadyFired: false, transcript: ""))
+    }
+
+    func testDoesNotFireWhenTranscriptIsWhitespaceOnly() {
+        XCTAssertFalse(VoiceButton.shouldFireSpeechHaptic(alreadyFired: false, transcript: "   "))
+    }
+
+    func testDoesNotFireWhenTranscriptIsTabAndNewline() {
+        XCTAssertFalse(VoiceButton.shouldFireSpeechHaptic(alreadyFired: false, transcript: "\t\n"))
+    }
+
+    func testDoesNotFireWhenAlreadyFiredEvenIfTranscriptChanges() {
+        XCTAssertFalse(VoiceButton.shouldFireSpeechHaptic(alreadyFired: true, transcript: "new words"))
+    }
+
+    func testFiresForSingleCharacterTranscript() {
+        XCTAssertTrue(VoiceButton.shouldFireSpeechHaptic(alreadyFired: false, transcript: "a"))
+    }
+
+    func testFiresForTranscriptWithLeadingTrailingWhitespace() {
+        XCTAssertTrue(VoiceButton.shouldFireSpeechHaptic(alreadyFired: false, transcript: "  word  "))
+    }
+}

--- a/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
+++ b/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
@@ -29,6 +29,9 @@ public struct VoiceButton: View {
     private let recordStopSuccessGenerator = UINotificationFeedbackGenerator()
     private let recordStopEmptyGenerator = UIImpactFeedbackGenerator(style: .light)
     private let permissionDeniedGenerator = UINotificationFeedbackGenerator()
+    private let speechDetectedGenerator = UIImpactFeedbackGenerator(style: .light)
+
+    @State private var didDetectSpeech = false
 
     public init(voiceService: VoiceService, onTranscript: @escaping (String) -> Void) {
         self.voiceService = voiceService
@@ -90,6 +93,7 @@ public struct VoiceButton: View {
                     recordStopSuccessGenerator.prepare()
                     recordStopEmptyGenerator.prepare()
                     permissionDeniedGenerator.prepare()
+                    speechDetectedGenerator.prepare()
                 }
                 .onEnded { _ in
                     if isRecording { stopRecording() }
@@ -176,6 +180,10 @@ public struct VoiceButton: View {
 
     // MARK: - Helpers
 
+    static func shouldFireSpeechHaptic(alreadyFired: Bool, transcript: String) -> Bool {
+        !alreadyFired && !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     private var formattedElapsed: String {
         let min = Int(elapsed) / 60
         let sec = Int(elapsed) % 60
@@ -200,6 +208,7 @@ public struct VoiceButton: View {
                 didAutoStop = false
                 autoStopMessage = nil
                 didWarnCountdown = false
+                didDetectSpeech = false
                 recordStartGenerator.impactOccurred()
                 if UIAccessibility.isVoiceOverRunning {
                     UIAccessibility.post(notification: .announcement,
@@ -211,7 +220,13 @@ public struct VoiceButton: View {
                     do {
                         for try await text in stream {
                             let animate = !reduceMotion
-                            await MainActor.run { withAnimation(animate ? .easeOut(duration: 0.18) : nil) { liveTranscript = text } }
+                            await MainActor.run {
+                                withAnimation(animate ? .easeOut(duration: 0.18) : nil) { liveTranscript = text }
+                                if VoiceButton.shouldFireSpeechHaptic(alreadyFired: didDetectSpeech, transcript: text) {
+                                    didDetectSpeech = true
+                                    speechDetectedGenerator.impactOccurred()
+                                }
+                            }
                         }
                     } catch {
                         guard !(error is CancellationError) else { return }


### PR DESCRIPTION
## Haptic confirmation on first speech detection in VoiceButton

When holding the voice button to speak, the user gets no tactile signal that the mic is actually capturing their words — they must watch the screen for the live transcript to confirm recognition started. Fire a single light impact haptic the instant the first non-empty partial transcript arrives, giving eyes-free confirmation that speech-to-text is working. This makes the voice-first flow feel responsive and trustworthy without the user having to look down.

### Acceptance
Holding the voice button and speaking produces a single light haptic tap the moment the first word is recognized, and no further speech-detection haptics for the remainder of that recording. Starting a new recording re-arms the haptic. The empty/too-short stop paths and the existing start/stop haptics are unchanged. `shouldFireSpeechHaptic` returns true only when not already fired and the transcript is non-blank; unit tests cover (fired=false, nonblank)→true, (fired=true, nonblank)→false, (fired=false, blank/whitespace)→false. `xcodebuild build` and the SoloCompassTests target pass.