### PR TITLE
auto: POI loading banner success flash — close the loading loop with a 'N places nearby' moment

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -290,6 +290,8 @@
 "map.loadingPOIs.a11yAnnouncement" = "Finding nearby places";
 /* Shown after ~6 s when the Overpass fetch is still running — reassures the user the app is not stuck */
 "map.loadingPOIs.slow" = "Still searching nearby…";
+/* Shown for ~1.2 s after the Overpass fetch completes — %d = number of POIs found */
+"map.loadingPOIs.done" = "%d places nearby";
 
 /* City picker */
 "city.all" = "All Cities";

--- a/apps/ios/SoloCompass/Views/Map/POILoadingBanner.swift
+++ b/apps/ios/SoloCompass/Views/Map/POILoadingBanner.swift
@@ -9,42 +9,90 @@ struct POILoadingBanner: View {
     @State private var isPulsing = false
     @State private var isSlow: Bool
     @State private var slowTask: Task<Void, Never>?
+    @State private var bannerState: BannerState = .loading
+    @State private var loadedCount: Int = 0
+
+    private enum BannerState {
+        case loading, succeeded
+    }
 
     // `previewSlow` is only used in #Preview blocks to skip the 6-second wait.
-    init(previewSlow: Bool = false) {
+    // `previewDone` is only used in #Preview blocks to show the success state directly.
+    init(previewSlow: Bool = false, previewDone: Bool = false) {
         _isSlow = State(initialValue: previewSlow)
+        _bannerState = State(initialValue: previewDone ? .succeeded : .loading)
+        _loadedCount = State(initialValue: previewDone ? 12 : 0)
+    }
+
+    @MainActor
+    func showSuccess(count: Int) async {
+        slowTask?.cancel()
+        slowTask = nil
+
+        withAnimation(reduceMotion ? nil : .easeInOut) {
+            isPulsing = false
+            loadedCount = count
+            bannerState = .succeeded
+        }
+
+        Haptics.notify(.success)
+
+        UIAccessibility.post(
+            notification: .announcement,
+            argument: String(format: NSLocalizedString("map.loadingPOIs.done", comment: "Shown for ~1.2 s after the Overpass fetch completes — %d = number of POIs found"), count)
+        )
+
+        try? await Task.sleep(nanoseconds: 1_200_000_000)
     }
 
     var body: some View {
         GlassmorphismCapsule(
             verticalPadding: 8,
             leading: {
-                ProgressView()
-                    .controlSize(.mini)
-                    .scaleEffect(isPulsing ? 1.08 : 0.92)
-                    .opacity(isPulsing ? 1.0 : 0.6)
+                Group {
+                    if bannerState == .succeeded {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.green)
+                            .transition(reduceMotion ? .opacity : .scale.combined(with: .opacity))
+                    } else {
+                        ProgressView()
+                            .controlSize(.mini)
+                            .scaleEffect(isPulsing ? 1.08 : 0.92)
+                            .opacity(isPulsing ? 1.0 : 0.6)
+                    }
+                }
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.25), value: bannerState)
             },
             content: {
-                Text(isSlow
-                     ? NSLocalizedString("map.loadingPOIs.slow", comment: "Reassurance shown when POI fetch exceeds ~6 s")
-                     : NSLocalizedString("map.loadingPOIs", comment: "Loading nearby places banner"))
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                    .contentTransition(.opacity)
-                    .animation(reduceMotion ? nil : .easeInOut, value: isSlow)
+                Group {
+                    if bannerState == .succeeded {
+                        Text(String(format: NSLocalizedString("map.loadingPOIs.done", comment: "Shown for ~1.2 s after the Overpass fetch completes — %d = number of POIs found"), loadedCount))
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.green)
+                    } else {
+                        Text(isSlow
+                             ? NSLocalizedString("map.loadingPOIs.slow", comment: "Reassurance shown when POI fetch exceeds ~6 s")
+                             : NSLocalizedString("map.loadingPOIs", comment: "Loading nearby places banner"))
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .contentTransition(.opacity)
+                            .animation(reduceMotion ? nil : .easeInOut, value: isSlow)
+                    }
+                }
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.25), value: bannerState)
             }
         )
         .transition(.move(edge: .top).combined(with: .opacity))
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(Text(isSlow
-            ? NSLocalizedString("map.loadingPOIs.slow", comment: "Reassurance shown when POI fetch exceeds ~6 s")
-            : NSLocalizedString("map.loadingPOIs", comment: "Loading nearby places banner")))
+        .accessibilityLabel(accessibilityLabel)
         .onAppear {
             UIAccessibility.post(
                 notification: .announcement,
                 argument: NSLocalizedString("map.loadingPOIs.a11yAnnouncement", comment: "VoiceOver announcement when POI fetch begins")
             )
             guard !reduceMotion else { return }
+            guard bannerState == .loading else { return }
             withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
                 isPulsing = true
             }
@@ -66,6 +114,7 @@ struct POILoadingBanner: View {
             slowTask = nil
         }
         .onChange(of: reduceMotion) { _, reduced in
+            guard bannerState == .loading else { return }
             if reduced {
                 withAnimation(.default) { isPulsing = false }
             } else {
@@ -73,6 +122,17 @@ struct POILoadingBanner: View {
                     isPulsing = true
                 }
             }
+        }
+    }
+
+    private var accessibilityLabel: Text {
+        switch bannerState {
+        case .succeeded:
+            return Text(String(format: NSLocalizedString("map.loadingPOIs.done", comment: "Shown for ~1.2 s after the Overpass fetch completes — %d = number of POIs found"), loadedCount))
+        case .loading:
+            return Text(isSlow
+                ? NSLocalizedString("map.loadingPOIs.slow", comment: "Reassurance shown when POI fetch exceeds ~6 s")
+                : NSLocalizedString("map.loadingPOIs", comment: "Loading nearby places banner"))
         }
     }
 }
@@ -89,6 +149,14 @@ struct POILoadingBanner: View {
     ZStack {
         Color(.systemBackground).ignoresSafeArea()
         POILoadingBanner(previewSlow: true)
+            .padding(.top, 60)
+    }
+}
+
+#Preview("Done") {
+    ZStack {
+        Color(.systemBackground).ignoresSafeArea()
+        POILoadingBanner(previewDone: true)
             .padding(.top, 60)
     }
 }


### PR DESCRIPTION
## POI loading banner success flash — close the loading loop with a 'N places nearby' moment

POILoadingBanner currently vanishes abruptly when an Overpass fetch completes, leaving no positive confirmation that the work finished. Mirror OfflineBanner's existing `.recovered` green-checkmark pattern by flashing a brief success state ('12 places nearby') for ~1.2s before the banner dismisses, giving the fetch a satisfying close instead of a silent disappearance.

### Acceptance
When an Overpass POI fetch completes, the loading pill briefly shows a green checkmark + 'N places nearby' for ~1.2s (with success haptic and VoiceOver announcement) before dismissing, instead of disappearing instantly. With Reduce Motion on, no scale animation plays but the haptic and announcement still fire. The new string is in Localizable.strings (StringsParityTests still passes), a `#Preview("Done")` renders the success state, and `xcodebuild build` succeeds.