### PR TITLE
auto: Warm up the empty 'Nearby' state with a headline + supporting line

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1499,6 +1499,10 @@
 "a11y.empty.filterResults" = "No results for this filter";
 "a11y.empty.list" = "No experiences to show";
 
+/* Empty Nearby two-tier empty state (headline + subtitle) */
+"empty.nearby.headline" = "Nothing here — yet";
+"empty.nearby.subtitle" = "Pan the map or widen the view to find experiences around you.";
+
 /* Empty Nearby CTA — nudges the traveler to recenter/zoom out */
 "empty.nearby.cta" = "Explore another area";
 

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1283,6 +1283,8 @@
 "detail.nearby.open.hint" = "打开体验详情";
 
 /* Empty states */
+"empty.nearby.headline" = "这附近还没有体验";
+"empty.nearby.subtitle" = "移动地图或拉远视野，看看周围有什么。";
 "empty.nearby.cta" = "探索其他区域";
 
 /* Favorites */

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -1327,9 +1327,13 @@ struct EmptySheetListView: View {
                     .foregroundStyle(.secondary)
                     .scaleEffect(breathing ? 1.08 : 1.0)
                     .opacity(breathing ? 0.7 : 1.0)
-                Text(localizedEmptyText)
+                Text(NSLocalizedString("empty.nearby.headline", comment: "Empty Nearby headline"))
+                    .font(.headline)
+                    .foregroundStyle(CT.fgPrimary)
+                    .multilineTextAlignment(.center)
+                Text(NSLocalizedString("empty.nearby.subtitle", comment: "Empty Nearby supporting subline"))
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(CT.fgMuted)
                     .multilineTextAlignment(.center)
             }
 


### PR DESCRIPTION
## Warm up the empty 'Nearby' state with a headline + supporting line

The BottomInfoSheet's empty Nearby list currently shows just a faded mappin.slash icon and one terse line ('No experiences nearby'), which reads like an error rather than the editorial, encouraging tone the rest of the app uses. Replace it with a two-tier empty state — a warm headline plus a supporting subline that reframes the moment ('You've wandered off the map — let's widen the view') — so the dead-end feels like an invitation, while keeping the existing breathing animation, Explore-elsewhere CTA, and VoiceOver announcement intact.

### Acceptance
When the Nearby list is empty, the sheet shows the breathing icon, a bold headline, and a softer supporting line (both localized in en + zh-Hans), above the unchanged 'Explore another area' CTA. VoiceOver still posts the single 'a11y.empty.nearby' announcement on appear. Reduce Motion still disables the icon breathing. xcodebuild build succeeds and the existing EmptySheetListView/empty-state tests still pass.