### PR TITLE
auto: Emphasize the strongest signal's strength bar in the ConfidenceBadge popover

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/ConfidenceBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/ConfidenceBadge.swift
@@ -284,13 +284,15 @@ private struct PopoverContent: View {
                 Text(value).fontWeight(.medium)
             }
             // Strength bar
+            let barHeight: CGFloat = isStrongest ? 5 : 3
             ZStack(alignment: .leading) {
                 Capsule()
                     .fill(Color.secondary.opacity(0.15))
-                    .frame(height: 3)
+                    .frame(height: barHeight)
                 Capsule()
-                    .fill(confidence.health.color.opacity(0.7))
-                    .frame(width: fillWidth, height: 3)
+                    .fill(confidence.health.color.opacity(isStrongest ? 1.0 : 0.7))
+                    .frame(width: fillWidth, height: barHeight)
+                    .shadow(color: isStrongest ? confidence.health.color.opacity(0.5) : .clear, radius: 3)
                     .animation(animation, value: barsFilled)
             }
         }
@@ -336,6 +338,16 @@ fileprivate func confidenceRelativeVerifiedString(_ confidence: Confidence) -> S
                 signals: .init(aiScrapeAgeDays: 20, passiveGpsHits30d: 2, activeReports30d: 3, trustedVerifications: 0)
             ),
             compact: true
+        )
+        // GPS dominant — strongest bar emphasis visible
+        ConfidenceBadge(
+            confidence: Confidence(
+                level: 3,
+                lastVerifiedAt: Date().addingTimeInterval(-5 * 86_400),
+                reason: "High passive GPS activity",
+                signals: .init(aiScrapeAgeDays: 60, passiveGpsHits30d: 28, activeReports30d: 1, trustedVerifications: 0)
+            ),
+            compact: false
         )
     }
     .padding()


### PR DESCRIPTION
## Emphasize the strongest signal's strength bar in the ConfidenceBadge popover

The confidence popover already calls out the strongest trust signal with a bold label and a 'Strongest: X' star caption, but its strength bar renders identically to the weaker signals — so the visual hierarchy doesn't match the textual one. This adds a subtle emphasis (taller, fully-opaque bar with a soft glow) to the strongest signal's bar so the eye lands where the caption points, reinforcing the trust signal that drives the whole app.

### Acceptance
xcodebuild build succeeds; existing SoloCompassTests pass. In the popover, the row matching the 'Strongest: X' caption has a visibly taller, brighter, softly-glowing strength bar while other rows are unchanged. Under Reduce Motion the bars still fill (no animation) and emphasis is preserved. VoiceOver output is unchanged (accessibilityValue still reports value + strength). No NSLocalizedString keys added or removed; no @Model/schema files touched; diff under 40 lines in one file.