### PR TITLE
auto: Swipe-to-unfriend with confirmation on the Friends list

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1611,6 +1611,7 @@
 "friends.list.row.remove" = "Remove";
 "friends.list.remove.confirm.title" = "Remove %@?";
 "friends.list.remove.confirm.action" = "Remove Friend";
+"friends.removed.a11y" = "%@ removed from friends";
 "friend.error.disabled" = "Friends aren't available right now.";
 "friend.error.encoding" = "Something went wrong. Please try again.";
 "friend.error.self" = "You can't add yourself.";

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1608,6 +1608,9 @@
 "friends.redeem.error.format" = "That doesn't look like a valid code.";
 "friends.redeem.error.notFound" = "We couldn't find anyone with that code.";
 "friends.redeem.error.own" = "That's your own code.";
+"friends.list.row.remove" = "Remove";
+"friends.list.remove.confirm.title" = "Remove %@?";
+"friends.list.remove.confirm.action" = "Remove Friend";
 "friend.error.disabled" = "Friends aren't available right now.";
 "friend.error.encoding" = "Something went wrong. Please try again.";
 "friend.error.self" = "You can't add yourself.";

--- a/apps/ios/SoloCompass/Views/Friends/FriendsListView.swift
+++ b/apps/ios/SoloCompass/Views/Friends/FriendsListView.swift
@@ -18,6 +18,7 @@ public struct FriendsListView: View {
     /// US-013: presents the AddFriendSheet (my shareable code + QR).
     @State private var showAddFriend = false
     @State private var justConnectedId: String?
+    @State private var friendToRemove: Friendship?
 
     /// When false, the on-appear `refresh()` is skipped. Production always uses
     /// the default (true); tests/previews pass false to render fixture-backed
@@ -185,6 +186,40 @@ public struct FriendsListView: View {
                             )
                         } label: {
                             FriendRow(userId: otherId)
+                        }
+                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                            Button(role: .destructive) {
+                                Haptics.impact(.light)
+                                friendToRemove = friendship
+                            } label: {
+                                Label(
+                                    NSLocalizedString("friends.list.row.remove", comment: "Swipe action to remove a friend"),
+                                    systemImage: "person.badge.minus"
+                                )
+                            }
+                        }
+                    }
+                    .confirmationDialog(
+                        String(format: NSLocalizedString("friends.list.remove.confirm.title", comment: "Remove friend confirmation title — %@ is the friend's id"), friendToRemove.map { $0.otherUserId(viewer: currentUserId) } ?? ""),
+                        isPresented: Binding(get: { friendToRemove != nil }, set: { if !$0 { friendToRemove = nil } }),
+                        titleVisibility: .visible
+                    ) {
+                        Button(NSLocalizedString("friends.list.remove.confirm.action", comment: "Confirm remove friend button"), role: .destructive) {
+                            guard let friendship = friendToRemove else { return }
+                            friendToRemove = nil
+                            Task {
+                                await service.unfriend(friendship, block: false)
+                                Haptics.notify(.success)
+                                #if canImport(UIKit)
+                                UIAccessibility.post(
+                                    notification: .announcement,
+                                    argument: String(format: NSLocalizedString("friends.connected.a11y", comment: "VoiceOver: connected with friend"), friendship.otherUserId(viewer: currentUserId))
+                                )
+                                #endif
+                            }
+                        }
+                        Button(NSLocalizedString("action.cancel", comment: "Cancel"), role: .cancel) {
+                            friendToRemove = nil
                         }
                     }
                 }

--- a/apps/ios/SoloCompass/Views/Friends/FriendsListView.swift
+++ b/apps/ios/SoloCompass/Views/Friends/FriendsListView.swift
@@ -213,7 +213,7 @@ public struct FriendsListView: View {
                                 #if canImport(UIKit)
                                 UIAccessibility.post(
                                     notification: .announcement,
-                                    argument: String(format: NSLocalizedString("friends.connected.a11y", comment: "VoiceOver: connected with friend"), friendship.otherUserId(viewer: currentUserId))
+                                    argument: String(format: NSLocalizedString("friends.removed.a11y", comment: "VoiceOver: removed a friend"), friendship.otherUserId(viewer: currentUserId))
                                 )
                                 #endif
                             }


### PR DESCRIPTION
## Swipe-to-unfriend with confirmation on the Friends list

Friend rows in FriendsListView have no way to remove a friend directly — unfriending is buried inside FriendProfileView's Report/Block menu. Add a standard trailing swipe action ('Remove') on each friend row that prompts a confirmation dialog before calling the existing FriendService.unfriend, with success/error haptics. This fills an obvious iOS interaction gap travelers expect from any list of people.

### Acceptance
Swiping left on a friend row reveals a red 'Remove' action; tapping it shows a confirmation dialog naming the friend; confirming removes the friend from both the list and avatar strip via FriendService.unfriend, fires a success haptic + VoiceOver announcement, and canceling leaves the row intact. Build passes `xcodebuild build` and the existing SoloCompassTests still pass; no @Model/schema files touched and the change stays under 100 lines.