### PR TITLE
auto: Tap the distance pill to recenter the map on the experience

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -343,6 +343,9 @@
 /* On-course cue appended to bearing arrow a11y label when user faces the experience within ±15° */
 "card.distance.onCourse.a11y" = "On course";
 
+/* Recenter hint on distance/bearing pill button */
+"card.distance.recenter.hint" = "Double tap to center the map here";
+
 /* Compass directions (8 sectors) for bearing arrow accessibility */
 "compass.N" = "north";
 "compass.NE" = "northeast";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -12,6 +12,9 @@ public struct ExperienceCardView: View {
     var onRecompile: (() -> Void)?
     /// True while THIS card is mid-recompile — swaps the menu for a spinner.
     var isRecompiling: Bool = false
+    /// Optional: tap handler for the distance/bearing pill. Fires with the
+    /// experience's coordinate so the map can recenter on it.
+    var onRecenter: ((CLLocationCoordinate2D) -> Void)? = nil
 
     private struct DragState {
         var translation: CGFloat = 0
@@ -168,13 +171,15 @@ public struct ExperienceCardView: View {
         onExpand: @escaping () -> Void,
         onDismiss: @escaping () -> Void,
         onRecompile: (() -> Void)? = nil,
-        isRecompiling: Bool = false
+        isRecompiling: Bool = false,
+        onRecenter: ((CLLocationCoordinate2D) -> Void)? = nil
     ) {
         self.experience = experience
         self.onExpand = onExpand
         self.onDismiss = onDismiss
         self.onRecompile = onRecompile
         self.isRecompiling = isRecompiling
+        self.onRecenter = onRecenter
     }
 
     /// Rubber-bands upward drags to 40% travel; downward dismissal drags follow 1:1.
@@ -277,16 +282,9 @@ public struct ExperienceCardView: View {
 
             FlowLayout(spacing: 8) {
                 SoloScoreBadge(score: experience.soloScore, style: .compact)
-                Group {
-                    if isArrived {
-                        arrivedPill
-                    } else if let meters = distanceMeters {
-                        let dl = Self.formatDistance(meters)
-                        distancePill(dl.text, symbol: dl.symbol)
-                    }
-                }
-                .contentTransition(.numericText())
-                .animation(.spring(response: 0.4), value: distanceMeters)
+                distancePillGroup
+                    .contentTransition(.numericText())
+                    .animation(.spring(response: 0.4), value: distanceMeters)
                 if let meters = distanceMeters, !isArrived, meters < Self.walkThresholdMeters {
                     etaPill(meters: meters)
                 }
@@ -557,6 +555,38 @@ public struct ExperienceCardView: View {
             .background(Capsule().fill(Color.green.opacity(0.12)))
             .contentTransition(reduceMotion ? .identity : .numericText())
             .accessibilityLabel(a11y)
+    }
+
+    /// The distance/arrived pill, optionally wrapped in a recenter Button.
+    @ViewBuilder
+    private var distancePillGroup: some View {
+        if let recenter = onRecenter, let coord = experience.coordinate {
+            Button {
+                Haptics.impact(.light)
+                recenter(coord)
+            } label: {
+                rawDistancePill
+            }
+            .buttonStyle(.plain)
+            .contentShape(Capsule())
+            .accessibilityHint(Text(NSLocalizedString("card.distance.recenter.hint", comment: "Double tap to center the map on this experience")))
+            .accessibilityAction(named: Text(NSLocalizedString("card.distance.recenter.hint", comment: "Double tap to center the map on this experience"))) {
+                Haptics.impact(.light)
+                recenter(coord)
+            }
+        } else {
+            rawDistancePill
+        }
+    }
+
+    @ViewBuilder
+    private var rawDistancePill: some View {
+        if isArrived {
+            arrivedPill
+        } else if let meters = distanceMeters {
+            let dl = Self.formatDistance(meters)
+            distancePill(dl.text, symbol: dl.symbol)
+        }
     }
 
     @ViewBuilder

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -761,7 +761,10 @@ struct CompassMapContentView: View {
                             onRecompile: {
                                 Task { await viewModel.recompileExperience(selected) }
                             },
-                            isRecompiling: viewModel.recompilingExperienceId == selected.id
+                            isRecompiling: viewModel.recompilingExperienceId == selected.id,
+                            onRecenter: { _ in
+                                viewModel.focusOnExperience(selected)
+                            }
                         )
                         .padding(.bottom, cardBottomInset)
                     }


### PR DESCRIPTION
## Tap the distance pill to recenter the map on the experience

The peek card's distance pill shows a bearing arrow pointing toward the place but is inert — tapping it does nothing. Make it a button that smoothly recenters the in-app map camera on the experience's coordinate, giving users a one-tap 'show me where this is' gesture distinct from the external-directions pill. This is the natural, expected interaction for a compass-first app and reuses the existing map-focus path.

### Acceptance
Tapping the distance/bearing pill on a peek card animates the map to center on that experience; a light haptic fires; the external 'Directions' pill behavior is unchanged. VoiceOver exposes a 'center the map here' action and hint. Reduce Motion users get an instant recenter (no animation). `xcodebuild build` and `xcodebuild test` pass on iPhone 17 Pro sim, including StringsParityTests; the card's #Preview still renders. No more than ~80 lines changed across the two files.