### PR TITLE
auto: Milestone shimmer sweep on the Favorites journey progress bar at 100%

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -716,6 +716,9 @@ private struct JourneyProgressBar: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var animatedFraction: CGFloat = 0
+    @State private var didCompletionSweep = false
+    @State private var sweepPhase: CGFloat = -1
+    @State private var fillScaleY: CGFloat = 1
 
     private var targetFraction: CGFloat {
         total > 0 ? CGFloat(completed) / CGFloat(total) : 0
@@ -732,10 +735,29 @@ private struct JourneyProgressBar: View {
                 Capsule()
                     .fill(isAllDone ? Color.green : Color.green.opacity(0.75))
                     .frame(width: geo.size.width * animatedFraction, height: 4)
+                    .scaleEffect(x: 1, y: fillScaleY, anchor: .center)
                     .shadow(
                         color: isAllDone ? Color.green.opacity(0.4) : Color.clear,
                         radius: 3
                     )
+                    .overlay(alignment: .leading) {
+                        if isAllDone && !reduceMotion {
+                            LinearGradient(
+                                stops: [
+                                    .init(color: .clear, location: 0),
+                                    .init(color: .white.opacity(0.6), location: 0.5),
+                                    .init(color: .clear, location: 1),
+                                ],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                            .frame(width: geo.size.width * 0.4, height: 4)
+                            .clipShape(Capsule())
+                            .offset(x: geo.size.width * sweepPhase)
+                            .allowsHitTesting(false)
+                        }
+                    }
+                    .clipShape(Capsule())
             }
         }
         .frame(height: 4)
@@ -747,6 +769,9 @@ private struct JourneyProgressBar: View {
                     animatedFraction = targetFraction
                 }
             }
+            if isAllDone && !reduceMotion {
+                fireSweep(width: 0)
+            }
         }
         .onChange(of: completed) { _, _ in
             if reduceMotion {
@@ -755,6 +780,29 @@ private struct JourneyProgressBar: View {
                 withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
                     animatedFraction = targetFraction
                 }
+            }
+            if !isAllDone {
+                didCompletionSweep = false
+            }
+            if isAllDone && !reduceMotion {
+                fireSweep(width: 0)
+            }
+        }
+    }
+
+    private func fireSweep(width: CGFloat) {
+        guard !didCompletionSweep else { return }
+        didCompletionSweep = true
+        sweepPhase = -1
+        withAnimation(.easeInOut(duration: 0.7).delay(0.15)) {
+            sweepPhase = 1.4
+        }
+        withAnimation(.spring(response: 0.18, dampingFraction: 0.45).delay(0.1)) {
+            fillScaleY = 1.25
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.38) {
+            withAnimation(.spring(response: 0.22, dampingFraction: 0.6)) {
+                fillScaleY = 1
             }
         }
     }
@@ -1445,6 +1493,35 @@ private struct DirectionsSwipeModifier: ViewModifier {
             content
         }
     }
+}
+
+#Preview("JourneyProgressBar — 100% sweep") {
+    struct SweepDemo: View {
+        @State private var completed = 4
+        let total = 5
+
+        var body: some View {
+            VStack(spacing: 24) {
+                JourneyProgressBar(completed: completed, total: total)
+                    .padding(.horizontal, 24)
+                HStack(spacing: 16) {
+                    Button("−1") { if completed > 0 { completed -= 1 } }
+                        .buttonStyle(.bordered)
+                    Text("\(completed)/\(total)")
+                        .monospacedDigit()
+                    Button("+1") { if completed < total { completed += 1 } }
+                        .buttonStyle(.borderedProminent)
+                }
+                Text("Tap +1 to reach 100% and watch the shimmer sweep")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+            .padding()
+        }
+    }
+    return SweepDemo()
 }
 
 #Preview {


### PR DESCRIPTION
## Milestone shimmer sweep on the Favorites journey progress bar at 100%

When a solo traveler marks their last remaining saved experience as visited, the full-width JourneyProgressBar in FavoritesListView currently just slides to full and turns solid green — silently — while only the tiny 22pt CompletionRing celebrates. This adds a one-shot light shimmer sweep plus a subtle spring overshoot across the bar the first time it reaches 100%, giving the most prominent 'journey complete' element the celebratory weight already used elsewhere in the app (HeartBurstView, CompletionCelebrationView). Fully gated behind Reduce Motion and fired only once per all-done transition.

### Acceptance
Building the SoloCompass scheme succeeds (xcodebuild build). Opening Favorites and marking the final remaining saved experience as visited plays a single left-to-right shimmer sweep with a brief height overshoot across the now-full green bar, exactly once. Marking one back to not-visited and completing again re-fires the sweep. With Reduce Motion enabled, the bar fills instantly with no sweep or overshoot. The bar remains accessibilityHidden and the existing JourneyProgressBar layout/height (4pt) and CompletionRing celebration are unchanged. Existing SoloCompassTests still pass.