### PR TITLE
auto: Make the radar chart's strongest/weakest caption tappable to reveal its dimension tooltip

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
@@ -336,6 +336,7 @@ public struct SoloScoreRadarChart: View {
         let weakCaptionVisible = values[weakestIndex] < 6
         let strongCaptionVisible = hasQualifyingStrongest
         let anyVisible = weakCaptionVisible || strongCaptionVisible
+        let fullyDrawn = drawProgress >= 0.99
         ZStack {
             VStack(spacing: 4) {
                 if strongCaptionVisible {
@@ -343,24 +344,34 @@ public struct SoloScoreRadarChart: View {
                         format: NSLocalizedString("solo.radar.strongest", comment: ""),
                         Self.axes[strongestIndex].label
                     )
-                    Label(strongText, systemImage: "star.fill")
-                        .font(.caption)
-                        .foregroundStyle(Self.greenAccent)
-                        .opacity(drawProgress >= 0.99 ? 1 : 0)
-                        .animation(reduceMotion ? nil : .easeIn(duration: 0.3), value: drawProgress >= 0.99)
-                        .accessibilityHidden(true)
+                    Button { if fullyDrawn { tapAxis(strongestIndex) } } label: {
+                        Label(strongText, systemImage: "star.fill")
+                            .font(.caption)
+                            .foregroundStyle(Self.greenAccent)
+                    }
+                    .buttonStyle(.plain)
+                    .opacity(fullyDrawn ? 1 : 0)
+                    .animation(reduceMotion ? nil : .easeIn(duration: 0.3), value: fullyDrawn)
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityLabel(Text(Self.axes[strongestIndex].label))
+                    .accessibilityHint(Text(NSLocalizedString("solo.axis.tap.hint", comment: "")))
                 }
                 if weakCaptionVisible {
                     let captionText = String(
                         format: NSLocalizedString("solo.radar.weakest", comment: ""),
                         Self.axes[weakestIndex].label
                     )
-                    Label(captionText, systemImage: "exclamationmark.bubble")
-                        .font(.caption)
-                        .foregroundStyle(Self.amberAccent)
-                        .opacity(drawProgress >= 0.99 ? 1 : 0)
-                        .animation(reduceMotion ? nil : .easeIn(duration: 0.3), value: drawProgress >= 0.99)
-                        .accessibilityHidden(true)
+                    Button { if fullyDrawn { tapAxis(weakestIndex) } } label: {
+                        Label(captionText, systemImage: "exclamationmark.bubble")
+                            .font(.caption)
+                            .foregroundStyle(Self.amberAccent)
+                    }
+                    .buttonStyle(.plain)
+                    .opacity(fullyDrawn ? 1 : 0)
+                    .animation(reduceMotion ? nil : .easeIn(duration: 0.3), value: fullyDrawn)
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityLabel(Text(Self.axes[weakestIndex].label))
+                    .accessibilityHint(Text(NSLocalizedString("solo.axis.tap.hint", comment: "")))
                 }
             }
         }


### PR DESCRIPTION
## Make the radar chart's strongest/weakest caption tappable to reveal its dimension tooltip

In SoloScoreRadarChart, the honest-tradeoff caption ("Weakest: Ambiance — expect it to be a tradeoff" / "Great for solo Safety") is currently decorative text with no interaction, while every axis label already opens a plain-language tooltip via tapAxis(). This wires each caption line to call tapAxis() for the dimension it names, so a traveler who reads "Weakest: Ambiance" can tap it directly to learn what 'Ambiance' means — closing the loop between the summary and the per-axis explanation using machinery that already exists.

### Acceptance
Tapping the 'Weakest: <dim>' caption selects that axis and floats its plain-language tooltip (same as tapping the axis label); tapping 'Great for solo <dim>' does the same for the strongest axis. The captions keep their existing green/amber styling and fade-in. VoiceOver exposes each caption as a button with the dimension name and the standard 'Double tap to learn more' hint instead of being hidden. Reduce Motion path is unaffected (tooltip still appears, no replay). xcodebuild build and the existing SoloScore radar tests pass.