### PR TITLE
auto: Announce live favorites search result count to VoiceOver

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -509,6 +509,10 @@
 "favorites.distance.mi" = "%.1f mi";
 "favorites.search.noResults" = "No matches for \"%@\"";
 "favorites.search.noResults.hint" = "Try a different word, or clear your search.";
+/* VoiceOver announcement when favorites search returns results: "%d matching favorites" */
+"favorites.search.resultCount.a11y" = "%d matching favorites";
+/* VoiceOver announcement when favorites search returns no results: "No favorites match <query>" */
+"favorites.search.noResults.a11y" = "No favorites match %@";
 "favorites.search.clear" = "Clear search";
 "favorites.search.clear.hint" = "Clears the search field and shows all favorites";
 "favorites.search.prompt" = "Search favorites";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -502,20 +502,18 @@ public struct FavoritesListView: View {
                 return
             }
             searchAnnounceTask?.cancel()
-            let count = filteredFavorites.count
-            searchAnnounceTask = Task {
+            searchAnnounceTask = Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(400))
                 guard !Task.isCancelled else { return }
                 guard UIAccessibility.isVoiceOverRunning else { return }
+                let count = filteredFavorites.count
                 let message: String
                 if count > 0 {
                     message = String(format: NSLocalizedString("favorites.search.resultCount.a11y", comment: "VoiceOver search result count in favorites: %d matching favorites"), count)
                 } else {
                     message = String(format: NSLocalizedString("favorites.search.noResults.a11y", comment: "VoiceOver no results announcement in favorites: No favorites match <query>"), query)
                 }
-                await MainActor.run {
-                    UIAccessibility.post(notification: .announcement, argument: message)
-                }
+                UIAccessibility.post(notification: .announcement, argument: message)
             }
         }
     }

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -33,6 +33,7 @@ public struct FavoritesListView: View {
     @State private var showRemainingOnly = false
     @State private var prioritizeGoodNow = false
     @State private var celebrationTrigger = 0
+    @State private var searchAnnounceTask: Task<Void, Never>?
 
     private var undoDismissSeconds: Double { voiceOverOn ? 12 : 4 }
 
@@ -491,6 +492,30 @@ public struct FavoritesListView: View {
         .onChange(of: goodNowCount) { _, newCount in
             if newCount == 0 && prioritizeGoodNow {
                 withAnimation(reduceMotion ? nil : .easeInOut) { prioritizeGoodNow = false }
+            }
+        }
+        .onChange(of: searchText) { _, newValue in
+            let query = newValue.trimmingCharacters(in: .whitespaces)
+            guard !query.isEmpty else {
+                searchAnnounceTask?.cancel()
+                searchAnnounceTask = nil
+                return
+            }
+            searchAnnounceTask?.cancel()
+            let count = filteredFavorites.count
+            searchAnnounceTask = Task {
+                try? await Task.sleep(for: .milliseconds(400))
+                guard !Task.isCancelled else { return }
+                guard UIAccessibility.isVoiceOverRunning else { return }
+                let message: String
+                if count > 0 {
+                    message = String(format: NSLocalizedString("favorites.search.resultCount.a11y", comment: "VoiceOver search result count in favorites: %d matching favorites"), count)
+                } else {
+                    message = String(format: NSLocalizedString("favorites.search.noResults.a11y", comment: "VoiceOver no results announcement in favorites: No favorites match <query>"), query)
+                }
+                await MainActor.run {
+                    UIAccessibility.post(notification: .announcement, argument: message)
+                }
             }
         }
     }


### PR DESCRIPTION
## Announce live favorites search result count to VoiceOver

When a VoiceOver user types in the Favorites search field, the result list updates silently — they get no feedback on how many favorites match until they manually navigate the list. Add a debounced UIAccessibility announcement (e.g. "3 matching favorites" / "No matches") that fires as the filtered count changes, matching the sighted-user count label already shown in the footer.

### Acceptance
With VoiceOver on, typing a query into the Favorites search field produces a spoken announcement of the match count ("3 matching favorites") debounced ~0.4s after typing stops, and "No favorites match <query>" when there are zero results; rapid typing does not produce a flood of announcements (only the final settled count is spoken); clearing the search produces no announcement; sighted behavior and the existing footer count label are unchanged; `xcodebuild build` and the SoloCompassTests suite pass.