### PR TITLE
auto: Strongest-signal pulse + settle haptic in the Confidence popover

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/ConfidenceBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/ConfidenceBadge.swift
@@ -94,6 +94,8 @@ private struct PopoverContent: View {
     let confidence: Confidence
     @State private var appeared = false
     @State private var barsFilled = false
+    @State private var strongestSettled = false
+    @State private var didHaptic = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     // Normalized 0...1 strength per signal
@@ -235,7 +237,17 @@ private struct PopoverContent: View {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
                     barsFilled = true
                 }
+                // Schedule the strongest-bar settle pulse: stagger delay + spring settle time
+                let strongestDelay = Double(strongestIndex) * 0.07 + 0.45
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15 + strongestDelay) {
+                    strongestSettled = true
+                }
             }
+        }
+        .onChange(of: strongestSettled) { _, settled in
+            guard settled, !didHaptic else { return }
+            didHaptic = true
+            Haptics.impact(.soft)
         }
     }
 
@@ -292,6 +304,21 @@ private struct PopoverContent: View {
                     .fill(confidence.health.color.opacity(0.7))
                     .frame(width: fillWidth, height: 3)
                     .animation(animation, value: barsFilled)
+                // One-shot glow pulse on the strongest bar as it settles
+                if isStrongest {
+                    Capsule()
+                        .fill(confidence.health.color)
+                        .frame(width: fillWidth, height: 3)
+                        .scaleEffect(strongestSettled ? 1.0 : 1.18, anchor: .leading)
+                        .opacity(strongestSettled ? 0.0 : 0.5)
+                        .animation(
+                            strongestSettled
+                                ? .easeOut(duration: 0.38)
+                                : .linear(duration: 0),
+                            value: strongestSettled
+                        )
+                        .animation(animation, value: barsFilled)
+                }
             }
         }
         .accessibilityElement(children: .combine)


### PR DESCRIPTION
## Strongest-signal pulse + settle haptic in the Confidence popover

When the confidence breakdown popover opens, its four strength bars already spring in with a stagger, but the 'strongest signal' is only marked with a static star — the eye has nothing to land on. Add a one-shot highlight pulse on the strongest bar as it settles, plus a soft haptic at that moment, so the trust signal reads at a glance and feels physical. Fully gated behind reduce-motion (no pulse, no delay) to match the rest of the app.

### Acceptance
Opening the popover springs the four bars in as before; the strongest bar shows a single subtle outward glow as it finishes filling and a soft haptic fires once at that instant. With Reduce Motion enabled, bars appear filled immediately with no glow, no delay, and no haptic. All existing #Preview cases compile and render; xcodebuild build succeeds for the SoloCompass scheme.