### PR TITLE
auto: Confetti celebration when marking a favorite visited via swipe

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -32,6 +32,7 @@ public struct FavoritesListView: View {
     @State private var ringDidCelebrate = false
     @State private var showRemainingOnly = false
     @State private var prioritizeGoodNow = false
+    @State private var celebrationTrigger = 0
 
     private var undoDismissSeconds: Double { voiceOverOn ? 12 : 4 }
 
@@ -465,6 +466,10 @@ public struct FavoritesListView: View {
         }
         .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)
+        .overlay(alignment: .center) {
+            CompletionCelebrationView(trigger: celebrationTrigger)
+                .allowsHitTesting(false)
+        }
         .overlay(alignment: .bottom) {
             if lastUnfavorited != nil {
                 undoBar
@@ -1406,10 +1411,10 @@ private extension FavoritesListView {
                         argument: NSLocalizedString("favorites.row.markNotVisited.announcement", comment: "VoiceOver announcement after marking as not visited")
                     )
                 } else {
-                    Haptics.notify(.success)
                     withAnimation(.easeInOut) {
                         preferences.markCompleted(exp.id)
                     }
+                    celebrationTrigger += 1
                     UIAccessibility.post(
                         notification: .announcement,
                         argument: String(format: NSLocalizedString("favorites.row.markVisited.announcement", comment: "VoiceOver announcement after marking as visited"), exp.title)
@@ -1439,8 +1444,8 @@ private extension FavoritesListView {
                     argument: NSLocalizedString("favorites.row.markNotVisited.announcement", comment: "VoiceOver announcement after marking as not visited")
                 )
             } else {
-                Haptics.notify(.success)
                 preferences.markCompleted(exp.id)
+                celebrationTrigger += 1
                 UIAccessibility.post(
                     notification: .announcement,
                     argument: String(format: NSLocalizedString("favorites.row.markVisited.announcement", comment: "VoiceOver announcement after marking as visited"), exp.title)


### PR DESCRIPTION
## Confetti celebration when marking a favorite visited via swipe

The Favorites list lets you swipe-right to mark an experience as visited, but unlike the experience detail screen it only fires a haptic — no visual reward. This wires the app's existing CompletionCelebrationView confetti/checkmark burst into the favorites swipe-to-complete action so the most rewarding, high-frequency gesture in the list gets the same delightful, consistent feedback already shown elsewhere.

### Acceptance
Swiping right to mark a favorite as visited shows the confetti + checkmark burst centered over the list and fires exactly one success haptic (no double-buzz). Un-completing a favorite shows no confetti. Reduce Motion shows only the checkmark pop, no particles (handled by CompletionCelebrationView). VoiceOver announcement still fires. `xcodebuild build` and existing `SoloCompassTests` pass; #Preview for FavoritesListView still renders.