### PR TITLE
auto: Make CompletionCelebrationView confetti deterministic (seeded from trigger), matching HeartBurstView

### DIFF
--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -7119,3 +7119,42 @@ final class ChatHistoryStoreTests: XCTestCase {
         XCTAssertEqual(toolCall?.argumentsJSON, #"{"radius_meters":3000}"#)
     }
 }
+
+final class CompletionCelebrationViewTests: XCTestCase {
+
+    func testMakeParticlesIsDeterministic() {
+        let a = CompletionCelebrationView.makeParticles(trigger: 42)
+        let b = CompletionCelebrationView.makeParticles(trigger: 42)
+        XCTAssertEqual(a.count, 14)
+        XCTAssertEqual(b.count, 14)
+        for i in 0..<14 {
+            XCTAssertEqual(a[i].id, b[i].id)
+            XCTAssertEqual(a[i].angle, b[i].angle, accuracy: 1e-10)
+            XCTAssertEqual(a[i].distance, b[i].distance, accuracy: 1e-6)
+            XCTAssertEqual(a[i].size, b[i].size, accuracy: 1e-6)
+            XCTAssertEqual(a[i].isCircle, b[i].isCircle)
+            XCTAssertEqual(a[i].rotation, b[i].rotation, accuracy: 1e-10)
+            XCTAssertEqual(a[i].delay, b[i].delay, accuracy: 1e-10)
+            XCTAssertEqual(a[i].gravity, b[i].gravity, accuracy: 1e-6)
+        }
+    }
+
+    func testDifferentTriggersYieldDifferentBursts() {
+        let p1 = CompletionCelebrationView.makeParticles(trigger: 1)
+        let p2 = CompletionCelebrationView.makeParticles(trigger: 2)
+        // Angle sequence and color index should differ for at least one particle
+        let anglesDiffer = zip(p1, p2).contains { abs($0.angle - $1.angle) > 1e-6 }
+        let colorsDiffer = zip(p1, p2).contains { $0.color != $1.color }
+        XCTAssertTrue(anglesDiffer, "Different triggers should produce different angle sequences")
+        XCTAssertTrue(colorsDiffer, "Different triggers should produce different color sequences")
+    }
+
+    func testParticleCountIsAlways14() {
+        for trigger in [0, 1, 7, 42, 100, -1, Int.max / 2] {
+            XCTAssertEqual(
+                CompletionCelebrationView.makeParticles(trigger: trigger).count, 14,
+                "Expected 14 particles for trigger \(trigger)"
+            )
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Views/Shared/CompletionCelebrationView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/CompletionCelebrationView.swift
@@ -10,15 +10,15 @@ public struct CompletionCelebrationView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private struct Particle: Identifiable {
-        let id = UUID()
+        let id: Int
         let color: Color
         let angle: Double       // radians
         let distance: CGFloat   // launch radius
         let size: CGFloat
         let isCircle: Bool
-        let rotation: Double    // final spin in degrees, random -180...180
-        let delay: Double       // stagger offset, random 0...0.08
-        let gravity: CGFloat    // downward drift, random 28...46
+        let rotation: Double    // final spin in degrees, seeded -180...180
+        let delay: Double       // stagger offset, seeded 0...0.08
+        let gravity: CGFloat    // downward drift, seeded 28...46
     }
 
     @State private var particles: [Particle] = []
@@ -27,6 +27,41 @@ public struct CompletionCelebrationView: View {
     @State private var milestoneVisible = false
 
     private static let palette: [Color] = ExperienceCategory.allCases.map(\.color)
+
+    /// Knuth multiplicative hash seed derived from trigger for per-burst variation.
+    private var burstSeed: Int { trigger &* 2654435761 }
+
+    /// Deterministic pseudo-random float in [-1, 1] for a given particle index.
+    private func jitter(_ index: Int) -> Double {
+        let hash = (burstSeed &+ index &* 1597334677) & 0x7FFFFFFF
+        return (Double(hash % 1000) / 500.0) - 1.0
+    }
+
+    static func makeParticles(trigger: Int, count: Int = 14) -> [Particle] {
+        let seed = trigger &* 2654435761
+        func jitter(_ index: Int) -> Double {
+            let hash = (seed &+ index &* 1597334677) & 0x7FFFFFFF
+            return (Double(hash % 1000) / 500.0) - 1.0
+        }
+        func lerp(_ range: ClosedRange<Double>, _ t: Double) -> Double {
+            range.lowerBound + (range.upperBound - range.lowerBound) * ((t + 1.0) / 2.0)
+        }
+        return (0..<count).map { i in
+            let baseAngle = Double(i) / Double(count) * .pi * 2
+            let shapeHash = (seed &+ i &* 1000003) & 0x7FFFFFFF
+            return Particle(
+                id: i,
+                color: palette[(i + abs(trigger)) % palette.count],
+                angle: baseAngle + jitter(i) * 0.3,
+                distance: CGFloat(lerp(52...92, jitter(i + 50))),
+                size: CGFloat(lerp(6...11, jitter(i + 100))),
+                isCircle: (shapeHash & 1) == 0,
+                rotation: lerp(-180...180, jitter(i + 150)),
+                delay: abs(jitter(i + 200)) * 0.08,
+                gravity: CGFloat(lerp(28...46, jitter(i + 250)))
+            )
+        }
+    }
 
     public var body: some View {
         ZStack {
@@ -94,19 +129,7 @@ public struct CompletionCelebrationView: View {
     // soft impact ~0.12s later synced to the checkmark pop. Haptics.notify/impact
     // guard on Reduce Motion, so nothing fires when particles are also suppressed.
     private func fire() {
-        let count = 14
-        particles = (0..<count).map { i in
-            Particle(
-                color: Self.palette[i % Self.palette.count],
-                angle: Double(i) / Double(count) * .pi * 2 + Double.random(in: -0.3...0.3),
-                distance: CGFloat.random(in: 52...92),
-                size: CGFloat.random(in: 6...11),
-                isCircle: Bool.random(),
-                rotation: Double.random(in: -180...180),
-                delay: Double.random(in: 0...0.08),
-                gravity: CGFloat.random(in: 28...46)
-            )
-        }
+        particles = Self.makeParticles(trigger: trigger)
         animated = false
         checkmarkPop = false
         milestoneVisible = false


### PR DESCRIPTION
## Make CompletionCelebrationView confetti deterministic (seeded from trigger), matching HeartBurstView

CompletionCelebrationView.fire() builds its 14 confetti particles with Double.random/CGFloat.random/Bool.random and uses UUID() ids, making the app's most important celebration (completing an experience) untestable and visually non-reproducible. Its sibling HeartBurstView was deliberately rewritten to use a deterministic seeded jitter derived from `trigger` for exactly this reason. This aligns the two: seed particle angle/distance/size/shape/rotation/delay/gravity from a `trigger`-derived hash so bursts still vary per completion but are reproducible and unit-testable.

### Acceptance
No `.random` calls or `UUID()` remain in CompletionCelebrationView. A new XCTest asserts makeParticles(trigger:) is deterministic (same trigger -> identical particle field arrays across two calls) and that different trigger values yield different angle/color sequences (visual variation preserved). Particle count stays 14; reduceMotion still suppresses particles; the checkmark pop, success/soft haptics, and VoiceOver announcements are unchanged. `xcodebuild build` and `xcodebuild test` for the SoloCompass scheme both pass; #Preview('Burst') still renders a varied confetti burst.