### PR TITLE
auto: Polish the empty state in MyHostedRoutesListView to match sibling list views

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1470,6 +1470,9 @@
 /* US-034 — MyHostedRoutesListView */
 "my.hosted.routes.title" = "我主理的路线";
 "my.hosted.routes.empty" = "You are not hosting any routes yet.";
+"my.hosted.routes.empty.title" = "No hosted routes yet";
+"my.hosted.routes.empty.hint" = "Create a route and invite companions to join you on your journey.";
+"my.hosted.routes.empty.cta" = "Create a route";
 "settings.companion.hosted.routes" = "我主理的路线";
 
 /* US-038 — CompletionMoment */

--- a/apps/ios/SoloCompass/Views/Companion/MyHostedRoutesListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/MyHostedRoutesListView.swift
@@ -9,7 +9,7 @@ public struct MyHostedRoutesListView: View {
 
     private let storeProvider: () -> RouteStore
     private let contextProvider: () -> ModelContext
-    var onCreateRoute: (() -> Void)? = nil
+    private let onCreateRoute: (() -> Void)?
 
     @State private var refreshToken: UUID = UUID()
 
@@ -108,7 +108,7 @@ public struct MyHostedRoutesListView: View {
 // MARK: - HostedRoutesEmptyState
 
 private struct HostedRoutesEmptyState: View {
-    var onCreateRoute: (() -> Void)? = nil
+    let onCreateRoute: (() -> Void)?
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isBreathing = false
@@ -143,7 +143,6 @@ private struct HostedRoutesEmptyState: View {
                 .buttonStyle(.borderedProminent)
                 .controlSize(.regular)
                 .padding(.top, 4)
-                .accessibilityLabel(Text(NSLocalizedString("my.hosted.routes.empty.cta", comment: "Create a route button in empty hosted routes state")))
             }
         }
         .padding(32)

--- a/apps/ios/SoloCompass/Views/Companion/MyHostedRoutesListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/MyHostedRoutesListView.swift
@@ -9,6 +9,7 @@ public struct MyHostedRoutesListView: View {
 
     private let storeProvider: () -> RouteStore
     private let contextProvider: () -> ModelContext
+    var onCreateRoute: (() -> Void)? = nil
 
     @State private var refreshToken: UUID = UUID()
 
@@ -16,10 +17,12 @@ public struct MyHostedRoutesListView: View {
         storeProvider: @escaping () -> RouteStore = { RouteStore() },
         contextProvider: @escaping () -> ModelContext = {
             ModelContext(SoloCompassModelContainer.shared)
-        }
+        },
+        onCreateRoute: (() -> Void)? = nil
     ) {
         self.storeProvider = storeProvider
         self.contextProvider = contextProvider
+        self.onCreateRoute = onCreateRoute
     }
 
     private var deviceId: String {
@@ -34,7 +37,7 @@ public struct MyHostedRoutesListView: View {
     public var body: some View {
         Group {
             if hostedRoutes.isEmpty {
-                emptyState
+                HostedRoutesEmptyState(onCreateRoute: onCreateRoute)
             } else {
                 routeList
             }
@@ -100,18 +103,54 @@ public struct MyHostedRoutesListView: View {
         }
     }
 
-    // MARK: - Empty state
+}
 
-    private var emptyState: some View {
-        List {
-            Text(NSLocalizedString(
-                "my.hosted.routes.empty",
-                comment: "Empty state — no hosted routes"
-            ))
-            .foregroundStyle(.secondary)
-            .font(.subheadline)
+// MARK: - HostedRoutesEmptyState
+
+private struct HostedRoutesEmptyState: View {
+    var onCreateRoute: (() -> Void)? = nil
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isBreathing = false
+
+    var body: some View {
+        VStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(Color.teal.opacity(0.12))
+                    .frame(width: 80, height: 80)
+                Image(systemName: "map.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(Color.teal.opacity(0.7))
+                    .scaleEffect(isBreathing ? 1.08 : 0.94)
+                    .opacity(isBreathing ? 1.0 : 0.7)
+                    .animation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true), value: isBreathing)
+                    .accessibilityHidden(true)
+            }
+            Text(NSLocalizedString("my.hosted.routes.empty.title", comment: "No hosted routes yet"))
+                .font(.headline)
+            Text(NSLocalizedString("my.hosted.routes.empty.hint", comment: "Hint to create a route"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            if let onCreateRoute {
+                Button {
+                    Haptics.selection()
+                    onCreateRoute()
+                } label: {
+                    Label(NSLocalizedString("my.hosted.routes.empty.cta", comment: "Create a route button in empty hosted routes state"), systemImage: "plus")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+                .padding(.top, 4)
+                .accessibilityLabel(Text(NSLocalizedString("my.hosted.routes.empty.cta", comment: "Create a route button in empty hosted routes state")))
+            }
         }
-        .listStyle(.insetGrouped)
+        .padding(32)
+        .onAppear {
+            guard !isBreathing, !reduceMotion else { return }
+            isBreathing = true
+        }
     }
 }
 
@@ -169,6 +208,6 @@ public struct MyHostedRoutesListView: View {
     let container = SoloCompassModelContainer.makeInMemory()
     let store = RouteStore(context: ModelContext(container))
     NavigationStack {
-        MyHostedRoutesListView(storeProvider: { store })
+        MyHostedRoutesListView(storeProvider: { store }, onCreateRoute: {})
     }
 }


### PR DESCRIPTION
## Polish the empty state in MyHostedRoutesListView to match sibling list views

MyHostedRoutesListView's empty state is a bare secondary-color Text row inside a List — a jarring inconsistency next to MyWalkedRoutesListView and FavoritesListView, which both render rich, icon-driven, gently-animated empty states with a clear call-to-action. This replaces it with a centered, breathing-icon empty state (respecting Reduce Motion) plus an optional 'Create a route' CTA, reusing the exact visual language already established in WalkedRoutesEmptyState.

### Acceptance
Build succeeds via `xcodebuild build -scheme SoloCompass`. In the Simulator, opening My Hosted Routes with no hosted routes shows a centered teal map icon that gently breathes (and is static when Reduce Motion is on), a headline + hint, and an optional 'Create a route' button when `onCreateRoute` is provided — visually consistent with the empty states in MyWalkedRoutesListView and FavoritesListView. The existing `#Preview("MyHostedRoutesListView — empty")` renders the new design, and StringsParityTests still passes with the new localization keys present in en.lproj.