### PR TITLE
auto: Add an animated exploration progress ring to the Me hub profile header

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -270,6 +270,7 @@
 "me.avatar.a11y.pending" = "You have pending friend requests";
 "me.stats.saved" = "Saved";
 "me.stats.explored" = "Explored";
+"me.profile.progress.a11y" = "%d of %d saved places explored";
 
 /* Map empty / loading */
 "map.empty.title" = "No experiences nearby";

--- a/apps/ios/SoloCompass/Views/Me/MeSheet.swift
+++ b/apps/ios/SoloCompass/Views/Me/MeSheet.swift
@@ -112,6 +112,72 @@ struct MeSheet: View {
     }
 }
 
+// MARK: - Ring avatar
+
+private struct RingAvatar: View {
+    let favoritedCount: Int
+    let exploredCount: Int
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var animatedFraction: CGFloat = 0
+
+    private var targetFraction: CGFloat {
+        guard favoritedCount > 0 else { return 0 }
+        return CGFloat(min(exploredCount, favoritedCount)) / CGFloat(favoritedCount)
+    }
+
+    private var showRing: Bool { favoritedCount > 0 }
+
+    var body: some View {
+        ZStack {
+            Text(CompanionProfile.sample.avatarEmoji)
+                .font(.system(size: 40))
+                .frame(width: 64, height: 64)
+                .background(Circle().fill(CT.accentSoft))
+
+            if showRing {
+                Circle()
+                    .stroke(CT.accent.opacity(0.15), lineWidth: 3)
+                    .frame(width: 72, height: 72)
+                Circle()
+                    .trim(from: 0, to: animatedFraction)
+                    .stroke(CT.accent, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                    .frame(width: 72, height: 72)
+            }
+        }
+        .accessibilityLabel(Text(CompanionProfile.sample.avatarEmoji))
+        .accessibilityValue(showRing ? Text(
+            String(format: NSLocalizedString("me.profile.progress.a11y", comment: "Profile progress ring accessibility value"),
+                   min(exploredCount, favoritedCount), favoritedCount)
+        ) : Text(""))
+        .onAppear {
+            let target = targetFraction
+            if reduceMotion {
+                animatedFraction = target
+            } else {
+                withAnimation(.easeInOut(duration: 0.6)) { animatedFraction = target }
+            }
+        }
+        .onChange(of: exploredCount) { _, _ in
+            let target = targetFraction
+            if reduceMotion {
+                animatedFraction = target
+            } else {
+                withAnimation(.easeInOut(duration: 0.6)) { animatedFraction = target }
+            }
+        }
+        .onChange(of: favoritedCount) { _, _ in
+            let target = targetFraction
+            if reduceMotion {
+                animatedFraction = target
+            } else {
+                withAnimation(.easeInOut(duration: 0.6)) { animatedFraction = target }
+            }
+        }
+    }
+}
+
 // MARK: - Profile header
 
 /// Lightweight identity card. US-007 only needs an entry point, so the header
@@ -123,10 +189,7 @@ private struct ProfileHeader: View {
 
     var body: some View {
         HStack(spacing: 14) {
-            Text(CompanionProfile.sample.avatarEmoji)
-                .font(.system(size: 40))
-                .frame(width: 64, height: 64)
-                .background(Circle().fill(CT.accentSoft))
+            RingAvatar(favoritedCount: favoritedCount, exploredCount: exploredCount)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(NSLocalizedString("me.profile.name", comment: "Default profile display name"))
@@ -377,6 +440,16 @@ struct MapAvatarBubble: View {
 #Preview("MeSheet") {
     MeSheet(pendingRequestCount: 2)
         .environment(UserPreferences())
+}
+
+#Preview("RingAvatar states") {
+    HStack(spacing: 24) {
+        RingAvatar(favoritedCount: 0, exploredCount: 0)   // no ring
+        RingAvatar(favoritedCount: 5, exploredCount: 0)   // 0%
+        RingAvatar(favoritedCount: 5, exploredCount: 2)   // 40%
+        RingAvatar(favoritedCount: 5, exploredCount: 5)   // 100%
+    }
+    .padding()
 }
 
 #Preview("Avatar bubble") {


### PR DESCRIPTION
## Add an animated exploration progress ring to the Me hub profile header

The MeSheet ProfileHeader currently shows two flat 'Saved'/'Explored' stat pills but no sense of journey or progress — unlike FavoritesListView which has a rich completion ring. Add a compact animated progress ring around the avatar showing the share of saved experiences explored, giving the personal hub a motivating at-a-glance signal that mirrors the app's existing journey language.

### Acceptance
xcodebuild build succeeds for the SoloCompass scheme; the Me hub avatar shows a progress ring that animates on open and reflects exploredCount/favoritedCount; ring is hidden (or empty track only) when no favorites exist; reduce-motion users see the final state with no animation; VoiceOver reads the new progress accessibility value; the new Localizable.strings key is present and parity:check / existing tests still pass.