### PR TITLE
auto: Halfway-milestone pulse on the Favorites journey progress bar

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -571,6 +571,9 @@
 "favorites.momentum.justDid" = "Nice — you just did %@";
 "favorites.momentum.closest" = "%@ is closest — go?";
 
+/* Favorites journey halfway milestone VoiceOver announcement */
+"favorites.journey.halfway" = "Halfway there — %1$d of %2$d explored";
+
 /* Favorites journey header — closest pill (shown when nearbyCount == 0) */
 "favorites.journey.closest" = "%1$@ · %2$@";
 "favorites.journey.closest.a11y" = "Closest favorite: %1$@, %2$@ away";

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -724,12 +724,33 @@ private struct JourneyProgressBar: View {
     @State private var didCompletionSweep = false
     @State private var sweepPhase: CGFloat = -1
     @State private var fillScaleY: CGFloat = 1
+    @State private var didHalfwayPulse = false
 
     private var targetFraction: CGFloat {
         total > 0 ? CGFloat(completed) / CGFloat(total) : 0
     }
 
     private var isAllDone: Bool { total > 0 && completed == total }
+    private var isPastHalfway: Bool { total > 0 && Double(completed) / Double(total) >= 0.5 }
+
+    private func firePulse() {
+        guard !didHalfwayPulse && !isAllDone else { return }
+        didHalfwayPulse = true
+        Haptics.impact(.soft)
+        UIAccessibility.post(
+            notification: .announcement,
+            argument: String(format: NSLocalizedString("favorites.journey.halfway", comment: "VoiceOver halfway milestone announcement"), completed, total)
+        )
+        guard !reduceMotion else { return }
+        withAnimation(.spring(response: 0.18, dampingFraction: 0.45)) {
+            fillScaleY = 1.18
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.28) {
+            withAnimation(.spring(response: 0.22, dampingFraction: 0.6)) {
+                fillScaleY = 1
+            }
+        }
+    }
 
     var body: some View {
         GeometryReader { geo in
@@ -791,6 +812,11 @@ private struct JourneyProgressBar: View {
             }
             if isAllDone && !reduceMotion {
                 fireSweep(width: 0)
+            }
+            if isPastHalfway {
+                firePulse()
+            } else {
+                didHalfwayPulse = false
             }
         }
     }


### PR DESCRIPTION
## Halfway-milestone pulse on the Favorites journey progress bar

The Favorites journey progress bar (`JourneyProgressBar`) only celebrates at 100% with a shimmer sweep — crossing 50% (the psychological turning point where a trip 'tips' from starting to finishing) passes silently. Add a one-time scale pulse on the fill plus a soft success haptic the moment the user crosses the halfway mark, mirroring the existing 100% sweep pattern but lighter, so progress feels rewarding earlier and not just at the very end.

### Acceptance
Marking favorites complete until the journey crosses 50% triggers exactly one soft haptic + a subtle fill bump; the bar does not pulse again on subsequent completions until it dips below and re-crosses half; the existing 100% shimmer sweep still fires independently; Reduce Motion suppresses the bump (haptic still allowed) and VoiceOver announces the halfway milestone once. `xcodebuild build` and the `SoloCompassTests` target both pass.