### PR TITLE
auto: Fix Solo Score popover bars skipping their fill animation on reopen

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -182,6 +182,7 @@ private struct SoloScorePopoverContent: View {
     @State private var appeared = false
     @State private var barsFilled = false
     @State private var expandedIndex: Int? = nil
+    @State private var animatedOverall: Double = 0
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let weakestThreshold: Double = 5.0
@@ -237,10 +238,11 @@ private struct SoloScorePopoverContent: View {
                 Text(NSLocalizedString("solo.breakdown.title", comment: "Solo Score breakdown"))
                     .font(.headline)
                 Spacer()
-                Text(String(format: "%.1f", score.overall))
+                Text(String(format: "%.1f", animatedOverall))
                     .font(.title3.bold())
                     .foregroundStyle(score.scoreColor)
                     .monospacedDigit()
+                    .contentTransition(.numericText(value: animatedOverall))
             }
 
             if let hint = score.hint {
@@ -332,12 +334,21 @@ private struct SoloScorePopoverContent: View {
             if reduceMotion {
                 appeared = true
                 barsFilled = true
+                animatedOverall = score.overall
             } else {
                 withAnimation(.easeIn(duration: 0.2)) {
                     appeared = true
                 }
                 barsFilled = true
+                withAnimation(.easeOut(duration: 0.6)) {
+                    animatedOverall = score.overall
+                }
             }
+        }
+        .onDisappear {
+            appeared = false
+            barsFilled = false
+            expandedIndex = nil
         }
     }
 


### PR DESCRIPTION
## Fix Solo Score popover bars skipping their fill animation on reopen

The Solo Score breakdown popover animates each dimension bar filling from 0 on first appearance, but `barsFilled` is never reset when the popover dismisses. On every subsequent open the bars snap to full instantly, losing the signature reveal that communicates the score's makeup. This adds an onDisappear reset plus a strongest/weakest count-up on the popover header score so the breakdown feels alive every time it's opened.

### Acceptance
Opening the Solo Score popover a second (and third) time replays the staggered bar-fill from zero and the header score counts up, identical to the first open. With Reduce Motion enabled, bars and the header score appear instantly at their final values with no animation. `xcodebuild build` and `xcodebuild test` for the SoloCompass scheme pass, and the existing #Preview entries still render.