### PR TITLE
auto: Add press-feedback + discoverable tap affordance to SoloScore radar axis labels

### DIFF
--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
@@ -13,7 +13,10 @@ public struct SoloScoreRadarChart: View {
     @State private var selectedAxis: Int? = nil
     @State private var tooltipDismissTask: Task<Void, Never>? = nil
     @State private var showReplayHint: Bool = false
+    @State private var pressedAxis: Int? = nil
+    @State private var hintPulse: Bool = false
     @AppStorage("radar.replayHintSeen") private var replayHintSeen: Bool = false
+    @AppStorage("radar.axisTapHintSeen") private var axisTapHintSeen: Bool = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private static let springDuration: Double = 0.7
@@ -120,6 +123,13 @@ public struct SoloScoreRadarChart: View {
                             withAnimation { showReplayHint = false }
                         }
                     }
+                    if !axisTapHintSeen {
+                        axisTapHintSeen = true
+                        withAnimation(.easeInOut(duration: 0.25)) { hintPulse = true }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                            withAnimation(.easeInOut(duration: 0.25)) { hintPulse = false }
+                        }
+                    }
                 }
             }
         }
@@ -223,9 +233,19 @@ public struct SoloScoreRadarChart: View {
                             .contentTransition(.numericText())
                             .animation(reduceMotion ? nil : .spring(response: Self.springDuration, dampingFraction: 0.75), value: animatedValue(values[i]))
                     }
+                    .scaleEffect(
+                        (!reduceMotion && pressedAxis == i) ? 0.88 :
+                        (!reduceMotion && hintPulse && i == weakestIndex) ? 1.12 : 1.0
+                    )
+                    .animation(reduceMotion ? nil : .spring(response: 0.25, dampingFraction: 0.6), value: pressedAxis)
+                    .animation(reduceMotion ? nil : .easeInOut(duration: 0.25), value: hintPulse)
                     .opacity(labelOpacity)
                     .position(pos)
-                    .onTapGesture { tapAxis(i) }
+                    .gesture(
+                        DragGesture(minimumDistance: 0)
+                            .onChanged { _ in pressedAxis = i }
+                            .onEnded { _ in pressedAxis = nil; tapAxis(i) }
+                    )
                     .accessibilityAddTraits(.isButton)
                     .accessibilityHint(Text(NSLocalizedString("solo.axis.tap.hint", comment: "")))
                     .accessibilityLabel(Text(axis.label))
@@ -433,7 +453,17 @@ public struct SoloScoreRadarChart: View {
                         .frame(width: 24, alignment: .trailing)
                         .accessibilityHidden(true)
                 }
-                .onTapGesture { tapAxis(i) }
+                .scaleEffect(
+                    (!reduceMotion && pressedAxis == i) ? 0.88 :
+                    (!reduceMotion && hintPulse && i == weakestIndex) ? 1.12 : 1.0
+                )
+                .animation(reduceMotion ? nil : .spring(response: 0.25, dampingFraction: 0.6), value: pressedAxis)
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.25), value: hintPulse)
+                .gesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { _ in pressedAxis = i }
+                        .onEnded { _ in pressedAxis = nil; tapAxis(i) }
+                )
                 .accessibilityAddTraits(.isButton)
                 .accessibilityHint(Text(NSLocalizedString("solo.axis.tap.hint", comment: "")))
                 .accessibilityLabel(Text(axis.label))


### PR DESCRIPTION
## Add press-feedback + discoverable tap affordance to SoloScore radar axis labels

The radar chart's six axis labels are tappable (they open a dimension tooltip) but give no visual press feedback, so users rarely discover the interaction. Add a brief scale-down on touch for each axis label and a one-time gentle pulse on the weakest axis to telegraph 'these are tappable', both gated behind Reduce Motion. This makes an existing-but-hidden interaction discoverable and tactile without changing any data or layout.

### Acceptance
Tapping any radar axis label (radar or fallback-bars mode) visibly scales it down and springs back, then toggles its dimension tooltip exactly as before. On first-ever view of a radar chart, the weakest (amber) axis label performs a single gentle pulse to signal tappability, and never pulses again on subsequent views. With Reduce Motion enabled, no press-scale or pulse animation runs but taps still open the tooltip. xcodebuild build and the existing SoloScoreRadarChart-related tests pass; #Preview renders unchanged.