### PR TITLE
auto: Announce favorite toggle to VoiceOver and add a milestone haptic on the card heart

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -322,6 +322,8 @@
 "experience.card.preview.a11y" = "Show quick preview";
 "card.favorite.add" = "Add to favorites";
 "card.favorite.remove" = "Remove from favorites";
+"card.favorite.added.a11y" = "Saved to favorites";
+"card.favorite.removed.a11y" = "Removed from favorites";
 "card.dismiss" = "Dismiss card";
 
 /* Experience card distance pill */

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -949,6 +949,8 @@
 /* Card */
 "card.favorite.add" = "加入收藏";
 "card.favorite.remove" = "取消收藏";
+"card.favorite.added.a11y" = "已加入收藏";
+"card.favorite.removed.a11y" = "已取消收藏";
 "card.dismiss" = "关闭卡片";
 "card.distance.walk" = "%d 分钟步行";
 "card.distance.walkSub1" = "不到 1 分钟步行";

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -224,11 +224,11 @@ public struct ExperienceCardView: View {
                 Spacer()
                 Button {
                     let wasFavorited = preferences.isFavorited(experience.id)
-                    Haptics.impact(.light)
                     withAnimation(.spring(response: 0.3)) {
                         preferences.toggleFavorite(experience.id)
                     }
                     if !wasFavorited {
+                        Haptics.notify(.success)
                         heartBounce += 1
                         if !reduceMotion {
                             heartBurst = true
@@ -237,6 +237,16 @@ public struct ExperienceCardView: View {
                                 heartBurst = false
                             }
                         }
+                        UIAccessibility.post(
+                            notification: .announcement,
+                            argument: NSLocalizedString("card.favorite.added.a11y", comment: "VoiceOver announcement when experience is saved to favorites")
+                        )
+                    } else {
+                        Haptics.impact(.light)
+                        UIAccessibility.post(
+                            notification: .announcement,
+                            argument: NSLocalizedString("card.favorite.removed.a11y", comment: "VoiceOver announcement when experience is removed from favorites")
+                        )
                     }
                 } label: {
                     let favorited = preferences.isFavorited(experience.id)
@@ -425,7 +435,21 @@ public struct ExperienceCardView: View {
                 ? NSLocalizedString("action.unfavorite", comment: "Remove favorite")
                 : NSLocalizedString("action.favorite", comment: "Add favorite"))
         ) {
+            let wasFavorited = isFavorited
             preferences.toggleFavorite(experience.id)
+            if !wasFavorited {
+                Haptics.notify(.success)
+                UIAccessibility.post(
+                    notification: .announcement,
+                    argument: NSLocalizedString("card.favorite.added.a11y", comment: "VoiceOver announcement when experience is saved to favorites")
+                )
+            } else {
+                Haptics.impact(.light)
+                UIAccessibility.post(
+                    notification: .announcement,
+                    argument: NSLocalizedString("card.favorite.removed.a11y", comment: "VoiceOver announcement when experience is removed from favorites")
+                )
+            }
         }
         .accessibilityAction(named: Text(NSLocalizedString("action.directions", comment: "Directions accessibility action"))) {
             guard let coord = experience.coordinate,


### PR DESCRIPTION
## Announce favorite toggle to VoiceOver and add a milestone haptic on the card heart

Favoriting an experience from the floating card fires a heart-burst animation and a light haptic, but unlike the proximity, arrival, and offline flows it posts no VoiceOver announcement — so blind users get no confirmation the action registered. This adds a UIAccessibility announcement ("Saved to favorites" / "Removed from favorites") on toggle and upgrades the add-to-favorites haptic from a generic light impact to a .success notification, matching the feedback weight the rest of the app gives primary actions.

### Acceptance
With VoiceOver on, tapping the heart announces 'Saved to favorites' and tapping again announces 'Removed from favorites'. Adding a favorite produces a success notification haptic; removing produces a light impact. The heart-burst animation and existing accessibilityLabel/accessibilityAction still work. Build passes (xcodebuild build, iPhone 17 Pro) and existing FavoriteFilterTests/SoloCompassTests still pass. No changes to SwiftData schema files.