### PR TITLE
auto: Add pull-to-refresh and tap haptics to FriendsListView empty & error states

### DIFF
--- a/apps/ios/SoloCompass/Views/Friends/FriendsListView.swift
+++ b/apps/ios/SoloCompass/Views/Friends/FriendsListView.swift
@@ -44,9 +44,17 @@ public struct FriendsListView: View {
                     CompanionSkeletonList(rows: 5)
                 }
             } else if let error = service.lastError {
-                errorView(message: error)
+                ScrollView {
+                    errorView(message: error)
+                        .frame(maxWidth: .infinity, minHeight: UIScreen.main.bounds.height * 0.7)
+                }
+                .refreshable { await service.refresh() }
             } else if service.friends.isEmpty && service.incomingRequests.isEmpty {
-                EmptyFriendsView(onAddFriend: { showAddFriend = true })
+                ScrollView {
+                    EmptyFriendsView(onAddFriend: { showAddFriend = true })
+                        .frame(maxWidth: .infinity, minHeight: UIScreen.main.bounds.height * 0.7)
+                }
+                .refreshable { await service.refresh() }
             } else {
                 friendsList
             }
@@ -223,6 +231,7 @@ public struct FriendsListView: View {
                         }
                     }
                     .buttonStyle(.plain)
+                    .simultaneousGesture(TapGesture().onEnded { Haptics.selection() })
                 }
             }
             .padding(.horizontal, 16)
@@ -640,5 +649,15 @@ private struct EmptyFriendsView: View {
     service.incomingRequests = []
     return NavigationStack {
         FriendsListView(service: service)
+    }
+}
+
+#Preview("Error") {
+    let service = FriendService()
+    service.friends = []
+    service.incomingRequests = []
+    service.lastError = NSLocalizedString("friends.list.error.preview", comment: "Preview error message")
+    return NavigationStack {
+        FriendsListView(service: service, autoRefresh: false)
     }
 }


### PR DESCRIPTION
## Add pull-to-refresh and tap haptics to FriendsListView empty & error states

FriendsListView only attaches `.refreshable` to the populated `friendsList`, so a user stuck in the empty or error state has no gesture to retry a load — they must hunt for the toolbar refresh button. This adds pull-to-refresh to both fallback states (wrapping them in a ScrollView so the gesture is available) and adds a light selection haptic to the avatar-strip taps for consistency with the rest of the app's tactile feedback.

### Acceptance
Pulling down in the empty-friends state and the error state both trigger `service.refresh()`. The empty/error content stays vertically centered and visually identical to before. Tapping an avatar in the strip fires a selection haptic. `xcodebuild build` succeeds and existing `SoloCompassTests` pass; new Error preview renders. No @Model/schema files touched; change is under ~60 lines across one file.