### PR TITLE
fix(ios): stop FilterBar stretching into a full-screen arch over the map

### DIFF
--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -217,6 +217,15 @@ public struct FilterBarView: View {
                     .padding(.vertical, 5)
                     .animation(.spring(response: 0.4, dampingFraction: 0.75), value: selectionID)
                 }
+                // A horizontal ScrollView places no bound on its own vertical
+                // extent, so inside the top overlay's VStack (filter bar above a
+                // Spacer) it greedily stretched to fill all remaining height. The
+                // GlassmorphismCapsule's `.background(in: Capsule())` then tracked
+                // that full-height frame, rendering the glass as a giant vertical
+                // capsule arching across the map — the dark "arch" scrim that
+                // covered the home screen. Pinning the scroll view to its content's
+                // intrinsic height keeps the bar one pill-row tall.
+                .fixedSize(horizontal: false, vertical: true)
                 .onAppear {
                     proxy.scrollTo(selectionID, anchor: .center)
                 }


### PR DESCRIPTION
## Problem

The home screen rendered a dark, semi-transparent **"arch"** — a tall vertical capsule with a rounded top and two vertical sides — over the centre of the map. It covered the filter controls and dimmed the home screen. The map tiles themselves were fine; this was an overlay rendering bug, present on every cold start regardless of city/data.

## Root cause

`FilterBarView` wraps its pills in:

```swift
GlassmorphismCapsule { ScrollView(.horizontal) { HStack(pills) } }
```

A horizontal `ScrollView` places **no bound on its own vertical extent**. Inside `MapOverlayView`'s top `VStack` (the filter bar sits above a `Spacer()`), it greedily stretched to fill all remaining height. The `GlassmorphismCapsule`'s `.background(.regularMaterial, in: Capsule())` then tracked that full-height frame and rendered the glass as a giant vertical capsule arching across the map — the dark scrim users saw.

## Fix

Pin the scroll view to its content's intrinsic height:

```swift
.fixedSize(horizontal: false, vertical: true)
```

This keeps the bar one pill-row tall. Pure layout constraint — **no behaviour change**.

## Verification

- ✅ `xcodebuild build` succeeds
- ✅ iPhone 17 Pro simulator, **Chiang Mai** (seeded) — arch gone, filter bar is a normal single-row capsule
- ✅ iPhone 17 Pro simulator, **Berkeley** (GPS cold start, the originally-reported scenario) — arch gone
- ✅ `FilterBarViewTests` (10 tests) all pass

## Diagnosis method

Located via binary-disable (`if false {}` wrapping each layer) + colour/border probes — disabling `MapOverlayView` made the arch vanish, then a `.border()` on `FilterBarView` framed it exactly. All probes reverted; only the one-line fix remains.