### PR TITLE
Tap empty map to dismiss the floating preview card

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -1407,6 +1407,21 @@ struct CompassMapContentView: View {
                         }
                     }
             )
+            // Tap empty map → dismiss the floating preview card, matching the
+            // tap-to-deselect convention of Apple/Google Maps. Pin `Button`s and
+            // the card itself sit in their own layers and consume their own taps
+            // first, so only a tap on bare map reaches here. Guarded to the
+            // preview state (selection without the detail sheet) so it never
+            // interferes with pin selection or the open detail view.
+            .simultaneousGesture(
+                TapGesture().onEnded {
+                    guard viewModel.selectedExperience != nil, !viewModel.isShowingDetail else { return }
+                    Haptics.selection()
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        viewModel.clearSelection()
+                    }
+                }
+            )
         }
     }
 


### PR DESCRIPTION
When an experience preview card is floating over the map, a single tap on empty map area now dismisses it — matching the tap-to-deselect convention of Apple Maps and Google Maps — instead of forcing the user to hit the small ⨯ button.

## What changed
- Added a guarded `.simultaneousGesture(TapGesture())` to the root `Map` in `CompassMapView`.
- Pin `Button`s and the preview card sit in their own layers and consume their own taps first, so only a tap on bare map reaches the handler.
- The handler is guarded to the preview state (`selectedExperience != nil && !isShowingDetail`), so it never interferes with pin selection or the open detail sheet.
- Reuses the existing `clearSelection()`, the selection haptic, and the same 0.25s ease-in-out as the card’s own ⨯ dismiss, so the feel is identical.

## Why
The floating preview card previously had exactly one dismiss affordance: the small ⨯ button. On a map-first app, tap-to-dismiss on empty map is a strong, learned user expectation. This closes that gap with a low-risk, well-scoped gesture.

## Notes
- 1 file changed, +15 lines, no new symbols — reuses existing view-model + haptics APIs.
- iOS build/test runs in CI (`ios-ci.yml`) since this host is Linux without `xcodebuild`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)