### PR TITLE
Interactive pill page indicator for empty-Favorites tips

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -502,6 +502,7 @@
 "favorites.empty.tip3" = "Favorites sort by what's good to do at this hour.";
 "favorites.empty.tip4" = "Swipe left on a saved spot to remove it — tap Undo to bring it back.";
 "favorites.empty.tip.hint" = "Double tap for the next tip";
+"favorites.empty.tip.page.a11y" = "Tip %1$d of %2$d";
 "favorites.undo" = "Removed — Undo";
 "favorites.undo.named" = "Removed \"%@\"";
 /* Plural forms handled by Localizable.stringsdict */

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -308,6 +308,7 @@
 "favorites.empty.title" = "还没有收藏";
 "favorites.empty.hint" = "点击任意体验上的爱心即可保存到这里。";
 "favorites.empty.tip.hint" = "双击查看下一条提示";
+"favorites.empty.tip.page.a11y" = "提示 %1$d / %2$d";
 "favorites.undo.named" = "已移除\"%@\"";
 
 /* Generic actions */

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -1041,6 +1041,13 @@ private struct EmptyFavoritesView: View {
         UIAccessibility.post(notification: .announcement, argument: tips[tipIndex])
     }
 
+    private func selectTip(_ index: Int) {
+        guard index != tipIndex else { return }
+        withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.4)) { tipIndex = index }
+        Haptics.selection()
+        UIAccessibility.post(notification: .announcement, argument: tips[index])
+    }
+
     var body: some View {
         VStack(spacing: 12) {
             ZStack {
@@ -1074,13 +1081,23 @@ private struct EmptyFavoritesView: View {
             .accessibilityHint(NSLocalizedString("favorites.empty.tip.hint", comment: "Hint to advance to the next tip"))
             HStack(spacing: 6) {
                 ForEach(0..<tips.count, id: \.self) { index in
-                    Circle()
-                        .fill(index == tipIndex ? Color.primary : Color.primary.opacity(0.2))
-                        .frame(width: 6, height: 6)
-                        .animation(reduceMotion ? nil : .easeInOut, value: tipIndex)
+                    let isActive = index == tipIndex
+                    Button {
+                        selectTip(index)
+                    } label: {
+                        Capsule()
+                            .fill(isActive ? Color.primary : Color.primary.opacity(0.2))
+                            // Active dot stretches into a pill so the carousel
+                            // reads as a real page indicator at a glance.
+                            .frame(width: isActive ? 16 : 6, height: 6)
+                            .contentShape(Capsule())
+                            .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7), value: tipIndex)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(String(format: NSLocalizedString("favorites.empty.tip.page.a11y", comment: "Jump to tip N of M page indicator dot"), index + 1, tips.count))
+                    .accessibilityAddTraits(isActive ? [.isButton, .isSelected] : .isButton)
                 }
             }
-            .accessibilityHidden(true)
             if let onExplore {
                 Button {
                     Haptics.selection()


### PR DESCRIPTION
## What

Make the empty-Favorites tip carousel dots tappable and give the active dot a polished elongated-pill shape so the row reads as a real page indicator.

## Why

Previously the pagination dots under the rotating tips in the empty Favorites state were purely decorative — uniform 6pt circles, marked `accessibilityHidden(true)`, with no tap handling. Only the tip text button advanced the carousel.

## Changes

- Active dot now stretches into a 16pt elongated **pill** (Capsule), with a spring animation, matching the standard iOS page-indicator pattern.
- Each dot is now a **tappable** `Button` that jumps directly to that tip (with selection haptic + VoiceOver announcement).
- Each dot is an accessible control labeled "Tip N of M", with the `.isSelected` trait on the active one (replacing the blanket `accessibilityHidden`).
- New localized string `favorites.empty.tip.page.a11y` added to both `en.lproj` and `zh-Hans.lproj` (keeps StringsParity + zh punctuation audits green).

Scope: 1 view + 2 strings files. Reduce-motion respected (no spring when enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)