### PR TITLE
feat(ios): make tap-to-copy address discoverable in LocationCard

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -833,6 +833,7 @@
 "location.copied.a11y" = "Coordinates copied";
 "location.copiedAddress" = "Address copied";
 "location.copiedAddress.a11y" = "Address copied to clipboard";
+"location.copyAddress.a11y" = "Copy address to clipboard";
 "location.openIn.apple" = "Apple Maps";
 "location.openIn.google" = "Google Maps";
 "location.openIn.amap" = "Amap";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1115,6 +1115,9 @@
 /* Location */
 "location.copied" = "已复制！";
 "location.copied.a11y" = "坐标已复制";
+"location.copiedAddress" = "地址已复制";
+"location.copiedAddress.a11y" = "地址已复制到剪贴板";
+"location.copyAddress.a11y" = "复制地址到剪贴板";
 
 /* My routes */
 "my.hosted.routes.title" = "我主理的路线";

--- a/apps/ios/SoloCompass/Views/Experience/LocationCard.swift
+++ b/apps/ios/SoloCompass/Views/Experience/LocationCard.swift
@@ -68,14 +68,32 @@ struct LocationCard: View {
                         .font(.subheadline.weight(.semibold))
                         .fixedSize(horizontal: false, vertical: true)
                     if let hint = addressHint, !hint.isEmpty {
-                        Text(hint)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .onTapGesture { performCopy() }
-                            .accessibilityAction(named: NSLocalizedString("location.copyCoords", comment: "Copy to clipboard")) {
-                                performCopy()
+                        // The address is tap-to-copy, but a bare Text gives no
+                        // hint that it's interactive. Pair it with a small copy
+                        // glyph (swapping to a green check on success) so the
+                        // affordance is discoverable, and give the row a 32pt
+                        // tappable height instead of the hairline text bounds.
+                        Button { performCopy() } label: {
+                            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                                Text(hint)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                                Image(systemName: didCopy ? "checkmark.circle.fill" : "doc.on.doc")
+                                    .font(.caption2)
+                                    .foregroundStyle(didCopy ? Color.green : Color.secondary.opacity(0.6))
+                                    .contentTransition(.symbolEffect(.replace))
+                                    .accessibilityHidden(true)
                             }
+                            .frame(minHeight: 32, alignment: .topLeading)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(Text(hint))
+                        .accessibilityValue(didCopy
+                            ? Text(NSLocalizedString("location.copiedAddress.a11y", comment: "VoiceOver: address was copied"))
+                            : Text(""))
+                        .accessibilityHint(Text(NSLocalizedString("location.copyAddress.a11y", comment: "Copy address to clipboard")))
                     } else {
                         // Raw lat/long means nothing to a traveler, so only fall
                         // back to coordinates when there's no address at all —


### PR DESCRIPTION
## What

The address hint in `LocationCard` was already tap-to-copy (`onTapGesture { performCopy() }`), but the interaction was invisible: a plain `Text` gave no cue it was tappable, and the tap target was just the hairline text bounds.

This makes the existing feature discoverable:

- Pairs the address with a subtle `doc.on.doc` copy glyph that swaps to a green `checkmark.circle.fill` on success (same `.symbolEffect(.replace)` pattern already used by the ghost copy button below it).
- Expands the tap target to a 32pt-min row via `contentShape(Rectangle())`.
- Adds a proper VoiceOver label / value / hint so the copy affordance is announced.
- Backfills the missing `zh-Hans` `location.copiedAddress` / `.a11y` strings (they previously fell back to the raw key) and adds `location.copyAddress.a11y` in both locales.

## Why

Solo travelers frequently copy an address to paste into a ride-hail or translation app. The capability shipped but was undiscoverable — surfacing it costs one glyph and improves accessibility.

## Testing

- `pnpm parity:check` ✅ (TS↔Swift / DB / Supabase / SwiftData parity all pass)
- `xcodebuild build`/`test` run in CI on `macos-latest` (no Swift toolchain on this Linux dev host).
- Symbols `doc.on.doc` and `checkmark.circle.fill` are already used in this file, so `SFSymbolExistenceTests` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)