### PR TITLE
fix(ios): city picker search — diacritic-insensitive + match city codes

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
@@ -162,7 +162,13 @@ public struct CityPickerSheet: View {
     private var filteredSortedCities: [(code: String, name: String, center: CLLocationCoordinate2D)] {
         let query = citySearchText.trimmingCharacters(in: .whitespaces)
         guard !query.isEmpty else { return sortedCities }
-        return sortedCities.filter { $0.name.localizedCaseInsensitiveContains(query) }
+        // `localizedStandardContains` is case- and diacritic-insensitive, so a
+        // traveler typing "zurich" still matches "Zürich". Also match the city
+        // code (e.g. "TYO" → Tokyo), mirroring ItineraryFormView's city search.
+        return sortedCities.filter {
+            $0.name.localizedStandardContains(query) ||
+            $0.code.localizedStandardContains(query)
+        }
     }
 
     private var sortedCities: [(code: String, name: String, center: CLLocationCoordinate2D)] {


### PR DESCRIPTION
## What

The map's **City Picker** search now matches more forgivingly:

- **Diacritic-insensitive** — typing `zurich` now matches **Zürich** (previously `localizedCaseInsensitiveContains` was diacritic-sensitive, so accented city names were missed).
- **Matches the city code** — typing a code like `TYO` now surfaces Tokyo.

## Why

A traveler quickly typing a city name rarely includes accents, and may type a known short code. Before this change, either case produced a "no results" state. This mirrors the search behavior already used in `ItineraryFormView`, keeping city search consistent across the app.

## Change

One computed property in `CityPickerSheet.swift`:

```swift
sortedCities.filter {
    $0.name.localizedStandardContains(query) ||
    $0.code.localizedStandardContains(query)
}
```

`localizedStandardContains` is the Foundation-recommended user-facing search comparison (case- and diacritic-insensitive, locale-aware).

## Testing

- Local host is Linux (no `xcodebuild`); relying on `ios-ci.yml` (schema parity → build → test on `macos-latest`) for compile/test verification.
- Change is purely additive to an existing filter predicate — no API/schema changes, so `parity:check` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)