### PR TITLE
feat(ios): "opens in ~Nm" nudge on imminent best-time hint pills

### DIFF
--- a/apps/ios/SoloCompass/Models/Experience.swift
+++ b/apps/ios/SoloCompass/Models/Experience.swift
@@ -795,6 +795,48 @@ extension Experience {
         }
         return "\(startStr)–\(endStr)"
     }
+
+    /// Minutes until the soonest applicable `bestTimes` window *opens* later today,
+    /// or nil when the experience is already best now, has no upcoming window today,
+    /// or the soonest window is further out than `within` minutes.
+    ///
+    /// Powers an "opens soon" nudge on the best-time hint pill: a static
+    /// "Best 7–9am" reads the same whether the window opens in 20 minutes or in
+    /// 8 hours, so callers use this to highlight only the imminent case.
+    public func minutesUntilNextBestWindow(at date: Date = Date(), within: Int = 90) -> Int? {
+        guard !isBestNow(at: date) else { return nil }
+        guard !bestTimes.isEmpty else { return nil }
+
+        let cal = Calendar.current
+        let weekday = cal.component(.weekday, from: date) - 1 // Sun=0
+        let month = cal.component(.month, from: date)
+        let currentHour = cal.component(.hour, from: date)
+
+        let applicable = bestTimes.filter { window in
+            if let days = window.dayOfWeek, !days.isEmpty, !days.contains(weekday) { return false }
+            if let seasons = window.season, !seasons.isEmpty, !seasons.contains(month) { return false }
+            return true
+        }
+        let pool = applicable.isEmpty ? bestTimes : applicable
+
+        // Only windows that start later today (same logic as bestTimeHint's
+        // `upcoming`); a window already underway is handled by isBestNow above.
+        guard let nextStartHour = pool
+            .map(\.startHour)
+            .filter({ $0 > currentHour })
+            .min()
+        else { return nil }
+
+        var components = cal.dateComponents([.year, .month, .day], from: date)
+        components.hour = nextStartHour
+        components.minute = 0
+        components.second = 0
+        guard let opensAt = cal.date(from: components) else { return nil }
+
+        let minutes = Int((opensAt.timeIntervalSince(date) / 60).rounded(.up))
+        guard minutes > 0, minutes <= within else { return nil }
+        return minutes
+    }
 }
 
 private extension Locale {

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -146,6 +146,8 @@
 "experience.viewDetails" = "View details →";
 "experience.bestTime.hint" = "Best %@";
 "experience.bestTime.hint.a11y" = "Best %@";
+"experience.bestTime.opensIn" = "opens in %dm";
+"experience.bestTime.opensIn.a11y" = "Opens in %d minutes";
 
 /* Bottom info */
 "info.morning" = "Good morning. %d coffee spots nearby are at their best right now.";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1044,6 +1044,8 @@
 "experience.bestNow.countdown.a11y" = "此刻最佳，还有 %d 分钟";
 "experience.bestTime.hint" = "最佳时段：%@";
 "experience.bestTime.hint.a11y" = "最佳时段：%@";
+"experience.bestTime.opensIn" = "%d 分钟后开始";
+"experience.bestTime.opensIn.a11y" = "%d 分钟后进入最佳时段";
 
 /* Explore */
 "explore.expand.alreadyMax" = "已在最大探索半径（100 公里）。";

--- a/apps/ios/SoloCompass/Tests/BestTimeOpensInTests.swift
+++ b/apps/ios/SoloCompass/Tests/BestTimeOpensInTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import SoloCompass
+
+/// Coverage for `Experience.minutesUntilNextBestWindow(at:within:)`, which powers
+/// the "· opens in Nm" tail on the best-time hint pill in ExperienceCardView.
+///
+/// A static "Best 7–9am" pill reads the same whether the window opens in 20
+/// minutes or in 8 hours; this method lets the card highlight only the imminent
+/// case, so these tests pin its boundaries: imminent window, far window, already
+/// best now, no upcoming window today, and the `within` budget.
+final class BestTimeOpensInTests: XCTestCase {
+
+    /// A Date at a fixed local hour + minute today, for deterministic checks.
+    private func date(hour: Int, minute: Int = 0) -> Date {
+        let cal = Calendar.current
+        var comps = cal.dateComponents([.year, .month, .day], from: Date())
+        comps.hour = hour
+        comps.minute = minute
+        comps.second = 0
+        return cal.date(from: comps)!
+    }
+
+    private static func makeExp(windows: [TimeWindow]) -> Experience {
+        let now = Date()
+        return Experience(
+            id: "opens_in_fixture",
+            title: "Opens In Fixture",
+            oneLiner: "Test",
+            whyItMatters: "Test",
+            category: .coffee,
+            location: ExperienceLocation(coordinates: [100.0, 13.0], cityCode: "bkk"),
+            bestTimes: windows,
+            durationMinutes: .init(min: 30, max: 60),
+            howTo: [],
+            realInconveniences: [],
+            soloScore: SoloScore(
+                overall: 7.0,
+                breakdown: .init(
+                    seatingFriendly: 7, soloPatronRatio: 7, staffPressure: 7,
+                    soloPortioning: 7, ambianceFit: 7, safety: 7
+                ),
+                basedOnCount: 1
+            ),
+            sources: [InformationSource(type: .user, attribution: "fixture", verifiedAt: now)],
+            confidence: Confidence(
+                level: 3,
+                lastVerifiedAt: now,
+                reason: "Fixture",
+                signals: .init(aiScrapeAgeDays: 1, passiveGpsHits30d: 0,
+                               activeReports30d: 0, trustedVerifications: 0)
+            ),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .active,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    /// Window opens at 10:00; from 09:30 that's 30 minutes out — within the
+    /// default 90-minute budget, so the nudge fires.
+    func testImminentWindowReportsMinutes() {
+        let exp = Self.makeExp(windows: [TimeWindow(startHour: 10, endHour: 12)])
+        let mins = exp.minutesUntilNextBestWindow(at: date(hour: 9, minute: 30))
+        XCTAssertEqual(mins, 30)
+    }
+
+    /// Window opens at 10:00 but it's only 06:00 — 4 hours out, beyond the
+    /// 90-minute budget, so no nudge.
+    func testFarWindowReturnsNil() {
+        let exp = Self.makeExp(windows: [TimeWindow(startHour: 10, endHour: 12)])
+        XCTAssertNil(exp.minutesUntilNextBestWindow(at: date(hour: 6)))
+    }
+
+    /// Exactly at the 90-minute budget boundary the nudge still fires; one
+    /// minute past it does not.
+    func testWithinBudgetBoundary() {
+        let exp = Self.makeExp(windows: [TimeWindow(startHour: 10, endHour: 12)])
+        XCTAssertEqual(exp.minutesUntilNextBestWindow(at: date(hour: 8, minute: 30)), 90)
+        XCTAssertNil(exp.minutesUntilNextBestWindow(at: date(hour: 8, minute: 29)))
+    }
+
+    /// While the window is open the experience is best-now, so the "opens in"
+    /// nudge is suppressed (the BestNowBadge takes over instead).
+    func testBestNowReturnsNil() {
+        let exp = Self.makeExp(windows: [TimeWindow(startHour: 10, endHour: 12)])
+        XCTAssertTrue(exp.isBestNow(at: date(hour: 11)))
+        XCTAssertNil(exp.minutesUntilNextBestWindow(at: date(hour: 11)))
+    }
+
+    /// After the only window has closed for the day there is nothing upcoming,
+    /// so the method returns nil rather than wrapping to tomorrow.
+    func testNoUpcomingWindowTodayReturnsNil() {
+        let exp = Self.makeExp(windows: [TimeWindow(startHour: 10, endHour: 12)])
+        XCTAssertNil(exp.minutesUntilNextBestWindow(at: date(hour: 15)))
+    }
+
+    /// With no best times at all there is no window to open.
+    func testEmptyBestTimesReturnsNil() {
+        let exp = Self.makeExp(windows: [])
+        XCTAssertNil(exp.minutesUntilNextBestWindow(at: date(hour: 9)))
+    }
+
+    /// Of two upcoming windows the soonest one wins. From 09:00, the 10:00
+    /// window (60 min) is chosen over the 14:00 window.
+    func testPicksSoonestUpcomingWindow() {
+        let exp = Self.makeExp(windows: [
+            TimeWindow(startHour: 14, endHour: 16),
+            TimeWindow(startHour: 10, endHour: 12),
+        ])
+        XCTAssertEqual(exp.minutesUntilNextBestWindow(at: date(hour: 9)), 60)
+    }
+}

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -303,7 +303,7 @@ public struct ExperienceCardView: View {
                 } else if experience.isBestNow() {
                     BestNowBadge(experience: experience)
                 } else if let hint = experience.bestTimeHint() {
-                    bestTimeHintPill(hint)
+                    bestTimeHintPill(hint, opensInMinutes: experience.minutesUntilNextBestWindow(at: clock.tick))
                 }
                 if let coord = experience.coordinate {
                     directionsControl(coordinate: coord)
@@ -717,31 +717,49 @@ public struct ExperienceCardView: View {
         }
     }
 
+    /// Static best-time hint ("Best 7–9am"). When the window opens within the
+    /// next ~90 min, `opensInMinutes` is non-nil and the pill warms to amber with
+    /// an "· opens in 25m" tail so an imminent window reads differently from one
+    /// that's still hours out (which the bare gray pill could not convey).
     @ViewBuilder
-    private func bestTimeHintPill(_ hint: String) -> some View {
-        Label(
-            String(format: NSLocalizedString("experience.bestTime.hint", comment: "Best time hint"), hint),
-            systemImage: "clock"
-        )
-        .font(.caption)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .foregroundStyle(Color.secondary)
-        .background(Capsule().fill(Color.secondary.opacity(0.12)))
-        .symbolEffect(.bounce, value: clockNudge)
-        .scaleEffect(bestTimeAppeared ? 1 : 0.85)
-        .opacity(bestTimeAppeared ? 1 : 0)
-        .onAppear {
-            if reduceMotion {
-                bestTimeAppeared = true
-            } else {
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+    private func bestTimeHintPill(_ hint: String, opensInMinutes: Int? = nil) -> some View {
+        let isImminent = opensInMinutes != nil
+        let tint = isImminent ? Self.bestTimeImminentAmber : Color.secondary
+        let label: String = {
+            let base = String(format: NSLocalizedString("experience.bestTime.hint", comment: "Best time hint"), hint)
+            guard let mins = opensInMinutes else { return base }
+            let tail = String(format: NSLocalizedString("experience.bestTime.opensIn", comment: "Best time window opens in N minutes tail"), mins)
+            return "\(base) · \(tail)"
+        }()
+        let a11y: String = {
+            let base = String(format: NSLocalizedString("experience.bestTime.hint.a11y", comment: "Best time accessibility"), hint)
+            guard let mins = opensInMinutes else { return base }
+            return base + ". " + String(format: NSLocalizedString("experience.bestTime.opensIn.a11y", comment: "Best time opens in N minutes accessibility"), mins)
+        }()
+        Label(label, systemImage: isImminent ? "clock.badge" : "clock")
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .foregroundStyle(tint)
+            .background(Capsule().fill(tint.opacity(isImminent ? 0.16 : 0.12)))
+            .symbolEffect(.bounce, value: clockNudge)
+            .scaleEffect(bestTimeAppeared ? 1 : 0.85)
+            .opacity(bestTimeAppeared ? 1 : 0)
+            .contentTransition(reduceMotion ? .identity : .numericText())
+            .accessibilityLabel(a11y)
+            .onAppear {
+                if reduceMotion {
                     bestTimeAppeared = true
+                } else {
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                        bestTimeAppeared = true
+                    }
+                    clockNudge.toggle()
                 }
-                clockNudge.toggle()
             }
-        }
     }
+
+    private static let bestTimeImminentAmber = Color(red: 0xF5/255, green: 0x9E/255, blue: 0x0B/255)
 
     // Severity order: safety > scam > weather > crowds > logistics > etiquette > other
     private static let inconvenienceSeverity: [RealInconvenience.Category] = [


### PR DESCRIPTION
## What

The best-time hint pill on `ExperienceCardView` showed a static gray **"Best 7–9am"** regardless of whether that window opened in 20 minutes or 8 hours. A solo traveler glancing at the card got no signal to *time* their visit.

This adds an **"opens in ~Nm"** nudge: when the soonest applicable best window opens within the next ~90 minutes, the pill warms to amber, swaps `clock` → `clock.badge`, and appends `· opens in 25m`. Further-out windows (and the already-best-now case) keep the existing quiet form.

## How

- **`Experience.minutesUntilNextBestWindow(at:within:)`** — new computed timing helper. Returns minutes until the soonest *upcoming-today* applicable window opens, or `nil` when best-now, no upcoming window today, empty `bestTimes`, or beyond the `within` budget (default 90). Mirrors the day/season filtering already used by `bestTimeHint`.
- **`bestTimeHintPill(_:opensInMinutes:)`** — when non-nil, amber tint + `clock.badge` + localized tail; VoiceOver label gains "Opens in N minutes". Numeric content transition so the countdown animates as the shared `BestNowClock` ticks.

## Tests

`BestTimeOpensInTests` — imminent window, far window (nil), 90-min boundary (inclusive / one-past), best-now suppression, no-upcoming-window-today, empty bestTimes, soonest-of-many.

## Parity / scope

Model-method only — no new stored field on the `Experience` struct, so TS↔Swift schema parity is unaffected. Localized in `en` + `zh-Hans`. xcodebuild verification skipped locally; CI builds + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)