### PR TITLE
feat(ios): flag "tomorrow" on best-time hint pills whose window has passed for today

### DIFF
--- a/apps/ios/SoloCompass/Models/Experience.swift
+++ b/apps/ios/SoloCompass/Models/Experience.swift
@@ -764,6 +764,39 @@ extension Experience {
         return Self.formatTimeRange(startHour: window.startHour, endHour: window.endHour)
     }
 
+    /// True when `bestTimeHint(at:)` would surface a window whose soonest
+    /// occurrence is *tomorrow* rather than later today — i.e. every applicable
+    /// window has already started by `date`, so the hint wraps to the earliest
+    /// window overall (which next opens the following morning).
+    ///
+    /// A bare "Best 7–9am" reads the same at 8am (opens later today) and at 11pm
+    /// (already passed; really means tomorrow). Callers use this to append a
+    /// "tomorrow" qualifier so the two cases don't look identical. Returns false
+    /// when there is no hint to qualify (best now, no best times, or a window
+    /// still opening later today).
+    public func nextBestWindowIsTomorrow(at date: Date = Date()) -> Bool {
+        guard !isBestNow(at: date) else { return false }
+        guard !bestTimes.isEmpty else { return false }
+
+        let cal = Calendar.current
+        let weekday = cal.component(.weekday, from: date) - 1 // Sun=0
+        let month = cal.component(.month, from: date)
+        let currentHour = cal.component(.hour, from: date)
+
+        let applicable = bestTimes.filter { window in
+            if let days = window.dayOfWeek, !days.isEmpty, !days.contains(weekday) { return false }
+            if let seasons = window.season, !seasons.isEmpty, !seasons.contains(month) { return false }
+            return true
+        }
+        let pool = applicable.isEmpty ? bestTimes : applicable
+
+        // Mirror bestTimeHint's selection: if any window starts later today the
+        // hint refers to today; only when none do does it fall back to the
+        // earliest window overall, which next opens tomorrow.
+        guard !pool.isEmpty else { return false }
+        return !pool.contains { $0.startHour > currentHour }
+    }
+
     private static func formatTimeRange(startHour: Int, endHour: Int) -> String {
         let cal = Calendar.current
         var start = cal.startOfDay(for: Date())

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -148,6 +148,8 @@
 "experience.bestTime.hint.a11y" = "Best %@";
 "experience.bestTime.opensIn" = "opens in %dm";
 "experience.bestTime.opensIn.a11y" = "Opens in %d minutes";
+"experience.bestTime.tomorrow" = "tomorrow";
+"experience.bestTime.tomorrow.a11y" = "Next opens tomorrow";
 
 /* Bottom info */
 "info.morning" = "Good morning. %d coffee spots nearby are at their best right now.";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1046,6 +1046,8 @@
 "experience.bestTime.hint.a11y" = "最佳时段：%@";
 "experience.bestTime.opensIn" = "%d 分钟后开始";
 "experience.bestTime.opensIn.a11y" = "%d 分钟后进入最佳时段";
+"experience.bestTime.tomorrow" = "明天";
+"experience.bestTime.tomorrow.a11y" = "明天才进入最佳时段";
 
 /* Explore */
 "explore.expand.alreadyMax" = "已在最大探索半径（100 公里）。";

--- a/apps/ios/SoloCompass/Tests/BestTimeTomorrowTests.swift
+++ b/apps/ios/SoloCompass/Tests/BestTimeTomorrowTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import SoloCompass
+
+/// Coverage for `Experience.nextBestWindowIsTomorrow(at:)`, which powers the
+/// "· tomorrow" tail on the best-time hint pill in ExperienceCardView.
+///
+/// A bare "Best 7–9am" pill reads the same at 8am (the window opens later today)
+/// and at 11pm (every window today has passed, so the hint really means tomorrow
+/// morning). This flag lets the card disambiguate the two. These tests pin its
+/// boundaries against the *same* window-selection logic `bestTimeHint(at:)` uses,
+/// so the flag never disagrees with the range actually shown.
+final class BestTimeTomorrowTests: XCTestCase {
+
+    /// A Date at a fixed local hour + minute today, for deterministic checks.
+    private func date(hour: Int, minute: Int = 0) -> Date {
+        let cal = Calendar.current
+        var comps = cal.dateComponents([.year, .month, .day], from: Date())
+        comps.hour = hour
+        comps.minute = minute
+        comps.second = 0
+        return cal.date(from: comps)!
+    }
+
+    private static func makeExp(windows: [TimeWindow]) -> Experience {
+        let now = Date()
+        return Experience(
+            id: "tomorrow_fixture",
+            title: "Tomorrow Fixture",
+            oneLiner: "Test",
+            whyItMatters: "Test",
+            category: .coffee,
+            location: ExperienceLocation(coordinates: [100.0, 13.0], cityCode: "bkk"),
+            bestTimes: windows,
+            durationMinutes: .init(min: 30, max: 60),
+            howTo: [],
+            realInconveniences: [],
+            soloScore: SoloScore(
+                overall: 7.0,
+                breakdown: .init(
+                    seatingFriendly: 7, soloPatronRatio: 7, staffPressure: 7,
+                    soloPortioning: 7, ambianceFit: 7, safety: 7
+                ),
+                basedOnCount: 1
+            ),
+            sources: [InformationSource(type: .user, attribution: "fixture", verifiedAt: now)],
+            confidence: Confidence(
+                level: 3,
+                lastVerifiedAt: now,
+                reason: "Fixture",
+                signals: .init(aiScrapeAgeDays: 1, passiveGpsHits30d: 0,
+                               activeReports30d: 0, trustedVerifications: 0)
+            ),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .active,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    /// Single 10–12 window. At 15:00 it has already passed for today, so the only
+    /// hint is tomorrow's morning occurrence → flag is true.
+    func testAfterTheOnlyWindowClosedIsTomorrow() {
+        let exp = Self.makeExp(windows: [TimeWindow(startHour: 10, endHour: 12)])
+        XCTAssertTrue(exp.nextBestWindowIsTomorrow(at: date(hour: 15)))
+    }
+
+    /// Same window, but at 06:00 it still opens later TODAY, so the hint refers to
+    /// today and the flag is false (even though it isn't imminent yet).
+    func testBeforeTheWindowOpensIsNotTomorrow() {
+        let exp = Self.makeExp(windows: [TimeWindow(startHour: 10, endHour: 12)])
+        XCTAssertFalse(exp.nextBestWindowIsTomorrow(at: date(hour: 6)))
+    }
+
+    /// While the window is open the experience is best-now, so there is no hint to
+    /// qualify and the flag is false (BestNowBadge takes over instead).
+    func testBestNowIsNotTomorrow() {
+        let exp = Self.makeExp(windows: [TimeWindow(startHour: 10, endHour: 12)])
+        XCTAssertTrue(exp.isBestNow(at: date(hour: 11)))
+        XCTAssertFalse(exp.nextBestWindowIsTomorrow(at: date(hour: 11)))
+    }
+
+    /// With no best times there is no window to wrap, so the flag is false.
+    func testEmptyBestTimesIsNotTomorrow() {
+        let exp = Self.makeExp(windows: [])
+        XCTAssertFalse(exp.nextBestWindowIsTomorrow(at: date(hour: 22)))
+    }
+
+    /// Two windows (10–12 and 14–16). At 13:00 the 14:00 window is still ahead
+    /// today, so even though the morning one has passed the hint is today → false.
+    func testStillAnUpcomingWindowTodayIsNotTomorrow() {
+        let exp = Self.makeExp(windows: [
+            TimeWindow(startHour: 10, endHour: 12),
+            TimeWindow(startHour: 14, endHour: 16),
+        ])
+        XCTAssertFalse(exp.nextBestWindowIsTomorrow(at: date(hour: 13)))
+    }
+
+    /// Both windows have passed by 17:00, so the soonest occurrence is tomorrow's
+    /// 10:00 window → true.
+    func testBothWindowsPassedIsTomorrow() {
+        let exp = Self.makeExp(windows: [
+            TimeWindow(startHour: 10, endHour: 12),
+            TimeWindow(startHour: 14, endHour: 16),
+        ])
+        XCTAssertTrue(exp.nextBestWindowIsTomorrow(at: date(hour: 17)))
+    }
+
+    /// The flag must agree with the hint: whenever `bestTimeHint` is non-nil and
+    /// no window starts later today, the flag is true; otherwise false. Sweep the
+    /// clock across the day for a morning-only window to lock the contract.
+    func testFlagAgreesWithHintAcrossTheDay() {
+        let exp = Self.makeExp(windows: [TimeWindow(startHour: 7, endHour: 9)])
+        for hour in 0..<24 {
+            let at = date(hour: hour)
+            guard exp.bestTimeHint(at: at) != nil else {
+                // No hint (best now) ⇒ flag must be false.
+                XCTAssertFalse(exp.nextBestWindowIsTomorrow(at: at), "hour \(hour): no hint but flagged tomorrow")
+                continue
+            }
+            let cal = Calendar.current
+            let currentHour = cal.component(.hour, from: at)
+            let expected = !(7 > currentHour) // window opens later today only when 7 > now
+            XCTAssertEqual(
+                exp.nextBestWindowIsTomorrow(at: at), expected,
+                "hour \(hour): tomorrow flag disagreed with the displayed hint"
+            )
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -302,8 +302,12 @@ public struct ExperienceCardView: View {
                     inconveniencePill
                 } else if experience.isBestNow() {
                     BestNowBadge(experience: experience)
-                } else if let hint = experience.bestTimeHint() {
-                    bestTimeHintPill(hint, opensInMinutes: experience.minutesUntilNextBestWindow(at: clock.tick))
+                } else if let hint = experience.bestTimeHint(at: clock.tick) {
+                    bestTimeHintPill(
+                        hint,
+                        opensInMinutes: experience.minutesUntilNextBestWindow(at: clock.tick),
+                        isTomorrow: experience.nextBestWindowIsTomorrow(at: clock.tick)
+                    )
                 }
                 if let coord = experience.coordinate {
                     directionsControl(coordinate: coord)
@@ -721,20 +725,39 @@ public struct ExperienceCardView: View {
     /// next ~90 min, `opensInMinutes` is non-nil and the pill warms to amber with
     /// an "· opens in 25m" tail so an imminent window reads differently from one
     /// that's still hours out (which the bare gray pill could not convey).
+    ///
+    /// When `isTomorrow` is true the soonest occurrence of the hinted window is
+    /// the following morning (every window today has already started), so a
+    /// "· tomorrow" tail is appended — otherwise "Best 7–9am" at 11pm reads
+    /// identically to the same hint at 8am. `isTomorrow` and the imminent case
+    /// are mutually exclusive (an imminent window is, by definition, later
+    /// today), and the imminent tail wins if both were ever set.
     @ViewBuilder
-    private func bestTimeHintPill(_ hint: String, opensInMinutes: Int? = nil) -> some View {
+    private func bestTimeHintPill(_ hint: String, opensInMinutes: Int? = nil, isTomorrow: Bool = false) -> some View {
         let isImminent = opensInMinutes != nil
+        let showTomorrow = isTomorrow && !isImminent
         let tint = isImminent ? Self.bestTimeImminentAmber : Color.secondary
         let label: String = {
             let base = String(format: NSLocalizedString("experience.bestTime.hint", comment: "Best time hint"), hint)
-            guard let mins = opensInMinutes else { return base }
-            let tail = String(format: NSLocalizedString("experience.bestTime.opensIn", comment: "Best time window opens in N minutes tail"), mins)
-            return "\(base) · \(tail)"
+            if let mins = opensInMinutes {
+                let tail = String(format: NSLocalizedString("experience.bestTime.opensIn", comment: "Best time window opens in N minutes tail"), mins)
+                return "\(base) · \(tail)"
+            }
+            if showTomorrow {
+                let tail = NSLocalizedString("experience.bestTime.tomorrow", comment: "Best time window next opens tomorrow tail")
+                return "\(base) · \(tail)"
+            }
+            return base
         }()
         let a11y: String = {
             let base = String(format: NSLocalizedString("experience.bestTime.hint.a11y", comment: "Best time accessibility"), hint)
-            guard let mins = opensInMinutes else { return base }
-            return base + ". " + String(format: NSLocalizedString("experience.bestTime.opensIn.a11y", comment: "Best time opens in N minutes accessibility"), mins)
+            if let mins = opensInMinutes {
+                return base + ". " + String(format: NSLocalizedString("experience.bestTime.opensIn.a11y", comment: "Best time opens in N minutes accessibility"), mins)
+            }
+            if showTomorrow {
+                return base + ". " + NSLocalizedString("experience.bestTime.tomorrow.a11y", comment: "Best time next opens tomorrow accessibility")
+            }
+            return base
         }()
         Label(label, systemImage: isImminent ? "clock.badge" : "clock")
             .font(.caption)


### PR DESCRIPTION
## Design rationale

The best-time hint pill on an Experience card shows **"Best 7–9am" identically** whether that window opens later **today** or has already passed for today (in which case `bestTimeHint` silently wraps to the earliest window overall — i.e. *tomorrow* morning). A solo traveler reading "Best 7–9am" at 11pm has no way to tell it means tomorrow.

This closes the same readability gap the existing **"· opens in Nm"** nudge already addresses for the *imminent* case (see `minutesUntilNextBestWindow`'s own doc comment: *"a static 'Best 7–9am' reads the same whether the window opens in 20 minutes or in 8 hours"*) — but for the **"tomorrow"** end of the spectrum, which was previously indistinguishable.

## What changed

- **`Experience.nextBestWindowIsTomorrow(at:)`** — pure value-type helper that mirrors `bestTimeHint`'s exact `applicable → pool → upcoming` window selection, returning `true` only when no applicable window starts later today (so the displayed range's soonest occurrence is tomorrow). Returns `false` for best-now, empty best-times, or a window still opening today.
- **`ExperienceCardView.bestTimeHintPill`** — appends a localized **"· tomorrow"** tail (label + a11y) in that case. `isTomorrow` and the imminent "opens in Nm" case are provably mutually exclusive (an imminent window is, by definition, later today); a documented `&& !isImminent` guard makes the precedence explicit regardless.
- Threads `clock.tick` into `bestTimeHint(at:)` so the hint and both timing flags derive from **one** clock tick (fixes a latent inconsistency where the hint used `Date()` while the flags used `clock.tick`).

## Quality

- **i18n:** `en` + `zh-Hans` parity; `·` separator matches the existing pattern; zh-Hans free of half-width punctuation (passes `ZhHansPunctuationTest`).
- **Tests:** `BestTimeTomorrowTests` pins the boundaries (passed/upcoming/best-now/empty/multi-window) and **sweeps all 24 hours** to lock the contract that the flag never disagrees with the displayed hint.
- No new SF Symbol literals (kept the real `clock` glyph); no force-unwraps in production paths; dark-mode/Reduce-Motion behavior unchanged (reuses the existing pill styling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)