### PR TITLE
feat(ios): live "closing soon" countdown on the peek pick and Nearby rows

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1329,6 +1329,9 @@
 "nearby.chip.driveMin" = "%d min drive";
 "nearby.chip.solo" = "Solo %.1f";
 "nearby.chip.bestNow" = "Best now";
+/* Compact closing-soon countdown chip on the peek pick + Nearby rows (≤45 min left). %d = minutes. */
+"nearby.chip.closingSoon" = "Closing · %dm";
+"nearby.chip.closingSoon.a11y" = "best now, closing soon, %d minutes left";
 "nearby.proximity.sparse" = "Quiet";
 "nearby.proximity.moderate" = "Moderate";
 "nearby.proximity.far" = "Far";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1214,6 +1214,9 @@
 "nearby.chip.driveMin" = "车程 %d 分钟";
 "nearby.chip.solo" = "Solo %.1f";
 "nearby.chip.bestNow" = "此刻最佳";
+/* 此刻最值得去卡片 + 附近列表上的紧凑「即将关闭」倒计时（剩余 ≤45 分钟）。%d = 分钟。 */
+"nearby.chip.closingSoon" = "即将关闭 · %d分";
+"nearby.chip.closingSoon.a11y" = "此刻最佳，即将关闭，还剩 %d 分钟";
 "nearby.proximity.sparse" = "稀疏";
 "nearby.proximity.moderate" = "中等";
 "nearby.proximity.far" = "较远";

--- a/apps/ios/SoloCompass/Tests/BestNowChipStateTests.swift
+++ b/apps/ios/SoloCompass/Tests/BestNowChipStateTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+import SwiftUI
+@testable import SoloCompass
+
+/// Unit coverage for `BestNowChipState` — the shared "此刻最佳 / Closing soon"
+/// chip model used by `PeekSummaryCard` and `NearbyExperienceRow`.
+///
+/// The chip flips to its amber countdown form once the active best-time window
+/// has ≤ 45 minutes left, matching `BestNowBadge` and the Saved-list pill. These
+/// tests pin the boundary, the visual switch (symbol / tint), the label/a11y
+/// formatting, and that both shipped locales carry the new keys.
+final class BestNowChipStateTests: XCTestCase {
+
+    // MARK: - Fixture
+
+    /// Experience whose single best-time window is [startHour, endHour).
+    private static func makeExp(startHour: Int, endHour: Int) -> Experience {
+        let now = Date()
+        return Experience(
+            id: "best_now_chip_fixture",
+            title: "Chip Fixture",
+            oneLiner: "Test",
+            whyItMatters: "Test",
+            category: .coffee,
+            location: ExperienceLocation(coordinates: [100.0, 13.0], cityCode: "bkk"),
+            bestTimes: [TimeWindow(startHour: startHour, endHour: endHour)],
+            durationMinutes: .init(min: 30, max: 60),
+            howTo: [],
+            realInconveniences: [],
+            soloScore: SoloScore(
+                overall: 7.0,
+                breakdown: .init(
+                    seatingFriendly: 7, soloPatronRatio: 7, staffPressure: 7,
+                    soloPortioning: 7, ambianceFit: 7, safety: 7
+                ),
+                basedOnCount: 1
+            ),
+            sources: [InformationSource(type: .user, attribution: "fixture", verifiedAt: now)],
+            confidence: Confidence(
+                level: 3,
+                lastVerifiedAt: now,
+                reason: "Fixture",
+                signals: .init(aiScrapeAgeDays: 1, passiveGpsHits30d: 0,
+                               activeReports30d: 0, trustedVerifications: 0)
+            ),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .active,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    /// Builds an experience whose active window ends `minutes` from `now`, with a
+    /// start safely in the past so the window is currently open. Mirrors the
+    /// approach in `FavoritesClosingSoonThresholdTest`.
+    private static func expEnding(inMinutes minutes: Int, now: Date) -> Experience {
+        let cal = Calendar.current
+        let endDate = now.addingTimeInterval(Double(minutes) * 60)
+        let endHour = cal.component(.hour, from: endDate)
+        let startHour = (endHour + 23) % 24
+        return makeExp(startHour: startHour, endHour: endHour)
+    }
+
+    // MARK: - Threshold
+
+    func testNotOpenYieldsNilMinutes() {
+        // 3–4am window — almost never open during a CI run.
+        let exp = Self.makeExp(startHour: 3, endHour: 4)
+        let now = Date()
+        guard !exp.isBestNow(at: now) else { return } // skip if run at 3–4am
+        let state = BestNowChipState.resolve(for: exp, at: now)
+        XCTAssertNil(state.minutesLeft, "Window not active → no minutes")
+        XCTAssertFalse(state.isClosingSoon, "Not open → never closing soon")
+    }
+
+    func testWellWithinWindowIsNotClosingSoon() {
+        let now = Date()
+        // ~3h59m left rounds comfortably above the 45-min threshold regardless of
+        // the current minute-of-hour.
+        let exp = Self.expEnding(inMinutes: 240, now: now)
+        let state = BestNowChipState.resolve(for: exp, at: now)
+        // Window is open …
+        XCTAssertNotNil(state.minutesLeft)
+        XCTAssertFalse(state.isClosingSoon, "≈4h left should not be closing soon")
+    }
+
+    func testInsideThresholdIsClosingSoon() {
+        let now = Date()
+        let exp = Self.expEnding(inMinutes: 20, now: now)
+        let state = BestNowChipState.resolve(for: exp, at: now)
+        guard let mins = state.minutesLeft else {
+            return XCTFail("Expected an active window with minutes left")
+        }
+        XCTAssertLessThanOrEqual(mins, BestNowChipState.closingSoonThresholdMinutes)
+        XCTAssertTrue(state.isClosingSoon, "20 min left should be closing soon (got \(mins))")
+    }
+
+    // MARK: - Visual switch
+
+    func testClosingSoonUsesAmberAlarmGlyph() {
+        let closing = BestNowChipState(isClosingSoon: true, minutesLeft: 10)
+        XCTAssertEqual(closing.symbol, "clock.badge.exclamationmark")
+        XCTAssertEqual(closing.foreground, BestNowChipState.amber)
+
+        let calm = BestNowChipState(isClosingSoon: false, minutesLeft: 180)
+        XCTAssertEqual(calm.symbol, "sparkles")
+        XCTAssertEqual(calm.foreground, CT.sunGoldDeep)
+    }
+
+    // MARK: - Label formatting
+
+    func testClosingSoonLabelEmbedsMinutes() {
+        let state = BestNowChipState(isClosingSoon: true, minutesLeft: 12)
+        XCTAssertTrue(state.label.contains("12"),
+                      "Closing-soon label should embed the minute count, got: \(state.label)")
+        XCTAssertTrue(state.accessibilityLabel.contains("12"),
+                      "Closing-soon a11y label should embed the minute count")
+    }
+
+    func testPlainLabelWhenNotClosingSoon() {
+        let state = BestNowChipState(isClosingSoon: false, minutesLeft: 180)
+        XCTAssertEqual(state.label,
+                       NSLocalizedString("nearby.chip.bestNow", comment: ""),
+                       "Non-closing chip should read the plain Best-now label")
+    }
+
+    /// A closing-soon state with no known minute count must not crash and falls
+    /// back to the plain best-now label (defensive: minutesLeft nil + isClosingSoon
+    /// can't arise from `resolve`, but the struct is public-shaped).
+    func testClosingSoonWithoutMinutesFallsBackToPlainLabel() {
+        let state = BestNowChipState(isClosingSoon: true, minutesLeft: nil)
+        XCTAssertEqual(state.label, NSLocalizedString("nearby.chip.bestNow", comment: ""))
+    }
+
+    // MARK: - Localization parity
+
+    func testClosingSoonKeysResolveInBothLocales() throws {
+        for lang in ["en", "zh-Hans"] {
+            let bundleURL = try XCTUnwrap(
+                Bundle(for: Self.self).url(forResource: lang, withExtension: "lproj"),
+                "missing \(lang).lproj in test bundle"
+            )
+            let bundle = try XCTUnwrap(Bundle(url: bundleURL))
+            for key in ["nearby.chip.closingSoon", "nearby.chip.closingSoon.a11y"] {
+                let value = bundle.localizedString(forKey: key, value: "__MISSING__", table: nil)
+                XCTAssertNotEqual(value, "__MISSING__", "\(key) missing in \(lang)")
+                XCTAssertTrue(value.contains("%d"),
+                              "\(key) in \(lang) must keep the %d minutes placeholder")
+            }
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -743,6 +743,10 @@ struct NearbyExperienceRow: View {
     let distanceMeters: Double?
     /// True when the experience's bestTimes include the current clock hour (Now sort mode only).
     let isOpenNow: Bool
+    /// Live "best now / closing soon" chip state, resolved by the parent section
+    /// from the shared `BestNowClock` so the countdown stays current. Only read
+    /// when `isOpenNow` is true; nil leaves the chip in its plain form.
+    var bestNowChipState: BestNowChipState? = nil
     /// Tapping the card jumps straight to the detail sheet.
     let onTap: () -> Void
     /// Long-pressing the card floats the quick preview card instead. Optional so
@@ -980,18 +984,23 @@ struct NearbyExperienceRow: View {
         .background(Capsule().fill(CT.verifiedGreen.opacity(0.12)))
     }
 
-    /// Golden chip: 此刻最佳 — shown when the experience is open in the current hour.
+    /// Golden chip: 此刻最佳 — shown when the experience is open in the current
+    /// hour. Flips to an amber "Closing · Nm" countdown when the active window
+    /// has ≤ 45 minutes left, matching the detail card and Saved list.
     private var bestNowChip: some View {
-        HStack(spacing: 3) {
-            Image(systemName: "sparkles")
+        let state = bestNowChipState ?? BestNowChipState(isClosingSoon: false, minutesLeft: nil)
+        return HStack(spacing: 3) {
+            Image(systemName: state.symbol)
                 .font(.system(size: 9, weight: .semibold))
-            Text(NSLocalizedString("nearby.chip.bestNow", comment: "此刻最佳 chip"))
+            Text(state.label)
                 .font(.caption2.weight(.semibold))
+                .monospacedDigit()
+                .contentTransition(reduceMotion ? .identity : .numericText())
         }
-        .foregroundStyle(CT.sunGoldDeep)
+        .foregroundStyle(state.foreground)
         .padding(.horizontal, 7)
         .padding(.vertical, 3)
-        .background(Capsule().fill(CT.sunGoldSoft))
+        .background(Capsule().fill(state.background))
     }
 
     private var subtitleText: String {
@@ -1077,7 +1086,13 @@ struct NearbyExperienceRow: View {
             label += ", " + NSLocalizedString("sheet.nearby.smartPick.a11y", comment: "AI pick")
         }
         if isOpenNow {
-            label += ", " + NSLocalizedString("sheet.nearby.openNow.a11y", comment: "Open now accessibility")
+            // Prefer the live closing-soon phrasing when the window is winding
+            // down; otherwise the plain open-now cue.
+            if let state = bestNowChipState, state.isClosingSoon {
+                label += ", " + state.accessibilityLabel
+            } else {
+                label += ", " + NSLocalizedString("sheet.nearby.openNow.a11y", comment: "Open now accessibility")
+            }
         }
         if isNearby {
             label += ", " + NSLocalizedString("peek.card.almostThere.a11y", comment: "VoiceOver: almost there proximity cue")
@@ -1291,11 +1306,19 @@ struct NearbySection: View {
                 // long lists.
                 LazyVStack(spacing: 10) {
                     ForEach(sortedExperiences) { exp in
+                        let openNow = sortMode == .now && isOpenNow(exp)
                         NearbyExperienceRow(
                             experience: exp,
                             isSmartPick: sortMode == .smart && smartPickIds.contains(exp.id),
                             distanceMeters: distance(to: exp),
-                            isOpenNow: sortMode == .now && isOpenNow(exp),
+                            isOpenNow: openNow,
+                            // Resolve the live chip state from the shared clock so
+                            // the "Best now" chip flips to an amber countdown as a
+                            // window winds down. Only computed for rows that show
+                            // the chip (Now sort) to avoid needless work.
+                            bestNowChipState: openNow
+                                ? BestNowChipState.resolve(for: exp, at: clock.tick)
+                                : nil,
                             onTap: { onSelectExperience(exp) },
                             onLongPress: onLongPressExperience.map { handler in { handler(exp) } }
                         )

--- a/apps/ios/SoloCompass/Views/Map/PeekSummaryCard.swift
+++ b/apps/ios/SoloCompass/Views/Map/PeekSummaryCard.swift
@@ -212,18 +212,24 @@ struct PeekSummaryCard: View {
         .accessibilityHidden(true)
     }
 
-    /// Golden chip: 此刻最佳 — shown when the experience is open in the current hour.
+    /// Golden chip: 此刻最佳 — shown when the experience is at its best right now.
+    /// Flips to an amber "Closing · Nm" countdown when the active window has
+    /// ≤ 45 minutes left, matching the detail card and Saved list so the peek
+    /// pick carries the same urgency cue the rest of the app already shows.
     private var bestNowChip: some View {
-        HStack(spacing: 3) {
-            Image(systemName: "sparkles")
+        let state = bestNowChipState
+        return HStack(spacing: 3) {
+            Image(systemName: state.symbol)
                 .font(.system(size: 9, weight: .semibold))
-            Text(NSLocalizedString("nearby.chip.bestNow", comment: "此刻最佳 chip"))
+            Text(state.label)
                 .font(.caption2.weight(.semibold))
+                .monospacedDigit()
+                .contentTransition(reduceMotion ? .identity : .numericText())
         }
-        .foregroundStyle(CT.sunGoldDeep)
+        .foregroundStyle(state.foreground)
         .padding(.horizontal, 7)
         .padding(.vertical, 3)
-        .background(Capsule().fill(CT.sunGoldSoft))
+        .background(Capsule().fill(state.background))
         .accessibilityHidden(true)
     }
 
@@ -299,9 +305,19 @@ struct PeekSummaryCard: View {
         return parts.joined(separator: " · ")
     }
 
+    /// Live "best now / closing soon" chip state, recomputed each time the shared
+    /// `BestNowClock` advances (the `clock.tick` read makes this card an observer).
+    private var bestNowChipState: BestNowChipState {
+        BestNowChipState.resolve(for: experience, at: clock.tick)
+    }
+
+    /// True when the experience is genuinely at its best right now. Uses
+    /// `minutesLeftInBestWindow` (via the chip state) as the single source of
+    /// truth — it honours weekday / season filters and midnight-wrapping
+    /// windows, unlike the old bare "current hour ∈ bestTimes" check which would
+    /// falsely flag a weekend-only or summer-only window on the wrong day.
     private var isOpenNow: Bool {
-        let hour = Calendar.current.component(.hour, from: clock.tick)
-        return experience.bestTimes.contains { $0.contains(hour: hour) }
+        bestNowChipState.minutesLeft != nil
     }
 
     private var relativeBearing: Double? {
@@ -337,6 +353,14 @@ struct PeekSummaryCard: View {
                 let minutes = max(1, Int((meters / 1000 * 6).rounded()))
                 label += ", \(String(format: NSLocalizedString("nearby.chip.driveMin", comment: "Drive minutes chip, e.g. '12 min drive'"), minutes))"
             }
+        }
+        if isOpenNow {
+            // Surface the live timing the same way the visible chip does: the
+            // closing-soon countdown when winding down, else a plain best-now cue.
+            let state = bestNowChipState
+            label += ", " + (state.isClosingSoon
+                ? state.accessibilityLabel
+                : NSLocalizedString("sheet.nearby.openNow.a11y", comment: "Open now accessibility"))
         }
         if isNearby {
             label += ", " + NSLocalizedString("peek.card.almostThere.a11y", comment: "VoiceOver: almost there proximity cue")
@@ -422,6 +446,49 @@ struct PeekEmptyCard: View {
                 )
             }
             PeekEmptyCard()
+        }
+        .padding(16)
+    }
+    .environment(LocationService.shared)
+    .environment(BestNowClock.shared)
+}
+
+#Preview("Best now vs. Closing soon") {
+    // Two synthetic picks at the same spot: one whose best window has hours left
+    // (plain gold "Best now" chip) and one whose window ends at the top of the
+    // next hour, so within ~45 min of most open times it renders the amber
+    // "Closing · Nm" chip. Demonstrates the live urgency treatment.
+    let cal = Calendar.current
+    let hour = cal.component(.hour, from: Date())
+    func pick(from base: Experience, id: String, endsInHours: Int) -> Experience {
+        Experience(
+            id: id, title: base.title, oneLiner: base.oneLiner, whyItMatters: base.whyItMatters,
+            category: base.category, location: base.location,
+            bestTimes: [TimeWindow(startHour: (hour + 23) % 24, endHour: (hour + endsInHours) % 24)],
+            durationMinutes: base.durationMinutes, howTo: base.howTo,
+            realInconveniences: base.realInconveniences, soloScore: base.soloScore,
+            sources: base.sources, confidence: base.confidence,
+            nearbyExperienceIds: base.nearbyExperienceIds, stats: base.stats, status: base.status,
+            createdAt: base.createdAt, updatedAt: base.updatedAt, userTags: base.userTags
+        )
+    }
+    return ZStack {
+        Color(.systemGroupedBackground).ignoresSafeArea()
+        VStack(spacing: 16) {
+            if let base = ExperienceService.hardcodedSeed.first {
+                PeekSummaryCard(
+                    experience: pick(from: base, id: "preview_open_all_evening", endsInHours: 4),
+                    isSmartPick: true,
+                    referenceCoordinate: base.coordinate,
+                    onTap: {}
+                )
+                PeekSummaryCard(
+                    experience: pick(from: base, id: "preview_closing_soon", endsInHours: 1),
+                    isSmartPick: false,
+                    referenceCoordinate: base.coordinate,
+                    onTap: {}
+                )
+            }
         }
         .padding(16)
     }

--- a/apps/ios/SoloCompass/Views/Shared/BestNowChipState.swift
+++ b/apps/ios/SoloCompass/Views/Shared/BestNowChipState.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+/// Shared "此刻最佳 / Best now" chip model for the map-browsing surfaces
+/// (`PeekSummaryCard`, `NearbyExperienceRow`).
+///
+/// Both surfaces previously rendered a *static* golden "Best now" chip whose
+/// text read identically whether the experience's best-time window had three
+/// hours left or eight minutes left. The detail card (`BestNowBadge`), the
+/// detail sheet, and the Saved list already surface a live countdown that flips
+/// to an amber "Closing soon · Nm left" treatment once the window has ≤ 45
+/// minutes remaining — but the two highest-traffic decision surfaces (the
+/// resting peek pick and the Nearby list) did not, hiding the urgency at the
+/// exact moment a solo traveler is choosing where to go *right now*.
+///
+/// This value resolves the chip's tone, glyph, label, and VoiceOver string from
+/// a single live instant so the two views stay consistent with each other and
+/// with the rest of the app. It is a pure, side-effect-free struct so the
+/// threshold/format rules are unit-testable without a SwiftUI graph.
+struct BestNowChipState {
+    /// Window has ≤ `closingSoonThresholdMinutes` left → amber urgency treatment.
+    let isClosingSoon: Bool
+    /// Minutes remaining in the active best-time window, when known.
+    let minutesLeft: Int?
+
+    /// Threshold below which the chip flips to its amber "closing soon" form.
+    /// Matches `BestNowBadge.closingSoonThresholdMinutes` and the Saved-list
+    /// pill so all four surfaces agree on what "closing soon" means.
+    static let closingSoonThresholdMinutes = 45
+
+    /// Amber used for the closing-soon treatment — identical to
+    /// `BestNowBadge.amber` (#F59E0B) so the urgency tone reads the same on the
+    /// peek card, the Nearby row, the detail card, and the Saved list.
+    static let amber = Color(red: 0xF5 / 255, green: 0x9E / 255, blue: 0x0B / 255)
+
+    /// Resolve the chip state for `experience` at the given instant.
+    ///
+    /// `minutesLeftInBestWindow(at:)` already honours weekday / season filters
+    /// and windows that wrap past midnight, returning nil when no window is
+    /// currently active — so a nil here means "not best now" and the caller can
+    /// keep its prior visibility gating.
+    static func resolve(for experience: Experience, at date: Date) -> BestNowChipState {
+        let minutes = experience.minutesLeftInBestWindow(at: date)
+        let closingSoon = (minutes ?? .max) <= closingSoonThresholdMinutes
+        return BestNowChipState(isClosingSoon: closingSoon, minutesLeft: minutes)
+    }
+
+    /// SF Symbol for the chip: an alarm-style clock when closing soon, else the
+    /// standard sparkles used by the existing "Best now" chips.
+    var symbol: String {
+        isClosingSoon ? "clock.badge.exclamationmark" : "sparkles"
+    }
+
+    /// Foreground tint: amber when closing soon, else the warm sun-gold-deep
+    /// used by the existing chips.
+    var foreground: Color {
+        isClosingSoon ? Self.amber : CT.sunGoldDeep
+    }
+
+    /// Capsule fill: a soft amber wash when closing soon, else the existing
+    /// sun-gold-soft.
+    var background: Color {
+        isClosingSoon ? Self.amber.opacity(0.16) : CT.sunGoldSoft
+    }
+
+    /// Visible chip label. When closing soon and a minute count is known, shows
+    /// the compact countdown ("Closing · Nm"); otherwise the plain "Best now".
+    var label: String {
+        if isClosingSoon, let minutes = minutesLeft {
+            return String(
+                format: NSLocalizedString(
+                    "nearby.chip.closingSoon",
+                    comment: "Compact closing-soon chip on map cards, e.g. 'Closing · 12m'"
+                ),
+                minutes
+            )
+        }
+        return NSLocalizedString("nearby.chip.bestNow", comment: "此刻最佳 chip")
+    }
+
+    /// VoiceOver phrase appended to the card's accessibility label.
+    var accessibilityLabel: String {
+        if isClosingSoon, let minutes = minutesLeft {
+            return String(
+                format: NSLocalizedString(
+                    "nearby.chip.closingSoon.a11y",
+                    comment: "VoiceOver: best now but closing soon, with minutes left"
+                ),
+                minutes
+            )
+        }
+        return NSLocalizedString("nearby.chip.bestNow", comment: "此刻最佳 chip")
+    }
+}


### PR DESCRIPTION
## What

Surfaces the **closing-soon urgency cue** on the two highest-traffic map-browsing surfaces — the resting peek pick (`PeekSummaryCard`) and the Nearby list (`NearbyExperienceRow`).

Both previously showed a *static* gold **"Best now"** chip that read identically whether a spot had three hours left or eight minutes. The amber `clock.badge.exclamationmark` + live "Nm left" countdown (≤ 45 min remaining) already shipped on the detail card, detail sheet, and Saved list — so this closes the consistency gap at the exact moment a solo traveler decides *where to go right now*.

| Before | After |
| --- | --- |
| `✨ Best now` (static, on peek + Nearby) | `✨ Best now` → flips to `⏰ Closing · 12m` (amber) as the window winds down |

## How

- New `BestNowChipState` value type centralises the 45-min threshold, amber tint (`#F59E0B`, matching `BestNowBadge`), glyph, and localized label/a11y formatting — so the peek card, Nearby row, detail card, and Saved list all agree.
- Both chips resolve their state from the existing shared `BestNowClock`, so the countdown stays live with no new timers.
- Aligns the peek card's `isOpenNow` to `minutesLeftInBestWindow` (the app-wide source of truth), which honours weekday/season filters and midnight-wrapping windows — fixing a false "Best now" on a wrong-day/season window.

## Scope / safety

- **No change to visibility gating**: the Nearby row still shows the chip only in `.now` sort; the peek card still shows it whenever best-now. Only the chip's *content/tone* became time-aware.
- Graceful fallback to plain "Best now" when the row's hour-gate and the window's day/season filter disagree (no wrong countdown, no crash).
- Reduce Motion (numeric transition gated) and Dynamic Type respected; chips live on the card's light-fixed surface, so dark mode is unchanged.
- `nearby.chip.closingSoon` (+ `.a11y`) added for **en** and **zh-Hans**.

## Tests

- New `BestNowChipStateTests`: threshold boundary, visual switch (symbol/tint), label + a11y formatting, and **locale parity** (both locales keep the `%d` placeholder).
- `pnpm parity:check` passes (no schema fields touched). Build/iOS tests run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)