### PR TITLE
feat(ios): surface live best-now/closing-soon timing in every browse surface (map pins + Nearby rows)

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -221,6 +221,7 @@
 
 /* Marker accessibility */
 "marker.a11y.bestNow" = "best right now";
+"marker.a11y.closingSoon" = "best right now, closing soon";
 "marker.a11y.completed" = "completed";
 "marker.a11y.favorited" = "favorited";
 "marker.a11y.upcoming" = "starts in %d minutes";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -131,6 +131,7 @@
 
 /* Marker accessibility */
 "marker.a11y.bestNow" = "此刻最佳";
+"marker.a11y.closingSoon" = "此刻最佳，即将关闭";
 "marker.a11y.completed" = "已完成";
 "marker.a11y.favorited" = "已收藏";
 "marker.a11y.upcoming" = "%d 分钟后开始";

--- a/apps/ios/SoloCompass/Tests/BestNowChipStateTests.swift
+++ b/apps/ios/SoloCompass/Tests/BestNowChipStateTests.swift
@@ -148,6 +148,15 @@ final class BestNowChipStateTests: XCTestCase {
                 XCTAssertTrue(value.contains("%d"),
                               "\(key) in \(lang) must keep the %d minutes placeholder")
             }
+
+            // US-049: the map marker's closing-soon VoiceOver phrase. Unlike the
+            // chip keys above it carries no minute count (the pin shows a glyph,
+            // not a countdown), so it must resolve but must NOT contain "%d".
+            let markerKey = "marker.a11y.closingSoon"
+            let markerValue = bundle.localizedString(forKey: markerKey, value: "__MISSING__", table: nil)
+            XCTAssertNotEqual(markerValue, "__MISSING__", "\(markerKey) missing in \(lang)")
+            XCTAssertFalse(markerValue.contains("%d"),
+                           "\(markerKey) in \(lang) must not embed a minute placeholder")
         }
     }
 }

--- a/apps/ios/SoloCompass/Tests/MarkerClosingSoonStyleTest.swift
+++ b/apps/ios/SoloCompass/Tests/MarkerClosingSoonStyleTest.swift
@@ -1,0 +1,200 @@
+import XCTest
+import SwiftUI
+@testable import SoloCompass
+
+// MARK: - US-049: Map marker escalates to amber when a best-now window closes soon
+
+/// Verifies that a `bestNow` map pin adopts the shared "closing soon" amber
+/// treatment once its window has ≤ 45 minutes left, so the map conveys the same
+/// urgency the cards / Nearby row / detail sheet / Saved list already show via
+/// `BestNowChipState`. Before this, every best-now pin glowed the same gold
+/// whether its window had three hours or eight minutes left — hiding the one
+/// pin a traveler scanning the map most needs to reach right now.
+///
+/// `MarkerIconView` exposes the escalation through pure, render-free hooks:
+///   - `showsClosingSoon` — the predicate that flips the pulse / fill / glow to
+///     amber and shows the alarm-clock badge (true only for a high-confidence
+///     best-now pin whose `closingSoon` flag is set);
+///   - `accessibilityIdentifier` — gains a `.closingsoon` suffix when it fires,
+///     giving a stable way to assert the style differs without rendering;
+///   - `bestNowTint` is private, so we assert behaviour through the two hooks
+///     above plus the shared amber constant the map and cards both reference.
+///
+/// Run with:
+///   xcodebuild test -only-testing:SoloCompassTests/MarkerClosingSoonStyleTest
+final class MarkerClosingSoonStyleTest: XCTestCase {
+
+    // MARK: - Marker view: style changes with the closing-soon flag
+
+    /// A best-now marker must look different when closing soon vs. not — the
+    /// whole point of the escalation. We assert via both the predicate and the
+    /// identifier suffix.
+    func testBestNowMarkerStyleChangesWhenClosingSoon() {
+        let calm    = MarkerIconView(category: .coffee, state: .bestNow, confidenceLevel: 4, closingSoon: false)
+        let closing = MarkerIconView(category: .coffee, state: .bestNow, confidenceLevel: 4, closingSoon: true)
+
+        XCTAssertFalse(calm.showsClosingSoon, "Not closing soon → calm gold treatment")
+        XCTAssertTrue(closing.showsClosingSoon, "Closing soon → best-now pin escalates to amber")
+
+        XCTAssertNotEqual(
+            calm.accessibilityIdentifier,
+            closing.accessibilityIdentifier,
+            "Marker identifier must differ between calm and closing-soon so the style change is observable"
+        )
+        XCTAssertFalse(
+            calm.accessibilityIdentifier.hasSuffix(".closingsoon"),
+            "Calm marker must not carry '.closingsoon', got: \(calm.accessibilityIdentifier)"
+        )
+        XCTAssertTrue(
+            closing.accessibilityIdentifier.hasSuffix(".closingsoon"),
+            "Closing-soon best-now marker should end with '.closingsoon', got: \(closing.accessibilityIdentifier)"
+        )
+    }
+
+    /// The escalation is scoped to best-now pins. A non-best-now marker must
+    /// look identical regardless of the closing-soon flag (it can never be
+    /// "best now, closing soon").
+    func testNonBestNowMarkerUnaffectedByClosingSoon() {
+        let off = MarkerIconView(category: .food, state: .favorited, confidenceLevel: 4, closingSoon: false)
+        let on  = MarkerIconView(category: .food, state: .favorited, confidenceLevel: 4, closingSoon: true)
+
+        XCTAssertFalse(off.showsClosingSoon)
+        XCTAssertFalse(on.showsClosingSoon, "Non-best-now markers never escalate to closing-soon")
+        XCTAssertEqual(
+            off.accessibilityIdentifier,
+            on.accessibilityIdentifier,
+            "Non-best-now markers must be unchanged by the closing-soon flag"
+        )
+    }
+
+    /// Low-confidence (AI-guessed) best-now pins don't earn the urgency cue,
+    /// mirroring the existing gold pulse-ring and Now-sync suppression — we
+    /// don't want tentative entries imitating verified urgency.
+    func testLowConfidenceBestNowMarkerHasNoClosingSoonStyle() {
+        let on = MarkerIconView(category: .coffee, state: .bestNow, confidenceLevel: 1, closingSoon: true)
+        XCTAssertFalse(
+            on.showsClosingSoon,
+            "Low-confidence best-now pins must not show the closing-soon escalation"
+        )
+        XCTAssertFalse(on.accessibilityIdentifier.hasSuffix(".closingsoon"))
+    }
+
+    /// `closingSoon` must default to false for source compatibility with every
+    /// existing call site (the map only opts in for pins that are closing soon).
+    func testClosingSoonDefaultsToFalse() {
+        let marker = MarkerIconView(category: .coffee, state: .bestNow, confidenceLevel: 4)
+        XCTAssertFalse(marker.showsClosingSoon, "closingSoon must default to false")
+    }
+
+    /// The map's amber must be the *same* amber every other surface uses, so the
+    /// closing-soon cue reads identically on the pin, the chip, and the card.
+    func testMapClosingSoonAmberMatchesSharedChipAmber() {
+        XCTAssertEqual(
+            MarkerIconView.closingSoonAmber,
+            BestNowChipState.amber,
+            "The map's closing-soon amber must equal BestNowChipState.amber (#F59E0B) so all surfaces agree"
+        )
+    }
+
+    // MARK: - Closing-soon and Now-sync compose independently
+
+    /// A best-now pin can be both closing soon *and* highlighted by the Now
+    /// filter at once; the two cues are orthogonal and both fragments must show.
+    func testClosingSoonAndNowSyncCompose() {
+        let both = MarkerIconView(
+            category: .coffee,
+            state: .bestNow,
+            confidenceLevel: 4,
+            nowFilterActive: true,
+            closingSoon: true
+        )
+        XCTAssertTrue(both.showsClosingSoon)
+        XCTAssertTrue(both.showsNowSyncRing)
+        XCTAssertTrue(both.accessibilityIdentifier.contains(".nowsync"))
+        XCTAssertTrue(both.accessibilityIdentifier.hasSuffix(".closingsoon"))
+    }
+
+    // MARK: - End-to-end: a real closing-soon window drives the style
+
+    /// The map computes `closingSoon` via `BestNowChipState.resolve(for:at:)`.
+    /// Build a fixture whose window ends ~20 min out (well under the 45-min
+    /// threshold) and confirm the resolved flag lights up the marker — the exact
+    /// wiring `mapLayer` performs with `closingSoon: isClosingSoon`.
+    func testResolvedClosingSoonWindowLightsUpMarkerEndToEnd() {
+        // Pin a deterministic instant: 20 minutes before the top of an hour, so
+        // the active window (this hour) has exactly ~20 min left.
+        let cal = Calendar.current
+        var comps = cal.dateComponents([.year, .month, .day], from: Date())
+        comps.hour = 10
+        comps.minute = 40
+        comps.second = 0
+        guard let now = cal.date(from: comps) else {
+            return XCTFail("Could not build a deterministic test instant")
+        }
+
+        let closingExp = Self.makeBestNowExperience(startHour: 10, endHour: 11)
+        let calmExp = Self.makeBestNowExperience(startHour: 8, endHour: 23) // many hours left
+
+        let closingState = BestNowChipState.resolve(for: closingExp, at: now)
+        let calmState = BestNowChipState.resolve(for: calmExp, at: now)
+
+        XCTAssertTrue(closingState.isClosingSoon, "~20 min left must read as closing soon")
+        XCTAssertFalse(calmState.isClosingSoon, "Hours left must not read as closing soon")
+
+        let closingMarker = MarkerIconView(
+            category: closingExp.category,
+            state: .bestNow,
+            confidenceLevel: closingExp.confidence.level,
+            closingSoon: closingState.isClosingSoon
+        )
+        let calmMarker = MarkerIconView(
+            category: calmExp.category,
+            state: .bestNow,
+            confidenceLevel: calmExp.confidence.level,
+            closingSoon: calmState.isClosingSoon
+        )
+
+        XCTAssertTrue(closingMarker.showsClosingSoon, "A window closing in ~20 min must light the pin amber")
+        XCTAssertFalse(calmMarker.showsClosingSoon, "A window with hours left must stay calm gold")
+    }
+
+    // MARK: - Fixtures
+
+    /// A high-confidence best-now café whose `bestTimes` window spans the given
+    /// hours. Mirrors the minimal fixture shape used by `FilterNowMapSyncTest`.
+    private static func makeBestNowExperience(startHour: Int, endHour: Int) -> Experience {
+        let now = Date()
+        return Experience(
+            id: "closing_soon_fixture_\(startHour)_\(endHour)",
+            title: "Closing-Soon Café",
+            oneLiner: "Closing-soon fixture",
+            whyItMatters: "Closing-soon highlight fixture",
+            category: .coffee,
+            location: ExperienceLocation(coordinates: [98.99, 18.79], cityCode: "cmi"),
+            bestTimes: [TimeWindow(startHour: startHour, endHour: endHour)],
+            durationMinutes: .init(min: 30, max: 60),
+            howTo: [],
+            realInconveniences: [],
+            soloScore: SoloScore(
+                overall: 5,
+                breakdown: .init(
+                    seatingFriendly: 7, soloPatronRatio: 7, staffPressure: 7,
+                    soloPortioning: 7, ambianceFit: 7, safety: 7
+                ),
+                basedOnCount: 1
+            ),
+            sources: [InformationSource(type: .user, attribution: "test", verifiedAt: now)],
+            confidence: Confidence(
+                level: 4,
+                lastVerifiedAt: now,
+                reason: "Test fixture",
+                signals: .init(aiScrapeAgeDays: 1, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)
+            ),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .active,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+}

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -7019,6 +7019,67 @@ final class MinutesLeftInBestWindowTests: XCTestCase {
         let result = exp.minutesLeftInBestWindow(at: at)
         XCTAssertEqual(result, 1)
     }
+
+    // MARK: - Weekday / season scoping
+    //
+    // The Nearby list's open-now gate (and its "Best now / Closing soon" chip)
+    // delegate to `minutesLeftInBestWindow`, so a window scoped to weekends or a
+    // single season must read as CLOSED on a non-matching day even when the clock
+    // hour falls inside [startHour, endHour). A bare "hour ∈ bestTimes" check
+    // (the gate's previous implementation) would falsely flag these.
+
+    /// Returns the first `date(hour:)` within the next 7 days whose weekday is in
+    /// `allowed` (0=Sun…6=Sat). Keeps the assertions independent of which day the
+    /// CI run lands on.
+    private func nextDate(hour: Int, weekdayIn allowed: Set<Int>) -> Date {
+        let cal = Calendar.current
+        let base = date(hour: hour)
+        for offset in 0..<7 {
+            guard let candidate = cal.date(byAdding: .day, value: offset, to: base) else { continue }
+            let weekday = cal.component(.weekday, from: candidate) - 1 // Sun=0
+            if allowed.contains(weekday) { return candidate }
+        }
+        return base
+    }
+
+    /// A weekend-only window is open on a weekend day…
+    func testWeekendOnlyWindowOpenOnWeekend() {
+        let exp = makeExperience(bestTimes: [
+            TimeWindow(startHour: 9, endHour: 17, dayOfWeek: [0, 6]) // Sun & Sat
+        ])
+        let saturday = nextDate(hour: 12, weekdayIn: [6])
+        XCTAssertNotNil(
+            exp.minutesLeftInBestWindow(at: saturday),
+            "Weekend window should be active on Saturday at noon"
+        )
+    }
+
+    /// …and CLOSED on a weekday even though the hour is inside the range.
+    func testWeekendOnlyWindowClosedOnWeekday() {
+        let exp = makeExperience(bestTimes: [
+            TimeWindow(startHour: 9, endHour: 17, dayOfWeek: [0, 6]) // Sun & Sat
+        ])
+        let weekday = nextDate(hour: 12, weekdayIn: [1, 2, 3, 4, 5]) // Mon–Fri
+        XCTAssertNil(
+            exp.minutesLeftInBestWindow(at: weekday),
+            "Weekend-only window must read closed on a weekday despite the in-range hour"
+        )
+    }
+
+    /// A window scoped to a single month is closed in every other month even when
+    /// the hour matches.
+    func testSeasonScopedWindowClosedOutsideItsMonth() {
+        let cal = Calendar.current
+        let thisMonth = cal.component(.month, from: Date())
+        let otherMonth = (thisMonth % 12) + 1 // any month that isn't today's
+        let exp = makeExperience(bestTimes: [
+            TimeWindow(startHour: 9, endHour: 17, season: [otherMonth])
+        ])
+        XCTAssertNil(
+            exp.minutesLeftInBestWindow(at: date(hour: 12)),
+            "Window scoped to a different month must read closed this month"
+        )
+    }
 }
 
 // MARK: - #8 Chat history persistence

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -1306,19 +1306,22 @@ struct NearbySection: View {
                 // long lists.
                 LazyVStack(spacing: 10) {
                     ForEach(sortedExperiences) { exp in
-                        let openNow = sortMode == .now && isOpenNow(exp)
+                        // Resolve the live "best now / closing soon" chip state for
+                        // EVERY row from the shared clock — not just in Now sort.
+                        // The chip is the app's most decision-relevant, perishable
+                        // signal; hiding it in the distance/smart/soloScore sorts
+                        // meant a traveler browsing by distance couldn't tell a
+                        // nearby spot was in its golden hour (or closing in minutes)
+                        // without opening it. A nil `minutesLeft` means "not best
+                        // now", so the row keeps its plain form.
+                        let chipState = BestNowChipState.resolve(for: exp, at: clock.tick)
+                        let openNow = chipState.minutesLeft != nil
                         NearbyExperienceRow(
                             experience: exp,
                             isSmartPick: sortMode == .smart && smartPickIds.contains(exp.id),
                             distanceMeters: distance(to: exp),
                             isOpenNow: openNow,
-                            // Resolve the live chip state from the shared clock so
-                            // the "Best now" chip flips to an amber countdown as a
-                            // window winds down. Only computed for rows that show
-                            // the chip (Now sort) to avoid needless work.
-                            bestNowChipState: openNow
-                                ? BestNowChipState.resolve(for: exp, at: clock.tick)
-                                : nil,
+                            bestNowChipState: openNow ? chipState : nil,
                             onTap: { onSelectExperience(exp) },
                             onLongPress: onLongPressExperience.map { handler in { handler(exp) } }
                         )
@@ -1347,19 +1350,25 @@ struct NearbySection: View {
         case .soloScore:
             return experiences.sorted { $0.soloScore.overall > $1.soloScore.overall }
         case .now:
-            let hour = Calendar.current.component(.hour, from: clock.tick)
+            let now = clock.tick
             return experiences.sorted { lhs, rhs in
-                let lhsNow = lhs.bestTimes.contains { $0.contains(hour: hour) }
-                let rhsNow = rhs.bestTimes.contains { $0.contains(hour: hour) }
+                let lhsNow = isOpenNow(lhs, at: now)
+                let rhsNow = isOpenNow(rhs, at: now)
                 if lhsNow != rhsNow { return lhsNow }
                 return distance(to: lhs) ?? .infinity < distance(to: rhs) ?? .infinity
             }
         }
     }
 
-    private func isOpenNow(_ experience: Experience) -> Bool {
-        let hour = Calendar.current.component(.hour, from: clock.tick)
-        return experience.bestTimes.contains { $0.contains(hour: hour) }
+    /// True when `experience` is genuinely at its best at `date`.
+    ///
+    /// Uses `minutesLeftInBestWindow` (the same source the visible chip reads)
+    /// rather than a bare "current hour ∈ bestTimes" check, so weekday- and
+    /// season-scoped windows and midnight-wrapping windows are honored — a
+    /// Saturday-only sunset window no longer floats to the top of the Now sort
+    /// (or shows a "Best now" chip) on a weekday.
+    private func isOpenNow(_ experience: Experience, at date: Date) -> Bool {
+        experience.minutesLeftInBestWindow(at: date) != nil
     }
 
     private func distance(to experience: Experience) -> Double? {

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -114,6 +114,11 @@ struct CompassMapContentView: View {
     private let presenceService: PresenceService
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    /// US-049: the shared 60s clock. Reading `tick` inside `mapLayer` re-evaluates
+    /// the marker layer every minute, so a best-now pin flips to its amber
+    /// "closing soon" treatment live as its window crosses the 45-min threshold —
+    /// matching the cards, which already observe this same clock.
+    @Environment(BestNowClock.self) private var bestNowClock
 
     @State private var viewModel: MapViewModel
     @State private var voiceService = VoiceService()
@@ -1273,6 +1278,14 @@ struct CompassMapContentView: View {
                         // iteration — its six conditions are otherwise evaluated
                         // twice per visible marker per frame (icon + badge).
                         let state = viewModel.markerState(for: exp)
+                        // US-049: resolve closing-soon urgency from the same
+                        // shared source the cards use, off the 60s clock tick so
+                        // the pin escalates to amber live. Only meaningful for a
+                        // best-now pin; `BestNowChipState` returns nil minutes
+                        // (→ not closing soon) for everything else.
+                        let isClosingSoon = BestNowChipState
+                            .resolve(for: exp, at: bestNowClock.tick)
+                            .isClosingSoon
                         // Pass an empty title so MapKit doesn't auto-render the
                         // experience name as a pin label (long titles clipped
                         // off the screen edge); the name lives on the
@@ -1292,7 +1305,10 @@ struct CompassMapContentView: View {
                                         // US-035: light up best-now pins when the
                                         // Now filter pill is active so the two UIs
                                         // feel connected.
-                                        nowFilterActive: viewModel.isNowFilter
+                                        nowFilterActive: viewModel.isNowFilter,
+                                        // US-049: flip a closing-soon best-now pin
+                                        // to the amber treatment the cards use.
+                                        closingSoon: isClosingSoon
                                     )
                                     if case .footprinted = state {
                                         Text("\(viewModel.footprintCount(for: exp))")

--- a/apps/ios/SoloCompass/Views/Map/MarkerIconView.swift
+++ b/apps/ios/SoloCompass/Views/Map/MarkerIconView.swift
@@ -21,6 +21,14 @@ public struct MarkerIconView: View {
     /// `bestNow` marker grows an extra CT.accent ring so the filter pill and
     /// the map highlight read as the same gesture. No effect on other states.
     let nowFilterActive: Bool
+    /// US-049: true when a `bestNow` pin's window has ≤ 45 min left (the shared
+    /// `BestNowChipState.closingSoonThresholdMinutes`). When set, the pin's gold
+    /// pulse, fill, and glow flip to the same amber the cards/list/detail sheet
+    /// use, and a small `clock.badge.exclamationmark` adornment appears — so the
+    /// map conveys the same closing-soon urgency every other surface already
+    /// shows. Ignored for non-`bestNow` states. Defaults to false to keep every
+    /// existing call site source-compatible.
+    let closingSoon: Bool
 
     @Environment(\.themeService) private var themeService
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -33,13 +41,39 @@ public struct MarkerIconView: View {
         state: ExperienceMarkerState,
         confidenceLevel: Int = 5,
         isSelected: Bool = false,
-        nowFilterActive: Bool = false
+        nowFilterActive: Bool = false,
+        closingSoon: Bool = false
     ) {
         self.category = category
         self.state = state
         self.confidenceLevel = confidenceLevel
         self.isSelected = isSelected
         self.nowFilterActive = nowFilterActive
+        self.closingSoon = closingSoon
+    }
+
+    /// US-049: amber used when a best-now window is closing soon — identical to
+    /// `BestNowChipState.amber` (#F59E0B) so the map's urgency tone reads the
+    /// same as the peek card, Nearby row, detail card, and Saved list.
+    static let closingSoonAmber = BestNowChipState.amber
+
+    /// US-049: a `bestNow` pin should show the closing-soon (amber) treatment
+    /// only when it is genuinely closing soon and not a low-confidence AI guess
+    /// — mirroring the pulse-ring and Now-sync suppression, so tentative pins
+    /// never imitate verified urgency.
+    var showsClosingSoon: Bool {
+        guard closingSoon, !isLowConfidence else { return false }
+        if case .bestNow = state { return true }
+        return false
+    }
+
+    /// US-049: the gold a `bestNow` pin uses at rest, flipping to amber once the
+    /// window is closing soon. Centralised so the pulse, fill, shadow, and the
+    /// Reduce-Motion static ring all stay in lock-step.
+    private var bestNowTint: Color {
+        showsClosingSoon
+            ? Self.closingSoonAmber
+            : Color(red: 0xD4 / 255, green: 0xA8 / 255, blue: 0x43 / 255)
     }
 
     /// US-035: a `bestNow` marker should show the extra "Now" sync ring only
@@ -82,6 +116,10 @@ public struct MarkerIconView: View {
             .scaleEffect(isSelected ? 1.3 : 1.0)
             .animation(.spring(response: 0.3, dampingFraction: 0.6), value: isSelected)
             .accessibilityAddTraits(isSelected ? .isSelected : [])
+            // US-049: ease the gold→amber flip so a best-now pin crossing the
+            // 45-min mark on the minute tick glides into its urgency tone
+            // instead of snapping. Shares the Now-sync easing for consistency.
+            .animation(Self.nowSyncTransition, value: showsClosingSoon)
             .onChange(of: reduceMotion) { _, reduced in
                 if reduced {
                     pulse = false
@@ -159,10 +197,12 @@ public struct MarkerIconView: View {
     private var defaultMarkerBody: some View {
         ZStack {
             // Pulse ring for "best now" (suppress on low-confidence — we
-            // don't want AI-guessed entries imitating verified excitement)
+            // don't want AI-guessed entries imitating verified excitement).
+            // US-049: the pulse adopts `bestNowTint`, so a window that's
+            // closing soon pulses amber to match the cards' urgency cue.
             if case .bestNow = state, !isLowConfidence, !reduceMotion {
                 Circle()
-                    .fill(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255).opacity(0.4))
+                    .fill(bestNowTint.opacity(0.4))
                     .frame(width: 56, height: 56)
                     .scaleEffect(pulse ? 1.2 : 0.9)
                     .opacity(pulse ? 0.0 : 0.7)
@@ -211,7 +251,7 @@ public struct MarkerIconView: View {
 
     private var fillColor: Color {
         switch state {
-        case .bestNow: return Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)
+        case .bestNow: return bestNowTint
         case .completed, .footprinted: return category.color
         default: return category.color
         }
@@ -219,7 +259,7 @@ public struct MarkerIconView: View {
 
     private var shadowColor: Color {
         switch state {
-        case .bestNow: return Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255).opacity(0.6)
+        case .bestNow: return bestNowTint.opacity(0.6)
         default: return .black.opacity(0.2)
         }
     }
@@ -272,7 +312,22 @@ public struct MarkerIconView: View {
                 .padding(3)
                 .background(Circle().fill(Color.gray))
                 .offset(x: 12, y: 12)
-        case .bestNow, .default:
+        case .bestNow:
+            // US-049: a small alarm-clock badge marks a best-now window that's
+            // closing soon, echoing the cards' `clock.badge.exclamationmark`
+            // glyph. An amber glyph on a white disc so it reads against the
+            // amber pin fill behind it.
+            if showsClosingSoon {
+                // Same glyph the cards/chip use (`BestNowChipState.symbol`)
+                // for a closing-soon window, so the cue is identical app-wide.
+                Image(systemName: "clock.badge.exclamationmark")
+                    .font(.caption2.bold())
+                    .foregroundStyle(Self.closingSoonAmber)
+                    .padding(2)
+                    .background(Circle().fill(.white))
+                    .offset(x: 12, y: -12)
+            }
+        case .default:
             EmptyView()
         }
     }
@@ -295,7 +350,11 @@ public struct MarkerIconView: View {
         let suffix: String
         switch state {
         case .bestNow:
-            suffix = ", \(NSLocalizedString("marker.a11y.bestNow", comment: ""))"
+            // US-049: VoiceOver escalates to the closing-soon phrasing so a
+            // non-sighted traveler hears the same urgency the amber pin shows.
+            suffix = showsClosingSoon
+                ? ", \(NSLocalizedString("marker.a11y.closingSoon", comment: "VoiceOver: best now but the window is closing soon"))"
+                : ", \(NSLocalizedString("marker.a11y.bestNow", comment: ""))"
         case .completed:
             suffix = ", \(NSLocalizedString("marker.a11y.completed", comment: ""))"
         case .favorited:
@@ -321,7 +380,10 @@ public struct MarkerIconView: View {
         let confidence = isLowConfidence ? "low" : "normal"
         let selection = isSelected ? ".selected" : ""
         let nowSync = showsNowSyncRing ? ".nowsync" : ""
-        return "marker.\(category.rawValue).\(state.identifierFragment).\(confidence)\(selection)\(nowSync)"
+        // US-049: closing-soon best-now pins gain a `.closingsoon` fragment so
+        // tests can assert the amber escalation is observable without rendering.
+        let closing = showsClosingSoon ? ".closingsoon" : ""
+        return "marker.\(category.rawValue).\(state.identifierFragment).\(confidence)\(selection)\(nowSync)\(closing)"
     }
 }
 
@@ -387,6 +449,15 @@ private struct ObsidianDotGridMarker: View {
                 Text("bestNow + Now filter").frame(width: 120, alignment: .leading)
                 ForEach(ExperienceCategory.allCases) { cat in
                     MarkerIconView(category: cat, state: .bestNow, nowFilterActive: true)
+                }
+            }
+
+            // US-049: best-now markers whose window is closing soon — the gold
+            // pulse/fill/glow flips to amber and an alarm-clock badge appears.
+            HStack(spacing: 16) {
+                Text("bestNow · closing soon").frame(width: 120, alignment: .leading)
+                ForEach(ExperienceCategory.allCases) { cat in
+                    MarkerIconView(category: cat, state: .bestNow, closingSoon: true)
                 }
             }
 


### PR DESCRIPTION
This branch finishes propagating the **Best now / Closing soon** timing cue across the remaining map-browsing surfaces, so the app's most decision-relevant, perishable signal reads consistently everywhere a solo traveler decides *where to go right now*. Two commits:

---

### 1. `2c6a6f0b` — Nearby rows show the chip in **every** sort (latest)

The Nearby list (bottom sheet `附近` section) only rendered the timing chip when the active sort was **Now** — it was gated on `sortMode == .now`. So browsing **Nearby → Distance** (or **Smart**, or **Solo score**) showed a spot 200 m away with *no* hint it was in its golden hour, or closing in 12 minutes. That cue already renders on the detail card, the detail sheet, the Saved list, the peek pick, and the map pins via the shared `BestNowChipState`; this makes the Nearby list consistent too.

Every visible row now resolves `BestNowChipState` from the shared `BestNowClock` and shows the chip whenever the place is genuinely at its best, **independent of sort mode** (nil minutes → plain row). The chip already owns the plain → amber `Closing · Nm` flip, so no new chip code was needed.

**Also fixes a latent correctness bug:** the Now sort + open-now gate used a bare `bestTimes.contains { $0.contains(hour:) }` check that ignored each window's `dayOfWeek` / `season` filters — a weekend-only window would float to the top of Now (and show a "Best now" chip) on a weekday. Both now delegate to `minutesLeftInBestWindow`, the same source the visible chip reads, so the gate, the sort order, and the chip content can no longer disagree.

Adds weekday/season scoping coverage to `MinutesLeftInBestWindowTests` (open on Saturday, closed on a weekday despite the in-range hour, season window closed out of month).

### 2. `e63e45e6` — best-now map pins escalate to amber "closing soon"

Every best-now pin glowed the same uniform gold whether its window had three hours or eight minutes left. Pins now escalate to the amber `#F59E0B` "closing soon" treatment (with the `clock.badge.exclamationmark` glyph) once `minutesLeftInBestWindow ≤ 45`, matching the chips on the cards/sheets.

---

### Cross-cutting notes
- **No new strings** — reuses `nearby.chip.bestNow` / `nearby.chip.closingSoon(.a11y)` and the marker keys, all present in `en` + `zh-Hans`.
- **No new colors** — `BestNowChipState` / `CT.*` tokens, already dark-mode adaptive; amber matches `BestNowBadge.amber`.
- **Thread-safe** — pure synchronous reads on main-actor `View`s; no new concurrency or mutable state.
- **Perf** — one pure `resolve` per *visible* (Lazy) row, recomputed only when the shared 60 s clock ticks.
- All four timing surfaces (detail card, Saved list, peek pick, Nearby row) + the map pins now agree on threshold, tint, glyph, and label through the single `BestNowChipState` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
