### PR TITLE
feat(ios): skip maps-app picker when only one is installed

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -828,6 +828,8 @@
 "location.openingHours" = "Posted hours";
 "location.openingHours.a11y" = "Posted hours: %@";
 "location.navigate" = "Navigate";
+"location.navigate.choose.a11y" = "Choose a maps app for walking directions";
+"location.navigate.walk.a11y" = "Open walking directions in Maps";
 "location.copyCoords" = "Copy coordinates";
 "location.copied" = "Copied!";
 "location.copied.a11y" = "Coordinates copied";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -464,6 +464,8 @@
 "location.openingHours" = "营业时间";
 "location.openingHours.a11y" = "营业时间：%@";
 "location.navigate" = "导航";
+"location.navigate.choose.a11y" = "选择地图应用以获取步行路线";
+"location.navigate.walk.a11y" = "在地图中打开步行路线";
 "location.copyCoords" = "复制坐标";
 "location.openIn.apple" = "苹果地图";
 "location.openIn.google" = "Google 地图";

--- a/apps/ios/SoloCompass/Views/Experience/LocationCard.swift
+++ b/apps/ios/SoloCompass/Views/Experience/LocationCard.swift
@@ -37,6 +37,20 @@ struct LocationCard: View {
         return (d.isFinite && d < .greatestFiniteMagnitude) ? d : nil
     }
 
+    /// Tapping Navigate should be a single tap when there's no choice to make.
+    /// With one installed maps app we launch it directly; the confirmation
+    /// dialog only earns its extra tap when the traveler has more than one app.
+    private func navigateTapped() {
+        Haptics.impact(.light)
+        let apps = NavigationLauncher.availableApps()
+        if apps.count <= 1 {
+            guard let app = apps.first else { return }
+            NavigationLauncher.open(app: app, coordinate: coordinate, name: displayName)
+        } else {
+            isShowingPicker = true
+        }
+    }
+
     private static let distanceFormatter: MeasurementFormatter = {
         let f = MeasurementFormatter()
         f.unitOptions = .naturalScale
@@ -121,8 +135,7 @@ struct LocationCard: View {
             HStack(spacing: 10) {
                 // US-010: Primary navigate button with gradient; 44pt HIG minimum
                 Button {
-                    isShowingPicker = true
-                    Haptics.impact(.light)
+                    navigateTapped()
                 } label: {
                     Label(
                         NSLocalizedString("location.navigate", comment: "Open external navigation app"),
@@ -142,6 +155,9 @@ struct LocationCard: View {
                     .foregroundStyle(.white)
                 }
                 .accessibilityLabel(Text(NSLocalizedString("location.navigate", comment: "")))
+                .accessibilityHint(Text(NavigationLauncher.availableApps().count > 1
+                    ? NSLocalizedString("location.navigate.choose.a11y", comment: "Navigate hint when multiple maps apps installed")
+                    : NSLocalizedString("location.navigate.walk.a11y", comment: "Navigate hint when one maps app installed")))
 
                 // US-010: Ghost copy button — icon only, no fill
                 Button {


### PR DESCRIPTION
## What

Tapping **Navigate** on a `LocationCard` always presented a confirmation dialog of installed maps apps — even when Apple Maps was the only one installed (the common case). That meant a single-option dialog plus a Cancel button: an unnecessary extra tap and decision for the traveler.

Now `navigateTapped()`:
- launches the sole maps app **directly** when only one is available, and
- shows the picker **only** when there's a genuine choice (2+ apps).

The button's accessibility hint also adapts to which behavior the tap will trigger ("Open walking directions in Maps" vs. "Choose a maps app…").

## Why

Fewer taps for the most common configuration, while preserving the picker for travelers who have Google Maps / Amap installed. Matches the direct-launch pattern already used in `FavoritesListView` (`availableApps().first`).

## Changes

- `LocationCard.swift`: extract `navigateTapped()`, branch on `availableApps().count`; adaptive a11y hint.
- New localized hint strings in `en.lproj` and `zh-Hans.lproj`.

## Testing

- SKIP local `xcodebuild` (CI builds). Logic is pure branching over `NavigationLauncher.availableApps()`, which is already unit-tested in `NavigationLauncherTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)