### PR TITLE
feat(ios): redesign Me hub and inline friend-code search

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		8B118DFAAE23443EF7D90735 /* FilterBarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1694A46513909CFE464D92E /* FilterBarViewTests.swift */; };
 		8B4F2A6E8F3C6EAD0F9A8E32 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = EA0858036CFEA9774139AFD7 /* PrivacyInfo.xcprivacy */; };
 		8BF4070A63A8B52C58F0E93E /* RouteCompanionStateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F48D7FA14E29D606FD11EA /* RouteCompanionStateMachineTests.swift */; };
+		8C106CF5C07EC37E7FBC0D67 /* FriendsHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4077595CC19D07EB22B8AA7 /* FriendsHubView.swift */; };
 		8D0C03425BA0C7D5E50B016D /* DiscoverFriendGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D06753CFAA5198FCB3FF96 /* DiscoverFriendGateTests.swift */; };
 		8D5DD4E0CD6237FA70C7F99F /* AddToItinerarySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A2953D1F2B46AFC9F85D42 /* AddToItinerarySheet.swift */; };
 		8D67669050D844812FA06CC8 /* RouteItineraryBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884AFD2A4ADF051FA9643166 /* RouteItineraryBridge.swift */; };
@@ -641,6 +642,7 @@
 		A267CD0DA0A8053B0AB072BC /* PrivacyAcknowledgementSheetSnapshotTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyAcknowledgementSheetSnapshotTest.swift; sourceTree = "<group>"; };
 		A2BE90CD51D94B3FEE2F5AFA /* CompanionReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionReport.swift; sourceTree = "<group>"; };
 		A38E5736BF6DF5644D687637 /* AgentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRouter.swift; sourceTree = "<group>"; };
+		A4077595CC19D07EB22B8AA7 /* FriendsHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsHubView.swift; sourceTree = "<group>"; };
 		A453FDDE85569DCA8FF70A8A /* RouteShareRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteShareRenderer.swift; sourceTree = "<group>"; };
 		A5435FBA9527C07A9FB07D46 /* SoloCompassModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassModelContainer.swift; sourceTree = "<group>"; };
 		A5F2BB13078B86C9BEDE7ADD /* WeatherCacheRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherCacheRecord.swift; sourceTree = "<group>"; };
@@ -1313,6 +1315,7 @@
 				6435C36695377646C7ED8FC2 /* AddFriendButton.swift */,
 				DB22C08A558D35B83043C83E /* AddFriendSheet.swift */,
 				AC6DF782C123E76E2F02EEEA /* FriendProfileView.swift */,
+				A4077595CC19D07EB22B8AA7 /* FriendsHubView.swift */,
 				4F7202B977A555239F367D02 /* FriendsListView.swift */,
 				4C3EE8D38604D12055F9E94C /* QRScannerView.swift */,
 			);
@@ -1799,6 +1802,7 @@
 				E861E14B62BBE9A96205354D /* FriendRequest.swift in Sources */,
 				9D78B88DE90BE5BF9316604C /* FriendRequestRecord.swift in Sources */,
 				980B4B61D10AA12BFF2CD171 /* FriendService.swift in Sources */,
+				8C106CF5C07EC37E7FBC0D67 /* FriendsHubView.swift in Sources */,
 				B2C98BCF4E0193B5740C7762 /* FriendsListView.swift in Sources */,
 				67D784ECDFE24AE5384975D2 /* Friendship.swift in Sources */,
 				BC5673F20B57CA6567972838 /* FriendshipRecord.swift in Sources */,

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1627,6 +1627,13 @@
 "friends.connected.label" = "Connected!";
 "friends.connected.a11y" = "You are now connected with %@";
 
+/* Inline friend-code search + my code (FriendsHubView) */
+"friends.inline.search.placeholder" = "Enter friend code SOLO-XXXX-XXXX";
+"friends.inline.scan.a11y" = "Scan a friend's QR code";
+"friends.inline.lookup.a11y" = "Look up friend";
+"friends.inline.myCode.show" = "My friend code";
+"friends.inline.myCode.hide" = "Hide my friend code";
+
 /* Add friend sheet — my shareable code + QR (US-013) */
 "friends.add.open.a11y" = "Show my friend code";
 "friends.add.title" = "Add Me";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1546,10 +1546,60 @@
 "friend.discover.error.lowTrust" = "暂时无法添加这位旅行者。";
 "friend.discover.error.rateLimited" = "你最近添加的人有点多，请稍后再试。";
 
+/* 个人中心（我 · MeSheet） */
+"me.title" = "我";
+"me.friends" = "好友";
+"me.messages" = "消息";
+"me.companion" = "旅伴";
+"me.settings" = "设置";
+"me.profile.name" = "独行旅人";
+"me.profile.subtitle" = "你的罗盘，你的旅程";
+"me.profile.progress.a11y" = "已探索 %d / %d 个收藏地点";
+"me.friends.incoming" = "好友申请";
+"me.friends.list" = "好友";
+"me.friends.empty" = "还没有好友";
+"me.stats.saved" = "收藏";
+"me.stats.explored" = "探索";
+"me.avatar.a11y" = "打开个人中心";
+"me.avatar.a11y.pending" = "你有待处理的好友申请";
+
 /* Friends hub empty state (MeSheet) */
 "me.friends.empty.title" = "还没有好友";
 "me.friends.empty.description" = "分享你的好友码或扫描对方的码，添加旅伴。";
 "me.friends.empty.cta" = "添加好友";
+
+/* 好友页内联搜索 + 我的好友码（FriendsHubView） */
+"friends.inline.search.placeholder" = "输入好友码 SOLO-XXXX-XXXX";
+"friends.inline.scan.a11y" = "扫描好友二维码";
+"friends.inline.lookup.a11y" = "查找好友";
+"friends.inline.myCode.show" = "我的好友码";
+"friends.inline.myCode.hide" = "收起我的好友码";
+
+/* 加好友 / 兑换好友码（内联到好友页 + AddFriendSheet 复用） */
+"friends.add.title" = "添加我";
+"friends.add.subtitle" = "分享这个码，或让旅伴扫描二维码即可添加你。";
+"friends.add.qr.a11y" = "你的好友码二维码";
+"friends.add.code.a11y" = "你的好友码是 %@";
+"friends.add.copy" = "复制好友码";
+"friends.add.copy.hint" = "长按好友码即可复制";
+"friends.add.copied" = "已复制！";
+"friends.add.share" = "分享好友码";
+"friends.add.rotate" = "更换好友码";
+"friends.add.error.title" = "无法加载你的好友码";
+"friends.add.error.description" = "请检查网络后重试。";
+"friends.add.mode.myCode" = "我的码";
+"friends.add.mode.addFriend" = "添加好友";
+"friends.redeem.subtitle" = "扫描旅伴的二维码，或输入对方好友码来添加。";
+"friends.redeem.scan" = "扫描二维码";
+"friends.redeem.scan.title" = "扫描好友码";
+"friends.redeem.scan.denied" = "无法使用相机，请改为手动输入好友码。";
+"friends.redeem.enter.label" = "或输入对方好友码";
+"friends.redeem.lookup" = "查找";
+"friends.redeem.preview.title" = "添加好友";
+"friends.redeem.sent" = "好友申请已发送";
+"friends.redeem.error.format" = "这看起来不是有效的好友码。";
+"friends.redeem.error.notFound" = "没有找到使用该好友码的人。";
+"friends.redeem.error.own" = "这是你自己的好友码。";
 
 /* US-017: 统一会话列表（我 ▸ 消息） */
 "messages.empty" = "暂无会话";

--- a/apps/ios/SoloCompass/Views/Friends/FriendsHubView.swift
+++ b/apps/ios/SoloCompass/Views/Friends/FriendsHubView.swift
@@ -1,0 +1,500 @@
+import CoreImage.CIFilterBuiltins
+import SwiftUI
+import UIKit
+
+/// The personal hub's Friends screen (pushed from `MeSheet`).
+///
+/// Redesigned per the "fewer steps, more elegant" brief: instead of an empty
+/// state whose only action opens a separate `AddFriendSheet`, the add-by-code
+/// search bar is **inlined at the top of the page**. Type (or scan) a friend
+/// code and the lookup fires inline → a profile card slides up to confirm. The
+/// user's own shareable code lives in a collapsible row below, so both halves
+/// of the flow are reachable without ever presenting a sheet.
+///
+/// The backend only supports friend-code add (`redeemFriendCode`), not free-text
+/// user search, so the "search bar" is a code field — the most direct shape the
+/// data layer allows.
+struct FriendsHubView: View {
+    @State private var service: FriendService
+
+    // Inline add-by-code state (lifted from the old AddFriendSheet).
+    @State private var typedCode = ""
+    @State private var isRedeeming = false
+    @State private var redeemError: String?
+    @State private var resolvedProfile: FriendProfileData?
+    @State private var isScanning = false
+    @State private var isSending = false
+    @State private var didSend = false
+
+    // My shareable code (collapsible).
+    @State private var showMyCode = false
+    @State private var myCode: FriendCode?
+    @State private var isLoadingMyCode = false
+    @State private var didCopy = false
+
+    init(service: FriendService = .shared) {
+        _service = State(initialValue: service)
+    }
+
+    private var normalisedTyped: String {
+        typedCode.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+    }
+
+    private var canRedeem: Bool {
+        FriendCode.isValidFormat(normalisedTyped) && !isRedeeming
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                searchBar
+                myCodeSection
+
+                if !service.incomingRequests.isEmpty || !service.friends.isEmpty {
+                    relationships
+                } else {
+                    emptyHint
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            .padding(.bottom, 32)
+        }
+        .background(CT.bgWarm)
+        .scrollDismissesKeyboard(.interactively)
+        .navigationTitle(NSLocalizedString("me.friends", comment: "Friends"))
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await service.refresh() }
+        .animation(.easeInOut(duration: 0.2), value: redeemError)
+        .animation(.easeInOut(duration: 0.25), value: showMyCode)
+        .sheet(isPresented: $isScanning) { scannerSheet }
+        .sheet(item: $resolvedProfile) { profile in previewSheet(profile: profile) }
+    }
+
+    // MARK: - Inline search bar (friend code + scan)
+
+    private var searchBar: some View {
+        HStack(spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(CT.fgSubtle)
+
+                TextField(
+                    NSLocalizedString("friends.inline.search.placeholder", comment: "Friend code search placeholder"),
+                    text: $typedCode
+                )
+                .font(.system(.body, design: .monospaced))
+                .textInputAutocapitalization(.characters)
+                .autocorrectionDisabled()
+                .submitLabel(.search)
+                .onChange(of: typedCode) { _, newValue in
+                    let upper = newValue.uppercased()
+                    if upper != newValue { typedCode = upper }
+                    redeemError = nil
+                }
+                .onSubmit { if canRedeem { Task { await redeem() } } }
+
+                if isRedeeming {
+                    ProgressView().controlSize(.small)
+                } else if canRedeem {
+                    Button {
+                        Task { await redeem() }
+                    } label: {
+                        Image(systemName: "arrow.right.circle.fill")
+                            .font(.system(size: 22))
+                            .foregroundStyle(CT.accent)
+                    }
+                    .accessibilityLabel(Text(NSLocalizedString("friends.inline.lookup.a11y", comment: "Look up friend")))
+                    .transition(.scale.combined(with: .opacity))
+                }
+            }
+            .padding(.horizontal, 14)
+            .frame(height: 48)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(CT.surfaceWhite)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .stroke(CT.borderSubtle, lineWidth: 1)
+                    )
+            )
+
+            Button {
+                Haptics.impact(.light)
+                isScanning = true
+            } label: {
+                Image(systemName: "qrcode.viewfinder")
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundStyle(CT.accent)
+                    .frame(width: 48, height: 48)
+                    .background(
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .fill(CT.accentSoft)
+                    )
+            }
+            .accessibilityLabel(Text(NSLocalizedString("friends.inline.scan.a11y", comment: "Scan friend QR")))
+        }
+        .animation(.easeInOut(duration: 0.15), value: canRedeem)
+        .overlay(alignment: .bottomLeading) {
+            if let redeemError {
+                Text(redeemError)
+                    .font(.caption)
+                    .foregroundStyle(CT.bannerError)
+                    .padding(.top, 4)
+                    .offset(y: 26)
+                    .transition(.opacity)
+            }
+        }
+    }
+
+    // MARK: - My friend code (collapsible)
+
+    private var myCodeSection: some View {
+        VStack(spacing: 0) {
+            Button {
+                Haptics.selection()
+                showMyCode.toggle()
+                if showMyCode, myCode == nil { Task { await loadMyCode() } }
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "qrcode")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(CT.accent)
+                        .frame(width: 28)
+                    Text(
+                        showMyCode
+                            ? NSLocalizedString("friends.inline.myCode.hide", comment: "Hide my code")
+                            : NSLocalizedString("friends.inline.myCode.show", comment: "Show my code")
+                    )
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(CT.fgPrimary)
+                    Spacer()
+                    if let myCode, !showMyCode {
+                        Text(myCode.rawValue)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(CT.fgSubtle)
+                    }
+                    Image(systemName: "chevron.down")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(CT.fgSubtle)
+                        .rotationEffect(.degrees(showMyCode ? 180 : 0))
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 12)
+            }
+            .buttonStyle(.plain)
+
+            if showMyCode {
+                Divider().overlay(CT.borderSubtle)
+                myCodeExpanded
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(CT.surfaceWhite)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(CT.borderSubtle, lineWidth: 1)
+                )
+        )
+    }
+
+    @ViewBuilder
+    private var myCodeExpanded: some View {
+        VStack(spacing: 16) {
+            if isLoadingMyCode {
+                ProgressView().frame(height: 200)
+            } else if let myCode {
+                qrImage(for: myCode.rawValue)
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 180, height: 180)
+                    .padding(14)
+                    .background(Color.white, in: RoundedRectangle(cornerRadius: 18))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 18)
+                            .stroke(CT.borderSubtle, lineWidth: 1)
+                    )
+                    .accessibilityLabel(NSLocalizedString("friends.add.qr.a11y", comment: "QR a11y"))
+
+                VStack(spacing: 4) {
+                    Text(myCode.rawValue)
+                        .font(.system(.title3, design: .monospaced).weight(.bold))
+                        .tracking(2)
+                        .foregroundStyle(CT.fgPrimary)
+                        .textSelection(.enabled)
+                    Text(
+                        didCopy
+                            ? NSLocalizedString("friends.add.copied", comment: "Copied")
+                            : NSLocalizedString("friends.add.copy.hint", comment: "Copy hint")
+                    )
+                    .font(.caption)
+                    .foregroundStyle(didCopy ? CT.verifiedGreen : CT.fgSubtle)
+                    .contentTransition(.opacity)
+                }
+
+                HStack(spacing: 10) {
+                    ShareLink(item: myCode.rawValue) {
+                        Label(
+                            NSLocalizedString("friends.add.share", comment: "Share"),
+                            systemImage: "square.and.arrow.up"
+                        )
+                        .font(.subheadline.weight(.medium))
+                        .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(CT.accent)
+
+                    Button {
+                        copy(myCode)
+                    } label: {
+                        Label(
+                            NSLocalizedString("friends.add.copy", comment: "Copy"),
+                            systemImage: "doc.on.doc"
+                        )
+                        .font(.subheadline.weight(.medium))
+                        .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(CT.accent)
+                }
+            }
+        }
+        .padding(16)
+    }
+
+    // MARK: - Relationships (requests + friends)
+
+    private var relationships: some View {
+        VStack(spacing: 16) {
+            if !service.incomingRequests.isEmpty {
+                section(title: NSLocalizedString("me.friends.incoming", comment: "Incoming requests")) {
+                    ForEach(service.incomingRequests, id: \.id) { req in
+                        friendRow(label: req.requesterId)
+                    }
+                }
+            }
+            if !service.friends.isEmpty {
+                section(title: NSLocalizedString("me.friends.list", comment: "Friends list")) {
+                    ForEach(service.friends, id: \.id) { friendship in
+                        friendRow(label: friendship.userHighId)
+                    }
+                }
+            }
+        }
+    }
+
+    private func section<Content: View>(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(CT.fgSubtle)
+                .textCase(.uppercase)
+                .padding(.leading, 4)
+            VStack(spacing: 0) { content() }
+                .background(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(CT.surfaceWhite)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                .stroke(CT.borderSubtle, lineWidth: 1)
+                        )
+                )
+        }
+    }
+
+    private func friendRow(label: String) -> some View {
+        HStack(spacing: 12) {
+            Text("🧭")
+                .font(.system(size: 18))
+                .frame(width: 36, height: 36)
+                .background(Circle().fill(CT.accentSoft))
+            Text(label)
+                .font(.subheadline)
+                .foregroundStyle(CT.fgPrimary)
+                .lineLimit(1)
+            Spacer()
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+
+    private var emptyHint: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "person.2")
+                .font(.system(size: 32, weight: .light))
+                .foregroundStyle(CT.fgSubtle)
+            Text(NSLocalizedString("me.friends.empty.title", comment: "Empty title"))
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(CT.fgPrimary)
+            Text(NSLocalizedString("me.friends.empty.description", comment: "Empty description"))
+                .font(.caption)
+                .foregroundStyle(CT.fgSubtle)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 40)
+    }
+
+    // MARK: - Scanner + preview sheets
+
+    private var scannerSheet: some View {
+        NavigationStack {
+            QRScannerView(
+                onCode: { raw in
+                    isScanning = false
+                    handleScanned(raw)
+                },
+                onError: {
+                    isScanning = false
+                    redeemError = NSLocalizedString("friends.redeem.scan.denied", comment: "Camera unavailable")
+                }
+            )
+            .ignoresSafeArea()
+            .navigationTitle(NSLocalizedString("friends.redeem.scan.title", comment: "Scan title"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(NSLocalizedString("action.cancel", comment: "Cancel")) { isScanning = false }
+                }
+            }
+        }
+    }
+
+    private func previewSheet(profile: FriendProfileData) -> some View {
+        NavigationStack {
+            FriendProfileView(
+                profile: profile,
+                relation: service.relationState(with: profile.userId),
+                onAddFriend: { Task { await sendRequest(to: profile.userId) } }
+            )
+            .navigationTitle(NSLocalizedString("friends.redeem.preview.title", comment: "Preview title"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(NSLocalizedString("action.cancel", comment: "Cancel")) { resolvedProfile = nil }
+                }
+            }
+            .overlay(alignment: .bottom) {
+                if didSend {
+                    Text(NSLocalizedString("friends.redeem.sent", comment: "Sent"))
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
+                        .background(Color.green, in: Capsule())
+                        .padding(.bottom, 24)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+            }
+            .animation(.easeInOut, value: didSend)
+        }
+    }
+
+    // MARK: - QR generation (CoreImage)
+
+    private func qrImage(for string: String) -> Image {
+        let context = CIContext()
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(string.utf8)
+        filter.correctionLevel = "M"
+        if let output = filter.outputImage {
+            let scaled = output.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
+            if let cgImage = context.createCGImage(scaled, from: scaled.extent) {
+                return Image(decorative: cgImage, scale: 1, orientation: .up)
+            }
+        }
+        return Image(systemName: "qrcode")
+    }
+
+    // MARK: - Actions
+
+    private func handleScanned(_ raw: String) {
+        let upper = raw.uppercased()
+        let extracted = extractCode(from: upper) ?? upper
+        typedCode = extracted
+        Task { await redeem() }
+    }
+
+    private func extractCode(from text: String) -> String? {
+        let allowed = Set("SOLO-" + String(FriendCode.unambiguousAlphabet))
+        let cleaned = String(text.filter { allowed.contains($0) })
+        for start in cleaned.indices {
+            let end = cleaned.index(start, offsetBy: 14, limitedBy: cleaned.endIndex)
+            guard let end else { break }
+            let candidate = String(cleaned[start..<end])
+            if FriendCode.isValidFormat(candidate) { return candidate }
+        }
+        return nil
+    }
+
+    private func redeem() async {
+        guard !isRedeeming else { return }
+        isRedeeming = true
+        redeemError = nil
+        let result = await service.redeemFriendCode(FriendCode(rawValue: normalisedTyped))
+        isRedeeming = false
+        switch result {
+        case .success(let profile):
+            didSend = false
+            resolvedProfile = profile
+            Haptics.impact(.light)
+        case .failure(let err):
+            redeemError = err.localizedDescription
+            Haptics.notify(.error)
+        }
+    }
+
+    private func sendRequest(to userId: String) async {
+        guard !isSending else { return }
+        isSending = true
+        let result = await service.sendRequest(to: userId, source: .friendCode)
+        isSending = false
+        switch result {
+        case .success:
+            withAnimation { didSend = true }
+            Haptics.notify(.success)
+            typedCode = ""
+            Task {
+                try? await Task.sleep(for: .seconds(1.2))
+                resolvedProfile = nil
+                didSend = false
+            }
+        case .failure(let err):
+            resolvedProfile = nil
+            redeemError = err.localizedDescription
+            Haptics.notify(.error)
+        }
+    }
+
+    private func loadMyCode() async {
+        isLoadingMyCode = true
+        let result = await service.loadOrCreateFriendCode()
+        isLoadingMyCode = false
+        if case .success(let value) = result { myCode = value }
+    }
+
+    private func copy(_ code: FriendCode) {
+        UIPasteboard.general.string = code.rawValue
+        Haptics.impact(.light)
+        withAnimation { didCopy = true }
+        Task {
+            try? await Task.sleep(for: .seconds(2))
+            withAnimation { didCopy = false }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Friends hub (empty)") {
+    NavigationStack {
+        FriendsHubView(service: FriendService())
+    }
+}

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -330,6 +330,12 @@ struct CompassMapContentView: View {
                 if CompassMapView.debugForceShowSettings {
                     viewModel.isShowingSettings = true
                 }
+                // Visual-verification entry point: `-openMe` opens the personal hub
+                // (MeSheet) on launch so its layout can be screenshotted without an
+                // avatar-bubble tap (idb/simctl tapping is unreliable on Xcode 26).
+                if ProcessInfo.processInfo.arguments.contains("-openMe") {
+                    isShowingMe = true
+                }
                 #endif
                 locationService.requestPermission()
                 // US-021: `viewModel` is built eagerly in `init`, so there is no

--- a/apps/ios/SoloCompass/Views/Me/MeSheet.swift
+++ b/apps/ios/SoloCompass/Views/Me/MeSheet.swift
@@ -29,6 +29,7 @@ struct MeSheet: View {
     /// inline `NavigationLink`s; only the message deep link drives `path`.
     private enum MeDestination: Hashable {
         case messages(deepLinkConversationId: String?)
+        case friends
     }
 
     var body: some View {
@@ -91,6 +92,8 @@ struct MeSheet: View {
                 switch destination {
                 case .messages(let conversationId):
                     ConversationListView(deepLinkConversationId: conversationId)
+                case .friends:
+                    FriendsHubView()
                 }
             }
             .toolbar {
@@ -107,6 +110,14 @@ struct MeSheet: View {
                 if let conversationId = deepLinkConversationId, path.isEmpty {
                     path = [.messages(deepLinkConversationId: conversationId)]
                 }
+                #if DEBUG
+                // Visual-verification entry point: `-openFriends` pushes the
+                // Friends hub on appear so its inline add-by-code search can be
+                // screenshotted without an unreliable simulator tap.
+                if ProcessInfo.processInfo.arguments.contains("-openFriends"), path.isEmpty {
+                    path = [.friends]
+                }
+                #endif
             }
         }
     }
@@ -117,6 +128,8 @@ struct MeSheet: View {
 private struct RingAvatar: View {
     let favoritedCount: Int
     let exploredCount: Int
+    /// Diameter of the inner emoji bubble; the progress ring sits 8pt outside it.
+    var size: CGFloat = 64
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var animatedFraction: CGFloat = 0
@@ -127,23 +140,30 @@ private struct RingAvatar: View {
     }
 
     private var showRing: Bool { favoritedCount > 0 }
+    private var ringSize: CGFloat { size + 8 }
+    private var ringWidth: CGFloat { size >= 80 ? 4 : 3 }
 
     var body: some View {
         ZStack {
             Text(CompanionProfile.sample.avatarEmoji)
-                .font(.system(size: 40))
-                .frame(width: 64, height: 64)
-                .background(Circle().fill(CT.accentSoft))
+                .font(.system(size: size * 0.55))
+                .frame(width: size, height: size)
+                .background(
+                    Circle()
+                        .fill(CT.accentSoft)
+                        .overlay(Circle().stroke(CT.surfaceWhite, lineWidth: 2))
+                )
+                .shadow(color: CT.accent.opacity(0.12), radius: 6, y: 3)
 
             if showRing {
                 Circle()
-                    .stroke(CT.accent.opacity(0.15), lineWidth: 3)
-                    .frame(width: 72, height: 72)
+                    .stroke(CT.accent.opacity(0.15), lineWidth: ringWidth)
+                    .frame(width: ringSize, height: ringSize)
                 Circle()
                     .trim(from: 0, to: animatedFraction)
-                    .stroke(CT.accent, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                    .stroke(CT.accent, style: StrokeStyle(lineWidth: ringWidth, lineCap: .round))
                     .rotationEffect(.degrees(-90))
-                    .frame(width: 72, height: 72)
+                    .frame(width: ringSize, height: ringSize)
             }
         }
         .accessibilityLabel(Text(CompanionProfile.sample.avatarEmoji))
@@ -188,38 +208,74 @@ private struct ProfileHeader: View {
     let exploredCount: Int
 
     var body: some View {
-        HStack(spacing: 14) {
-            RingAvatar(favoritedCount: favoritedCount, exploredCount: exploredCount)
+        VStack(spacing: 16) {
+            RingAvatar(
+                favoritedCount: favoritedCount,
+                exploredCount: exploredCount,
+                size: 88
+            )
+            .padding(.top, 4)
 
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(spacing: 4) {
                 Text(NSLocalizedString("me.profile.name", comment: "Default profile display name"))
-                    .font(.title3.weight(.semibold))
+                    .font(.title2.weight(.bold))
                     .foregroundStyle(CT.fgPrimary)
                 Text(NSLocalizedString("me.profile.subtitle", comment: "Profile subtitle"))
                     .font(.subheadline)
-                    .foregroundStyle(CT.fgSubtle)
-                HStack(spacing: 12) {
-                    StatPill(
-                        target: favoritedCount,
-                        caption: NSLocalizedString("me.stats.saved", comment: "Saved experiences stat label")
-                    )
-                    StatPill(
-                        target: exploredCount,
-                        caption: NSLocalizedString("me.stats.explored", comment: "Explored experiences stat label")
-                    )
-                }
-                .padding(.top, 4)
+                    .foregroundStyle(CT.fgMuted)
             }
-            Spacer()
+
+            // Twin stat tiles, split by a hairline divider so the two metrics read
+            // as one balanced unit rather than two floating pills.
+            HStack(spacing: 0) {
+                StatTile(
+                    target: favoritedCount,
+                    caption: NSLocalizedString("me.stats.saved", comment: "Saved experiences stat label")
+                )
+                Rectangle()
+                    .fill(CT.borderSubtle)
+                    .frame(width: 1, height: 36)
+                StatTile(
+                    target: exploredCount,
+                    caption: NSLocalizedString("me.stats.explored", comment: "Explored experiences stat label")
+                )
+            }
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(CT.surfaceWhite)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .stroke(CT.borderSubtle, lineWidth: 1)
+                    )
+            )
         }
-        .padding(.vertical, 16)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 20)
+        .padding(.top, 20)
+        .padding(.bottom, 20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [CT.accentSoft, CT.surfaceWhite],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .stroke(CT.accentBorder, lineWidth: 1)
+                )
+        )
         .padding(.horizontal, 16)
+        .padding(.top, 8)
     }
 }
 
 // MARK: - Stat pill
 
-private struct StatPill: View {
+private struct StatTile: View {
     let target: Int
     let caption: String
 
@@ -231,17 +287,21 @@ private struct StatPill: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        HStack(spacing: 3) {
+        VStack(spacing: 2) {
             Text("\(shown)")
-                .font(.subheadline.weight(.semibold).monospacedDigit())
-                .foregroundStyle(CT.fgPrimary)
+                .font(.title3.weight(.bold).monospacedDigit())
+                .foregroundStyle(CT.accent)
                 .contentTransition(.numericText())
                 .scaleEffect(pop ? 1.18 : 1.0)
                 .animation(.spring(response: 0.3, dampingFraction: 0.5), value: pop)
             Text(caption)
                 .font(.caption)
-                .foregroundStyle(CT.fgSubtle)
+                .foregroundStyle(CT.fgMuted)
         }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 10)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text("\(target) \(caption)"))
         .onAppear {
             if reduceMotion {
                 shown = target
@@ -296,79 +356,9 @@ private struct StatPill: View {
     }
 }
 
-// MARK: - Friends hub (placeholder list within the Me stack)
-
-/// Minimal friends overview pushed from the hub. Lists confirmed friends and
-/// surfaces incoming requests; the dedicated friends-management UI arrives in a
-/// later FRD. Kept self-contained so US-007 wires the entry point end-to-end.
-private struct FriendsHubView: View {
-    @State private var service = FriendService.shared
-    @State private var showingAddFriend = false
-
-    var body: some View {
-        Group {
-            if service.friends.isEmpty && service.incomingRequests.isEmpty {
-                emptyState
-            } else {
-                friendList
-            }
-        }
-        .navigationTitle(NSLocalizedString("me.friends", comment: "Friends"))
-        .navigationBarTitleDisplayMode(.inline)
-        .task { await service.refresh() }
-        .sheet(isPresented: $showingAddFriend) {
-            AddFriendSheet()
-        }
-    }
-
-    private var emptyState: some View {
-        ContentUnavailableView {
-            Label(
-                NSLocalizedString("me.friends.empty.title", comment: "Friends empty state title"),
-                systemImage: "person.2.slash"
-            )
-        } description: {
-            Text(NSLocalizedString("me.friends.empty.description", comment: "Friends empty state description"))
-        } actions: {
-            Button {
-                Haptics.impact(.light)
-                showingAddFriend = true
-            } label: {
-                Text(NSLocalizedString("me.friends.empty.cta", comment: "Add a friend CTA"))
-            }
-            .buttonStyle(.borderedProminent)
-        }
-    }
-
-    private var friendList: some View {
-        List {
-            if !service.incomingRequests.isEmpty {
-                Section(NSLocalizedString("me.friends.incoming", comment: "Incoming friend requests")) {
-                    ForEach(service.incomingRequests, id: \.id) { req in
-                        Text(req.requesterId)
-                            .font(.subheadline)
-                            .foregroundStyle(CT.fgPrimary)
-                    }
-                }
-            }
-            Section(NSLocalizedString("me.friends.list", comment: "Friends list")) {
-                ForEach(service.friends, id: \.id) { friendship in
-                    Text(friendship.userHighId)
-                        .font(.subheadline)
-                        .foregroundStyle(CT.fgPrimary)
-                }
-            }
-        }
-    }
-}
-
-// MARK: - FriendsHubView Preview
-
-#Preview("Friends empty state") {
-    NavigationStack {
-        FriendsHubView()
-    }
-}
+// `FriendsHubView` (pushed from the Friends row above) now lives in its own
+// file — Views/Friends/FriendsHubView.swift — where the add-by-code search is
+// inlined at the top of the page instead of behind a separate AddFriendSheet.
 
 // MARK: - Row
 
@@ -380,9 +370,13 @@ private struct MeRow: View {
     var body: some View {
         HStack(spacing: 14) {
             Image(systemName: systemImage)
-                .font(.body.weight(.semibold))
+                .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(CT.accent)
-                .frame(width: 28)
+                .frame(width: 34, height: 34)
+                .background(
+                    RoundedRectangle(cornerRadius: 9, style: .continuous)
+                        .fill(CT.accentSoft)
+                )
             Text(title)
                 .font(.body)
                 .foregroundStyle(CT.fgPrimary)
@@ -395,8 +389,11 @@ private struct MeRow: View {
                     .padding(.vertical, 2)
                     .background(Capsule().fill(Color.red))
             }
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(CT.fgSubtle)
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, 6)
     }
 }
 
@@ -444,10 +441,10 @@ struct MapAvatarBubble: View {
 
 #Preview("RingAvatar states") {
     HStack(spacing: 24) {
-        RingAvatar(favoritedCount: 0, exploredCount: 0)   // no ring
-        RingAvatar(favoritedCount: 5, exploredCount: 0)   // 0%
-        RingAvatar(favoritedCount: 5, exploredCount: 2)   // 40%
-        RingAvatar(favoritedCount: 5, exploredCount: 5)   // 100%
+        RingAvatar(favoritedCount: 0, exploredCount: 0, size: 88)   // no ring
+        RingAvatar(favoritedCount: 5, exploredCount: 0, size: 88)   // 0%
+        RingAvatar(favoritedCount: 5, exploredCount: 2, size: 88)   // 40%
+        RingAvatar(favoritedCount: 5, exploredCount: 5, size: 88)   // 100%
     }
     .padding()
 }


### PR DESCRIPTION
## Summary

Two improvements to the personal hub (`MeSheet`) and Friends screen.

**Me hub**
- **Fix zh-Hans garbled UI.** Chinese builds were rendering raw keys like `me.profile.name` / `me.title` because `zh-Hans.lproj/Localizable.strings` was missing 15 `me.*` keys (en had 18, zh had 3). Added the full Chinese translations.
- **Redesign `ProfileHeader`** from a thin horizontal List row into a centered identity card: gradient surface (`accentSoft → surfaceWhite`), 88pt avatar with progress ring, twin stat tiles split by a hairline divider.
- **Polish `MeRow`** with accent-soft rounded icon chips + trailing chevrons.

**Friends**
- **Inline the add-by-code search** at the top of the Friends hub. Before: empty state → tap *Add a friend* → AddFriendSheet → switch tab → type. Now: open Friends → type/scan code in the inline search bar → lookup fires → profile card confirms. The user's own shareable code lives in a collapsible row. No sheet hop.
- **Extract `FriendsHubView`** into its own file (`Views/Friends/FriendsHubView.swift`, 500 lines). Redeem/scan/QR logic lifted from the proven `AddFriendSheet`, which is kept (`FriendsListView` still presents it).
- **Add missing `friends.redeem.*` / `friends.add.*` / `friends.inline.*` keys** — zh had zero of these, so inlining them would have rendered raw keys.

Note: the backend only supports friend-code add (`redeemFriendCode`), not free-text user search, so the "search bar" is a code field — the most direct shape the data layer allows.

A DEBUG-only `-openMe` / `-openFriends` launch arg was added so these screens can be screenshotted directly (idb/simctl tapping is unreliable on Xcode 26).

## Test Coverage

UI + localization change. No new business logic — the Friends inline flow reuses redeem/scan/sendRequest paths already covered by `AddFriendSheetTests`. No new unit tests added; the lifted logic is unchanged from the tested original.

## Pre-Landing Review

1 informational finding auto-fixed: removed dead `isRotating` @State left over from the AddFriendSheet lift. 1 orphaned key (`me.friends.empty.cta`) left in place — harmless, may be reused. No critical findings.

## Design Review

Frontend (SwiftUI) change. Identity card + inline Friends search both follow the existing `CT` design tokens (fixed light surfaces paired with fixed dark `CT.fg*` foregrounds, per the project's dark-mode contrast rule). Verified visually in the simulator.

## Test plan

- [x] `xcodebuild build` — **BUILD SUCCEEDED** (iPhone 17 Pro, iOS latest)
- [x] Me hub renders correctly in **en** and **zh** (no raw keys) — simulator screenshots
- [x] Inline Friends hub renders correctly in **zh** — search bar + collapsible my-code + empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)