### PR TITLE
feat(ios): rich experience cards — per-category facts + place photos

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 		7DE0D7D331590BFAC64D55B9 /* RouteDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1C7F381BB5EE2493C06407 /* RouteDetailView.swift */; };
 		8004F51AA0F117D38EC71610 /* BilingualCityRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95DD95393E5BF9C89FB4977 /* BilingualCityRow.swift */; };
 		80C4122C30C52DC2BEF38206 /* InviteFriendsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F22DFB53BF47FEF26D9441BE /* InviteFriendsSheet.swift */; };
+		80D6C58420D8D1E463936E47 /* ExperienceRecordHighlightsRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97CFC524C0531291FC21FE47 /* ExperienceRecordHighlightsRoundTripTests.swift */; };
 		81470D06CD0593B278B110CC /* ColdStartExperienceLoadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907EA19EC9B84B93AB110C70 /* ColdStartExperienceLoadTests.swift */; };
 		83328E4B13133FBCDA9E0A5D /* DiscoverListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADDD17473F138874328A33E /* DiscoverListView.swift */; };
 		83BF31EF553028D19D695105 /* RouteSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C6C906BAD8DBC107491B7F /* RouteSharePayload.swift */; };
@@ -231,6 +232,7 @@
 		9D799B457AC16C84BB460D18 /* RouteCardTappableGuardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4317C293B762EA1C8A436B8A /* RouteCardTappableGuardTest.swift */; };
 		9D81327AE55FA8142F9E5B8D /* ChatUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0709110B381DEDA32C3292AE /* ChatUIState.swift */; };
 		9DA3FB74B38298C6CFB72B08 /* ConversationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB5FD37267074EF4015F95D /* ConversationListView.swift */; };
+		9E0C778CF1FD76DB9E0CEB9D /* ExperienceImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F91F51C79F4EC2D9464FDA /* ExperienceImageService.swift */; };
 		9F8D8133FC74C4E206A11DB9 /* ItineraryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD7871A003B28A7C46AC8D7 /* ItineraryStoreTests.swift */; };
 		9FDC9CE4E9D3B505758EDB7D /* AttachmentBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9055347887EF473171916120 /* AttachmentBubble.swift */; };
 		A12DF78B6B05519D2177A519 /* RouteCompanionForceUnwrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF2CEF9FE62124F51460453 /* RouteCompanionForceUnwrapTests.swift */; };
@@ -332,6 +334,7 @@
 		D825B4D4C81AC33373DA1437 /* AgentMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DCEFC3560FED53D0CB5D19 /* AgentMessage.swift */; };
 		D8A9D1CB20E6D46FD5EE373C /* PeekSummarySelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710E82F0D31AB629848EA729 /* PeekSummarySelectionTests.swift */; };
 		DB1CF6212A00A37058317559 /* StartRouteCoordinateResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377590D8F67E082E58EDEAB9 /* StartRouteCoordinateResolutionTests.swift */; };
+		DC8EEFCE455618DDDF900B28 /* ExperienceImageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28FE205E7AA6068F6E0C837 /* ExperienceImageServiceTests.swift */; };
 		DD17BA9771494EA9F0E4ECC5 /* TopOverlayLayoutTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30D09E054C6CE013359301E /* TopOverlayLayoutTest.swift */; };
 		DD2D33487360F16C48C55EE8 /* HeartBurstView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295A9108AFAF3BEE4EFF7524 /* HeartBurstView.swift */; };
 		DE7491E6540301BC07A37D10 /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39F3D5F813E5C3B23C7EE30 /* FlowLayout.swift */; };
@@ -424,6 +427,7 @@
 		10F48D7FA14E29D606FD11EA /* RouteCompanionStateMachineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCompanionStateMachineTests.swift; sourceTree = "<group>"; };
 		112319E8315F5F6961C95264 /* VoiceAgentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAgentSession.swift; sourceTree = "<group>"; };
 		112365ED9467BFB0994BC0A0 /* CompanionProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionProfile.swift; sourceTree = "<group>"; };
+		11F91F51C79F4EC2D9464FDA /* ExperienceImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceImageService.swift; sourceTree = "<group>"; };
 		120FC7465285714C5FA8F96D /* VoiceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceService.swift; sourceTree = "<group>"; };
 		12F087E4FA7161529378098C /* ExperienceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceService.swift; sourceTree = "<group>"; };
 		130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingCheckInBanner.swift; sourceTree = "<group>"; };
@@ -620,6 +624,7 @@
 		9504D49E879C4D2BB34F99E9 /* Geohash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Geohash.swift; sourceTree = "<group>"; };
 		9748B0A808BC06F6EDED3C3B /* RecentExploreRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentExploreRegion.swift; sourceTree = "<group>"; };
 		977F66FB36894EA4088C2905 /* WebSearchEnrichmentSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchEnrichmentSource.swift; sourceTree = "<group>"; };
+		97CFC524C0531291FC21FE47 /* ExperienceRecordHighlightsRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceRecordHighlightsRoundTripTests.swift; sourceTree = "<group>"; };
 		97E92D314B6B62ED3B6EA2AE /* ShareCardComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareCardComponents.swift; sourceTree = "<group>"; };
 		97FCA9C12D9640983F75474E /* NowSignal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowSignal.swift; sourceTree = "<group>"; };
 		98A9885BEB8D9686F5384BEC /* AttachmentInputBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentInputBar.swift; sourceTree = "<group>"; };
@@ -756,6 +761,7 @@
 		F1B30F2AF51F41DB5DA21899 /* ImminenceProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImminenceProgressTests.swift; sourceTree = "<group>"; };
 		F1D68F42114231582501CB90 /* NowCountCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowCountCacheTests.swift; sourceTree = "<group>"; };
 		F22DFB53BF47FEF26D9441BE /* InviteFriendsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteFriendsSheet.swift; sourceTree = "<group>"; };
+		F28FE205E7AA6068F6E0C837 /* ExperienceImageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceImageServiceTests.swift; sourceTree = "<group>"; };
 		F336099C48E0B04CD7612E4C /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		F4814DBCEAB5975B6338558D /* AIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIService.swift; sourceTree = "<group>"; };
 		F494ACF8BB53CF5EEB1D4FB8 /* MapDensityLODTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapDensityLODTests.swift; sourceTree = "<group>"; };
@@ -932,6 +938,8 @@
 				A7D06753CFAA5198FCB3FF96 /* DiscoverFriendGateTests.swift */,
 				DA75549DB586E5FB6689BEAE /* DiscoverPostDetailRenderTest.swift */,
 				763DF01F638C99097DD5FE20 /* EmptyStateAnnouncementTest.swift */,
+				F28FE205E7AA6068F6E0C837 /* ExperienceImageServiceTests.swift */,
+				97CFC524C0531291FC21FE47 /* ExperienceRecordHighlightsRoundTripTests.swift */,
 				AA17ED8FE9ABA2F5CC1D557E /* FavoriteFilterTests.swift */,
 				F8547EB44AE47A5D653D3994 /* FavoritesBounceAvailabilityTest.swift */,
 				5C94CC0395CC7FCC0A56D077 /* FavoritesClosingSoonThresholdTest.swift */,
@@ -1186,6 +1194,7 @@
 				7B2B85A119750C65697903E0 /* CustomCityStore.swift */,
 				CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */,
 				820F9980B60883E879851303 /* DiscoverFriendGate.swift */,
+				11F91F51C79F4EC2D9464FDA /* ExperienceImageService.swift */,
 				12F087E4FA7161529378098C /* ExperienceService.swift */,
 				79B73212B8F704EABD27EF5B /* FeatureFlags.swift */,
 				67DAE302128E657E150C4B0D /* FoursquareService.swift */,
@@ -1606,6 +1615,8 @@
 				8D0C03425BA0C7D5E50B016D /* DiscoverFriendGateTests.swift in Sources */,
 				38569000AFC1017483C20063 /* DiscoverPostDetailRenderTest.swift in Sources */,
 				30293CB7BCCE6B600A82C292 /* EmptyStateAnnouncementTest.swift in Sources */,
+				DC8EEFCE455618DDDF900B28 /* ExperienceImageServiceTests.swift in Sources */,
+				80D6C58420D8D1E463936E47 /* ExperienceRecordHighlightsRoundTripTests.swift in Sources */,
 				37D5A0FD622C9649308BD14D /* FavoriteFilterTests.swift in Sources */,
 				F721E7FE777AF2AFA0FA264D /* FavoritesBounceAvailabilityTest.swift in Sources */,
 				4617863D79206886BE4A5586 /* FavoritesClosingSoonThresholdTest.swift in Sources */,
@@ -1786,6 +1797,7 @@
 				56F3055416F4A5316100F9B2 /* ExperienceCardView.swift in Sources */,
 				CF8B2BDE6D707CE2537C8688 /* ExperienceDetailView.swift in Sources */,
 				A84320715E7CBDA91FC3F26F /* ExperienceDetailViewModel.swift in Sources */,
+				9E0C778CF1FD76DB9E0CEB9D /* ExperienceImageService.swift in Sources */,
 				116FF0278F882D45402B0E78 /* ExperienceRecord.swift in Sources */,
 				7C14629A3FAB31975BFBB0A6 /* ExperienceRepository.swift in Sources */,
 				E7B5B022519434F7C07818CF /* ExperienceService.swift in Sources */,

--- a/apps/ios/SoloCompass/Models/Experience.swift
+++ b/apps/ios/SoloCompass/Models/Experience.swift
@@ -105,6 +105,17 @@ public struct ExperienceLocation: Codable, Hashable {
         return CLLocationCoordinate2D(latitude: coordinates[1], longitude: coordinates[0])
     }
 
+    /// Returns a copy with `photoUrls` replaced. Used when photos resolve after
+    /// the location was first built (e.g. async Wikidata enrichment).
+    public func withPhotoUrls(_ urls: [String]?) -> ExperienceLocation {
+        ExperienceLocation(
+            coordinates: coordinates, cityCode: cityCode, addressHint: addressHint,
+            placeNameLocal: placeNameLocal, placeNameRomanized: placeNameRomanized,
+            rating: rating, openingHours: openingHours, priceLevel: priceLevel,
+            website: website, phone: phone, photoUrls: urls
+        )
+    }
+
     public init(
         coordinates: [Double],
         cityCode: String,
@@ -267,6 +278,73 @@ public struct SoloScore: Codable, Hashable {
     }
 }
 
+// MARK: - Category highlight
+
+/// A category-specific, scannable fact surfaced on the card — the detail that
+/// matters most for *this kind* of place. A café highlight might be
+/// "Wi-Fi · fast", a meal "Signature · pho bo", a temple "Best light · sunrise".
+///
+/// Kept deliberately generic (icon + label + value) so the LLM can emit a
+/// different *set* of highlights per category without the schema growing a
+/// dozen optional columns, and the UI renders them all with one pill view.
+/// Only facts derivable from real signals/tags should be filled — never invented.
+public struct CategoryHighlight: Codable, Hashable, Identifiable {
+    /// A small, fixed vocabulary of highlight kinds. The raw value doubles as a
+    /// stable id and selects the SF Symbol + accent, so the LLM picks from this
+    /// set rather than free-forming icons.
+    public enum Kind: String, Codable, Hashable, CaseIterable {
+        // food
+        case signature        // a dish/specialty the place is known for
+        case pricePerPerson   // typical spend for one
+        case waitTime         // expect a queue / walk right in
+        // coffee / work
+        case wifi             // wifi availability / quality
+        case power            // power outlets at seats
+        case longStay         // comfortable to linger 2h+
+        // culture / nature
+        case bestLight        // golden hour / best time to see
+        case ticket           // entry fee / free
+        case duration         // how long to budget
+        // wellness / nightlife / generic
+        case booking          // reservation needed / walk-in
+        case vibe             // ambiance one-word
+        case note             // anything else worth a glance
+
+        /// SF Symbol shown on the highlight pill.
+        public var symbol: String {
+            switch self {
+            case .signature:      return "star.circle"
+            case .pricePerPerson: return "yensign.circle"
+            case .waitTime:       return "hourglass"
+            case .wifi:           return "wifi"
+            case .power:          return "powerplug"
+            case .longStay:       return "clock.arrow.circlepath"
+            case .bestLight:      return "sun.max"
+            case .ticket:         return "ticket"
+            case .duration:       return "timer"
+            case .booking:        return "calendar"
+            case .vibe:           return "sparkles"
+            case .note:           return "info.circle"
+            }
+        }
+    }
+
+    public let kind: Kind
+    /// Short noun for the fact, e.g. "Wi-Fi", "Signature". Localized upstream
+    /// (model emits it in the requested output language).
+    public let label: String
+    /// The actual value, e.g. "fast", "pho bo", "free". Kept under ~4 words.
+    public let value: String
+
+    public var id: String { "\(kind.rawValue)-\(value)" }
+
+    public init(kind: Kind, label: String, value: String) {
+        self.kind = kind
+        self.label = label
+        self.value = value
+    }
+}
+
 // MARK: - Health & Confidence
 
 /// How likely an experience is still real and accurate, shown to travelers as a
@@ -419,6 +497,10 @@ public struct Experience: Codable, Hashable, Identifiable {
     public let bestTimes: [TimeWindow]
     public let durationMinutes: DurationRange
     public let howTo: [HowToStep]
+    /// Category-specific scannable facts (Wi-Fi for cafés, signature dish for
+    /// food, best light for sights). Optional + decoded leniently so older
+    /// persisted/seed entries without it stay valid; treated as `[]` in the UI.
+    public let categoryHighlights: [CategoryHighlight]?
     public let realInconveniences: [RealInconvenience]
     public let soloScore: SoloScore
     public let sources: [InformationSource]
@@ -452,7 +534,8 @@ public struct Experience: Codable, Hashable, Identifiable {
         status: Status,
         createdAt: Date,
         updatedAt: Date,
-        userTags: [String]? = nil
+        userTags: [String]? = nil,
+        categoryHighlights: [CategoryHighlight]? = nil
     ) {
         self.id = id
         self.title = title
@@ -473,9 +556,13 @@ public struct Experience: Codable, Hashable, Identifiable {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.userTags = userTags
+        self.categoryHighlights = categoryHighlights
     }
 
     public var coordinate: CLLocationCoordinate2D? { location.clCoordinate }
+
+    /// Non-nil category highlights, never nil — UI iterates this directly.
+    public var highlights: [CategoryHighlight] { categoryHighlights ?? [] }
 
     /// True when this entry was discovered via OpenStreetMap Explore
     /// (vs. a curated seed entry). Used to surface provenance in the UI.
@@ -572,15 +659,18 @@ public struct Experience: Codable, Hashable, Identifiable {
     }
 
     /// Returns a new Experience with selected fields overridden. Use this when
-    /// mutating tracked stats/status/etc. without rewriting all 18 init args.
+    /// mutating tracked stats/status/location/etc. without rewriting all 18 init
+    /// args. `location` lets callers swap in an enriched location (e.g. photos
+    /// resolved after synthesis) without rebuilding the whole value.
     public func copy(
+        location: ExperienceLocation? = nil,
         stats: Stats? = nil,
         status: Status? = nil,
         updatedAt: Date? = nil
     ) -> Experience {
         Experience(
             id: id, title: title, oneLiner: oneLiner, whyItMatters: whyItMatters,
-            category: category, location: location, bestTimes: bestTimes,
+            category: category, location: location ?? self.location, bestTimes: bestTimes,
             durationMinutes: durationMinutes, howTo: howTo, realInconveniences: realInconveniences,
             soloScore: soloScore, sources: sources, confidence: confidence,
             nearbyExperienceIds: nearbyExperienceIds,
@@ -588,7 +678,8 @@ public struct Experience: Codable, Hashable, Identifiable {
             status: status ?? self.status,
             createdAt: createdAt,
             updatedAt: updatedAt ?? self.updatedAt,
-            userTags: self.userTags
+            userTags: self.userTags,
+            categoryHighlights: self.categoryHighlights
         )
     }
 

--- a/apps/ios/SoloCompass/Persistence/Models/ExperienceRecord.swift
+++ b/apps/ios/SoloCompass/Persistence/Models/ExperienceRecord.swift
@@ -85,6 +85,11 @@ public final class ExperienceRecord {
     /// migrated from earlier schema versions decode as `nil`.
     public var photoUrlsBlob: Data?
 
+    /// Category-specific scannable facts (SchemaV1_5). JSON-encoded
+    /// `[CategoryHighlight]`. Optional so rows migrated from earlier schema
+    /// versions decode as `nil`, treated as empty by `asValue`.
+    public var categoryHighlightsBlob: Data?
+
     public init(
         id: String,
         title: String,
@@ -116,7 +121,8 @@ public final class ExperienceRecord {
         statsBlob: Data,
         nearbyExperienceIdsBlob: Data,
         userTagsBlob: Data? = nil,
-        photoUrlsBlob: Data? = nil
+        photoUrlsBlob: Data? = nil,
+        categoryHighlightsBlob: Data? = nil
     ) {
         self.id = id
         self.title = title
@@ -149,6 +155,7 @@ public final class ExperienceRecord {
         self.nearbyExperienceIdsBlob = nearbyExperienceIdsBlob
         self.userTagsBlob = userTagsBlob
         self.photoUrlsBlob = photoUrlsBlob
+        self.categoryHighlightsBlob = categoryHighlightsBlob
     }
 }
 
@@ -160,6 +167,13 @@ public final class ExperienceRecord {
 private func encodedPhotoUrls(_ urls: [String]?, encoder: JSONEncoder) -> Data? {
     guard let urls else { return nil }
     return try? encoder.encode(urls)
+}
+
+/// Encode optional category highlights to a JSON blob, or `nil` when there are
+/// none. Free function for the same fast-type-check reason as `encodedPhotoUrls`.
+private func encodedHighlights(_ highlights: [CategoryHighlight]?, encoder: JSONEncoder) -> Data? {
+    guard let highlights, !highlights.isEmpty else { return nil }
+    return try? encoder.encode(highlights)
 }
 
 extension ExperienceRecord {
@@ -202,7 +216,8 @@ extension ExperienceRecord {
                 statsBlob: try encoder.encode(experience.stats),
                 nearbyExperienceIdsBlob: try encoder.encode(experience.nearbyExperienceIds),
                 userTagsBlob: try encoder.encode(experience.userTags ?? []),
-                photoUrlsBlob: encodedPhotoUrls(experience.location.photoUrls, encoder: encoder)
+                photoUrlsBlob: encodedPhotoUrls(experience.location.photoUrls, encoder: encoder),
+                categoryHighlightsBlob: encodedHighlights(experience.categoryHighlights, encoder: encoder)
             )
         } catch {
             fatalError("Failed to encode Experience \(experience.id): \(error)")
@@ -214,6 +229,11 @@ extension ExperienceRecord {
     /// should crash loud rather than silently degrade.
     public var asValue: Experience {
         let decoder = JSONDecoder.iso8601Decoder
+        // Decode the optional highlights blob up front so the big Experience
+        // initializer below stays within the type-checker's time budget.
+        let highlights: [CategoryHighlight]? = categoryHighlightsBlob.flatMap {
+            try? decoder.decode([CategoryHighlight].self, from: $0)
+        }
         do {
             return Experience(
                 id: id,
@@ -246,7 +266,8 @@ extension ExperienceRecord {
                 status: Experience.Status(rawValue: status) ?? .active,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
-                userTags: userTagsBlob.map { (try? decoder.decode([String].self, from: $0)) ?? [] } ?? []
+                userTags: userTagsBlob.map { (try? decoder.decode([String].self, from: $0)) ?? [] } ?? [],
+                categoryHighlights: highlights
             )
         } catch {
             fatalError("Failed to decode ExperienceRecord \(id): \(error)")

--- a/apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift
+++ b/apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift
@@ -150,8 +150,23 @@ public enum SoloCompassSchemaV1_4: VersionedSchema {
     }
 }
 
-/// Migration plan stitching v1.0 → v1.1 → v1.2 → v1.3 → v1.4. Each change is
-/// additive (an optional `Data?` column, new @Model tables) or a NOT NULL
+/// Schema v1.5 — adds the optional `ExperienceRecord.categoryHighlightsBlob`
+/// column carrying category-specific scannable facts (Wi-Fi for cafés,
+/// signature dish for food, best light for sights). Like v1.2's photoUrls, the
+/// new column is `Data?`, so existing rows migrate with NULL and no data is
+/// rewritten. `asValue` treats a nil blob as `nil` highlights. The model set is
+/// identical to v1.4 — only the column is new.
+// swiftlint:disable:next type_name
+public enum SoloCompassSchemaV1_5: VersionedSchema {
+    public static var versionIdentifier: Schema.Version { .init(1, 5, 0) }
+
+    public static var models: [any PersistentModel.Type] {
+        SoloCompassSchemaV1_4.models
+    }
+}
+
+/// Migration plan stitching v1.0 → v1.1 → v1.2 → v1.3 → v1.4 → v1.5. Each change
+/// is additive (an optional `Data?` column, new @Model tables) or a NOT NULL
 /// relaxation, so every hop is a lightweight migration.
 public enum SoloCompassMigrationPlan: SchemaMigrationPlan {
     public static var schemas: [any VersionedSchema.Type] {
@@ -161,6 +176,7 @@ public enum SoloCompassMigrationPlan: SchemaMigrationPlan {
             SoloCompassSchemaV1_2.self,
             SoloCompassSchemaV1_3.self,
             SoloCompassSchemaV1_4.self,
+            SoloCompassSchemaV1_5.self,
         ]
     }
 
@@ -181,6 +197,10 @@ public enum SoloCompassMigrationPlan: SchemaMigrationPlan {
             .lightweight(
                 fromVersion: SoloCompassSchemaV1_3.self,
                 toVersion: SoloCompassSchemaV1_4.self
+            ),
+            .lightweight(
+                fromVersion: SoloCompassSchemaV1_4.self,
+                toVersion: SoloCompassSchemaV1_5.self
             ),
         ]
     }

--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -973,7 +973,12 @@ public final class AIService {
         let prompt = Self.synthesisPrompt(pois: capped, cityCode: cityCode, locale: locale)
         do {
             let raw = try await sendMessage(prompt: prompt, kind: .synthesis)
-            let experiences = try Self.parseSynthesizedExperiences(raw, pois: capped, cityCode: cityCode)
+            let parsed = try Self.parseSynthesizedExperiences(raw, pois: capped, cityCode: cityCode)
+            // Wikidata P18 photo enrichment for places that had no cheaper image
+            // source (no OSM `image`/`wikimedia_commons` tag). Bounded + best-effort:
+            // it never throws and is capped so it can't stall Explore. Done before
+            // the cache write so the cached set carries the photos too.
+            let experiences = await Self.enrichWithWikidataPhotos(parsed, pois: capped, session: session)
             await writeCachedSynthesis(
                 cacheKey: cacheKey,
                 experiences: experiences,
@@ -1529,6 +1534,10 @@ public final class AIService {
         let website = poi.tags["website"]
         let phone = poi.tags["phone"]
         let addr = poi.tags["addr"]
+        // Zero-cost photo resolution from OSM `image` / `wikimedia_commons`
+        // tags. The `wikidata` P18 fallback needs a network call and is
+        // resolved separately (lazily) so it never blocks Explore.
+        let photoUrls = ExperienceImageService.syncPhotoURLs(from: poi.tags)
         return ExperienceLocation(
             coordinates: [poi.lon, poi.lat],
             cityCode: cityCode,
@@ -1539,8 +1548,67 @@ public final class AIService {
             openingHours: openingHours,
             priceLevel: priceLevel,
             website: website,
-            phone: phone
+            phone: phone,
+            photoUrls: photoUrls
         )
+    }
+
+    /// Maximum POIs we'll resolve a Wikidata photo for in one synthesis run.
+    /// Bounds the network fan-out so a dense Pro Explore can't fire dozens of
+    /// EntityData requests.
+    private static let wikidataEnrichCap = 12
+
+    /// Best-effort Wikidata P18 photo enrichment. For each experience that has
+    /// NO photo yet but whose POI carries a `wikidata` tag, resolves the entity's
+    /// image to a Commons thumbnail and folds it into `location.photoUrls`.
+    ///
+    /// Never throws and never blocks Explore meaningfully: only the first
+    /// `wikidataEnrichCap` candidates are looked up, requests run concurrently,
+    /// and any failure leaves that experience unchanged. Experiences that already
+    /// have a photo (OSM `image`/`wikimedia_commons`) pass through untouched.
+    static func enrichWithWikidataPhotos(
+        _ experiences: [Experience],
+        pois: [OverpassService.POI],
+        session: URLSession
+    ) async -> [Experience] {
+        let poiById = Dictionary(uniqueKeysWithValues: pois.map { ($0.osmId, $0) })
+
+        // Index of experiences that need (and can get) a Wikidata lookup.
+        let candidates: [(index: Int, qid: String)] = experiences.enumerated().compactMap { idx, exp in
+            guard exp.location.photoUrls?.isEmpty ?? true else { return nil }
+            guard let osmId = Int64(exp.id.replacingOccurrences(of: "exp_osm_", with: "")),
+                  let poi = poiById[osmId],
+                  ExperienceImageService.needsWikidataLookup(tags: poi.tags),
+                  let qid = poi.tags["wikidata"] else { return nil }
+            return (idx, qid)
+        }
+        guard !candidates.isEmpty else { return experiences }
+
+        let capped = Array(candidates.prefix(wikidataEnrichCap))
+        // Resolve concurrently; collect (index → url) for the ones that hit.
+        let resolved: [(Int, String)] = await withTaskGroup(of: (Int, String?).self) { group in
+            for candidate in capped {
+                group.addTask {
+                    let url = await ExperienceImageService.wikidataImageURL(
+                        entityId: candidate.qid, session: session
+                    )
+                    return (candidate.index, url)
+                }
+            }
+            var out: [(Int, String)] = []
+            for await (index, url) in group {
+                if let url { out.append((index, url)) }
+            }
+            return out
+        }
+        guard !resolved.isEmpty else { return experiences }
+
+        var result = experiences
+        for (index, url) in resolved {
+            let enrichedLocation = result[index].location.withPhotoUrls([url])
+            result[index] = result[index].copy(location: enrichedLocation)
+        }
+        return result
     }
 
     /// True when a POI carries at least one provider hard signal (rating /
@@ -1557,7 +1625,10 @@ public final class AIService {
         let lines = pois.map { poi -> String in
             let displayName = poi.nameEn ?? poi.name
             let tagSummary = poi.tags
-                .filter { ["amenity", "tourism", "leisure", "natural", "shop", "cuisine", "opening_hours"].contains($0.key) }
+                .filter { [
+                    "amenity", "tourism", "leisure", "natural", "shop", "cuisine",
+                    "opening_hours", "internet_access", "fee", "outdoor_seating",
+                ].contains($0.key) }
                 .map { "\($0.key)=\($0.value)" }
                 .sorted()
                 .joined(separator: ", ")
@@ -1582,6 +1653,18 @@ public final class AIService {
         - When a POI has NO `realSignals`, fall back to generic-safe framing exactly as before: bestStartHour 9 / bestEndHour 21 when category gives no better hint.
         - howTo must contain navigation/orientation steps only. Do NOT write "order the X", "try the X", "ask for X", "sit at the bar/window/back" — those are interior specifics you cannot verify.
         - Solo Score: anchor on REAL signals when present. A high rating (>= 8/10) or strong popularity supports up to 9.0–9.5; a low/absent rating or sparse data should stay 6.5–8.0. With NO realSignals, keep it conservative 7.0–8.0. Make the six breakdown dimensions genuinely DIFFERENT from each other based on the place type (e.g. a library scores high on seatingFriendly + low staffPressure; a bar scores lower on soloPatronRatio) — do NOT output the same number across all six.
+
+        CATEGORY-SPECIFIC SHAPE — a temple, a noodle shop, and a café need DIFFERENT facts. Tailor your output to the POI's category:
+
+        • food → frame around the meal & eating alone. Score soloPortioning + staffPressure hardest. Highlights to prefer: pricePerPerson (only if realSignals priceLevel present), waitTime (only if you can infer a queue from popularity), signature (ONLY a cuisine type derivable from the `cuisine=` tag, e.g. "Vietnamese" — NEVER an invented dish name).
+        • coffee / work → frame around lingering & focus. Score seatingFriendly + ambianceFit hardest. Highlights to prefer: wifi (only if `internet_access` tag present), power, longStay, vibe.
+        • culture → frame around the sight & its meaning. Score safety + ambianceFit. Highlights to prefer: ticket (only if `fee`/`fee=no` tag present), bestLight (from category knowledge, e.g. temples at sunrise), duration.
+        • nature → frame around the outdoor moment. Score safety + soloPatronRatio. Highlights to prefer: bestLight, duration, vibe.
+        • wellness → frame around the calm solo ritual. Score ambianceFit + staffPressure. Highlights to prefer: booking, duration, vibe.
+        • nightlife → frame around the evening scene for one. Score soloPatronRatio + safety hardest. Highlights to prefer: vibe, booking.
+        • hidden / other → keep it generic; at most one `note` highlight.
+
+        HIGHLIGHTS RULES (the `highlights` array): 0–3 short scannable facts, each {kind,label,value}. `kind` MUST be one of: signature, pricePerPerson, waitTime, wifi, power, longStay, bestLight, ticket, duration, booking, vibe, note. Emit a highlight ONLY when its value is derivable from a tag or realSignal or safe category knowledge (bestLight/duration are OK from category alone). `label` is a 1-word noun ("Wi-Fi", "Signature", "Best light"), `value` is ≤4 words ("fast", "Vietnamese", "sunrise"). NEVER invent menu items, prices without priceLevel, or hours without opening_hours. Prefer FEWER true highlights over padding. Output `highlights: []` when nothing is derivable.
 
         DISTANCE AWARENESS: The POI list may span 0–12 km from the user (a Pro radial Explore covers 4 rings: 1.5/3/6/12 km). Infer approximate distance from each POI's lat/lon relative to the others; closer POIs should lean toward in-the-moment framings (walk-up, sidewalk), farther POIs toward half-day-out framings (worth a transit ride). Do NOT mention distances or rings explicitly in the output — just let the framing reflect the proximity.
 
@@ -1617,7 +1700,10 @@ public final class AIService {
             "soloPortioning": <0-10>,
             "ambianceFit": <0-10>,
             "safety": <0-10>
-          }
+          },
+          "highlights": [
+            {"kind": "<one of the allowed kinds>", "label": "<1-word noun>", "value": "<=4 words>"}
+          ]
         }
 
         Output a JSON array containing one object per POI, in input order. No prose. No markdown fences.
@@ -1658,6 +1744,7 @@ public final class AIService {
             let soloHint: String?
             let soloOverall: Double?
             let soloBreakdown: Breakdown?
+            let highlights: [Highlight]?
 
             struct Breakdown: Decodable {
                 let seatingFriendly: Double?
@@ -1666,6 +1753,12 @@ public final class AIService {
                 let soloPortioning: Double?
                 let ambianceFit: Double?
                 let safety: Double?
+            }
+
+            struct Highlight: Decodable {
+                let kind: String?
+                let label: String?
+                let value: String?
             }
         }
         let items = try JSONDecoder().decode([Item].self, from: data)
@@ -1695,6 +1788,9 @@ public final class AIService {
                 safety: dim(item.soloBreakdown?.safety)
             )
             let howTo = (item.howTo ?? []).enumerated().map { HowToStep(order: $0.offset + 1, text: $0.element) }
+            let highlights = Self.mapHighlights(
+                item.highlights?.map { (kind: $0.kind, label: $0.label, value: $0.value) }
+            )
             // basedOnCount reflects whether this score is anchored on real
             // provider signals (>0) or pure category inference (0).
             let basedOnCount = hasHardSignals(poi) ? 1 : 0
@@ -1734,9 +1830,43 @@ public final class AIService {
                 stats: .init(completionCount: 0, averageRating: 0),
                 status: .candidate,
                 createdAt: now,
-                updatedAt: now
+                updatedAt: now,
+                categoryHighlights: highlights
             )
         }
+    }
+
+    /// Map raw AI highlight triples to validated `CategoryHighlight` values:
+    /// drops any with an unknown `kind` or empty label/value, trims, and caps
+    /// the count so a card never overflows. Returns nil when nothing survives so
+    /// the Experience leaves `categoryHighlights` nil rather than an empty array.
+    ///
+    /// Takes plain optional-string triples (not a Decodable type) so it stays
+    /// decoupled from the function-local `Item` shape and is unit-testable.
+    static func mapHighlights(
+        _ raw: [(kind: String?, label: String?, value: String?)]?
+    ) -> [CategoryHighlight]? {
+        guard let raw else { return nil }
+        let mapped: [CategoryHighlight] = raw.compactMap { h in
+            guard
+                let kindRaw = h.kind,
+                let kind = CategoryHighlight.Kind(rawValue: kindRaw),
+                let label = h.label?.trimmingCharacters(in: .whitespacesAndNewlines),
+                let value = h.value?.trimmingCharacters(in: .whitespacesAndNewlines),
+                !label.isEmpty, !value.isEmpty
+            else { return nil }
+            // Cap length: the prompt asks for a 1-word label / ≤4-word value,
+            // but that's an instruction to the LLM, not a guarantee. A malformed
+            // response with a 500-char value would persist to SwiftData and be
+            // read verbatim by VoiceOver. Bound it defensively.
+            return CategoryHighlight(
+                kind: kind,
+                label: String(label.prefix(40)),
+                value: String(value.prefix(40))
+            )
+        }
+        guard !mapped.isEmpty else { return nil }
+        return Array(mapped.prefix(3))
     }
 
     /// Build a minimal Experience from raw OSM data, used when AI is unavailable.

--- a/apps/ios/SoloCompass/Services/ExperienceImageService.swift
+++ b/apps/ios/SoloCompass/Services/ExperienceImageService.swift
@@ -1,0 +1,165 @@
+import Foundation
+import os
+
+// MARK: - Experience image resolution
+
+/// Resolves the most *accurate* photo URLs for a place from its OpenStreetMap
+/// tags, in descending order of trust:
+///
+/// 1. `image` — a direct photo URL the mapper attached. Most specific.
+/// 2. `wikimedia_commons` — a `File:…` on Wikimedia Commons. Free, CC-licensed,
+///    and tied to the exact place. Resolved via the stable `Special:FilePath`
+///    redirect (no API call), with a `width` so we fetch a thumbnail, not a 20MB
+///    original.
+/// 3. `wikidata` — a `Q…` entity. The actual image lives in property `P18`,
+///    which needs one network round-trip. Used as a last resort and resolved
+///    lazily so it never blocks the Explore first paint.
+///
+/// We deliberately do NOT invent images (no stock photos, no AI generation):
+/// every URL here is anchored to real provider data for the specific place, so
+/// a café card never shows a generic "coffee" stock shot that misleads.
+///
+/// Distinct from `PlacePhotoStore`, which persists user-captured photos to disk
+/// as `file://` URLs. This service only *reads* remote, place-specific sources.
+public enum ExperienceImageService {
+    private static let logger = Logger(subsystem: "com.solocompass.app", category: "ExperienceImageService")
+
+    /// Thumbnail width requested from Commons. Cards show a small image; this
+    /// keeps payloads tiny and avoids downloading multi-MB originals.
+    private static let commonsThumbWidth = 800
+
+    // MARK: Synchronous resolution (no network)
+
+    /// Build photo URL strings from OSM tags using only the zero-cost sources
+    /// (`image`, `wikimedia_commons`). Returns `nil` when neither tag is present
+    /// so callers can leave `photoUrls` nil rather than an empty array.
+    ///
+    /// Order matters: a direct `image` is the single best photo, so it leads;
+    /// the Commons thumbnail follows as a reliable fallback/second shot.
+    public static func syncPhotoURLs(from tags: [String: String]) -> [String]? {
+        var urls: [String] = []
+
+        if let direct = tags["image"], let normalized = normalizedDirectImageURL(direct) {
+            urls.append(normalized)
+        }
+
+        if let commons = tags["wikimedia_commons"],
+           let commonsURL = commonsFilePathURL(from: commons) {
+            urls.append(commonsURL)
+        }
+
+        return urls.isEmpty ? nil : urls
+    }
+
+    /// True when the tags carry a `wikidata` entity but no cheaper image source,
+    /// i.e. the only way to get a photo is the async P18 lookup. Lets callers
+    /// batch just the POIs that actually need a network round-trip.
+    public static func needsWikidataLookup(tags: [String: String]) -> Bool {
+        guard tags["wikidata"] != nil else { return false }
+        return syncPhotoURLs(from: tags) == nil
+    }
+
+    // MARK: Async resolution (Wikidata P18)
+
+    /// Resolve the `P18` image of a `wikidata` entity to a Commons thumbnail URL,
+    /// or `nil` when the entity has no image / the lookup fails. One network
+    /// round-trip; safe to call off the main actor. Never throws — image
+    /// enrichment is best-effort and must never fail an Explore.
+    public static func wikidataImageURL(
+        entityId rawId: String,
+        session: URLSession = .shared
+    ) async -> String? {
+        // Accept "Q42", "wikidata=Q42", or a stray "https://www.wikidata.org/...Q42".
+        guard let qid = normalizedWikidataQID(rawId) else { return nil }
+        guard let endpoint = URL(
+            string: "https://www.wikidata.org/wiki/Special:EntityData/\(qid).json"
+        ) else { return nil }
+
+        do {
+            // Per-request timeout so one slow/hung entity can't stall the
+            // bounded enrichment group that calls this concurrently.
+            var request = URLRequest(url: endpoint)
+            request.timeoutInterval = 5
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                return nil
+            }
+            guard let fileName = Self.parseP18FileName(data, qid: qid) else { return nil }
+            // P18 stores a bare "File name.jpg" without the File: prefix.
+            return commonsFilePathURL(from: fileName)
+        } catch {
+            logger.debug("wikidata image lookup failed for \(qid, privacy: .public): \(String(describing: error), privacy: .public)")
+            return nil
+        }
+    }
+
+    // MARK: - URL construction helpers
+
+    /// Normalize a direct `image` tag value into an https URL string, or nil.
+    ///
+    /// The value is untrusted third-party data (OSM tags anyone can edit), so we
+    /// require **https** specifically — not just any http(s) scheme. This blocks
+    /// three things a hostile `image` tag could otherwise do via `AsyncImage`:
+    /// mixed-content `http://` loads, IP-based user tracking, and pointing the
+    /// client at internal hosts (`http://192.168.x.x`). Commons/Wikidata URLs are
+    /// hardcoded-host https, so this only constrains the direct-tag path.
+    static func normalizedDirectImageURL(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed),
+              url.scheme?.lowercased() == "https",
+              url.host?.isEmpty == false else {
+            return nil
+        }
+        return url.absoluteString
+    }
+
+    /// Turn a Commons `File:Example.jpg` (or bare `Example.jpg`) into a stable
+    /// thumbnail URL via `Special:FilePath`, which 302-redirects to the current
+    /// file location — no API key, no API call.
+    static func commonsFilePathURL(from raw: String) -> String? {
+        var name = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return nil }
+        // Strip an optional "File:" / "Image:" prefix (any case).
+        for prefix in ["File:", "Image:", "file:", "image:"] {
+            if name.hasPrefix(prefix) {
+                name = String(name.dropFirst(prefix.count))
+                break
+            }
+        }
+        // Commons normalizes spaces to underscores; FilePath accepts either but
+        // we percent-encode to be safe.
+        guard let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
+            return nil
+        }
+        return "https://commons.wikimedia.org/wiki/Special:FilePath/\(encoded)?width=\(commonsThumbWidth)"
+    }
+
+    /// Extract a `Q…` id from various raw forms (bare, tag=value, or a URL).
+    static func normalizedWikidataQID(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Pull the last "Q<digits>" token — covers "Q42", "wikidata=Q42",
+        // and full wikidata.org URLs ending in the qid.
+        guard let range = trimmed.range(
+            of: "Q[0-9]+",
+            options: [.regularExpression, .backwards]
+        ) else { return nil }
+        return String(trimmed[range])
+    }
+
+    /// Parse the `P18` (image) claim's filename out of a Wikidata EntityData
+    /// JSON blob. Returns the bare "File name.jpg" or nil when absent.
+    static func parseP18FileName(_ data: Data, qid: String) -> String? {
+        guard
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let entities = root["entities"] as? [String: Any],
+            let entity = entities[qid] as? [String: Any],
+            let claims = entity["claims"] as? [String: Any],
+            let p18 = claims["P18"] as? [[String: Any]],
+            let first = p18.first,
+            let mainsnak = first["mainsnak"] as? [String: Any],
+            let datavalue = mainsnak["datavalue"] as? [String: Any],
+            let fileName = datavalue["value"] as? String
+        else { return nil }
+        return fileName
+    }
+}

--- a/apps/ios/SoloCompass/Tests/ExperienceImageServiceTests.swift
+++ b/apps/ios/SoloCompass/Tests/ExperienceImageServiceTests.swift
@@ -1,0 +1,235 @@
+import XCTest
+@testable import SoloCompass
+
+/// Unit tests for the pure URL-construction and parsing helpers in
+/// `ExperienceImageService` and the highlight mapping in `AIService`. These are
+/// network-free: only the string/JSON transforms are exercised, since those are
+/// where the accuracy of the image pipeline actually lives.
+final class ExperienceImageServiceTests: XCTestCase {
+
+    // MARK: - syncPhotoURLs
+
+    func testSyncPhotoURLs_prefersDirectImageThenCommons() {
+        let tags = [
+            "image": "https://example.org/photo.jpg",
+            "wikimedia_commons": "File:Wat_Phra_Singh.jpg",
+        ]
+        let urls = ExperienceImageService.syncPhotoURLs(from: tags)
+        XCTAssertEqual(urls?.count, 2)
+        XCTAssertEqual(urls?.first, "https://example.org/photo.jpg")
+        XCTAssertTrue(urls?[1].contains("Special:FilePath/Wat_Phra_Singh.jpg") ?? false)
+    }
+
+    func testSyncPhotoURLs_nilWhenNoImageTags() {
+        XCTAssertNil(ExperienceImageService.syncPhotoURLs(from: ["amenity": "cafe"]))
+    }
+
+    func testSyncPhotoURLs_rejectsNonHTTPImage() {
+        // A javascript: or file: scheme must not become a card image.
+        let urls = ExperienceImageService.syncPhotoURLs(from: ["image": "javascript:alert(1)"])
+        XCTAssertNil(urls)
+    }
+
+    // MARK: - commonsFilePathURL
+
+    func testCommonsFilePathURL_stripsFilePrefixAndEncodes() {
+        let url = ExperienceImageService.commonsFilePathURL(from: "File:Eiffel Tower.jpg")
+        XCTAssertNotNil(url)
+        XCTAssertTrue(url!.contains("Special:FilePath/Eiffel%20Tower.jpg"))
+        XCTAssertTrue(url!.contains("width="))
+    }
+
+    func testCommonsFilePathURL_acceptsBareName() {
+        let url = ExperienceImageService.commonsFilePathURL(from: "Photo.jpg")
+        XCTAssertTrue(url?.contains("Special:FilePath/Photo.jpg") ?? false)
+    }
+
+    func testCommonsFilePathURL_nilOnEmpty() {
+        XCTAssertNil(ExperienceImageService.commonsFilePathURL(from: "  "))
+    }
+
+    // MARK: - normalizedWikidataQID
+
+    func testWikidataQID_fromBare() {
+        XCTAssertEqual(ExperienceImageService.normalizedWikidataQID("Q243"), "Q243")
+    }
+
+    func testWikidataQID_fromURL() {
+        XCTAssertEqual(
+            ExperienceImageService.normalizedWikidataQID("https://www.wikidata.org/wiki/Q243"),
+            "Q243"
+        )
+    }
+
+    func testWikidataQID_nilWhenAbsent() {
+        XCTAssertNil(ExperienceImageService.normalizedWikidataQID("not-an-id"))
+    }
+
+    func testNeedsWikidataLookup_onlyWhenNoCheaperSource() {
+        XCTAssertTrue(ExperienceImageService.needsWikidataLookup(tags: ["wikidata": "Q1"]))
+        XCTAssertFalse(ExperienceImageService.needsWikidataLookup(
+            tags: ["wikidata": "Q1", "image": "https://x.org/a.jpg"]
+        ))
+        XCTAssertFalse(ExperienceImageService.needsWikidataLookup(tags: ["amenity": "cafe"]))
+    }
+
+    // MARK: - parseP18FileName
+
+    func testParseP18FileName_extractsImage() {
+        let json = """
+        {"entities":{"Q243":{"claims":{"P18":[{"mainsnak":{"datavalue":{"value":"Tower.jpg"}}}]}}}}
+        """.data(using: .utf8)!
+        XCTAssertEqual(ExperienceImageService.parseP18FileName(json, qid: "Q243"), "Tower.jpg")
+    }
+
+    func testParseP18FileName_nilWhenNoP18() {
+        let json = """
+        {"entities":{"Q243":{"claims":{}}}}
+        """.data(using: .utf8)!
+        XCTAssertNil(ExperienceImageService.parseP18FileName(json, qid: "Q243"))
+    }
+
+    // MARK: - AIService.mapHighlights
+
+    func testMapHighlights_dropsUnknownKindAndEmpties() {
+        let raw: [(kind: String?, label: String?, value: String?)] = [
+            ("wifi", "Wi-Fi", "fast"),          // valid
+            ("bogus", "X", "y"),                 // unknown kind → dropped
+            ("signature", "Signature", "  "),    // empty value → dropped
+            ("ticket", "Ticket", "free"),        // valid
+        ]
+        let mapped = AIService.mapHighlights(raw)
+        XCTAssertEqual(mapped?.count, 2)
+        XCTAssertEqual(mapped?.first?.kind, .wifi)
+        XCTAssertEqual(mapped?.first?.value, "fast")
+    }
+
+    func testMapHighlights_capsAtThree() {
+        let raw: [(kind: String?, label: String?, value: String?)] = (0..<6).map { _ in
+            ("vibe", "Vibe", "calm")
+        }
+        XCTAssertEqual(AIService.mapHighlights(raw)?.count, 3)
+    }
+
+    func testMapHighlights_nilWhenNoneSurvive() {
+        let raw: [(kind: String?, label: String?, value: String?)] = [("bogus", "X", "y")]
+        XCTAssertNil(AIService.mapHighlights(raw))
+    }
+
+    func testMapHighlights_nilOnNilInput() {
+        XCTAssertNil(AIService.mapHighlights(nil))
+    }
+
+    func testMapHighlights_capsLabelAndValueLength() {
+        // A malformed/adversarial LLM response with an overlong value must be
+        // truncated before it persists / reaches VoiceOver.
+        let long = String(repeating: "x", count: 500)
+        let raw: [(kind: String?, label: String?, value: String?)] = [("note", long, long)]
+        let mapped = AIService.mapHighlights(raw)
+        XCTAssertEqual(mapped?.count, 1)
+        XCTAssertLessThanOrEqual(mapped?.first?.label.count ?? 999, 40)
+        XCTAssertLessThanOrEqual(mapped?.first?.value.count ?? 999, 40)
+    }
+
+    // MARK: - normalizedDirectImageURL (https hardening)
+
+    func testDirectImageURL_rejectsHTTP() {
+        // http:// is rejected to block mixed-content + IP tracking via OSM tags.
+        XCTAssertNil(ExperienceImageService.normalizedDirectImageURL("http://192.168.1.1/a.jpg"))
+    }
+
+    func testDirectImageURL_acceptsHTTPS() {
+        XCTAssertEqual(
+            ExperienceImageService.normalizedDirectImageURL("https://x.org/a.jpg"),
+            "https://x.org/a.jpg"
+        )
+    }
+
+    func testDirectImageURL_rejectsSchemeRelativeNoHost() {
+        XCTAssertNil(ExperienceImageService.normalizedDirectImageURL("https://"))
+    }
+
+    // MARK: - wikidataImageURL (async, stubbed network)
+
+    private func stubbedSession(_ handler: @escaping @Sendable (URLRequest) -> (HTTPURLResponse, Data)) -> URLSession {
+        StubURLProtocol.handler = handler
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    private func httpResponse(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://www.wikidata.org/")!,
+            statusCode: status, httpVersion: nil, headerFields: nil
+        )!
+    }
+
+    func testWikidataImageURL_resolvesP18ToCommonsURL() async {
+        let session = stubbedSession { _ in
+            let body = #"{"entities":{"Q243":{"claims":{"P18":[{"mainsnak":{"datavalue":{"value":"Tower.jpg"}}}]}}}}"#
+            return (self.httpResponse(200), body.data(using: .utf8)!)
+        }
+        let url = await ExperienceImageService.wikidataImageURL(entityId: "Q243", session: session)
+        XCTAssertNotNil(url)
+        XCTAssertTrue(url?.contains("Special:FilePath/Tower.jpg") ?? false)
+    }
+
+    func testWikidataImageURL_nilOnNon200() async {
+        let session = stubbedSession { _ in (self.httpResponse(404), Data()) }
+        let url = await ExperienceImageService.wikidataImageURL(entityId: "Q243", session: session)
+        XCTAssertNil(url)
+    }
+
+    func testWikidataImageURL_nilWhenNoP18() async {
+        let session = stubbedSession { _ in
+            (self.httpResponse(200), #"{"entities":{"Q243":{"claims":{}}}}"#.data(using: .utf8)!)
+        }
+        let url = await ExperienceImageService.wikidataImageURL(entityId: "Q243", session: session)
+        XCTAssertNil(url)
+    }
+
+    func testWikidataImageURL_nilOnBadId() async {
+        let session = stubbedSession { _ in (self.httpResponse(200), Data()) }
+        let url = await ExperienceImageService.wikidataImageURL(entityId: "not-an-id", session: session)
+        XCTAssertNil(url)
+    }
+
+    // MARK: - enrichWithWikidataPhotos (end-to-end)
+
+    private func osmPOI(id: Int64, tags: [String: String]) -> OverpassService.POI {
+        OverpassService.POI(osmId: id, name: "P\(id)", nameEn: "P\(id)", lat: 1, lon: 2, tags: tags)
+    }
+
+    func testEnrich_addsPhotoForWikidataOnlyPOI() async {
+        let session = stubbedSession { _ in
+            let body = #"{"entities":{"Q5":{"claims":{"P18":[{"mainsnak":{"datavalue":{"value":"Wat.jpg"}}}]}}}}"#
+            return (self.httpResponse(200), body.data(using: .utf8)!)
+        }
+        let poi = osmPOI(id: 5, tags: ["tourism": "attraction", "wikidata": "Q5"])
+        let exp = AIService.skeletonExperience(from: poi, cityCode: "CNX")
+        XCTAssertNil(exp.location.photoUrls, "precondition: no photo before enrich")
+
+        let enriched = await AIService.enrichWithWikidataPhotos([exp], pois: [poi], session: session)
+        XCTAssertTrue(enriched[0].location.photoUrls?.first?.contains("Wat.jpg") ?? false)
+    }
+
+    func testEnrich_skipsPOIThatAlreadyHasPhoto() async {
+        // image tag already gives a photo → no Wikidata lookup, value unchanged.
+        let session = stubbedSession { _ in (self.httpResponse(500), Data()) } // would fail if called
+        let poi = osmPOI(id: 6, tags: ["image": "https://x.org/a.jpg", "wikidata": "Q6"])
+        let exp = AIService.skeletonExperience(from: poi, cityCode: "CNX")
+        XCTAssertEqual(exp.location.photoUrls?.first, "https://x.org/a.jpg")
+
+        let enriched = await AIService.enrichWithWikidataPhotos([exp], pois: [poi], session: session)
+        XCTAssertEqual(enriched[0].location.photoUrls?.first, "https://x.org/a.jpg")
+    }
+
+    func testEnrich_noWikidataTagPassesThrough() async {
+        let session = stubbedSession { _ in (self.httpResponse(500), Data()) }
+        let poi = osmPOI(id: 7, tags: ["amenity": "cafe"])
+        let exp = AIService.skeletonExperience(from: poi, cityCode: "CNX")
+        let enriched = await AIService.enrichWithWikidataPhotos([exp], pois: [poi], session: session)
+        XCTAssertNil(enriched[0].location.photoUrls)
+    }
+}

--- a/apps/ios/SoloCompass/Tests/ExperienceRecordHighlightsRoundTripTests.swift
+++ b/apps/ios/SoloCompass/Tests/ExperienceRecordHighlightsRoundTripTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import SoloCompass
+
+/// SchemaV1_5 round-trip coverage: `categoryHighlights` must survive
+/// Experience → ExperienceRecord → Experience without loss, and rows from
+/// before the field existed (nil blob) must decode cleanly as nil. The existing
+/// round-trip tests use seed data with no highlights, so the populated-value
+/// path was previously unasserted.
+final class ExperienceRecordHighlightsRoundTripTests: XCTestCase {
+
+    private func makeExperience(highlights: [CategoryHighlight]?) -> Experience {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        return Experience(
+            id: "exp_osm_42",
+            title: "Test",
+            oneLiner: "Line",
+            whyItMatters: "Why",
+            category: .coffee,
+            location: ExperienceLocation(coordinates: [98.98, 18.79], cityCode: "CNX"),
+            bestTimes: [],
+            durationMinutes: .init(min: 30, max: 60),
+            howTo: [],
+            realInconveniences: [],
+            soloScore: SoloScore(
+                overall: 8,
+                breakdown: .init(seatingFriendly: 8, soloPatronRatio: 8, staffPressure: 8,
+                                 soloPortioning: 8, ambianceFit: 8, safety: 8),
+                basedOnCount: 1
+            ),
+            sources: [],
+            confidence: Confidence(level: 2, lastVerifiedAt: now, reason: "t",
+                                   signals: .init(aiScrapeAgeDays: 0, passiveGpsHits30d: 0,
+                                                  activeReports30d: 0, trustedVerifications: 0)),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .candidate,
+            createdAt: now,
+            updatedAt: now,
+            categoryHighlights: highlights
+        )
+    }
+
+    func testRoundTrip_preservesPopulatedHighlights() {
+        let highlights = [
+            CategoryHighlight(kind: .wifi, label: "Wi-Fi", value: "fast"),
+            CategoryHighlight(kind: .power, label: "Power", value: "at seats"),
+        ]
+        let record = ExperienceRecord(from: makeExperience(highlights: highlights))
+        let decoded = record.asValue
+        XCTAssertEqual(decoded.highlights.count, 2)
+        XCTAssertEqual(decoded.highlights.first?.kind, .wifi)
+        XCTAssertEqual(decoded.highlights.first?.value, "fast")
+        XCTAssertEqual(decoded.highlights.last?.kind, .power)
+    }
+
+    func testRoundTrip_nilHighlightsStayNil() {
+        let record = ExperienceRecord(from: makeExperience(highlights: nil))
+        XCTAssertNil(record.categoryHighlightsBlob, "nil highlights should not persist an empty blob")
+        XCTAssertTrue(record.asValue.highlights.isEmpty)
+    }
+
+    func testRoundTrip_emptyHighlightsDoNotPersistBlob() {
+        // encodedHighlights returns nil for an empty array — avoids writing `[]`.
+        let record = ExperienceRecord(from: makeExperience(highlights: []))
+        XCTAssertNil(record.categoryHighlightsBlob)
+        XCTAssertTrue(record.asValue.highlights.isEmpty)
+    }
+
+    func testExperienceJSON_roundTripsHighlights() throws {
+        let highlights = [CategoryHighlight(kind: .signature, label: "Signature", value: "Thai")]
+        let original = makeExperience(highlights: highlights)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Experience.self, from: data)
+        XCTAssertEqual(decoded.highlights.first?.kind, .signature)
+        XCTAssertEqual(decoded.highlights.first?.value, "Thai")
+    }
+
+    func testExperienceJSON_absentHighlightsDecodeNil() throws {
+        // A JSON payload from before the field existed must still decode.
+        let json = """
+        {"id":"exp_osm_1","title":"T","oneLiner":"O","whyItMatters":"W","category":"coffee",
+         "location":{"coordinates":[98.98,18.79],"cityCode":"CNX"},"bestTimes":[],
+         "durationMinutes":{"min":30,"max":60},"howTo":[],"realInconveniences":[],
+         "soloScore":{"overall":8,"breakdown":{"seatingFriendly":8,"soloPatronRatio":8,"staffPressure":8,"soloPortioning":8,"ambianceFit":8,"safety":8},"basedOnCount":1},
+         "sources":[],"confidence":{"level":2,"lastVerifiedAt":0,"reason":"t","signals":{"aiScrapeAgeDays":0,"passiveGpsHits30d":0,"activeReports30d":0,"trustedVerifications":0}},
+         "nearbyExperienceIds":[],"stats":{"completionCount":0,"averageRating":0},
+         "status":"candidate","createdAt":0,"updatedAt":0}
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(Experience.self, from: json)
+        XCTAssertTrue(decoded.highlights.isEmpty)
+    }
+}

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -207,10 +207,7 @@ public struct ExperienceCardView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 10) {
-                Image(systemName: experience.category.symbol)
-                    .foregroundStyle(.white)
-                    .frame(width: 32, height: 32)
-                    .background(Circle().fill(experience.category.color))
+                categoryThumbnail
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(experience.title)
@@ -292,6 +289,12 @@ public struct ExperienceCardView: View {
 
             FlowLayout(spacing: 8) {
                 SoloScoreBadge(score: experience.soloScore, style: .compact)
+                // Category-specific scannable facts (Wi-Fi, signature, best
+                // light…). Placed right after the score so the detail that
+                // matters for *this* kind of place reads before distance/ETA.
+                ForEach(experience.highlights) { highlight in
+                    highlightPill(highlight)
+                }
                 distancePillGroup
                     .contentTransition(.numericText())
                     .animation(.spring(response: 0.4), value: distanceMeters)
@@ -815,6 +818,78 @@ public struct ExperienceCardView: View {
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(String(format: a11yFormat, count, category.label))
         }
+    }
+
+    /// Leading visual: a real place photo when one resolved (OSM image /
+    /// Wikimedia), with the category color as a small corner badge so the type
+    /// stays scannable. Falls back to the original category-icon circle when
+    /// there's no photo, so photo-less places look exactly as before.
+    @ViewBuilder
+    private var categoryThumbnail: some View {
+        if let urlString = experience.location.photoUrls?.first,
+           let url = URL(string: urlString) {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFill()
+                case .empty:
+                    ZStack {
+                        Rectangle().fill(experience.category.color.opacity(0.15))
+                        ProgressView()
+                    }
+                case .failure:
+                    categoryIconCircle
+                @unknown default:
+                    categoryIconCircle
+                }
+            }
+            .frame(width: 52, height: 52)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            // Category color corner badge keeps the type glanceable over a photo.
+            .overlay(alignment: .bottomTrailing) {
+                Image(systemName: experience.category.symbol)
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 18, height: 18)
+                    .background(Circle().fill(experience.category.color))
+                    .overlay(Circle().stroke(.background, lineWidth: 1.5))
+                    .offset(x: 3, y: 3)
+            }
+            .accessibilityHidden(true)
+        } else {
+            categoryIconCircle
+        }
+    }
+
+    /// The original category-icon circle, reused for photo-less places and as
+    /// the AsyncImage failure/placeholder fallback.
+    private var categoryIconCircle: some View {
+        Image(systemName: experience.category.symbol)
+            .foregroundStyle(.white)
+            .frame(width: 32, height: 32)
+            .background(Circle().fill(experience.category.color))
+    }
+
+    /// A category-specific highlight pill (Wi-Fi · fast, Signature · pho bo…).
+    /// Mirrors the existing pill styling (caption, tinted capsule) for a
+    /// consistent FlowLayout row. Uses the secondary label tint so it reads as
+    /// neutral context, not an alert.
+    private func highlightPill(_ highlight: CategoryHighlight) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: highlight.kind.symbol)
+                .font(.caption2)
+            Text(highlight.value)
+                .font(.caption)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .foregroundStyle(.secondary)
+        .background(Capsule().fill(Color.secondary.opacity(0.12)))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(highlight.label): \(highlight.value)")
     }
 }
 

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -68,7 +68,11 @@ public struct ExperienceDetailView: View {
         ScrollViewReader { proxy in
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
+                heroImageBanner
                 heroSection
+                if !viewModel.experience.highlights.isEmpty {
+                    highlightsSection
+                }
                 compassDirectionView
                 askSoloSection
                 if let coord = viewModel.experience.location.clCoordinate {
@@ -227,6 +231,70 @@ public struct ExperienceDetailView: View {
     }
 
     // MARK: - Hero
+
+    /// Full-bleed hero photo at the top of the detail sheet, shown only when a
+    /// real place photo resolved (OSM image / Wikimedia). Breaks out of the 20pt
+    /// horizontal padding to sit edge-to-edge. Absent → nothing renders and the
+    /// sheet starts at the hero text exactly as before.
+    @ViewBuilder
+    private var heroImageBanner: some View {
+        if let urlString = viewModel.experience.location.photoUrls?.first,
+           let url = URL(string: urlString) {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFill()
+                case .empty:
+                    ZStack {
+                        Rectangle().fill(viewModel.experience.category.color.opacity(0.12))
+                        ProgressView()
+                    }
+                case .failure:
+                    EmptyView()
+                @unknown default:
+                    EmptyView()
+                }
+            }
+            .frame(height: 200)
+            .frame(maxWidth: .infinity)
+            .clipped()
+            // Break out of the VStack's 20pt horizontal padding for a full-bleed
+            // banner; the negative top padding closes the gap above it.
+            .padding(.horizontal, -20)
+            .padding(.top, -16)
+            .accessibilityHidden(true)
+        }
+    }
+
+    /// Category-specific scannable facts (Wi-Fi, signature, best light…) shown
+    /// as a pill row near the top, so the detail that matters for *this* kind of
+    /// place reads right after the hero. Only renders when highlights exist
+    /// (guarded at the call site).
+    private var highlightsSection: some View {
+        FlowLayout(spacing: 8) {
+            ForEach(viewModel.experience.highlights) { highlight in
+                HStack(spacing: 5) {
+                    Image(systemName: highlight.kind.symbol)
+                        .font(.caption)
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(highlight.label)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Text(highlight.value)
+                            .font(.caption.weight(.medium))
+                            .lineLimit(1)
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(Capsule().fill(Color(.tertiarySystemFill)))
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("\(highlight.label): \(highlight.value)")
+            }
+        }
+    }
 
     private var heroSection: some View {
         VStack(alignment: .leading, spacing: 12) {

--- a/packages/core/src/experience.ts
+++ b/packages/core/src/experience.ts
@@ -109,6 +109,37 @@ export interface RealInconvenience {
 }
 
 /**
+ * A category-specific, scannable fact surfaced on the experience card — the
+ * detail that matters most for *this kind* of place. A café highlight is
+ * "Wi-Fi · fast", a meal "Signature · pho bo", a temple "Best light · sunrise".
+ *
+ * Deliberately generic (kind + label + value) so a different *set* of
+ * highlights can be emitted per category without the schema growing a column
+ * per category, and one card view renders them all. Mirrors the Swift
+ * `CategoryHighlight`. Only facts derivable from real signals — never invented.
+ */
+export interface CategoryHighlight {
+  /** Fixed vocabulary; selects icon/accent in the UI and keeps the LLM on-rails. */
+  readonly kind:
+    | "signature"
+    | "pricePerPerson"
+    | "waitTime"
+    | "wifi"
+    | "power"
+    | "longStay"
+    | "bestLight"
+    | "ticket"
+    | "duration"
+    | "booking"
+    | "vibe"
+    | "note";
+  /** Short noun for the fact, e.g. "Wi-Fi", "Signature". */
+  readonly label: string;
+  /** The value, e.g. "fast", "pho bo", "free". Under ~4 words. */
+  readonly value: string;
+}
+
+/**
  * Where the seed information for this experience came from. Persists with the
  * experience forever — the user can always trace back to original sources.
  *
@@ -196,6 +227,11 @@ export interface Experience {
   /** User-defined free-form tags layered on top of the category enum.
    *  Optional in JSON; absence is equivalent to an empty array. */
   readonly userTags?: readonly string[];
+
+  /** Category-specific scannable facts (Wi-Fi for cafés, signature dish for
+   *  food, best light for sights). Optional in JSON; absence = empty. Mirrors
+   *  the Swift `Experience.categoryHighlights`. */
+  readonly categoryHighlights?: readonly CategoryHighlight[];
 }
 
 /**

--- a/packages/db/src/schema/experiences.ts
+++ b/packages/db/src/schema/experiences.ts
@@ -52,4 +52,8 @@ export const experiences = pgTable("experiences", {
   // User-defined free-form tags layered on top of the category enum (US-005).
   // Optional JSONB array of strings; absence is equivalent to an empty array.
   userTags: jsonb("user_tags"),
+  // Category-specific scannable facts (Wi-Fi for cafés, signature dish for
+  // food, best light for sights). Optional JSONB array of {kind,label,value};
+  // absence is equivalent to an empty array. Mirrors Experience.categoryHighlights.
+  categoryHighlights: jsonb("category_highlights"),
 });


### PR DESCRIPTION
## Summary

景点卡片之前信息质量低、结构固化(所有 category 同一套 prompt schema)、无图片。这个 PR 让卡片按 category 差异化并加入真实地点照片。

**Per-category 差异化 (`feat(core)` + `feat(ios): per-category synthesis`)**
- 新增通用 `CategoryHighlight{kind,label,value}` 字段,让 LLM 按 POI 类型输出不同亮点,无需为每类加列。咖啡→Wi-Fi/插座/久坐;美食→招牌(只许从 `cuisine` 标签派生)/人均;景点→最佳光线/门票/时长。
- synthesisPrompt 按 category 给不同字段指引 + soloScore 维度按类调整。
- `mapHighlights` 校验 LLM 输出:kind 在固定词表、trim、空值丢弃、长度上限 40、最多 3 个。

**图片管线 (`feat(ios): photo pipeline`)**
- 新建 `ExperienceImageService`,按准确度优先级解析:OSM `image` 标签 → `wikimedia_commons`(Commons `Special:FilePath`,免 API key) → `wikidata` P18(异步,合成后有界并发 enrich,≤12 个、单请求 5s 超时)。
- **刻意不用 AI 生成图/通用图库** —— 每张图锚定真实地点数据。
- 安全:直接 `image` 标签强制 https,挡 mixed-content 与经敌意 OSM 标签做的 IP 追踪。

**UI 渲染 (`feat(ios): render photos and highlights`)**
- 卡片左侧缩略图(有图显示+category 角标,无图回退原图标)+ 亮点 pill 行。
- 详情页满宽头图 + 亮点区块。

## Test Coverage
40 个相关测试全过,新增 32 个:
- `ExperienceImageServiceTests` (27): URL 构造、Wikidata P18 异步解析(stubbed)、端到端 enrich、https 收紧、mapHighlights 校验与长度上限。
- `ExperienceRecordHighlightsRoundTripTests` (5): SchemaV1_5 populated/nil/empty round-trip + Experience JSON 向后兼容。
- 回归:AISynthesisQuality (2)、ColdStartExperienceLoad (6) 全过,证明新字段不破坏现有解码。

覆盖率:纯函数核心 100%,接入生产后 Wikidata 异步路径 + 持久化 round-trip 已补测(初审 55% → 已覆盖 HIGH gap)。

## Pre-Landing Review
独立对抗性审查,无 P0/P1。处理的发现:
- **[P2 已修]** mapHighlights 无长度上限 → 加 `.prefix(40)`,防超长 LLM 输出持久化并被 VoiceOver 读出。
- **[P3 已修]** 直接 image 标签无 host 限制 → 强制 https。
- **[P2 已处理]** Wikidata 异步路径原是死代码(只测试调用)→ 按决策接入生产(合成后后台 enrich),并补全测试。
- 已核对无误:percent 编码注入(已防)、SchemaV1_5 迁移(正确)、round-trip 对称、copy() 透传、三处 schema parity 绿。

## Schema Parity
全 4 项绿:TS↔Swift、TS↔DB(Drizzle `category_highlights` jsonb)、Supabase SQL↔Swift、TS↔SwiftData。

## Verification
- iOS build SUCCEEDED (iPhone 17 Pro)
- 40 个相关 iOS 测试 0 失败
- TS 全量 6/6 包通过,`pnpm typecheck` 10/10
- ImageRenderer 视觉验证三类卡片(咖啡/美食/文化)确认差异化布局与无图回退

## Notes
- 仓库无 VERSION/CHANGELOG 约定,沿用 Conventional Commits + PR 流程。
- DB `category_highlights` 列已定义(过 parity),web/DB 实际同步是未来工作 —— 本轮是 iOS 闭环。

🤖 Generated with [Claude Code](https://claude.com/claude-code)