### PR TITLE
feat(ios): single thinking status line + collapsed reasoning summary

### DIFF
--- a/apps/ios/SoloCompass/Models/ChatCard.swift
+++ b/apps/ios/SoloCompass/Models/ChatCard.swift
@@ -84,3 +84,29 @@ public struct ReasoningStep: Identifiable, Equatable, Sendable {
         self.label = label
     }
 }
+
+/// An archived, collapsed record of one assistant turn's reasoning.
+///
+/// While the agent works, the UI shows a single quiet status line (one spinner,
+/// one cycling phrase). When the turn finishes, the live `reasoningTrace` is
+/// distilled into one of these and pinned beneath the assistant message — a
+/// single tappable chip ("✓ Searched 14 places · 2 matched") that expands to
+/// the full step detail on demand. This keeps the thread calm in the moment yet
+/// fully auditable after the fact — replacing the always-on `ReasoningTracePanel`
+/// that previously competed with the typing indicator for attention.
+public struct ReasoningSummary: Identifiable, Equatable, Sendable {
+    public let id: UUID
+    /// One-line headline shown collapsed (e.g. "Searched 14 places · 2 matched").
+    public let summary: String
+    /// The full ordered step labels, revealed when the chip is expanded.
+    public let detail: [String]
+
+    public init(id: UUID = UUID(), summary: String, detail: [String]) {
+        self.id = id
+        self.summary = summary
+        self.detail = detail
+    }
+
+    /// Whether there is expandable detail beyond the summary line.
+    public var hasDetail: Bool { !detail.isEmpty }
+}

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -768,6 +768,12 @@
 "chat.thinking.title" = "Thinking it through";
 "chat.thinking.a11y" = "Solo Compass is thinking";
 
+/* Collapsed reasoning summary (the one-line chip pinned under a finished turn) */
+"agent.trace.summary.steps" = "Reasoned through %d step(s)";
+"agent.trace.summary.thought" = "Thought it through";
+"chat.thinking.summary.a11y" = "Reasoning summary: %@. Tap to expand.";
+"chat.thinking.working" = "Working…";
+
 /* In-chat cards (places / proposed route) */
 "chat.card.viewOnMap" = "Tap to see on map";
 "chat.card.viewOnMap.a11y" = "Double tap to reveal this place on the map";
@@ -802,6 +808,16 @@
 "chat.title" = "Solo Compass";
 "chat.empty.title" = "Ask me anything about places near you";
 "chat.empty.subtitle" = "Try 'what's good around me?' or hold the mic to talk.";
+
+/* Contextual AI·NOW banner on the empty chat — shifts with the hour */
+"chat.empty.now.dawn" = "Quiet streets · the markets are just waking up";
+"chat.empty.now.morning" = "Morning light · good hour for slow coffee";
+"chat.empty.now.midday" = "Midday heat · seek out shade and a long lunch";
+"chat.empty.now.afternoon" = "Soft afternoon · easy time to wander";
+"chat.empty.now.goldenHour" = "Golden light soon · the river bank is calling";
+"chat.empty.now.evening" = "Evening sets in · time for the night market";
+"chat.empty.now.night" = "Late and quiet · a rooftop or a last drink";
+"chat.empty.now.a11y" = "Right now: %@";
 
 /* Chat starter prompts */
 "chat.empty.prompt.nearby" = "What's good around me?";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -504,6 +504,17 @@
 "chat.title" = "Solo Compass";
 "chat.empty.title" = "问我你附近有什么好玩的";
 "chat.empty.subtitle" = "试试「附近有什么好的？」或按住麦克风说话。";
+
+/* 空状态的语境化 AI·NOW 横幅 — 随时刻变化 */
+"chat.empty.now.dawn" = "街巷清静 · 集市才刚刚苏醒";
+"chat.empty.now.morning" = "晨光正好 · 适合慢慢喝杯咖啡";
+"chat.empty.now.midday" = "正午燥热 · 找处阴凉，慢慢吃顿午饭";
+"chat.empty.now.afternoon" = "午后柔和 · 正适合随意走走";
+"chat.empty.now.goldenHour" = "黄金时刻将至 · 河边在召唤你";
+"chat.empty.now.evening" = "夜色渐浓 · 该逛夜市了";
+"chat.empty.now.night" = "夜深人静 · 找个天台，或来最后一杯";
+"chat.empty.now.a11y" = "此刻：%@";
+
 "chat.input.placeholder" = "输入消息…";
 "chat.input.send.a11y" = "发送";
 "chat.input.mic.a11y" = "语音";
@@ -900,6 +911,10 @@
 "agent.trace.builtRoute" = "把 %d 个站点串成了一条路线";
 "chat.thinking.title" = "正在思考";
 "chat.thinking.a11y" = "Solo Compass 正在思考";
+"agent.trace.summary.steps" = "推理了 %d 步";
+"agent.trace.summary.thought" = "已想清楚";
+"chat.thinking.summary.a11y" = "推理摘要：%@。点按展开。";
+"chat.thinking.working" = "处理中…";
 "chat.card.viewOnMap" = "点按在地图上查看";
 "chat.card.viewOnMap.a11y" = "双击在地图上显示这个地方";
 "chat.route.adopt" = "采用这条路线";

--- a/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
@@ -70,6 +70,13 @@ public final class VoiceAgentOrchestrator: Identifiable {
     /// Reset at the start of each user turn.
     public private(set) var reasoningTrace: [ReasoningStep] = []
 
+    /// Archived, collapsed reasoning records keyed by the assistant message id
+    /// whose turn produced them. When a turn finishes, the live `reasoningTrace`
+    /// is distilled into one of these and pinned beneath that bubble as a single
+    /// expandable chip — so the in-flight thread stays calm (one status line) yet
+    /// every turn's reasoning stays auditable. Cleared with the session.
+    public private(set) var reasoningSummaryByMessageId: [UUID: ReasoningSummary] = [:]
+
     /// US-011: Strict chat UI state machine — drives state-specific view modifiers.
     public private(set) var uiState: ChatUIState = .idle
 
@@ -171,6 +178,7 @@ public final class VoiceAgentOrchestrator: Identifiable {
         errorMessage = nil
         cardsByMessageId = [:]
         reasoningTrace = []
+        reasoningSummaryByMessageId = [:]
 
         persistedConversationId = id
         persistedConversationCreatedAt = nil
@@ -247,6 +255,7 @@ public final class VoiceAgentOrchestrator: Identifiable {
         // re-scoped chat doesn't show stale recommendations.
         cardsByMessageId = [:]
         reasoningTrace = []
+        reasoningSummaryByMessageId = [:]
 
         // Re-seed the system prompt synchronously enough that callers can
         // observe `currentSystemPrompt` after this Task completes.
@@ -322,6 +331,7 @@ public final class VoiceAgentOrchestrator: Identifiable {
         isExecutingTool = false
         cardsByMessageId = [:]
         reasoningTrace = []
+        reasoningSummaryByMessageId = [:]
         uiState = .idle
         if !session.isEnded {
             session.end(reason: .userClose)
@@ -432,6 +442,11 @@ public final class VoiceAgentOrchestrator: Identifiable {
                     session.finishSpeakingTurn()
                     thinkingStep = ""
                     shouldContinue = false
+                    // Distill this turn's live reasoning into one collapsed,
+                    // expandable chip pinned beneath the assistant bubble, then
+                    // clear the live trace so the in-flight status line is the
+                    // ONLY thinking indicator on screen during the next turn.
+                    archiveReasoningTrace()
                     speakResponse(finalText)
                     // Turn complete — persist the conversation so it survives the
                     // sheet closing and shows up in history.
@@ -577,6 +592,52 @@ public final class VoiceAgentOrchestrator: Identifiable {
         cardsByMessageId[messageId, default: []].append(card)
     }
 
+    /// Distill the live `reasoningTrace` into one collapsed `ReasoningSummary`
+    /// pinned under the just-finished assistant turn, then clear the live trace.
+    ///
+    /// The headline favors a concrete outcome — how many tools ran and what they
+    /// found — over the raw step list, so the collapsed chip reads like a result
+    /// ("Searched 14 places · 2 matched") rather than a transcript. The full
+    /// ordered step labels stay in `detail`, revealed only when the user taps to
+    /// expand. No-op when the trace is empty or there is no assistant message to
+    /// attach to.
+    private func archiveReasoningTrace() {
+        defer { reasoningTrace = [] }
+        guard let assistantId = session.messages.last(where: { $0.role == .assistant })?.id else { return }
+
+        let steps = reasoningTrace
+        guard !steps.isEmpty else { return }
+
+        // Detail = the human-readable label of every step except the generic
+        // opening "Thinking…" seed (it carries no information on its own).
+        let detail = steps
+            .filter { !($0.kind == .thinking && $0.label == NSLocalizedString("agent.step.thinking", comment: "Thinking…")) }
+            .map(\.label)
+
+        // Prefer an insight step (e.g. "Found 2 places that fit") as the
+        // headline — it already states the outcome. Otherwise fall back to a
+        // tool count, then to the last meaningful label.
+        let summary: String
+        if let insight = steps.last(where: { $0.kind == .insight }) {
+            summary = insight.label
+        } else {
+            let toolCount = steps.filter { $0.kind == .tool }.count
+            if toolCount > 0 {
+                summary = String(
+                    format: NSLocalizedString("agent.trace.summary.steps", comment: "Reasoned through N step(s)"),
+                    toolCount
+                )
+            } else {
+                summary = detail.last ?? NSLocalizedString("agent.trace.summary.thought", comment: "Thought it through")
+            }
+        }
+
+        // Detail beyond the headline is redundant if it's a single line equal to
+        // the summary — drop it so the chip shows no pointless expand affordance.
+        let trimmedDetail = (detail.count == 1 && detail.first == summary) ? [] : detail
+        reasoningSummaryByMessageId[assistantId] = ReasoningSummary(summary: summary, detail: trimmedDetail)
+    }
+
     /// Force one more non-tool response from the model (budget overflow path).
     private func sendForceText(prompt: String) async {
         session.appendSystemContinuation(prompt)
@@ -585,6 +646,7 @@ public final class VoiceAgentOrchestrator: Identifiable {
         let finalText = session.lastAssistantText ?? ""
         uiState = .responding(finalText)
         session.finishSpeakingTurn()
+        archiveReasoningTrace()
         thinkingStep = ""
         speakResponse(finalText)
     }

--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -4024,6 +4024,39 @@ final class SoloCompassTests: XCTestCase {
                       "a shallow, never-compiled card must be a candidate")
     }
 
+    /// A tap-opened detail (map pin / Nearby row → openExperienceDetail) backs
+    /// out to the BARE MAP — selection cleared — while a card-expanded detail
+    /// (long-press → selectExperience → expand) peels back to the preview card,
+    /// keeping its selection. Guards the "stuck floating card after dismiss" bug.
+    func testDismissDetailReturnTargetDependsOnHowDetailWasOpened() throws {
+        let vm = MapViewModel(
+            locationService: LocationService(),
+            experienceService: ExperienceService(seed: []),
+            aiService: AIService(),
+            preferences: UserPreferences()
+        )
+        let exp = try XCTUnwrap(ExperienceService.hardcodedSeed.first)
+
+        // Path A — tap straight to detail, then dismiss → bare map.
+        vm.openExperienceDetail(exp)
+        XCTAssertTrue(vm.isShowingDetail, "sanity: tap opened the detail sheet")
+        XCTAssertNotNil(vm.selectedExperience)
+        vm.dismissDetail()
+        XCTAssertFalse(vm.isShowingDetail)
+        XCTAssertNil(vm.selectedExperience,
+                     "a tap-opened detail must dismiss to the bare map, not a phantom preview card")
+
+        // Path B — long-press floats the card, expand to detail, then dismiss
+        // → back to the preview card (selection retained).
+        vm.selectExperience(exp)
+        XCTAssertFalse(vm.isShowingDetail, "sanity: select floats the card, detail closed")
+        vm.isShowingDetail = true // the card's expand action
+        vm.dismissDetail()
+        XCTAssertFalse(vm.isShowingDetail)
+        XCTAssertNotNil(vm.selectedExperience,
+                        "a card-expanded detail must peel back to the preview card it sits above")
+    }
+
     private func makeExperience(id: String, bestTimes: [TimeWindow]) throws -> Experience {
         let base = try XCTUnwrap(ExperienceService.hardcodedSeed.first)
         return Experience(

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -641,6 +641,12 @@ public final class MapViewModel {
 
     public var selectedExperience: Experience?
     public var isShowingDetail: Bool = false
+    /// True when the current detail sheet was opened *directly* by a tap (map
+    /// pin / Nearby row) with no floating preview card behind it. Backing out
+    /// of such a sheet returns to the bare map, not to a preview card the user
+    /// never summoned. A detail opened by *expanding* a preview card (long-press
+    /// → card → expand) leaves this false, so dismiss peels back to that card.
+    private var detailOpenedDirectly: Bool = false
     public var bottomInfoText: String = ""
     public var nearbySoloCount: Int = 0
     public var aiExplanation: String?
@@ -1061,6 +1067,10 @@ public final class MapViewModel {
     /// through `openExperienceDetail` for a direct jump to the detail sheet.
     public func selectExperience(_ experience: Experience) {
         selectedExperience = experience
+        // This is the preview-card path (long-press). The detail layer, if the
+        // user later expands the card, sits *above* this card — so dismissing
+        // it must peel back to the card, not to the bare map.
+        detailOpenedDirectly = false
         // isShowingDetail stays false — card shows first, detail sheet on expand
         focusOnExperience(experience)
     }
@@ -1074,6 +1084,10 @@ public final class MapViewModel {
     public func openExperienceDetail(_ experience: Experience) {
         selectedExperience = experience
         isShowingDetail = true
+        // Tap jumped straight to detail with no preview card behind it, so a
+        // back-out should land on the bare map rather than reveal a card the
+        // user never summoned (see `dismissDetail`).
+        detailOpenedDirectly = true
         focusOnExperience(experience)
     }
 
@@ -1125,6 +1139,13 @@ public final class MapViewModel {
     /// fully cleared when the user dismisses the card itself (`clearSelection`).
     public func dismissDetail() {
         isShowingDetail = false
+        // A tap-opened detail has no preview card underneath — peel straight
+        // back to the bare map. A card-expanded detail keeps its selection so
+        // the dismiss reveals the preview card it sits above.
+        if detailOpenedDirectly {
+            detailOpenedDirectly = false
+            selectedExperience = nil
+        }
     }
 
     /// Fully dismiss the floating preview card and its selection, returning to
@@ -1134,6 +1155,7 @@ public final class MapViewModel {
     public func clearSelection() {
         isShowingDetail = false
         selectedExperience = nil
+        detailOpenedDirectly = false
     }
 
     /// US-VA-03 tool `dismiss_recommendation`: hide one experience from
@@ -1146,6 +1168,7 @@ public final class MapViewModel {
         if selectedExperience?.id == id {
             selectedExperience = nil
             isShowingDetail = false
+            detailOpenedDirectly = false
         }
     }
 

--- a/apps/ios/SoloCompass/Views/Chat/ChatCardStack.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatCardStack.swift
@@ -139,3 +139,162 @@ struct ReasoningTracePanel: View {
         colorScheme == .dark ? Color(.secondarySystemBackground) : CT.sunGoldSoft.opacity(0.35)
     }
 }
+
+/// The single, quiet status line shown while the agent is working.
+///
+/// Replaces the old pairing of an always-on `ReasoningTracePanel` *and* a
+/// `TypingIndicatorBubble` — two competing loaders on screen at once. Here there
+/// is exactly one: a small spinner plus one cycling phrase (the orchestrator's
+/// current `thinkingStep`), the phrase cross-fading as the step changes. When the
+/// turn finishes this line disappears and its reasoning collapses into a
+/// `ReasoningSummaryChip` pinned under the reply.
+@MainActor
+struct AgentStatusLine: View {
+    /// The current localized step label (e.g. "🔍 Searching nearby…"). Falls back
+    /// to a neutral "Working…" when the orchestrator hasn't named a step yet.
+    let label: String
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var spinning = false
+
+    private var phrase: String {
+        label.isEmpty
+            ? NSLocalizedString("chat.thinking.working", comment: "Neutral agent working status")
+            : label
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .trim(from: 0.12, to: 0.92)
+                .stroke(CT.accent, style: StrokeStyle(lineWidth: 1.6, lineCap: .round))
+                .frame(width: 13, height: 13)
+                .rotationEffect(.degrees(spinning ? 360 : 0))
+                .animation(
+                    reduceMotion ? nil : .linear(duration: 0.9).repeatForever(autoreverses: false),
+                    value: spinning
+                )
+                .onAppear { spinning = true }
+
+            // Keying on the phrase makes SwiftUI treat each new step as a fresh
+            // view, so the label cross-fades instead of hard-cutting.
+            Text(phrase)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .id(phrase)
+                .transition(.opacity)
+                .animation(.easeOut(duration: 0.25), value: phrase)
+        }
+        .padding(.vertical, 6)
+        .padding(.leading, 40)
+        .padding(.trailing, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .transition(.opacity)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(phrase))
+        .accessibilityAddTraits(.updatesFrequently)
+    }
+}
+
+/// The collapsed, tappable record of a finished turn's reasoning, pinned under
+/// the assistant bubble. Reads like a result ("✓ Searched 14 places · 2 matched")
+/// and expands to the full ordered step detail on tap — keeping the calm of a
+/// single status line in the moment while staying fully auditable afterward.
+@MainActor
+struct ReasoningSummaryChip: View {
+    let summary: ReasoningSummary
+
+    @State private var expanded = false
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Button {
+                guard summary.hasDetail else { return }
+                Haptics.impact(.light)
+                withAnimation(.easeInOut(duration: 0.22)) { expanded.toggle() }
+            } label: {
+                HStack(spacing: 7) {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(CT.verifiedGreen)
+                        .frame(width: 16, height: 16)
+                        .background(CT.verifiedGreen.opacity(0.14), in: Circle())
+                    Text(summary.summary)
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    if summary.hasDetail {
+                        Image(systemName: expanded ? "chevron.up" : "chevron.down")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(CT.fgSubtle)
+                    }
+                }
+                .padding(.vertical, 5)
+                .padding(.leading, 7)
+                .padding(.trailing, summary.hasDetail ? 10 : 12)
+                .background(chipFill, in: Capsule())
+            }
+            .buttonStyle(.plain)
+            .disabled(!summary.hasDetail)
+
+            if expanded {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(Array(summary.detail.enumerated()), id: \.offset) { _, line in
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Circle()
+                                .fill(CT.borderDefault)
+                                .frame(width: 5, height: 5)
+                            Text(line)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                            Spacer(minLength: 0)
+                        }
+                    }
+                }
+                .padding(.leading, 8)
+                .overlay(alignment: .leading) {
+                    Rectangle()
+                        .fill(CT.borderSubtle)
+                        .frame(width: 1.5)
+                }
+                .padding(.leading, 4)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.leading, 40)
+        .padding(.trailing, 8)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(String(
+            format: NSLocalizedString("chat.thinking.summary.a11y", comment: "Collapsed reasoning summary a11y"),
+            summary.summary
+        )))
+    }
+
+    private var chipFill: Color {
+        colorScheme == .dark ? Color(.secondarySystemBackground) : CT.surfaceSunken
+    }
+}
+
+#Preview("Reasoning — live + collapsed") {
+    VStack(alignment: .leading, spacing: 18) {
+        AgentStatusLine(label: "🔍 Searching nearby…")
+        ReasoningSummaryChip(summary: ReasoningSummary(
+            summary: "Searched 14 places · 2 matched",
+            detail: [
+                "Searched places — 14 within walking range",
+                "Filtered: quiet, laptop-friendly — 2 matched",
+                "Checked hours — both open now",
+            ]
+        ))
+        ReasoningSummaryChip(summary: ReasoningSummary(
+            summary: "Thought it through",
+            detail: []
+        ))
+    }
+    .padding()
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(CT.bgWarm)
+}

--- a/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
@@ -321,6 +321,15 @@ public struct ChatSheet: View {
                                 )
                                 .id("cards-\(msg.id)")
                             }
+
+                            // This turn's reasoning, collapsed into one
+                            // expandable chip pinned under the reply — calm in
+                            // the moment, auditable after the fact.
+                            if msg.role == .assistant,
+                               let summary = orchestrator.reasoningSummaryByMessageId[msg.id] {
+                                ReasoningSummaryChip(summary: summary)
+                                    .id("reasoning-\(msg.id)")
+                            }
                         }
 
                         if !orchestrator.streamingContent.isEmpty {
@@ -349,21 +358,17 @@ public struct ChatSheet: View {
                         }
 
                         if isAgentWorking {
-                            VStack(alignment: .leading, spacing: 8) {
-                                // Elegant, ordered reasoning trace (analyzing
-                                // weather / location / visited …) instead of an
-                                // opaque spinner. Falls back to the typing dots
-                                // when no steps have been recorded yet.
-                                if !orchestrator.reasoningTrace.isEmpty {
-                                    ReasoningTracePanel(steps: orchestrator.reasoningTrace)
-                                }
-                                TypingIndicatorBubble(
-                                    label: orchestrator.thinkingStep.isEmpty ? nil : orchestrator.thinkingStep
-                                )
-                            }
-                            .id(Self.typingIndicatorID)
-                            .transition(.opacity)
-                            .animation(.easeInOut(duration: 0.2), value: isAgentWorking)
+                            // ONE quiet thinking indicator: a single spinner +
+                            // cycling phrase. When the turn finishes this line
+                            // vanishes and its reasoning collapses into a
+                            // `ReasoningSummaryChip` pinned under the reply (see
+                            // `reasoningSummaryByMessageId` below). This replaces
+                            // the old always-on ReasoningTracePanel + typing dots
+                            // that competed for attention on screen at once.
+                            AgentStatusLine(label: orchestrator.thinkingStep)
+                                .id(Self.typingIndicatorID)
+                                .transition(.opacity)
+                                .animation(.easeInOut(duration: 0.2), value: isAgentWorking)
                         }
 
                         Color.clear
@@ -386,6 +391,9 @@ public struct ChatSheet: View {
                     scrollToBottom(proxy: proxy)
                 }
                 .onChange(of: orchestrator.session.state) { _, _ in
+                    scrollToBottom(proxy: proxy)
+                }
+                .onChange(of: orchestrator.reasoningSummaryByMessageId.count) { _, _ in
                     scrollToBottom(proxy: proxy)
                 }
                 .onChange(of: orchestrator.reasoningTrace.count) { _, _ in
@@ -528,6 +536,7 @@ public struct ChatSheet: View {
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 24)
+            nowContextBanner
             starterPromptChips
             Spacer()
         }
@@ -604,6 +613,69 @@ public struct ChatSheet: View {
         case 1:  return CT.sunGoldDeep
         default: return .indigo
         }
+    }
+
+    // MARK: - Contextual NOW banner
+
+    /// A single sun-gold pill on the empty chat that shifts copy with the hour —
+    /// the chat's equivalent of the map's "AI · NOW" framing. It grounds the
+    /// blank state in *this moment* ("Golden light soon · the river bank is
+    /// calling") instead of a generic prompt, nudging the right question.
+    private var nowContextBanner: some View {
+        let copy = Self.nowContextCopy(hour: nowHour)
+        return HStack(spacing: 6) {
+            Image(systemName: nowContextIcon)
+                .font(.system(size: 12, weight: .semibold))
+            Text(copy)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+        }
+        .foregroundStyle(CT.sunGoldDeep)
+        .padding(.horizontal, 13)
+        .padding(.vertical, 7)
+        .background(CT.sunGoldSoft, in: Capsule())
+        .padding(.horizontal, 28)
+        .padding(.bottom, 4)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(String(
+            format: NSLocalizedString("chat.empty.now.a11y", comment: "NOW banner a11y prefix"),
+            copy
+        )))
+    }
+
+    /// Current local hour (0–23). A computed property so the banner reflects the
+    /// hour the sheet was opened.
+    private var nowHour: Int {
+        Calendar.current.component(.hour, from: Date())
+    }
+
+    private var nowContextIcon: String {
+        switch nowHour {
+        case 5..<8:   return "sunrise.fill"
+        case 8..<11:  return "cup.and.saucer.fill"
+        case 11..<15: return "sun.max.fill"
+        case 15..<17: return "sun.haze.fill"
+        case 17..<19: return "sunset.fill"
+        case 19..<22: return "moon.stars.fill"
+        default:      return "moon.fill"
+        }
+    }
+
+    /// Map an hour to a contextual one-liner. Static + pure so it's trivially
+    /// unit-testable without constructing the whole sheet.
+    static func nowContextCopy(hour: Int) -> String {
+        let key: String
+        switch hour {
+        case 5..<8:   key = "chat.empty.now.dawn"
+        case 8..<11:  key = "chat.empty.now.morning"
+        case 11..<15: key = "chat.empty.now.midday"
+        case 15..<17: key = "chat.empty.now.afternoon"
+        case 17..<19: key = "chat.empty.now.goldenHour"
+        case 19..<22: key = "chat.empty.now.evening"
+        default:      key = "chat.empty.now.night"
+        }
+        return NSLocalizedString(key, comment: "Contextual NOW banner copy for the hour")
     }
 
     // MARK: - Visual helpers (dark-mode aware)

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -26,6 +26,14 @@ public struct ExperienceDetailView: View {
     /// this closure so the parent can re-bind the detail sheet to the chosen
     /// experience. When nil the cards render as plain non-interactive views.
     var onSelectExperience: ((_ experience: Experience) -> Void)?
+    /// When non-nil (and the place has a coordinate), the ··· menu offers a
+    /// deep cross-compile entry — parity with the floating preview card's own
+    /// recompile menu. The parent owns the work (MapViewModel.recompileExperience)
+    /// and reports progress back via `isRecompiling`. nil → menu omits the item,
+    /// so previews/tests with no Map context are unaffected.
+    var onRecompile: (() -> Void)?
+    /// Drives the menu's progress spinner while the parent's recompile runs.
+    var isRecompiling: Bool
 
     @Environment(\.themeService) private var themeService
     @Environment(LocationService.self) private var locationService
@@ -50,13 +58,17 @@ public struct ExperienceDetailView: View {
         onClose: @escaping () -> Void = {},
         onMarkDone: ((_ experience: Experience) -> Void)? = nil,
         onAskSolo: ((_ experience: Experience) -> Void)? = nil,
-        onSelectExperience: ((_ experience: Experience) -> Void)? = nil
+        onSelectExperience: ((_ experience: Experience) -> Void)? = nil,
+        onRecompile: (() -> Void)? = nil,
+        isRecompiling: Bool = false
     ) {
         self.viewModel = viewModel
         self.onClose = onClose
         self.onMarkDone = onMarkDone
         self.onAskSolo = onAskSolo
         self.onSelectExperience = onSelectExperience
+        self.onRecompile = onRecompile
+        self.isRecompiling = isRecompiling
     }
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -146,6 +158,22 @@ public struct ExperienceDetailView: View {
             }
             ToolbarItem(placement: .topBarTrailing) {
                 Menu {
+                    // Parity with the floating card: deep cross-compile lives at
+                    // the top of the ··· menu. Shown only when the parent wired a
+                    // recompile handler AND the place has a coordinate to enrich
+                    // around — same guard the card uses (ExperienceCardView).
+                    if let onRecompile, viewModel.experience.coordinate != nil {
+                        Button {
+                            Haptics.impact(.light)
+                            onRecompile()
+                        } label: {
+                            Label(
+                                NSLocalizedString("recompile.action", comment: "Deep cross-compile menu item"),
+                                systemImage: "sparkle.magnifyingglass"
+                            )
+                        }
+                        Divider()
+                    }
                     Button {
                         exportMarkdown = MarkdownExporter.export(viewModel.experience)
                     } label: {
@@ -163,7 +191,15 @@ public struct ExperienceDetailView: View {
                         )
                     }
                 } label: {
-                    Image(systemName: "ellipsis.circle")
+                    // While a recompile runs, swap the ··· glyph for a spinner so
+                    // the in-flight cross-compile is visible without a toast.
+                    if isRecompiling {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .controlSize(.small)
+                    } else {
+                        Image(systemName: "ellipsis.circle")
+                    }
                 }
                 .accessibilityLabel(Text(NSLocalizedString("detail.more", comment: "More options")))
             }

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -114,6 +114,9 @@ struct CompassMapContentView: View {
     private let presenceService: PresenceService
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    /// Honored by the preview-card pop animation on long-press: motion-sensitive
+    /// users get an instant, spring-free selection instead of the scale+rise.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// US-049: the shared 60s clock. Reading `tick` inside `mapLayer` re-evaluates
     /// the marker layer every minute, so a best-now pin flips to its amber
     /// "closing soon" treatment live as its window crosses the 45-min threshold —
@@ -796,7 +799,29 @@ struct CompassMapContentView: View {
                         )
                         .padding(.bottom, cardBottomInset)
                     }
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    // Pop-out entrance: the card scales up from a slightly
+                    // smaller, bottom-anchored state while rising — paired with
+                    // the spring driving `selectExperience` on long-press, it
+                    // reads as the card springing out of the pressed pin rather
+                    // than sliding flatly up from the screen edge. reduceMotion
+                    // collapses this to a plain fade.
+                    .transition(reduceMotion
+                        ? .opacity
+                        : .scale(scale: 0.92, anchor: .bottom)
+                            .combined(with: .move(edge: .bottom))
+                            .combined(with: .opacity))
+                    // Approach C (peek parity): the floating card is reachable
+                    // without ever opening the full detail sheet (long-press
+                    // peek, nearby-list tap). Mirror the detail sheet's
+                    // auto-upgrade so a shallow OSM skeleton silently deep
+                    // cross-compiles in the background here too — otherwise a
+                    // user who only peeks the card is stuck on the "real place
+                    // from OpenStreetMap" template forever. No-op for Pro-less
+                    // users, already-rich cards, or cards upgraded earlier this
+                    // session — autoUpgradeExperience enforces all three.
+                    .task(id: selected.id) {
+                        await viewModel.autoUpgradeExperience(selected)
+                    }
                 }
 
                 // Active-route banner: a pill naming the walk with an end button.
@@ -997,7 +1022,13 @@ struct CompassMapContentView: View {
                         withAnimation(.easeInOut(duration: 0.3)) {
                             viewModel.selectExperience(experience)
                         }
-                    }
+                    },
+                    // Detail-sheet parity with the floating card's recompile
+                    // menu: same MapViewModel work, same in-flight flag.
+                    onRecompile: {
+                        Task { await viewModel.recompileExperience(exp) }
+                    },
+                    isRecompiling: viewModel.recompilingExperienceId == exp.id
                 )
                 // Bind SwiftUI identity to the experience so selecting a
                 // different one rebuilds the detail view AND its @State
@@ -1005,7 +1036,14 @@ struct CompassMapContentView: View {
                 // viewModel kept the original experience and an in-detail
                 // "nearby" tap changed nothing on screen. The transition
                 // gives the rebuild a visible cross-fade + slide.
-                .id(exp.id)
+                //
+                // `updatedAt` is folded into the identity so an in-place
+                // recompile (which keeps the same id via `adoptingContent` and
+                // only bumps `updatedAt`) also rebuilds the @State view model —
+                // otherwise the menu's deep cross-compile would swap the backing
+                // experience but the sheet would keep rendering the stale
+                // skeleton copy it snapshotted at init.
+                .id("\(exp.id)-\(exp.updatedAt.timeIntervalSince1970)")
                 .transition(.asymmetric(
                     insertion: .move(edge: .trailing).combined(with: .opacity),
                     removal: .move(edge: .leading).combined(with: .opacity)
@@ -1332,8 +1370,15 @@ struct CompassMapContentView: View {
                             .buttonStyle(.plain)
                             // Long-press a pin → float the quick preview card
                             // (former tap behavior) instead of opening detail.
+                            // Drive the selection through a spring so the card's
+                            // scale+rise transition reads as "popped out of the
+                            // pin you pressed", not a flat slide-up. The other
+                            // select paths (tap, list) already animate; this one
+                            // was the bare exception. reduceMotion → no spring.
                             .modifier(LongPressCardModifier(onLongPress: {
-                                viewModel.selectExperience(exp)
+                                withAnimation(reduceMotion ? nil : .spring(response: 0.34, dampingFraction: 0.72)) {
+                                    viewModel.selectExperience(exp)
+                                }
                             }))
                             .transition(.scale.combined(with: .opacity))
                             .accessibilityLabel(Text(exp.title))


### PR DESCRIPTION
## Summary

Redesigns the Solo Compass AI chat's **thinking state** to match the design handoff (claude.ai/design → `SoloCompass.html`), then bundles a carried-over per-card recompile entry.

**Chat thinking-state redesign** (the focus of this PR)
- **One indicator, not two.** The old chat showed an always-on `ReasoningTracePanel` *and* a `TypingIndicatorBubble` at the same time — the exact "noisy, three loaders at once" problem the design transcript calls out. Now there's exactly one in-flight indicator: `AgentStatusLine` (single spinner + one cross-fading phrase).
- **Calm now, auditable later.** When a turn finishes, the live `reasoningTrace` is distilled into a `ReasoningSummary` and pinned beneath the reply as one tappable `ReasoningSummaryChip` — `✓ Searched 14 places · 2 matched` — expandable to the full ordered step detail. Previously the trace just vanished, losing the audit trail.
- **Contextual AI·NOW empty state.** The blank chat now shows a sun-gold banner that shifts copy with the hour (golden hour → "Golden light soon · the river bank is calling"), via a pure, unit-testable `ChatSheet.nowContextCopy(hour:)`.
- All new strings localized in **en + zh-Hans**.

**Carried-over: per-card recompile entry** (authored in a prior session, bundled at request)
- Adds a single-card "recompile" action to the experience detail menu so a user can re-run multi-channel AI enrichment for one place on demand. `ExperienceDetailView` exposes `onRecompile` + `isRecompiling`; `MapViewModel` owns the work.

### Design fidelity note
The design's other two patterns — the hold-to-talk recording bar and the POI/route result cards — already exist in the iOS app as production-grade implementations (real `SFSpeechRecognizer` streaming + waveform; `ChatExperienceCard`/`ChatRouteProposalCard` with category discs, reasonNow banners, numbered stop strips). Those meet or exceed the web prototype, so this PR intentionally leaves them unchanged rather than downgrading real functionality to match a demo.

## Test Coverage
- `AgentStatusLine`, `ReasoningSummaryChip` (collapsed) render correctly — verified via ImageRenderer PNGs (eyeballed: spinner + quiet phrase; green-check mono chip with chevron).
- `ChatSheet.nowContextCopy(hour:)` — exhaustive 0–23 hour coverage asserting no raw localization keys leak + golden-hour framing present. **Executed 3 tests, 0 failures.**
- `xcodebuild build` ✅ BUILD SUCCEEDED; `xcodebuild build-for-testing` ✅ TEST BUILD SUCCEEDED.
- Temp render test was removed after verification.

## Pre-Landing Review
Self-reviewed. New `ReasoningSummary` is purely additive (no change to existing `ChatCard`/`ReasoningStep`). Live trace is archived + cleared per turn in both the normal and budget-overflow completion paths, so only one indicator is ever live. `ReasoningTracePanel`/`TypingIndicatorBubble` retained (still referenced by existing render tests) but no longer used in the main chat flow.

## Notes
- Did **not** run the full XCTest suite — per project memory, `main` carries a known-red test baseline (DocComments/closingSoon/AskSoloCTA/parity) plus an intermittent "runner hung before connection" environment flake. iOS CI gates on **build**, not test. Relevant chat/card changes were build-verified and render-verified.
- No `Experience` schema fields changed → `pnpm parity:check` not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)