### PR TITLE
feat: platform moderator/admin roles + friend auto-accept

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		8E347182E133BD35C712AADB /* FilterChipContrastTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E8F519A353F18BDE4C3307 /* FilterChipContrastTest.swift */; };
 		8F8ED2236A149DAE2B3923CF /* ShareCardComponentsL10nTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7324256A8D7E93FBA67F91 /* ShareCardComponentsL10nTest.swift */; };
 		90C2EC1E98DDE7C3D3A5B4E9 /* GroupConversationAutoCreateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48ADAE2497800574C4E8819B /* GroupConversationAutoCreateTests.swift */; };
+		915E4532026427BA9F00B39D /* ModerationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71031524B916484E4C152E6 /* ModerationView.swift */; };
 		95389B7D23017957CB6C69E0 /* RouteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66273C940FD90B51EBCD97BC /* RouteBuilder.swift */; };
 		953C7BD48AF4AF55608145A6 /* LanguageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87002BB6D344B384A3FDFBFD /* LanguageService.swift */; };
 		95960204376DC82FBC3EBB9D /* WeatherSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B922F9040238050C82A5F312 /* WeatherSignal.swift */; };
@@ -221,6 +222,7 @@
 		96454A8DFA4F596AAD8B790E /* ChatCardStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91E024770F8793AB27EF247 /* ChatCardStack.swift */; };
 		96A79D8DD36F5B67B3146998 /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F32B7DE32405561C4159843 /* ChatMessage.swift */; };
 		9711B8A5617CB02D05776B6C /* SettingsLanguageSwitchRestartTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB0F8921D16545D7234EF2F /* SettingsLanguageSwitchRestartTest.swift */; };
+		974571FE2F043041CD3A0DD4 /* AdminService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF753CC02718028B12891042 /* AdminService.swift */; };
 		980B4B61D10AA12BFF2CD171 /* FriendService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3671315E80FB41CDA396AF69 /* FriendService.swift */; };
 		98245881AB35CB7BB16688FC /* JoinRouteRequestSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099B762F3026466B64C18015 /* JoinRouteRequestSheet.swift */; };
 		987A873E2C50C8064135E1EF /* ShareCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5895B058A34A2634E816A72F /* ShareCardModel.swift */; };
@@ -661,6 +663,7 @@
 		A5F2BB13078B86C9BEDE7ADD /* WeatherCacheRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherCacheRecord.swift; sourceTree = "<group>"; };
 		A644911E7B2824A7ABBA4D6F /* SeedRoutesParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedRoutesParityTests.swift; sourceTree = "<group>"; };
 		A6F061EC88D5CC60CDEE2515 /* PushTokenService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTokenService.swift; sourceTree = "<group>"; };
+		A71031524B916484E4C152E6 /* ModerationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationView.swift; sourceTree = "<group>"; };
 		A744E7B767BDEC07E9C58F4D /* PressableButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PressableButtonStyle.swift; sourceTree = "<group>"; };
 		A7D06753CFAA5198FCB3FF96 /* DiscoverFriendGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverFriendGateTests.swift; sourceTree = "<group>"; };
 		A7E8E3F1E2D1A0382CC5D9A6 /* ChatService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatService.swift; sourceTree = "<group>"; };
@@ -789,6 +792,7 @@
 		FAFFA243BC698EF20C6BC1EF /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 		FBBF77E10D341C38C093D22D /* CompanionBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionBlock.swift; sourceTree = "<group>"; };
 		FC366DD24E9174448BF06A2D /* CompassMapViewBodyTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompassMapViewBodyTypeTests.swift; sourceTree = "<group>"; };
+		FF753CC02718028B12891042 /* AdminService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminService.swift; sourceTree = "<group>"; };
 		FF7D0A1F8E3B8909F465194C /* ObsidianThemeContrastTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObsidianThemeContrastTest.swift; sourceTree = "<group>"; };
 		FFC5559A4AAF4E3CD77E38B6 /* MapViewModelCityCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModelCityCacheTests.swift; sourceTree = "<group>"; };
 		FFED848E66BBE2A234AAA3CC /* FilterBarScrollAffordanceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarScrollAffordanceTest.swift; sourceTree = "<group>"; };
@@ -888,6 +892,14 @@
 				382EF7CC608A45DB8A46A2EE /* Share */,
 			);
 			path = Companion;
+			sourceTree = "<group>";
+		};
+		2993AE82E369996DD34779DC /* Admin */ = {
+			isa = PBXGroup;
+			children = (
+				A71031524B916484E4C152E6 /* ModerationView.swift */,
+			);
+			path = Admin;
 			sourceTree = "<group>";
 		};
 		2A5B2A9CBB684C51EA76313E /* Map */ = {
@@ -1199,6 +1211,7 @@
 		68417DC1101B6DFD2DB9673C /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				FF753CC02718028B12891042 /* AdminService.swift */,
 				F4814DBCEAB5975B6338558D /* AIService.swift */,
 				42FC5ADBFDDA89BC42C8748D /* AppleSignInService.swift */,
 				4617984392FDCCA6F2F9FAD7 /* BestNowClock.swift */,
@@ -1362,6 +1375,7 @@
 		993B6773487C7744097F4175 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				2993AE82E369996DD34779DC /* Admin */,
 				78E954A36C9CA4C8D59A4CD8 /* Chat */,
 				1E97D71FC3AACEBF3EAB70F0 /* Companion */,
 				0807CE55F43B61AC22836519 /* Experience */,
@@ -1747,6 +1761,7 @@
 				09D620F3F748072EBF4AD680 /* AddFriendButton.swift in Sources */,
 				6FAA75544A1755C5712F30BA /* AddFriendSheet.swift in Sources */,
 				8D5DD4E0CD6237FA70C7F99F /* AddToItinerarySheet.swift in Sources */,
+				974571FE2F043041CD3A0DD4 /* AdminService.swift in Sources */,
 				D825B4D4C81AC33373DA1437 /* AgentMessage.swift in Sources */,
 				371DDBAF4C385267248ABC83 /* AgentRouter.swift in Sources */,
 				1D8CCDA07285B75840FCF194 /* AppleSignInService.swift in Sources */,
@@ -1876,6 +1891,7 @@
 				561418100F2F7D4D88DE1BC4 /* MessageBubble.swift in Sources */,
 				C7F4A9BD252AC60BDBD74585 /* MicroSurveyRecord.swift in Sources */,
 				214AF641496E8E50E3EC5FE4 /* MicroSurveySheet.swift in Sources */,
+				915E4532026427BA9F00B39D /* ModerationView.swift in Sources */,
 				5F3ACD03660F3E8B88814C56 /* MyHostedRoutesListView.swift in Sources */,
 				4F85ADCAE47D7654A6A91068 /* MyRequestsListView.swift in Sources */,
 				690ED25AA3EDA8529E915850 /* MyWalkedRoutesListView.swift in Sources */,

--- a/apps/ios/SoloCompass/Models/CompanionProfile.swift
+++ b/apps/ios/SoloCompass/Models/CompanionProfile.swift
@@ -22,6 +22,24 @@ public enum CompanionVisibility: String, Codable, CaseIterable, Sendable {
     case nearby_and_itinerary
 }
 
+// MARK: - UserRole
+
+/// Platform-level access role. Mirrors `UserRole` in `packages/core/src/companion.ts`.
+///
+/// Orthogonal to the P2P friend graph — `moderator` and `admin` can read the
+/// full moderation queue and take moderation actions. Defaults to `.user`;
+/// elevation is server-side only.
+public enum UserRole: String, Codable, CaseIterable, Sendable {
+    case user
+    case moderator
+    case admin
+
+    /// True when this role can access the moderation queue and act on reports.
+    public var canModerate: Bool {
+        self == .moderator || self == .admin
+    }
+}
+
 // MARK: - CompanionProfile
 
 /// A user's public-facing companion identity — avatar, bio, languages, and discovery visibility.
@@ -36,6 +54,8 @@ public struct CompanionProfile: Identifiable, Codable, Sendable {
     public let languages: [String]
     /// Controls whether and how the user appears in discovery. Default: off.
     public let visibility: CompanionVisibility
+    /// Platform access role. Default: .user. Elevated server-side only.
+    public let role: UserRole
     /// ISO 8601 UTC timestamp.
     public let createdAt: String
     /// ISO 8601 UTC timestamp.
@@ -48,6 +68,7 @@ public struct CompanionProfile: Identifiable, Codable, Sendable {
         bio: String,
         languages: [String],
         visibility: CompanionVisibility = .off,
+        role: UserRole = .user,
         createdAt: String,
         updatedAt: String
     ) {
@@ -57,8 +78,25 @@ public struct CompanionProfile: Identifiable, Codable, Sendable {
         self.bio = bio
         self.languages = languages
         self.visibility = visibility
+        self.role = role
         self.createdAt = createdAt
         self.updatedAt = updatedAt
+    }
+
+    // Custom decoder so older payloads / cached rows without `role` (or
+    // `visibility`) decode leniently to a default rather than throwing — same
+    // posture as FriendRequest / Friendship / Conversation.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(CompanionProfileId.self, forKey: .id)
+        self.userId = try c.decode(String.self, forKey: .userId)
+        self.avatarEmoji = try c.decode(String.self, forKey: .avatarEmoji)
+        self.bio = try c.decode(String.self, forKey: .bio)
+        self.languages = try c.decode([String].self, forKey: .languages)
+        self.visibility = (try? c.decode(CompanionVisibility.self, forKey: .visibility)) ?? .off
+        self.role = (try? c.decode(UserRole.self, forKey: .role)) ?? .user
+        self.createdAt = try c.decode(String.self, forKey: .createdAt)
+        self.updatedAt = try c.decode(String.self, forKey: .updatedAt)
     }
 }
 
@@ -72,6 +110,7 @@ extension CompanionProfile {
         bio: "Solo traveler, 12 countries. Loves quiet coffee shops, hidden temples, and dawn hikes.",
         languages: ["en", "zh"],
         visibility: .itinerary_only,
+        role: .user,
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z"
     )

--- a/apps/ios/SoloCompass/Models/CompanionReport.swift
+++ b/apps/ios/SoloCompass/Models/CompanionReport.swift
@@ -33,6 +33,10 @@ public struct CompanionReport: Identifiable, Codable, Sendable {
     public let details: String?
     /// ISO 8601 UTC timestamp.
     public let createdAt: String
+    /// ISO 8601 UTC timestamp when a moderator handled this report. nil = open.
+    public let resolvedAt: String?
+    /// The moderator/admin user id that resolved this report.
+    public let resolvedBy: String?
 
     public init(
         id: CompanionReportId,
@@ -40,7 +44,9 @@ public struct CompanionReport: Identifiable, Codable, Sendable {
         targetUserId: String,
         reason: CompanionReportReason,
         details: String? = nil,
-        createdAt: String
+        createdAt: String,
+        resolvedAt: String? = nil,
+        resolvedBy: String? = nil
     ) {
         self.id = id
         self.reporterId = reporterId
@@ -48,6 +54,59 @@ public struct CompanionReport: Identifiable, Codable, Sendable {
         self.reason = reason
         self.details = details
         self.createdAt = createdAt
+        self.resolvedAt = resolvedAt
+        self.resolvedBy = resolvedBy
+    }
+
+    // Custom Codable: PostgREST returns snake_case columns, and older rows
+    // predate the resolution fields. Decode tolerates both camelCase and
+    // snake_case keys (missing → nil / open). Encode emits camelCase (the
+    // shape the rest of the app and the TS core type use).
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case reporterId, reporter_id
+        case targetUserId, target_user_id
+        case reason
+        case details
+        case createdAt, created_at
+        case resolvedAt, resolved_at
+        case resolvedBy, resolved_by
+    }
+
+    /// First non-nil string across the given keys (camelCase then snake_case).
+    private static func firstString(
+        _ c: KeyedDecodingContainer<CodingKeys>,
+        _ keys: [CodingKeys]
+    ) -> String? {
+        for key in keys {
+            // `try?` flattens the `String??` from decodeIfPresent to `String?`.
+            if let v = try? c.decodeIfPresent(String.self, forKey: key) { return v }
+        }
+        return nil
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(CompanionReportId.self, forKey: .id)
+        self.reporterId = Self.firstString(c, [.reporterId, .reporter_id]) ?? ""
+        self.targetUserId = Self.firstString(c, [.targetUserId, .target_user_id]) ?? ""
+        self.reason = (try? c.decode(CompanionReportReason.self, forKey: .reason)) ?? .other
+        self.details = Self.firstString(c, [.details])
+        self.createdAt = Self.firstString(c, [.createdAt, .created_at]) ?? ""
+        self.resolvedAt = Self.firstString(c, [.resolvedAt, .resolved_at])
+        self.resolvedBy = Self.firstString(c, [.resolvedBy, .resolved_by])
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(reporterId, forKey: .reporterId)
+        try c.encode(targetUserId, forKey: .targetUserId)
+        try c.encode(reason, forKey: .reason)
+        try c.encodeIfPresent(details, forKey: .details)
+        try c.encode(createdAt, forKey: .createdAt)
+        try c.encodeIfPresent(resolvedAt, forKey: .resolvedAt)
+        try c.encodeIfPresent(resolvedBy, forKey: .resolvedBy)
     }
 }
 

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -273,6 +273,23 @@
 "me.messages" = "Messages";
 "me.companion" = "Companion";
 "me.settings" = "Settings";
+"me.admin.section" = "Moderation";
+"me.moderation" = "Report queue";
+
+/* Moderation queue (admin / moderator) */
+"moderation.title" = "Moderation";
+"moderation.empty.title" = "All clear";
+"moderation.empty.message" = "No safety reports to review.";
+"moderation.section.open" = "Open";
+"moderation.section.resolved" = "Resolved";
+"moderation.action.ban" = "Ban";
+"moderation.action.resolve" = "Resolve";
+"moderation.row.target" = "Reported: %@";
+"moderation.reason.spam" = "Spam";
+"moderation.reason.harassment" = "Harassment";
+"moderation.reason.inappropriate" = "Inappropriate content";
+"moderation.reason.fakeProfile" = "Fake profile";
+"moderation.reason.other" = "Other";
 "me.profile.name" = "Solo Traveler";
 "me.profile.subtitle" = "Your compass, your journey";
 "me.friends.incoming" = "Friend Requests";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1593,6 +1593,23 @@
 "me.messages" = "消息";
 "me.companion" = "旅伴";
 "me.settings" = "设置";
+"me.admin.section" = "审核";
+"me.moderation" = "举报队列";
+
+/* 审核队列（管理员 / 审核员） */
+"moderation.title" = "内容审核";
+"moderation.empty.title" = "一切正常";
+"moderation.empty.message" = "暂无待处理的安全举报。";
+"moderation.section.open" = "待处理";
+"moderation.section.resolved" = "已处理";
+"moderation.action.ban" = "封禁";
+"moderation.action.resolve" = "标记已处理";
+"moderation.row.target" = "被举报：%@";
+"moderation.reason.spam" = "垃圾信息";
+"moderation.reason.harassment" = "骚扰";
+"moderation.reason.inappropriate" = "不当内容";
+"moderation.reason.fakeProfile" = "虚假资料";
+"moderation.reason.other" = "其他";
 "me.profile.name" = "独行旅人";
 "me.profile.subtitle" = "你的罗盘，你的旅程";
 "me.profile.progress.a11y" = "已探索 %d / %d 个收藏地点";

--- a/apps/ios/SoloCompass/Services/AdminService.swift
+++ b/apps/ios/SoloCompass/Services/AdminService.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Observation
+
+/// Platform moderation client. Wraps the three things a moderator / admin
+/// needs from the backend:
+///
+///   1. the current user's platform `role` (drives whether the moderation
+///      entry point appears at all),
+///   2. the full moderation queue (companion_reports — readable only by
+///      moderators/admins thanks to the 0012 RLS policy),
+///   3. moderation actions (ban / unban / setRole / resolveReport), all routed
+///      through the `moderate-action` Edge Function so the privilege-guard
+///      trigger permits the write.
+///
+/// Everything degrades to a no-op / empty result when `FF_BACKEND_SYNC` is off
+/// (the underlying `SupabaseClient` short-circuits), preserving the local-first
+/// invariant: a moderator simply sees an empty queue offline rather than an
+/// error.
+@Observable
+@MainActor
+public final class AdminService {
+    public static let shared = AdminService()
+
+    private let client: SupabaseClientProtocol
+
+    /// The current user's platform role. `.user` until `refreshRole()` lands a
+    /// value from the backend. Drives the admin-gated UI.
+    public private(set) var currentRole: UserRole = .user
+
+    /// The moderation queue (unresolved reports first). Empty until loaded.
+    public private(set) var reports: [CompanionReport] = []
+
+    public private(set) var isLoading: Bool = false
+    public private(set) var lastError: String?
+
+    public init(client: SupabaseClientProtocol = SupabaseClient.shared) {
+        self.client = client
+    }
+
+    /// True when the current user can open the moderation tools.
+    public var canModerate: Bool { currentRole.canModerate }
+
+    /// True when the current user can change roles (admin only).
+    public var canManageRoles: Bool { currentRole == .admin }
+
+    private var currentUserId: String { client.currentSession?.userId ?? "local" }
+
+    // MARK: - Role
+
+    /// Fetch the current user's `role` from `companion_profiles`. Falls back to
+    /// `.user` on any miss (no row, backend off, decode failure).
+    public func refreshRole() async {
+        let query = [
+            URLQueryItem(name: "select", value: "role,is_banned"),
+            URLQueryItem(name: "user_id", value: "eq.\(currentUserId)"),
+            URLQueryItem(name: "limit", value: "1"),
+        ]
+        let result = await client.get(table: "companion_profiles", query: query)
+        guard case .success(let data) = result, !data.isEmpty else {
+            currentRole = .user
+            return
+        }
+        struct Row: Decodable { let role: String?; let is_banned: Bool? }
+        let rows = (try? JSONDecoder().decode([Row].self, from: data)) ?? []
+        guard let row = rows.first, row.is_banned != true,
+              let raw = row.role, let parsed = UserRole(rawValue: raw) else {
+            currentRole = .user
+            return
+        }
+        currentRole = parsed
+    }
+
+    // MARK: - Queue
+
+    /// Load the moderation queue. The 0012 `companion_reports moderator-select`
+    /// policy returns the full table for moderators/admins; for a plain user it
+    /// returns only their own reports, so guard on `canModerate` first.
+    public func refreshReports() async {
+        guard canModerate else { reports = []; return }
+        isLoading = true
+        lastError = nil
+        defer { isLoading = false }
+
+        let query = [
+            URLQueryItem(name: "select", value: "*"),
+            URLQueryItem(name: "order", value: "resolved_at.asc.nullsfirst,created_at.desc"),
+            URLQueryItem(name: "limit", value: "200"),
+        ]
+        let result = await client.get(table: "companion_reports", query: query)
+        switch result {
+        case .success(let data):
+            guard !data.isEmpty else { reports = []; return }
+            reports = (try? JSONDecoder().decode([CompanionReport].self, from: data)) ?? []
+        case .failure(let err):
+            lastError = err.localizedDescription
+        }
+    }
+
+    // MARK: - Actions
+
+    public enum ModerationAction {
+        case ban(targetUserId: String)
+        case unban(targetUserId: String)
+        case resolveReport(reportId: String)
+        case setRole(targetUserId: String, role: UserRole)
+
+        var body: [String: String] {
+            switch self {
+            case .ban(let id):            return ["action": "ban", "targetUserId": id]
+            case .unban(let id):          return ["action": "unban", "targetUserId": id]
+            case .resolveReport(let id):  return ["action": "resolveReport", "reportId": id]
+            case .setRole(let id, let r): return ["action": "setRole", "targetUserId": id, "role": r.rawValue]
+            }
+        }
+    }
+
+    /// Perform a moderation action via the Edge Function. Returns true on
+    /// success. On success the local queue is refreshed so resolved/handled
+    /// rows update immediately.
+    @discardableResult
+    public func perform(_ action: ModerationAction) async -> Bool {
+        guard canModerate else { lastError = "forbidden"; return false }
+        guard let body = try? JSONSerialization.data(withJSONObject: action.body) else {
+            lastError = "could not encode action"
+            return false
+        }
+        let result = await client.invoke(function: "moderate-action", body: body)
+        switch result {
+        case .success(let data):
+            // Edge function returns { ok: true } / { error }. A backend-off
+            // no-op returns empty Data — treat as success (nothing to do).
+            if data.isEmpty { return true }
+            struct Resp: Decodable { let ok: Bool?; let error: String? }
+            let resp = try? JSONDecoder().decode(Resp.self, from: data)
+            if let err = resp?.error { lastError = err; return false }
+            await refreshReports()
+            return resp?.ok ?? true
+        case .failure(let err):
+            lastError = err.localizedDescription
+            return false
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Services/FeatureFlags.swift
+++ b/apps/ios/SoloCompass/Services/FeatureFlags.swift
@@ -91,11 +91,32 @@ public enum FeatureFlags {
     ///
     /// When false, all itinerary mutations still persist locally (SwiftData)
     /// but the outbox rows are never created, so no network traffic is
-    /// generated. Flip to true after `0003_companion.sql` is deployed.
+    /// generated.
     ///
-    /// Default off in Phase 1 beta — local-first invariant (PRD G7).
+    /// This is the master gate for the whole backend social stack — friends,
+    /// DMs (ChatService), companion discovery, presence, moderation reads, and
+    /// itinerary sync all check it. It also requires `backendSync` to be on for
+    /// any network call to actually fire.
+    ///
+    /// DEBUG builds default to ON so the social / friends / moderation surfaces
+    /// are immediately exercisable in the Simulator. Release builds read the
+    /// plist/env (`FF_COMPANION`) and default OFF, preserving the staged-rollout
+    /// posture (PRD G7 local-first invariant) until the backend is ready.
+    /// Override in DEBUG without rebuilding:
+    ///
+    ///     defaults write <app-bundle-id> FF_COMPANION -bool NO
     public static var companion: Bool {
-        readBool("FF_COMPANION", default: false)
+        #if DEBUG
+        if UserDefaults.standard.object(forKey: "FF_COMPANION") != nil {
+            return UserDefaults.standard.bool(forKey: "FF_COMPANION")
+        }
+        if let env = ProcessInfo.processInfo.environment["FF_COMPANION"] {
+            return env == "1" || env.lowercased() == "true"
+        }
+        return true
+        #else
+        return readBool("FF_COMPANION", default: false)
+        #endif
     }
 
     /// US-009: Master gate for the in-map Companion *layer* toggle (the

--- a/apps/ios/SoloCompass/Services/FriendService.swift
+++ b/apps/ios/SoloCompass/Services/FriendService.swift
@@ -86,7 +86,8 @@ public final class FriendService {
     public func sendRequest(
         to recipientId: String,
         source: FriendRequestSource,
-        note: String? = nil
+        note: String? = nil,
+        autoAcceptPolicy: AutoAcceptPolicy = .none
     ) async -> Result<SendRequestOutcome, Error> {
         guard FeatureFlags.companion else {
             return .failure(FriendServiceError.featureDisabled)
@@ -99,10 +100,23 @@ public final class FriendService {
         let hasInbound = incomingRequests.contains {
             $0.requesterId == recipientId && $0.status == .pending
         }
+        // Resolve the effective auto-accept policy: an explicit policy from the
+        // caller (co-traveler / opted-in) wins; otherwise fall back to a staff
+        // lookup so friending a moderator/admin always connects directly.
+        let effectivePolicy: AutoAcceptPolicy
+        if autoAcceptPolicy.grantsImmediate {
+            effectivePolicy = autoAcceptPolicy
+        } else if await isStaff(recipientId) {
+            effectivePolicy = .staffRecipient
+        } else {
+            effectivePolicy = .none
+        }
+
         let outcome = FriendshipStateMachine.resolveSendRequest(
             currentState: currentState,
             hasInboundPending: hasInbound,
-            isBlockedEitherWay: isBlocked(recipientId)
+            isBlockedEitherWay: isBlocked(recipientId),
+            autoAcceptPolicy: effectivePolicy
         )
 
         switch outcome {
@@ -119,6 +133,11 @@ public final class FriendService {
                 return res.map { _ in .autoAccepted }
             }
             return .success(.autoAccepted)
+
+        case .autoAcceptedDirect:
+            // Policy grants an immediate friendship with no inbound request.
+            let res = await createFriendshipDirect(with: recipientId)
+            return res.map { _ in .autoAcceptedDirect }
 
         case .createdPending:
             let trimmedNote = note.map { String($0.prefix(120)) }
@@ -837,6 +856,58 @@ public final class FriendService {
         // Without a loaded block list we conservatively return false and let
         // the server silently drop.
         false
+    }
+
+    /// True when `userId` is a platform moderator/admin. Friending staff
+    /// auto-connects (so users can always reach help). Reads the public
+    /// `companion_profiles.role`; any miss → false (normal pending flow).
+    private func isStaff(_ userId: String) async -> Bool {
+        let query = [
+            URLQueryItem(name: "select", value: "role,is_banned"),
+            URLQueryItem(name: "user_id", value: "eq.\(userId)"),
+            URLQueryItem(name: "limit", value: "1"),
+        ]
+        guard case .success(let data) = await client.get(table: "companion_profiles", query: query),
+              !data.isEmpty else { return false }
+        struct Row: Decodable { let role: String?; let is_banned: Bool? }
+        let rows = (try? JSONDecoder().decode([Row].self, from: data)) ?? []
+        guard let row = rows.first, row.is_banned != true,
+              let role = row.role.flatMap(UserRole.init(rawValue:)) else { return false }
+        return role.canModerate
+    }
+
+    /// Create a confirmed friendship immediately (no pending step), used when an
+    /// `AutoAcceptPolicy` applies. Mirrors `accept(_:)`'s friendship write minus
+    /// the inbound-request bookkeeping. `initiatedBy` is the current user.
+    @discardableResult
+    private func createFriendshipDirect(with recipientId: String) async -> Result<Friendship, Error> {
+        // Idempotency: if we somehow already have this friend, no-op success.
+        if let existing = friendship(with: recipientId) {
+            return .success(existing)
+        }
+        let pair = Friendship.orderedPair(currentUserId, recipientId)
+        let now = nowISO()
+        let friendship = Friendship(
+            id: FriendshipId(rawValue: "fnd_\(UUID().uuidString)"),
+            userLowId: pair.low,
+            userHighId: pair.high,
+            initiatedBy: currentUserId,
+            conversationId: nil,
+            acceptedAt: now,
+            createdAt: now,
+            updatedAt: now
+        )
+        guard let data = try? JSONEncoder.iso8601Encoder.encode(friendship) else {
+            return .failure(FriendServiceError.encodingFailed)
+        }
+        switch await client.post(table: "friendships", body: data) {
+        case .success:
+            friends.append(friendship)
+            persistFriendship(friendship)
+            return .success(friendship)
+        case .failure(let err):
+            return .failure(err)
+        }
     }
 
     // MARK: - Private: request status update

--- a/apps/ios/SoloCompass/Services/FriendshipStateMachine.swift
+++ b/apps/ios/SoloCompass/Services/FriendshipStateMachine.swift
@@ -42,14 +42,37 @@ public enum SendRequestOutcome: Equatable, Sendable {
     /// A normal new pending request should be created.
     case createdPending
     /// The recipient already had a pending request to the requester → both
-    /// want it, so auto-accept and create the friendship.
+    /// want it, so auto-accept the *existing inbound* request.
     case autoAccepted
+    /// An auto-accept policy applies (recipient is staff, a co-traveler, or the
+    /// recipient opted into auto-accept) with NO inbound request → create the
+    /// friendship directly, skipping the pending step.
+    case autoAcceptedDirect
     /// Already friends → no-op, return the existing friendship.
     case alreadyFriends
     /// The requester is blocked by the recipient (or vice-versa) → silently
     /// drop. We never reveal block status, so this *looks* like success to the
     /// caller but enqueues nothing.
     case silentlyDropped
+}
+
+/// Why a `sendRequest` should bypass the pending step and become an immediate
+/// friendship. Computed by the caller (which has the I/O to know these facts)
+/// and handed to the pure resolver. `.none` = normal pending flow.
+public enum AutoAcceptPolicy: Equatable, Sendable {
+    /// No auto-accept — the recipient must approve the request.
+    case none
+    /// The recipient is a platform moderator/admin (staff are reachable
+    /// directly so users can always get help).
+    case staffRecipient
+    /// Both users are confirmed members of the same route (co-travelers skip
+    /// the approval friction — FRIENDS_DESIGN §4).
+    case coTraveler
+    /// The recipient has turned on "auto-accept friend requests".
+    case recipientOptedIn
+
+    /// True when this policy grants an immediate friendship.
+    public var grantsImmediate: Bool { self != .none }
 }
 
 // MARK: - FriendshipStateMachine
@@ -104,11 +127,18 @@ public enum FriendshipStateMachine {
     ///   - hasInboundPending: true when the recipient already sent the
     ///     requester a still-pending request (the reverse direction).
     ///   - isBlockedEitherWay: true when either user has blocked the other.
+    ///   - autoAcceptPolicy: a non-`.none` policy makes the request bypass the
+    ///     pending step and become an immediate friendship (staff recipient,
+    ///     co-traveler, or recipient opted-in). Block/already-friends/mutual
+    ///     rules still take precedence over the policy.
     public static func resolveSendRequest(
         currentState: FriendRelationState,
         hasInboundPending: Bool,
-        isBlockedEitherWay: Bool
+        isBlockedEitherWay: Bool,
+        autoAcceptPolicy: AutoAcceptPolicy = .none
     ) -> SendRequestOutcome {
+        // Safety rules win over any auto-accept policy: never override a block,
+        // never re-create an existing friendship.
         if isBlockedEitherWay || currentState == .blocked {
             return .silentlyDropped
         }
@@ -117,6 +147,11 @@ public enum FriendshipStateMachine {
         }
         if hasInboundPending {
             return .autoAccepted
+        }
+        // No inbound request, relationship is open → an auto-accept policy
+        // creates the friendship directly; otherwise a normal pending request.
+        if autoAcceptPolicy.grantsImmediate {
+            return .autoAcceptedDirect
         }
         // currentState is .none or our own .pending (re-send) → pending.
         return .createdPending

--- a/apps/ios/SoloCompass/Tests/FriendshipStateMachineTests.swift
+++ b/apps/ios/SoloCompass/Tests/FriendshipStateMachineTests.swift
@@ -164,4 +164,88 @@ final class FriendshipStateMachineTests: XCTestCase {
         )
         XCTAssertEqual(outcome, .createdPending)
     }
+
+    // MARK: resolveSendRequest — auto-accept policy (default-friends rules)
+
+    func testResolveSendRequest_staffRecipient_autoAcceptsDirect() {
+        // Friending a moderator/admin from a clean slate → immediate friendship.
+        let outcome = FriendshipStateMachine.resolveSendRequest(
+            currentState: .none,
+            hasInboundPending: false,
+            isBlockedEitherWay: false,
+            autoAcceptPolicy: .staffRecipient
+        )
+        XCTAssertEqual(outcome, .autoAcceptedDirect)
+    }
+
+    func testResolveSendRequest_coTraveler_autoAcceptsDirect() {
+        let outcome = FriendshipStateMachine.resolveSendRequest(
+            currentState: .none,
+            hasInboundPending: false,
+            isBlockedEitherWay: false,
+            autoAcceptPolicy: .coTraveler
+        )
+        XCTAssertEqual(outcome, .autoAcceptedDirect)
+    }
+
+    func testResolveSendRequest_optedIn_autoAcceptsDirect() {
+        let outcome = FriendshipStateMachine.resolveSendRequest(
+            currentState: .none,
+            hasInboundPending: false,
+            isBlockedEitherWay: false,
+            autoAcceptPolicy: .recipientOptedIn
+        )
+        XCTAssertEqual(outcome, .autoAcceptedDirect)
+    }
+
+    func testResolveSendRequest_policyNone_staysPending() {
+        // The default policy must preserve the normal approval flow.
+        let outcome = FriendshipStateMachine.resolveSendRequest(
+            currentState: .none,
+            hasInboundPending: false,
+            isBlockedEitherWay: false,
+            autoAcceptPolicy: .none
+        )
+        XCTAssertEqual(outcome, .createdPending)
+    }
+
+    func testResolveSendRequest_block_winsOverAutoAcceptPolicy() {
+        // Safety: a block is never overridden by an auto-accept policy.
+        let outcome = FriendshipStateMachine.resolveSendRequest(
+            currentState: .none,
+            hasInboundPending: false,
+            isBlockedEitherWay: true,
+            autoAcceptPolicy: .staffRecipient
+        )
+        XCTAssertEqual(outcome, .silentlyDropped)
+    }
+
+    func testResolveSendRequest_alreadyFriends_winsOverAutoAcceptPolicy() {
+        let outcome = FriendshipStateMachine.resolveSendRequest(
+            currentState: .accepted,
+            hasInboundPending: false,
+            isBlockedEitherWay: false,
+            autoAcceptPolicy: .staffRecipient
+        )
+        XCTAssertEqual(outcome, .alreadyFriends)
+    }
+
+    func testResolveSendRequest_inboundPending_winsOverAutoAcceptPolicy() {
+        // A real inbound request folds to .autoAccepted (accept the existing
+        // request), not .autoAcceptedDirect (create fresh).
+        let outcome = FriendshipStateMachine.resolveSendRequest(
+            currentState: .none,
+            hasInboundPending: true,
+            isBlockedEitherWay: false,
+            autoAcceptPolicy: .staffRecipient
+        )
+        XCTAssertEqual(outcome, .autoAccepted)
+    }
+
+    func testAutoAcceptPolicy_grantsImmediate() {
+        XCTAssertFalse(AutoAcceptPolicy.none.grantsImmediate)
+        XCTAssertTrue(AutoAcceptPolicy.staffRecipient.grantsImmediate)
+        XCTAssertTrue(AutoAcceptPolicy.coTraveler.grantsImmediate)
+        XCTAssertTrue(AutoAcceptPolicy.recipientOptedIn.grantsImmediate)
+    }
 }

--- a/apps/ios/SoloCompass/Views/Admin/ModerationView.swift
+++ b/apps/ios/SoloCompass/Views/Admin/ModerationView.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+
+/// Moderation queue — the admin / moderator surface for safety reports.
+///
+/// Lists every `CompanionReport` (the 0012 RLS policy grants moderators/admins
+/// full-table read; plain users can't reach this screen — the MeSheet entry is
+/// gated on `AdminService.canModerate`). Each row shows who reported whom and
+/// why, and offers two actions: **Ban** the target user and **Resolve** the
+/// report (mark handled). Both route through the `moderate-action` Edge
+/// Function via `AdminService`.
+///
+/// Purely presentational + dispatch; all I/O lives in `AdminService`.
+public struct ModerationView: View {
+    @State private var service: AdminService
+    @State private var inFlightId: String?
+
+    private let autoRefresh: Bool
+
+    public init(service: AdminService = .shared, autoRefresh: Bool = true) {
+        _service = State(initialValue: service)
+        self.autoRefresh = autoRefresh
+    }
+
+    private var unresolved: [CompanionReport] {
+        service.reports.filter { $0.resolvedAt == nil }
+    }
+
+    private var resolved: [CompanionReport] {
+        service.reports.filter { $0.resolvedAt != nil }
+    }
+
+    public var body: some View {
+        Group {
+            if service.isLoading && service.reports.isEmpty {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if service.reports.isEmpty {
+                ContentUnavailableView(
+                    NSLocalizedString("moderation.empty.title", comment: "No reports title"),
+                    systemImage: "checkmark.shield",
+                    description: Text(NSLocalizedString("moderation.empty.message", comment: "No reports message"))
+                )
+            } else {
+                queueList
+            }
+        }
+        .navigationTitle(NSLocalizedString("moderation.title", comment: "Moderation queue title"))
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            if autoRefresh {
+                await service.refreshRole()
+                await service.refreshReports()
+            }
+        }
+        .refreshable { await service.refreshReports() }
+        .overlay(alignment: .bottom) {
+            if let error = service.lastError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(Color.red, in: Capsule())
+                    .padding(.bottom, 16)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .animation(.easeInOut, value: service.lastError)
+    }
+
+    private var queueList: some View {
+        List {
+            if !unresolved.isEmpty {
+                Section(NSLocalizedString("moderation.section.open", comment: "Open reports section")) {
+                    ForEach(unresolved, id: \.id.rawValue) { report in
+                        ReportRow(report: report, isResolved: false)
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button(role: .destructive) {
+                                    act(.ban(targetUserId: report.targetUserId), id: report.id.rawValue)
+                                } label: {
+                                    Label(NSLocalizedString("moderation.action.ban", comment: "Ban user"), systemImage: "hand.raised.fill")
+                                }
+                                Button {
+                                    act(.resolveReport(reportId: report.id.rawValue), id: report.id.rawValue)
+                                } label: {
+                                    Label(NSLocalizedString("moderation.action.resolve", comment: "Resolve report"), systemImage: "checkmark")
+                                }
+                                .tint(.green)
+                            }
+                    }
+                }
+            }
+
+            if !resolved.isEmpty {
+                Section(NSLocalizedString("moderation.section.resolved", comment: "Resolved reports section")) {
+                    ForEach(resolved, id: \.id.rawValue) { report in
+                        ReportRow(report: report, isResolved: true)
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .disabled(inFlightId != nil)
+    }
+
+    private func act(_ action: AdminService.ModerationAction, id: String) {
+        inFlightId = id
+        Haptics.impact(.medium)
+        Task {
+            await service.perform(action)
+            inFlightId = nil
+        }
+    }
+}
+
+// MARK: - Row
+
+private struct ReportRow: View {
+    let report: CompanionReport
+    let isResolved: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Image(systemName: reasonIcon)
+                    .foregroundStyle(isResolved ? Color.secondary : Color.orange)
+                Text(reasonLabel)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Spacer()
+                if isResolved {
+                    Image(systemName: "checkmark.seal.fill")
+                        .foregroundStyle(.green)
+                        .font(.caption)
+                }
+            }
+
+            Text(String(
+                format: NSLocalizedString("moderation.row.target", comment: "Reported user id: %@"),
+                UserDirectory.displayName(forId: report.targetUserId)
+            ))
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+
+            if let details = report.details, !details.isEmpty {
+                Text(details)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(3)
+            }
+
+            Text(report.createdAt)
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .monospacedDigit()
+        }
+        .padding(.vertical, 2)
+        .opacity(isResolved ? 0.55 : 1.0)
+    }
+
+    private var reasonLabel: String {
+        switch report.reason {
+        case .spam:                  return NSLocalizedString("moderation.reason.spam", comment: "Spam")
+        case .harassment:            return NSLocalizedString("moderation.reason.harassment", comment: "Harassment")
+        case .inappropriate_content: return NSLocalizedString("moderation.reason.inappropriate", comment: "Inappropriate content")
+        case .fake_profile:          return NSLocalizedString("moderation.reason.fakeProfile", comment: "Fake profile")
+        case .other:                 return NSLocalizedString("moderation.reason.other", comment: "Other")
+        }
+    }
+
+    private var reasonIcon: String {
+        switch report.reason {
+        case .spam:                  return "envelope.badge.shield.half.filled"
+        case .harassment:            return "exclamationmark.bubble.fill"
+        case .inappropriate_content: return "eye.trianglebadge.exclamationmark.fill"
+        case .fake_profile:          return "person.crop.circle.badge.xmark"
+        case .other:                 return "flag.fill"
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        ModerationView(autoRefresh: false)
+    }
+}

--- a/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
@@ -332,6 +332,8 @@ public struct ChatSheet: View {
     private var messageList: some View {
         if visibleMessages.isEmpty && orchestrator.streamingContent.isEmpty {
             emptyState
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(emptyStateBackground)
         } else {
             ScrollViewReader { proxy in
                 ScrollView {
@@ -566,37 +568,105 @@ public struct ChatSheet: View {
         }
     }
 
-    /// Hour-aware global empty state (the "+" entry). Unchanged voice: glyph →
-    /// title → subtitle → NOW banner → starter chips.
+    /// Hour-aware global empty state (the "+" entry). Sequence: hero glyph →
+    /// title → subtitle → NOW banner → starter cards. Rebuilt for a single warm
+    /// identity in both schemes — the cold systemGray fallback is gone; every
+    /// surface here sits on the amber ladder (`warm*Dark` / `CT.surface*`) with
+    /// a deliberate vertical rhythm instead of evenly-spaced rows.
     private var genericEmptyState: some View {
-        VStack(spacing: 14) {
-            Spacer()
-            Image(systemName: "bubble.left.and.bubble.right.fill")
-                .font(.title2.weight(.semibold))
-                .foregroundStyle(CT.accent)
-                .frame(width: 64, height: 64)
-                .background(CT.accentSoft, in: Circle())
-                .overlay(Circle().strokeBorder(CT.accentBorder, lineWidth: 0.5))
-                .shadow(color: CT.accent.opacity(0.12), radius: 8, y: 3)
+        VStack(spacing: 0) {
+            Spacer(minLength: 24)
+
+            heroGlyph
+                .padding(.bottom, 20)
+
             Text(NSLocalizedString("chat.empty.title", comment: "Ask me anything about places near you"))
-                .font(.subheadline.weight(.medium))
-                .foregroundStyle(.primary)
+                .font(CT.displayRounded(22, .bold))
+                .foregroundStyle(emptyTitleColor)
                 .multilineTextAlignment(.center)
-            Text(NSLocalizedString("chat.empty.subtitle", comment: "Try ‘what’s good around me?’ or hold the mic to talk."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
                 .padding(.horizontal, 24)
+                .padding(.bottom, 7)
+
+            Text(NSLocalizedString("chat.empty.subtitle", comment: "Try ‘what’s good around me?’ or hold the mic to talk."))
+                .font(.system(size: 13.5, weight: .regular))
+                .foregroundStyle(emptySubtitleColor)
+                .multilineTextAlignment(.center)
+                .lineSpacing(2)
+                .padding(.horizontal, 36)
+                .padding(.bottom, 18)
+
             nowContextBanner
+                .padding(.bottom, 22)
+
             starterPromptChips
-            Spacer()
+
+            Spacer(minLength: 24)
         }
         .frame(maxWidth: .infinity)
+        .opacity(starterPromptsAppeared ? 1 : 0)
         .onAppear {
-            withAnimation(.easeOut(duration: 0.4).delay(0.15)) {
+            withAnimation(.easeOut(duration: 0.45).delay(0.1)) {
                 starterPromptsAppeared = true
             }
         }
+    }
+
+    /// Hero glyph for the global empty state — a layered, breathing badge rather
+    /// than a flat disc. Two soft amber halos radiate behind a gradient-filled
+    /// inner circle so the mark reads as warm and dimensional on the dark sheet,
+    /// not a hard米白 cutout. The faint outer ring + inner highlight give it the
+    /// "lit from within" quality the detail page hero has.
+    private var heroGlyph: some View {
+        ZStack {
+            // Outer ambient halo — barely-there bloom that softens the edge
+            // against the near-black sheet.
+            Circle()
+                .fill(CT.accent.opacity(colorScheme == .dark ? 0.16 : 0.10))
+                .frame(width: 108, height: 108)
+                .blur(radius: 14)
+
+            // Mid ring — a thin warm border floating just outside the core.
+            Circle()
+                .strokeBorder(CT.sunGold.opacity(colorScheme == .dark ? 0.30 : 0.40), lineWidth: 1)
+                .frame(width: 82, height: 82)
+
+            // Core — gradient amber fill with a top highlight, white glyph.
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: colorScheme == .dark
+                            ? [CT.accent, CT.accentHover]
+                            : [CT.sunGoldSoft, CT.accentSoft],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: 68, height: 68)
+                .overlay(
+                    Circle().strokeBorder(
+                        Color.white.opacity(colorScheme == .dark ? 0.10 : 0.55),
+                        lineWidth: 0.75
+                    )
+                )
+                .overlay(
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 26, weight: .semibold))
+                        .foregroundStyle(colorScheme == .dark ? Color.white : CT.accent)
+                )
+                .shadow(color: CT.accent.opacity(colorScheme == .dark ? 0.45 : 0.18), radius: 12, y: 5)
+        }
+        .scaleEffect(starterPromptsAppeared ? 1 : 0.88)
+        .animation(reduceMotion ? nil : .spring(response: 0.5, dampingFraction: 0.7), value: starterPromptsAppeared)
+        .accessibilityHidden(true)
+    }
+
+    private var emptyTitleColor: Color {
+        colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary
+    }
+
+    private var emptySubtitleColor: Color {
+        colorScheme == .dark ? CT.fgMutedDark : CT.fgMuted
     }
 
     /// Place-anchored empty state. Leads with a compact hero of the place the
@@ -807,7 +877,7 @@ public struct ChatSheet: View {
     }
 
     private var starterPromptChips: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 11) {
             ForEach(Array(Self.starterPrompts.enumerated()), id: \.offset) { index, prompt in
                 Button {
                     Haptics.impact(.light)
@@ -822,17 +892,16 @@ public struct ChatSheet: View {
                 .buttonStyle(PressableButtonStyle())
                 .accessibilityLabel(prompt)
                 .opacity(starterPromptsAppeared ? 1 : 0)
-                .offset(y: starterPromptsAppeared ? 0 : 8)
+                .offset(y: starterPromptsAppeared ? 0 : 10)
                 .animation(
                     reduceMotion
                         ? nil
-                        : .easeOut(duration: 0.35).delay(Double(index) * 0.08),
+                        : .spring(response: 0.42, dampingFraction: 0.8).delay(0.18 + Double(index) * 0.07),
                     value: starterPromptsAppeared
                 )
             }
         }
-        .padding(.horizontal, 28)
-        .padding(.top, 4)
+        .padding(.horizontal, 24)
     }
 
     /// One opener row — shared by the global starter prompts and the
@@ -841,33 +910,59 @@ public struct ChatSheet: View {
     /// a step up in tactility from a bare glyph, and the chevron is the quiet
     /// "go" cue on the trailing edge.
     private func starterCardRow(icon: String, iconColor: Color, label: String) -> some View {
-        HStack(spacing: 12) {
+        HStack(spacing: 13) {
+            // Gradient-filled rounded tile — a tactile chip, not a flat tint.
+            // The diagonal gradient + hairline highlight give each icon a small
+            // bit of dimension so the row reads as a card, not a list cell.
             Image(systemName: icon)
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(iconColor)
-                .frame(width: 32, height: 32)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 38, height: 38)
                 .background(
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .fill(iconColor.opacity(colorScheme == .dark ? 0.22 : 0.12))
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(
+                            LinearGradient(
+                                colors: [iconColor, iconColor.opacity(0.82)],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
                 )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(Color.white.opacity(0.18), lineWidth: 0.5)
+                )
+                .shadow(color: iconColor.opacity(0.35), radius: 5, y: 2)
+
             Text(label)
-                .font(.system(size: 14, weight: .medium))
-                .foregroundStyle(.primary)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(starterCardTextColor)
                 .multilineTextAlignment(.leading)
+                .lineLimit(2)
+
             Spacer(minLength: 8)
+
             Image(systemName: "chevron.right")
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(CT.fgSubtle)
+                .font(.system(size: 12, weight: .bold))
+                .foregroundStyle(starterCardChevronColor)
         }
-        .padding(.horizontal, 13)
-        .padding(.vertical, 12)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 14)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(starterCardFill, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .background(starterCardFill, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .strokeBorder(starterCardBorder, lineWidth: 0.5)
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .strokeBorder(starterCardBorder, lineWidth: 0.75)
         )
-        .shadow(color: .black.opacity(0.04), radius: 2, y: 1)
+        .shadow(color: .black.opacity(colorScheme == .dark ? 0.28 : 0.05), radius: 10, y: 4)
+    }
+
+    private var starterCardTextColor: Color {
+        colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary
+    }
+
+    private var starterCardChevronColor: Color {
+        colorScheme == .dark ? CT.fgMutedDark.opacity(0.7) : CT.fgSubtle
     }
 
     private func promptIcon(for index: Int) -> String {
@@ -878,11 +973,14 @@ public struct ChatSheet: View {
         }
     }
 
+    /// Warm-family icon tints for the three starter cards. Deep-amber accent →
+    /// sun-gold → a dusk plum that still lives next to the amber palette (not a
+    /// cold `.indigo` that fights the warm sheet). All three read as one family.
     private func promptIconColor(for index: Int) -> Color {
         switch index {
         case 0:  return CT.accent
         case 1:  return CT.sunGoldDeep
-        default: return .indigo
+        default: return Color(.sRGB, red: 0x6B / 255, green: 0x4E / 255, blue: 0x7D / 255, opacity: 1) // dusk plum #6B4E7D
         }
     }
 
@@ -894,25 +992,42 @@ public struct ChatSheet: View {
     /// calling") instead of a generic prompt, nudging the right question.
     private var nowContextBanner: some View {
         let copy = Self.nowContextCopy(hour: nowHour)
-        return HStack(spacing: 6) {
+        return HStack(spacing: 7) {
             Image(systemName: nowContextIcon)
                 .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(CT.sunGold)
             Text(copy)
-                .font(.system(size: 11, weight: .medium, design: .monospaced))
-                .lineLimit(2)
-                .multilineTextAlignment(.leading)
+                .font(.system(size: 11.5, weight: .medium))
+                .lineLimit(1)
+                .foregroundStyle(nowBannerTextColor)
         }
-        .foregroundStyle(CT.sunGoldDeep)
-        .padding(.horizontal, 13)
-        .padding(.vertical, 7)
-        .background(CT.sunGoldSoft, in: Capsule())
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(
+            Capsule().fill(nowBannerFill)
+        )
+        .overlay(
+            Capsule().strokeBorder(CT.sunGold.opacity(colorScheme == .dark ? 0.30 : 0.0), lineWidth: 0.75)
+        )
         .padding(.horizontal, 28)
-        .padding(.bottom, 4)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(Text(String(
             format: NSLocalizedString("chat.empty.now.a11y", comment: "NOW banner a11y prefix"),
             copy
         )))
+    }
+
+    /// NOW pill fill — warm-translucent gold on the dark sheet (so it reads as
+    /// "lit, belongs here" not a pasted-on bright yellow chip), the original
+    /// soft-gold parchment in light mode.
+    private var nowBannerFill: Color {
+        colorScheme == .dark
+            ? CT.sunGold.opacity(0.14)
+            : CT.sunGoldSoft
+    }
+
+    private var nowBannerTextColor: Color {
+        colorScheme == .dark ? CT.fgPrimaryDark : CT.sunGoldDeep
     }
 
     /// Current local hour (0–23). A computed property so the banner reflects the
@@ -957,16 +1072,31 @@ public struct ChatSheet: View {
         colorScheme == .dark ? Color(.systemBackground) : CT.bgWarm
     }
 
+    /// Empty-state canvas — a faint warm vertical wash so the starter cards
+    /// float on an amber-tinted ground in both schemes, rather than a flat
+    /// cold-black (dark) or plain white (light) plane. The gradient is whisper-
+    /// quiet: just enough to make the surface feel lit from the top.
+    private var emptyStateBackground: some View {
+        LinearGradient(
+            colors: colorScheme == .dark
+                ? [CT.warmSheetDark, Color(.systemBackground)]
+                : [CT.bgWarm, CT.surfaceWhite],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+        .ignoresSafeArea(edges: .bottom)
+    }
+
     private var closeButtonFill: Color {
         colorScheme == .dark ? Color(.secondarySystemBackground) : CT.surfaceSunken
     }
 
     private var starterCardFill: Color {
-        colorScheme == .dark ? Color(.secondarySystemBackground) : CT.surfaceSunken
+        colorScheme == .dark ? CT.warmCardDark : CT.surfaceWhite
     }
 
     private var starterCardBorder: Color {
-        colorScheme == .dark ? Color(.separator) : CT.borderDefault
+        colorScheme == .dark ? CT.warmBorderDark : CT.borderSubtle
     }
 
     /// Small sun-gold pulse marking that the mic is hot while the tentative

--- a/apps/ios/SoloCompass/Views/Me/MeSheet.swift
+++ b/apps/ios/SoloCompass/Views/Me/MeSheet.swift
@@ -22,6 +22,9 @@ struct MeSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(UserPreferences.self) private var preferences
     @State private var showingSettings = false
+    /// Platform role gate for the moderation entry. Refreshed on appear; the
+    /// admin/moderator section only renders once `canModerate` is true.
+    @State private var admin = AdminService.shared
     /// Programmatic nav path so a `message` deep link can push the Messages hub.
     @State private var path: [MeDestination] = []
 
@@ -74,6 +77,23 @@ struct MeSheet: View {
                     }
                 }
 
+                // Moderation — only visible to platform moderators/admins.
+                // `canModerate` is false until `admin.refreshRole()` lands, so a
+                // plain user never sees this section.
+                if admin.canModerate {
+                    Section(NSLocalizedString("me.admin.section", comment: "Admin tools section")) {
+                        NavigationLink {
+                            ModerationView()
+                        } label: {
+                            MeRow(
+                                systemImage: "shield.lefthalf.filled",
+                                title: NSLocalizedString("me.moderation", comment: "Moderation queue row"),
+                                badge: admin.reports.filter { $0.resolvedAt == nil }.count
+                            )
+                        }
+                    }
+                }
+
                 Section {
                     Button {
                         showingSettings = true
@@ -88,6 +108,12 @@ struct MeSheet: View {
             }
             .navigationTitle(NSLocalizedString("me.title", comment: "Personal hub title"))
             .navigationBarTitleDisplayMode(.inline)
+            .task {
+                // Resolve the platform role so the moderation section can appear.
+                // Cheap + cached; a non-moderator just gets `.user` back.
+                await admin.refreshRole()
+                if admin.canModerate { await admin.refreshReports() }
+            }
             .navigationDestination(for: MeDestination.self) { destination in
                 switch destination {
                 case .messages(let conversationId):

--- a/apps/ios/SoloCompass/Views/Shared/CompareTokens.swift
+++ b/apps/ios/SoloCompass/Views/Shared/CompareTokens.swift
@@ -30,6 +30,17 @@ public enum CT {
     public static let bannerError         = rgb(0xC0, 0x3B, 0x1E) // #C03B1E — banner error tone
     public static let chatAIBubbleBgDark  = rgb(0x28, 0x24, 0x1E) // dark-mode AI bubble fill
 
+    // Dark-mode warm neutrals — keep the amber identity alive on a near-black
+    // sheet instead of falling back to cold systemGray. Sheet → card → sunken
+    // form a low-contrast warm-charcoal ladder; warm hairline borders separate
+    // them without the harsh blue-gray of `.separator`.
+    public static let warmSheetDark   = rgb(0x17, 0x14, 0x10) // sheet base
+    public static let warmCardDark    = rgb(0x23, 0x1F, 0x19) // raised card fill
+    public static let warmSunkenDark  = rgb(0x2C, 0x27, 0x20) // icon tile / sunken
+    public static let warmBorderDark  = rgb(0x3A, 0x33, 0x29) // hairline on dark
+    public static let fgPrimaryDark   = rgb(0xF4, 0xEF, 0xE7) // warm off-white text
+    public static let fgMutedDark     = rgb(0xB0, 0xA6, 0x97) // warm secondary text
+
     // Verified green (路线已验证 / closed companion) — #1F7B4D text, #2FA46A dot.
     public static let verifiedGreen    = rgb(0x1F, 0x7B, 0x4D)
     public static let verifiedGreenDot = rgb(0x2F, 0xA4, 0x6A)

--- a/infra/supabase/functions/moderate-action/index.ts
+++ b/infra/supabase/functions/moderate-action/index.ts
@@ -1,0 +1,177 @@
+// Edge Function: moderate-action
+//
+// Platform moderation gateway. Lets a signed-in moderator/admin take actions
+// that clients are NOT allowed to perform directly (the companion_profiles
+// guard trigger blocks role/ban writes from anyone but the service role).
+//
+// Request:  POST + Authorization: Bearer <JWT>
+//   { action: "ban",          targetUserId }                — moderator | admin
+//   { action: "unban",        targetUserId }                — moderator | admin
+//   { action: "resolveReport", reportId }                   — moderator | admin
+//   { action: "setRole",      targetUserId, role }          — admin only
+//
+// Response: 200 { ok: true, ... }
+//           400 { error } invalid body
+//           401 { error } missing/invalid JWT
+//           403 { error } caller lacks the required role
+//           404 { error } target/report not found
+//
+// Security:
+//   - Verifies the caller's Supabase JWT.
+//   - Looks up the caller's role via the service role (bypassing RLS) and
+//     enforces it server-side — never trusts a client-sent role.
+//   - All writes go through the service role so the privilege guard trigger
+//     permits the role/ban change.
+//   - A moderator/admin cannot ban or demote themselves through this path
+//     (prevents self-lockout / accidental privilege loss).
+//
+// Deploy: `supabase functions deploy moderate-action`
+// Secrets: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY.
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+type Action = "ban" | "unban" | "resolveReport" | "setRole";
+type Role = "user" | "moderator" | "admin";
+
+const VALID_ROLES: ReadonlySet<string> = new Set(["user", "moderator", "admin"]);
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "Authorization, Content-Type",
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+      },
+    });
+  }
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+
+  // 1. Verify the caller's JWT.
+  const authHeader = req.headers.get("Authorization") ?? "";
+  const jwt = authHeader.replace(/^Bearer /i, "");
+  if (!jwt) return json({ error: "missing bearer token" }, 401);
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+  const userClient = createClient(supabaseUrl, jwt, {
+    global: { headers: { Authorization: `Bearer ${jwt}` } },
+    auth: { persistSession: false },
+  });
+  const {
+    data: { user },
+    error: authError,
+  } = await userClient.auth.getUser();
+  if (authError || !user) return json({ error: "unauthorized" }, 401);
+  const callerId = user.id;
+
+  // 2. Parse the body.
+  let body: { action?: unknown; targetUserId?: unknown; reportId?: unknown; role?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "invalid json body" }, 400);
+  }
+  const action = body.action as Action | undefined;
+  if (!action || !["ban", "unban", "resolveReport", "setRole"].includes(action)) {
+    return json({ error: "unknown action" }, 400);
+  }
+
+  // 3. Service-role client + caller role lookup (enforced server-side).
+  const svc = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false },
+  });
+
+  const callerRole = await roleOf(svc, callerId);
+  if (callerRole !== "moderator" && callerRole !== "admin") {
+    return json({ error: "forbidden" }, 403);
+  }
+
+  // 4. Dispatch.
+  switch (action) {
+    case "ban":
+    case "unban": {
+      const targetUserId = strOrNull(body.targetUserId);
+      if (!targetUserId) return json({ error: "targetUserId is required" }, 400);
+      if (targetUserId === callerId) {
+        return json({ error: "cannot ban yourself" }, 400);
+      }
+      // A moderator may not ban an admin; only an admin can touch an admin.
+      const targetRole = await roleOf(svc, targetUserId);
+      if (targetRole === "admin" && callerRole !== "admin") {
+        return json({ error: "forbidden" }, 403);
+      }
+      const { error } = await svc
+        .from("companion_profiles")
+        .update({ is_banned: action === "ban", updated_at: new Date().toISOString() })
+        .eq("user_id", targetUserId);
+      if (error) return json({ error: error.message }, 500);
+      return json({ ok: true, action, targetUserId });
+    }
+
+    case "resolveReport": {
+      const reportId = strOrNull(body.reportId);
+      if (!reportId) return json({ error: "reportId is required" }, 400);
+      const { data, error } = await svc
+        .from("companion_reports")
+        .update({ resolved_at: new Date().toISOString(), resolved_by: callerId })
+        .eq("id", reportId)
+        .select("id")
+        .maybeSingle();
+      if (error) return json({ error: error.message }, 500);
+      if (!data) return json({ error: "not found" }, 404);
+      return json({ ok: true, action, reportId });
+    }
+
+    case "setRole": {
+      // Role changes are admin-only.
+      if (callerRole !== "admin") return json({ error: "forbidden" }, 403);
+      const targetUserId = strOrNull(body.targetUserId);
+      const role = strOrNull(body.role);
+      if (!targetUserId) return json({ error: "targetUserId is required" }, 400);
+      if (!role || !VALID_ROLES.has(role)) return json({ error: "invalid role" }, 400);
+      if (targetUserId === callerId) {
+        // Guard against an admin demoting themselves and losing access.
+        return json({ error: "cannot change your own role" }, 400);
+      }
+      const { error } = await svc
+        .from("companion_profiles")
+        .update({ role: role as Role, updated_at: new Date().toISOString() })
+        .eq("user_id", targetUserId);
+      if (error) return json({ error: error.message }, 500);
+      return json({ ok: true, action, targetUserId, role });
+    }
+
+    default:
+      return json({ error: "unknown action" }, 400);
+  }
+});
+
+/** Resolve a user's platform role via the service role. Defaults to "user". */
+async function roleOf(svc: ReturnType<typeof createClient>, userId: string): Promise<Role> {
+  const { data } = await svc
+    .from("companion_profiles")
+    .select("role, is_banned")
+    .eq("user_id", userId)
+    .maybeSingle();
+  // A banned account is treated as having no privileges.
+  if (data?.is_banned) return "user";
+  const r = data?.role as string | undefined;
+  return r === "admin" || r === "moderator" ? r : "user";
+}
+
+function strOrNull(v: unknown): string | null {
+  return typeof v === "string" && v.trim().length > 0 ? v.trim() : null;
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}

--- a/infra/supabase/migrations/0012_user_roles.sql
+++ b/infra/supabase/migrations/0012_user_roles.sql
@@ -1,0 +1,205 @@
+-- Solo Compass — Platform roles & moderation (admin / moderator)
+--
+-- Adds a platform-level access role orthogonal to the P2P friend graph, plus
+-- the server-side plumbing a moderation team needs:
+--
+--   • companion_profiles.role        — user | moderator | admin (default user)
+--   • companion_profiles.is_banned   — soft ban flag (default false)
+--   • sc_is_moderator() / sc_is_admin() helpers (SECURITY DEFINER)
+--   • companion_reports moderator/admin select-all policy
+--       (previously self-select only — nobody could read the queue)
+--   • a guard trigger so clients CANNOT escalate their own role or ban flag
+--       (only service_role / the moderate-action Edge Function may write them)
+--   • banned users are blocked from inserting friend requests & chat messages
+--   • admin seed: ADMIN_USER_IDS env (app.settings.admin_user_ids GUC) takes
+--       precedence; falls back to the hardcoded default list below.
+--
+-- Mirrors `UserRole` in packages/core/src/companion.ts.
+
+begin;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 1. Columns on companion_profiles
+-- ──────────────────────────────────────────────────────────────────────────────
+
+alter table public.companion_profiles
+  add column if not exists role text not null default 'user'
+    check (role in ('user','moderator','admin'));
+
+alter table public.companion_profiles
+  add column if not exists is_banned boolean not null default false;
+
+create index if not exists companion_profiles_role_idx
+  on public.companion_profiles(role)
+  where role <> 'user';
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 2. Role helpers (SECURITY DEFINER so RLS policies can call them without
+--    recursing into companion_profiles' own row-level policies)
+-- ──────────────────────────────────────────────────────────────────────────────
+
+create or replace function public.sc_is_moderator(uid uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1 from public.companion_profiles
+    where user_id = uid
+      and role in ('moderator','admin')
+      and is_banned = false
+  );
+$$;
+
+create or replace function public.sc_is_admin(uid uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1 from public.companion_profiles
+    where user_id = uid
+      and role = 'admin'
+      and is_banned = false
+  );
+$$;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 3. Guard: clients may NOT set their own role / is_banned.
+--
+--    companion_profiles already has a "self-update" policy (a user owns their
+--    row), which would otherwise let anyone PATCH role='admin'. This trigger
+--    rejects any change to role/is_banned unless the session is service_role
+--    (the moderate-action Edge Function runs with the service key).
+-- ──────────────────────────────────────────────────────────────────────────────
+
+create or replace function public.sc_guard_profile_privilege()
+returns trigger
+language plpgsql
+as $$
+begin
+  if (new.role is distinct from old.role)
+     or (new.is_banned is distinct from old.is_banned) then
+    if coalesce(current_setting('request.jwt.claim.role', true), '') <> 'service_role'
+       and coalesce(auth.role(), '') <> 'service_role' then
+      raise exception 'role/ban changes are service-role only'
+        using errcode = '42501';  -- insufficient_privilege
+    end if;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists companion_profiles_guard_privilege on public.companion_profiles;
+create trigger companion_profiles_guard_privilege
+  before update on public.companion_profiles
+  for each row execute function public.sc_guard_profile_privilege();
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 4. companion_reports: let moderators/admins read the full queue.
+--    (Existing "self-select" stays so a reporter still sees their own report.)
+-- ──────────────────────────────────────────────────────────────────────────────
+
+drop policy if exists "companion_reports moderator-select" on public.companion_reports;
+create policy "companion_reports moderator-select" on public.companion_reports
+  for select using (public.sc_is_moderator(auth.uid()));
+
+-- Resolution bookkeeping so the queue can hide handled reports.
+alter table public.companion_reports
+  add column if not exists resolved_at timestamptz;
+alter table public.companion_reports
+  add column if not exists resolved_by uuid references auth.users(id) on delete set null;
+
+drop policy if exists "companion_reports moderator-update" on public.companion_reports;
+create policy "companion_reports moderator-update" on public.companion_reports
+  for update
+  using (public.sc_is_moderator(auth.uid()))
+  with check (public.sc_is_moderator(auth.uid()));
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 5. Banned users can't act: block friend-request inserts & chat-message sends.
+--    Layered on top of existing policies (RESTRICTIVE → must also pass).
+-- ──────────────────────────────────────────────────────────────────────────────
+
+create or replace function public.sc_is_banned(uid uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1 from public.companion_profiles
+    where user_id = uid and is_banned = true
+  );
+$$;
+
+drop policy if exists "friend_requests not-banned" on public.friend_requests;
+create policy "friend_requests not-banned" on public.friend_requests
+  as restrictive
+  for insert
+  with check (not public.sc_is_banned(auth.uid()));
+
+drop policy if exists "chat_messages not-banned" on public.chat_messages;
+create policy "chat_messages not-banned" on public.chat_messages
+  as restrictive
+  for insert
+  with check (not public.sc_is_banned(auth.uid()));
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 6. Admin seed.
+--
+--    Precedence: the `app.settings.admin_user_ids` GUC (set from the
+--    ADMIN_USER_IDS env at deploy time, comma-separated uuids) wins. When that
+--    GUC is empty/unset, fall back to the hardcoded default list below.
+--
+--    A profile row may not exist yet for a seeded id (e.g. the account exists
+--    in auth.users but never opened the companion sheet), so we upsert a
+--    minimal profile and stamp role='admin'.
+-- ──────────────────────────────────────────────────────────────────────────────
+
+do $$
+declare
+  v_env   text := coalesce(current_setting('app.settings.admin_user_ids', true), '');
+  -- Hardcoded fallback admins. Replace with real auth.users uuids before
+  -- production; left empty here so a fresh DB doesn't grant admin to a
+  -- placeholder. Format: array['00000000-0000-0000-0000-000000000000']::uuid[]
+  v_default uuid[] := array[]::uuid[];
+  v_ids   uuid[];
+  v_id    uuid;
+begin
+  if length(trim(v_env)) > 0 then
+    -- parse comma-separated uuids from the env-derived GUC
+    select array_agg(trim(x)::uuid)
+      into v_ids
+      from unnest(string_to_array(v_env, ',')) as x
+      where length(trim(x)) > 0;
+  else
+    v_ids := v_default;
+  end if;
+
+  if v_ids is null or array_length(v_ids, 1) is null then
+    raise notice 'sc admin seed: no admin ids configured (set ADMIN_USER_IDS)';
+    return;
+  end if;
+
+  foreach v_id in array v_ids loop
+    -- only seed ids that exist in auth.users
+    if exists (select 1 from auth.users where id = v_id) then
+      insert into public.companion_profiles (id, user_id, role)
+      values ('cprof_admin_' || replace(v_id::text, '-', ''), v_id, 'admin')
+      on conflict (user_id)
+      do update set role = 'admin', updated_at = now();
+      raise notice 'sc admin seed: granted admin to %', v_id;
+    else
+      raise notice 'sc admin seed: skipped % (no auth.users row)', v_id;
+    end if;
+  end loop;
+end;
+$$;
+
+commit;

--- a/packages/core/src/companion.ts
+++ b/packages/core/src/companion.ts
@@ -91,6 +91,15 @@ export interface CompanionRequest {
 
 export type CompanionVisibility = "off" | "itinerary_only" | "nearby_and_itinerary";
 
+/**
+ * Platform-level access role. Orthogonal to the P2P friend graph — `moderator`
+ * and `admin` can read the full moderation queue (companion reports) and take
+ * moderation actions (ban / role change) via the `moderate-action` Edge
+ * Function. Defaults to `user` for every account; elevation is server-side
+ * only (the client never writes its own role).
+ */
+export type UserRole = "user" | "moderator" | "admin";
+
 export interface CompanionProfile {
   readonly id: CompanionProfileId;
   readonly userId: UserId;
@@ -102,6 +111,8 @@ export interface CompanionProfile {
   readonly languages: readonly string[];
   /** Controls whether and how the user appears in discovery. Default: off. */
   readonly visibility: CompanionVisibility;
+  /** Platform access role. Default: "user". Elevated server-side only. */
+  readonly role: UserRole;
   /** ISO 8601 UTC timestamp. */
   readonly createdAt: string;
   /** ISO 8601 UTC timestamp. */
@@ -178,4 +189,8 @@ export interface CompanionReport {
   readonly details?: string;
   /** ISO 8601 UTC timestamp. */
   readonly createdAt: string;
+  /** ISO 8601 UTC timestamp when a moderator handled this report. Unset = open. */
+  readonly resolvedAt?: string;
+  /** The moderator/admin user id that resolved this report. */
+  readonly resolvedBy?: UserId;
 }


### PR DESCRIPTION
## Summary

Two parallel pieces of work, shipped together.

**Platform moderator/admin roles** (orthogonal to the P2P friend graph — the friend system is strict-by-design with no role layer, so this is a new dimension):
- `UserRole` (user/moderator/admin) on `CompanionProfile`, mirrored TS↔Swift.
- `companion_reports` was self-select-only RLS — **no one could read the moderation queue**. Migration `0012` adds a moderator select-all policy so a safety team can actually see reports.
- Guard trigger blocks self-escalation: a user can't PATCH their own `role`/`is_banned` (only the service-role `moderate-action` Edge Function can).
- Banned users are blocked from sending friend requests / chat messages.
- Admin seed: `ADMIN_USER_IDS` env (→ `app.settings.admin_user_ids` GUC) takes precedence, falls back to a hardcoded list.
- iOS audit queue (`ModerationView` + `AdminService`), MeSheet entry gated on `canModerate`, en/zh localized.

**Friend system enablement + auto-accept**:
- `FeatureFlags.companion` (the backend-social master gate) now DEBUG-default-on, Release reads plist/env (default off).
- `AutoAcceptPolicy` + `autoAcceptedDirect`: friending staff/co-travelers/opted-in recipients skips the pending step and connects directly. Safety rules (block / already-friends / mutual-pending fold) still win over the policy.

## Test Coverage
- `FriendshipStateMachineTests`: +9 tests covering the new auto-accept policy (staff/co-traveler/opted-in → direct; block & already-friends precedence; inbound-pending fold vs direct).
- Pure-function state machine fully covered. Auto-accept I/O paths (`isStaff`, `createFriendshipDirect`) exercised via build-time type checking.

## Pre-Landing Review
Self-reviewed. Key safety property: clients can never write their own role/ban — enforced at DB (guard trigger) + Edge Function (service-role only). `setRole` is admin-only; ban/unban can't target yourself or (for moderators) an admin.

## Verification
- `xcodebuild build` → **BUILD SUCCEEDED**
- `pnpm parity:check` → **all green** (TS↔Swift, TS↔DB, SQL↔Swift, SwiftData)
- ⚠️ XCTest runner hung pre-connection 3× this session (Xcode 26.4 / iOS 26.4 environment issue, not code — documented in CLAUDE memory). The new tests target pure functions that compile clean; run `xcodebuild test -only-testing:SoloCompassTests/FriendshipStateMachineTests` on a healthy runner to confirm green.

## Notes
- Bundled prior-session `ChatSheet.swift` / `CompareTokens.swift` changes per request (pre-existing uncommitted work).
- Admin seed default list is empty by design — set `ADMIN_USER_IDS` or fill `v_default` before production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)