### PR TITLE
feat(ios): live activities + companion/route notifications

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		11A994FC5FFCF2618FBD7A3A /* AvatarStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D52E68EDCAB1AEF0737B201 /* AvatarStack.swift */; };
 		1350233CA736639A10ED3CD1 /* SunsetSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674F2B0EE0E3C7A47802DBC4 /* SunsetSignal.swift */; };
 		13E5AEAEE5194DDB79AE92AC /* SoloCompassModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5435FBA9527C07A9FB07D46 /* SoloCompassModelContainer.swift */; };
+		14CEE4C5885B0643A52E0DA3 /* SoloCompassActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D52416277C10558C0CD7096 /* SoloCompassActivityAttributes.swift */; };
 		15530E784D55EED02B3EE21F /* CompanionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405A56207920EA0DDADF8FC5 /* CompanionRequest.swift */; };
 		15A48470CBEBB6D31C2201D9 /* Configuration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = D4C10384834D53FE83113D51 /* Configuration.storekit */; };
 		160DDEADA76E50A05D4F76EE /* VoiceProcessingToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EDF4F9F84F50797290FF9E0 /* VoiceProcessingToast.swift */; };
@@ -96,6 +97,7 @@
 		3CB7E26BCF3339F2CE297528 /* ItineraryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D60D55727FB72C1C202C90 /* ItineraryListView.swift */; };
 		3CBA775B8C215CBAE3A73EA0 /* CardBottomInsetClearanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0674DC5D526883C657A63C38 /* CardBottomInsetClearanceTest.swift */; };
 		3D393CD7ACFD865D7297FA5D /* AIProviderSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7295DF9392F0361C0B2E313D /* AIProviderSettingsView.swift */; };
+		3DEF046380F3BD907DE834C0 /* IslandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CCB9E36FDC56604136090F /* IslandPalette.swift */; };
 		3E24606FB907D7BB18E3C496 /* Itinerary.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F5D58C93D87AC9205148CC /* Itinerary.swift */; };
 		3E92704051F386C38C3A5533 /* RouteBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C8EE9D6C64872261609DEF /* RouteBuilderTests.swift */; };
 		3EF7E97963960C09B7A5575D /* StringsParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14FE2118ED82DD0593F5C3C /* StringsParityTests.swift */; };
@@ -103,6 +105,7 @@
 		40C8E92653FC718890E3CA5D /* PressableButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A744E7B767BDEC07E9C58F4D /* PressableButtonStyle.swift */; };
 		42E436DB35CF90AD3E43083E /* DeviceIdentityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */; };
 		436C2BF0D0723B2B07428F07 /* CompanionBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBBF77E10D341C38C093D22D /* CompanionBlock.swift */; };
+		4403970297A5C7ACA70DE877 /* SoloCompassActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D52416277C10558C0CD7096 /* SoloCompassActivityAttributes.swift */; };
 		45A4E8EED0300F00253EC049 /* MarkdownExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F3FDE4BC9458E490AEA67A /* MarkdownExporter.swift */; };
 		4617863D79206886BE4A5586 /* FavoritesClosingSoonThresholdTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C94CC0395CC7FCC0A56D077 /* FavoritesClosingSoonThresholdTest.swift */; };
 		464746A44182622D4F617462 /* AIUsageRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */; };
@@ -150,6 +153,7 @@
 		61951D68523CF51B987F4385 /* NowScoreEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3900AAACEFB8C75AC3F123C3 /* NowScoreEngine.swift */; };
 		627258EB2A310E2C979787E8 /* SkeletonBadgeViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B418AD0352AC3402D6609E4C /* SkeletonBadgeViewTests.swift */; };
 		62BB74EC16B92899A9A6A44C /* ReverseGeocodeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BDF8B4B7CC82F3845C5068 /* ReverseGeocodeService.swift */; };
+		62DB07EFC7BCAF019D757805 /* IslandComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C6B8684C2A7737474A182A /* IslandComponents.swift */; };
 		63059F4B8EFE54C8E2699330 /* ItineraryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0AA21CD490B436012818D9D /* ItineraryDetailView.swift */; };
 		6368700EA304CE63F6CC9DB8 /* FriendsListRenderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC6E2F5AF146A5D51579286 /* FriendsListRenderTest.swift */; };
 		63A45A90C2748A2729742C2F /* FilterBarScrollAffordanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFED848E66BBE2A234AAA3CC /* FilterBarScrollAffordanceTest.swift */; };
@@ -163,6 +167,7 @@
 		6AA87132BC6ACDDDC6D98735 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF007DB5F72E30021CADA555 /* NetworkMonitor.swift */; };
 		6BC4542A9B952BA2AFA9332C /* FilterNowMapSyncTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C75D64D462A03DBEFFC4EB /* FilterNowMapSyncTest.swift */; };
 		6BDE2B5BBBFDFB98C3A12BE4 /* ReportBlockSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023CB5AE8B0D41EBB5E17DAC /* ReportBlockSheet.swift */; };
+		6E89D69A55FBB0EE0E476728 /* NotificationCategories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46582FC424C8220DC144B906 /* NotificationCategories.swift */; };
 		6F0618797804108791374E34 /* SeedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23157DCAE693C4DE3CC5F7A6 /* SeedUser.swift */; };
 		6F8492E7BB9870C7E4C99CA1 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 7F7384A5D63B5A4A7371F923 /* Sentry */; };
 		6FAA75544A1755C5712F30BA /* AddFriendSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB22C08A558D35B83043C83E /* AddFriendSheet.swift */; };
@@ -179,6 +184,7 @@
 		76F57DBD1B6F0020E8BF91E5 /* RecruitingModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612BA64E761957615DD63D34 /* RecruitingModule.swift */; };
 		78EA2DE7E8AA6F5847BE4FAA /* ShareCardScoreL10nTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314F06EBA1DCBD3AC987BEEF /* ShareCardScoreL10nTest.swift */; };
 		79E4FD6C7F9522BDB1106F56 /* PublicAPIDocCommentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCD0D2CE7423C29CD668866 /* PublicAPIDocCommentTests.swift */; };
+		79F37B0641366345F2BDF4F5 /* SoloCompassWidgets.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 8493FBDFD443A8E28CE84518 /* SoloCompassWidgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		7A089AEA89FE3ECC1F8F1E0D /* BestTimeTomorrowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA0493569A1D4BC9304DCB7 /* BestTimeTomorrowTests.swift */; };
 		7A5F7752DE91A7FEE6571C7A /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038BEE46BF2DFAF762B605D5 /* Route.swift */; };
 		7ACAAE18D2EFA3E880AD6744 /* PressableButtonStyleHapticTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFE48683692E4C00E0A2DC5 /* PressableButtonStyleHapticTest.swift */; };
@@ -273,6 +279,7 @@
 		B6B9B93525A5E3F8DD5EA34E /* DiscoverPostDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542C0D57002828AF85367C94 /* DiscoverPostDetailView.swift */; };
 		B6FA45D117293C3829DE99A9 /* RouteMapSnapshotter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8970A53A6D6C42A614F7B414 /* RouteMapSnapshotter.swift */; };
 		B7366111257111EC98F4A0C4 /* ChatSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9263FC2737FA209F3CD4B5E /* ChatSheet.swift */; };
+		B80813E9E3CDD855C12F7D58 /* LockScreenLiveActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02DB2C9C0BC30785E0A80F3 /* LockScreenLiveActivityView.swift */; };
 		B9EDA827F7E00B19DF97512C /* ConversationRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12888843433B2A00D7CAB18 /* ConversationRecord.swift */; };
 		BA0DD7D5C46016E81A23B2B4 /* ChatInputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88D9F377D7AF634DAE07A3E /* ChatInputBar.swift */; };
 		BA870AD09C34F9B1E703086D /* DiscoverFriendGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820F9980B60883E879851303 /* DiscoverFriendGate.swift */; };
@@ -290,6 +297,7 @@
 		BF6359994CAD4D857DE384EE /* OfflineBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C62D0EFA5859698D9C70B7D /* OfflineBanner.swift */; };
 		BF7D61FAEF133A0E77C585C9 /* BottomSheetSectionSeparationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999E8DA69CB660A94E71D02A /* BottomSheetSectionSeparationTest.swift */; };
 		C09361B1A5560755F3C5DD67 /* Conversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9864D3AA45FA7D5ADC4D2ED /* Conversation.swift */; };
+		C2073015CFF96A49C31767C8 /* LiveActivityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDB30483C5FCCD42CA92A00 /* LiveActivityService.swift */; };
 		C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */; };
 		C220FEC091B645D82519465E /* VoiceAgentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112319E8315F5F6961C95264 /* VoiceAgentSession.swift */; };
 		C2AE6B28BA196E2EDEE89012 /* BottomInfoSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F91067B8A0FACD9369243B /* BottomInfoSheetTests.swift */; };
@@ -330,6 +338,7 @@
 		D28FA83853E30AF27C34876F /* IntentAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7A57DAFF92B20BE0BAB1F4 /* IntentAgent.swift */; };
 		D2BCD302B16BBC174B71F84A /* CityPillHitTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 308B7A34171C74B1CF2DE3F9 /* CityPillHitTargetTests.swift */; };
 		D2E9B20230FDE14CB1029DC3 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535B5FA4ADF216CEC74FE056 /* RouteTests.swift */; };
+		D391728579EB266152984A30 /* SoloCompassLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6982D2F9E150319AA0E1000F /* SoloCompassLiveActivity.swift */; };
 		D4193263CDA544D0995749B0 /* NavigationLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FB43528F45882868CCC203 /* NavigationLauncherTests.swift */; };
 		D51532D17022F9004544FFF3 /* WeatherSignalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672C97E1FBA4FEF7EE87D59B /* WeatherSignalTests.swift */; };
 		D52FCC8C2C36D630A8845DA6 /* LocalRouteCompanionRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433C1552FC95F4E8ECF4C695 /* LocalRouteCompanionRemote.swift */; };
@@ -370,6 +379,7 @@
 		EEEA71095A413286D8282F1C /* TravelerNoteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E595A6B9324B26C7FB2DBF55 /* TravelerNoteStoreTests.swift */; };
 		EF2003CC07F7787C25847BDF /* ReportIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576B08910782A58C3597E596 /* ReportIssueSheet.swift */; };
 		EF7C549F31EDA5ABE2B95FE8 /* CompiledPlace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C1DD2BA0AF4E693B9E36F90 /* CompiledPlace.swift */; };
+		EFD51797A3B206251326D412 /* SoloCompassWidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07D48FA11BD12DC2B5C864D /* SoloCompassWidgetsBundle.swift */; };
 		F00CB7BB8489D1F4F1925E60 /* SettingsAdminUnlockTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7022B4362225428DCEB74D59 /* SettingsAdminUnlockTest.swift */; };
 		F0A84EA46BBABC431C14C439 /* NowScoreTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654B60521DF1FC23A19F86CB /* NowScoreTestSupport.swift */; };
 		F11FDDDC600A1EF9C08E8193 /* EnrichmentAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FC71659A5BF9CB1A547907B /* EnrichmentAgent.swift */; };
@@ -404,7 +414,28 @@
 			remoteGlobalIDString = 54773438FB1E1E9F2C8DF91C;
 			remoteInfo = SoloCompass;
 		};
+		74F1616ACCE95887E9338A47 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 75685F3A029520F918427CD0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 718021C20FBE1F1F9A85A7D4;
+			remoteInfo = SoloCompassWidgets;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		53F177B638100983DD0C9979 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				79F37B0641366345F2BDF4F5 /* SoloCompassWidgets.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIUsageRecord.swift; sourceTree = "<group>"; };
@@ -435,6 +466,7 @@
 		112319E8315F5F6961C95264 /* VoiceAgentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAgentSession.swift; sourceTree = "<group>"; };
 		112365ED9467BFB0994BC0A0 /* CompanionProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionProfile.swift; sourceTree = "<group>"; };
 		1157BB60848F9C74D7E8C14E /* TravelerNoteRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelerNoteRecord.swift; sourceTree = "<group>"; };
+		11CCB9E36FDC56604136090F /* IslandPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IslandPalette.swift; sourceTree = "<group>"; };
 		11F91F51C79F4EC2D9464FDA /* ExperienceImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceImageService.swift; sourceTree = "<group>"; };
 		120FC7465285714C5FA8F96D /* VoiceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceService.swift; sourceTree = "<group>"; };
 		12F087E4FA7161529378098C /* ExperienceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceService.swift; sourceTree = "<group>"; };
@@ -511,6 +543,7 @@
 		45BB36326BBDD7860ECD722B /* CreateRouteEntryTappableGuardTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRouteEntryTappableGuardTest.swift; sourceTree = "<group>"; };
 		4609B3C2E77F98A59871C26E /* HapticServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticServiceTests.swift; sourceTree = "<group>"; };
 		4617984392FDCCA6F2F9FAD7 /* BestNowClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BestNowClock.swift; sourceTree = "<group>"; };
+		46582FC424C8220DC144B906 /* NotificationCategories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCategories.swift; sourceTree = "<group>"; };
 		48ADAE2497800574C4E8819B /* GroupConversationAutoCreateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupConversationAutoCreateTests.swift; sourceTree = "<group>"; };
 		48FF87CCF00DEEE87B290812 /* MapViewModelCityRegionSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModelCityRegionSyncTests.swift; sourceTree = "<group>"; };
 		4B5D9508FCA9CDB8EA088D76 /* OpenForCompanionsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenForCompanionsSheet.swift; sourceTree = "<group>"; };
@@ -527,6 +560,7 @@
 		53EB8B6538D85C6E3641D778 /* RouteShareStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteShareStyle.swift; sourceTree = "<group>"; };
 		53F836182A03FC067C4A9AB9 /* CompareTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompareTokens.swift; sourceTree = "<group>"; };
 		542C0D57002828AF85367C94 /* DiscoverPostDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverPostDetailView.swift; sourceTree = "<group>"; };
+		54C6B8684C2A7737474A182A /* IslandComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IslandComponents.swift; sourceTree = "<group>"; };
 		54F3FDE4BC9458E490AEA67A /* MarkdownExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownExporter.swift; sourceTree = "<group>"; };
 		55143D2090E3E5CADF4246B6 /* SolarEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolarEvents.swift; sourceTree = "<group>"; };
 		554BDD1F80E1A3D35F7FDF2B /* PeekSummaryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeekSummaryCard.swift; sourceTree = "<group>"; };
@@ -573,6 +607,7 @@
 		674F2B0EE0E3C7A47802DBC4 /* SunsetSignal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunsetSignal.swift; sourceTree = "<group>"; };
 		67DAE302128E657E150C4B0D /* FoursquareService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoursquareService.swift; sourceTree = "<group>"; };
 		69068DE8A2F71601627AE3E8 /* CompanionProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionProfileView.swift; sourceTree = "<group>"; };
+		6982D2F9E150319AA0E1000F /* SoloCompassLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassLiveActivity.swift; sourceTree = "<group>"; };
 		69C8C17C79CD2B4EAE72F385 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		6C5CA5533D846B39EF16CDFA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6D31F422914779D9228B0278 /* RouteCardNowReasonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCardNowReasonTests.swift; sourceTree = "<group>"; };
@@ -603,6 +638,7 @@
 		81A92E0AE1868C3A165F3E95 /* PendingSyncRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingSyncRecord.swift; sourceTree = "<group>"; };
 		820F9980B60883E879851303 /* DiscoverFriendGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverFriendGate.swift; sourceTree = "<group>"; };
 		8277318E6238F2F885ED2334 /* HapticService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticService.swift; sourceTree = "<group>"; };
+		8493FBDFD443A8E28CE84518 /* SoloCompassWidgets.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = SoloCompassWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		8509E525DD268E88ED3AD4FD /* LocationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationCard.swift; sourceTree = "<group>"; };
 		85591C678C692990339095E9 /* MarkdownShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownShareSheet.swift; sourceTree = "<group>"; };
 		85D78BE6F7E5B4B82CEAC0A3 /* ShareCardRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareCardRenderer.swift; sourceTree = "<group>"; };
@@ -622,6 +658,7 @@
 		8C8D88BCFAC97E436BE97274 /* seed_users.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = seed_users.json; sourceTree = "<group>"; };
 		8D0CBFD5114CC6728D6AA876 /* VoiceWaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceWaveformView.swift; sourceTree = "<group>"; };
 		8D41862432A45DC023C96B8D /* FilterNowMapAnimationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterNowMapAnimationTest.swift; sourceTree = "<group>"; };
+		8D52416277C10558C0CD7096 /* SoloCompassActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassActivityAttributes.swift; sourceTree = "<group>"; };
 		8E055BAC372B75F743428920 /* MyHostedRoutesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyHostedRoutesListView.swift; sourceTree = "<group>"; };
 		8F1F20B36F8441905A909DC2 /* ChatHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryStore.swift; sourceTree = "<group>"; };
 		8FDFA5F3503B8ABC4B5CB086 /* SoloCompassTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SoloCompassTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -652,11 +689,13 @@
 		9F10413877E80238BD52F34C /* VoiceServiceActorIsolationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceServiceActorIsolationTest.swift; sourceTree = "<group>"; };
 		9F32B7DE32405561C4159843 /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
 		A00295FF044E4D732D1EB2EA /* ColorExtensionScopeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtensionScopeTest.swift; sourceTree = "<group>"; };
+		A02DB2C9C0BC30785E0A80F3 /* LockScreenLiveActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenLiveActivityView.swift; sourceTree = "<group>"; };
 		A1F76E8EBB87A2F70FEA1BB0 /* ExploreCacheRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreCacheRecord.swift; sourceTree = "<group>"; };
 		A250916F91C8EF0BE90DF763 /* ExperienceRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceRepository.swift; sourceTree = "<group>"; };
 		A267CD0DA0A8053B0AB072BC /* PrivacyAcknowledgementSheetSnapshotTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyAcknowledgementSheetSnapshotTest.swift; sourceTree = "<group>"; };
 		A2BE90CD51D94B3FEE2F5AFA /* CompanionReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionReport.swift; sourceTree = "<group>"; };
 		A38E5736BF6DF5644D687637 /* AgentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRouter.swift; sourceTree = "<group>"; };
+		A3CCA6D836F4636724C8E31C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		A4077595CC19D07EB22B8AA7 /* FriendsHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsHubView.swift; sourceTree = "<group>"; };
 		A453FDDE85569DCA8FF70A8A /* RouteShareRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteShareRenderer.swift; sourceTree = "<group>"; };
 		A5435FBA9527C07A9FB07D46 /* SoloCompassModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassModelContainer.swift; sourceTree = "<group>"; };
@@ -676,6 +715,7 @@
 		AB46D6F6F8942CD390A5CCF4 /* SoloCompass.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SoloCompass.entitlements; sourceTree = "<group>"; };
 		AC6DF782C123E76E2F02EEEA /* FriendProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendProfileView.swift; sourceTree = "<group>"; };
 		ACC6E2F5AF146A5D51579286 /* FriendsListRenderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsListRenderTest.swift; sourceTree = "<group>"; };
+		AEDB30483C5FCCD42CA92A00 /* LiveActivityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityService.swift; sourceTree = "<group>"; };
 		AF007DB5F72E30021CADA555 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		B14FE2118ED82DD0593F5C3C /* StringsParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringsParityTests.swift; sourceTree = "<group>"; };
 		B28321E2C450664BF8B05147 /* FriendCodeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendCodeRow.swift; sourceTree = "<group>"; };
@@ -771,6 +811,7 @@
 		EDE5D2141CB2B68B7F1C560E /* SentryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryService.swift; sourceTree = "<group>"; };
 		EF3FB0F0B974CA1C89BA5201 /* RouteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteStore.swift; sourceTree = "<group>"; };
 		F0782F4AA0496B97DDAAA380 /* CreateRouteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRouteView.swift; sourceTree = "<group>"; };
+		F07D48FA11BD12DC2B5C864D /* SoloCompassWidgetsBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassWidgetsBundle.swift; sourceTree = "<group>"; };
 		F1B30F2AF51F41DB5DA21899 /* ImminenceProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImminenceProgressTests.swift; sourceTree = "<group>"; };
 		F1D68F42114231582501CB90 /* NowCountCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowCountCacheTests.swift; sourceTree = "<group>"; };
 		F22DFB53BF47FEF26D9441BE /* InviteFriendsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteFriendsSheet.swift; sourceTree = "<group>"; };
@@ -857,6 +898,14 @@
 				B99BC58510B4AF3E9B9E8377 /* Share */,
 			);
 			path = Experience;
+			sourceTree = "<group>";
+		};
+		18C2DC833B40212784EE9818 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				8D52416277C10558C0CD7096 /* SoloCompassActivityAttributes.swift */,
+			);
+			path = Shared;
 			sourceTree = "<group>";
 		};
 		1E97D71FC3AACEBF3EAB70F0 /* Companion */ = {
@@ -1108,6 +1157,7 @@
 				7E2FB1BFAED4DC291176B347 /* Persistence */,
 				AF2168B6372E0B357D17732C /* Resources */,
 				68417DC1101B6DFD2DB9673C /* Services */,
+				18C2DC833B40212784EE9818 /* Shared */,
 				66EE2097358C0479C8454592 /* ViewModels */,
 				993B6773487C7744097F4175 /* Views */,
 			);
@@ -1135,6 +1185,7 @@
 			children = (
 				9945A4E03F4C75ED89674594 /* SoloCompass.app */,
 				8FDFA5F3503B8ABC4B5CB086 /* SoloCompassTests.xctest */,
+				8493FBDFD443A8E28CE84518 /* SoloCompassWidgets.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1232,6 +1283,7 @@
 				8277318E6238F2F885ED2334 /* HapticService.swift */,
 				6556C23BF1B228BF686C5500 /* KeychainStore.swift */,
 				87002BB6D344B384A3FDFBFD /* LanguageService.swift */,
+				AEDB30483C5FCCD42CA92A00 /* LiveActivityService.swift */,
 				433C1552FC95F4E8ECF4C695 /* LocalRouteCompanionRemote.swift */,
 				E893D776B3D5A647320EDDB0 /* LocationSearchService.swift */,
 				2C7919EAFDE363B49C4B4C47 /* LocationService.swift */,
@@ -1239,6 +1291,7 @@
 				54F3FDE4BC9458E490AEA67A /* MarkdownExporter.swift */,
 				D07ACA7C1A1574A244E73796 /* NavigationLauncher.swift */,
 				AF007DB5F72E30021CADA555 /* NetworkMonitor.swift */,
+				46582FC424C8220DC144B906 /* NotificationCategories.swift */,
 				C215AE07BA32182A887226F9 /* NotificationService.swift */,
 				67173C74F1A76C3CE5C38C0A /* OverpassService.swift */,
 				D2F55E299C99F8D9916E0BA1 /* PlacePhotoStore.swift */,
@@ -1332,6 +1385,7 @@
 			isa = PBXGroup;
 			children = (
 				46CE435B49A97DAA511BDFE5 /* SoloCompass */,
+				E8145B11DE65BF09C059E7B9 /* SoloCompassWidgets */,
 				2CEE9F7CC15A1F0742A0CDDF /* Tests */,
 				501EF6E4D08477F134FAED1E /* Products */,
 			);
@@ -1464,6 +1518,19 @@
 			path = Cache;
 			sourceTree = "<group>";
 		};
+		E8145B11DE65BF09C059E7B9 /* SoloCompassWidgets */ = {
+			isa = PBXGroup;
+			children = (
+				A3CCA6D836F4636724C8E31C /* Info.plist */,
+				54C6B8684C2A7737474A182A /* IslandComponents.swift */,
+				11CCB9E36FDC56604136090F /* IslandPalette.swift */,
+				A02DB2C9C0BC30785E0A80F3 /* LockScreenLiveActivityView.swift */,
+				6982D2F9E150319AA0E1000F /* SoloCompassLiveActivity.swift */,
+				F07D48FA11BD12DC2B5C864D /* SoloCompassWidgetsBundle.swift */,
+			);
+			path = SoloCompassWidgets;
+			sourceTree = "<group>";
+		};
 		F041AA40AC029B779843B5D4 /* Paywall */ = {
 			isa = PBXGroup;
 			children = (
@@ -1483,10 +1550,12 @@
 				FD67F39E8160C7EC75CB5491 /* Sources */,
 				F9735D89646F00459C8018CB /* Resources */,
 				760FFA2394573B6BC3FB8434 /* Frameworks */,
+				53F177B638100983DD0C9979 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				64205F3B6070D95056B8C7DE /* PBXTargetDependency */,
 			);
 			name = SoloCompass;
 			packageProductDependencies = (
@@ -1497,6 +1566,23 @@
 			productName = SoloCompass;
 			productReference = 9945A4E03F4C75ED89674594 /* SoloCompass.app */;
 			productType = "com.apple.product-type.application";
+		};
+		718021C20FBE1F1F9A85A7D4 /* SoloCompassWidgets */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9FD3781E06E3513BAD79B567 /* Build configuration list for PBXNativeTarget "SoloCompassWidgets" */;
+			buildPhases = (
+				65CBB6BEF56A0527033EED3A /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SoloCompassWidgets;
+			packageProductDependencies = (
+			);
+			productName = SoloCompassWidgets;
+			productReference = 8493FBDFD443A8E28CE84518 /* SoloCompassWidgets.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 		D49FFD818AF5AD3EDE92522D /* SoloCompassTests */ = {
 			isa = PBXNativeTarget;
@@ -1529,6 +1615,10 @@
 						DevelopmentTeam = 6RG2F8YY59;
 						ProvisioningStyle = Manual;
 					};
+					718021C20FBE1F1F9A85A7D4 = {
+						DevelopmentTeam = 6RG2F8YY59;
+						ProvisioningStyle = Manual;
+					};
 					D49FFD818AF5AD3EDE92522D = {
 						DevelopmentTeam = 6RG2F8YY59;
 						ProvisioningStyle = Automatic;
@@ -1557,6 +1647,7 @@
 			targets = (
 				54773438FB1E1E9F2C8DF91C /* SoloCompass */,
 				D49FFD818AF5AD3EDE92522D /* SoloCompassTests */,
+				718021C20FBE1F1F9A85A7D4 /* SoloCompassWidgets */,
 			);
 		};
 /* End PBXProject section */
@@ -1605,6 +1696,19 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		65CBB6BEF56A0527033EED3A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62DB07EFC7BCAF019D757805 /* IslandComponents.swift in Sources */,
+				3DEF046380F3BD907DE834C0 /* IslandPalette.swift in Sources */,
+				B80813E9E3CDD855C12F7D58 /* LockScreenLiveActivityView.swift in Sources */,
+				4403970297A5C7ACA70DE877 /* SoloCompassActivityAttributes.swift in Sources */,
+				D391728579EB266152984A30 /* SoloCompassLiveActivity.swift in Sources */,
+				EFD51797A3B206251326D412 /* SoloCompassWidgetsBundle.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		90D79EF444F26D11575920A7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1872,6 +1976,7 @@
 				98245881AB35CB7BB16688FC /* JoinRouteRequestSheet.swift in Sources */,
 				48DF93F42CDDB1329B038865 /* KeychainStore.swift in Sources */,
 				953C7BD48AF4AF55608145A6 /* LanguageService.swift in Sources */,
+				C2073015CFF96A49C31767C8 /* LiveActivityService.swift in Sources */,
 				36E1316045802B2F642A9623 /* LocalAttachment.swift in Sources */,
 				D52FCC8C2C36D630A8845DA6 /* LocalRouteCompanionRemote.swift in Sources */,
 				23B40396E9D7B59CB71FBCD9 /* LocationCard.swift in Sources */,
@@ -1897,6 +2002,7 @@
 				690ED25AA3EDA8529E915850 /* MyWalkedRoutesListView.swift in Sources */,
 				C306F7501DA85110BE3C85B5 /* NavigationLauncher.swift in Sources */,
 				6AA87132BC6ACDDDC6D98735 /* NetworkMonitor.swift in Sources */,
+				6E89D69A55FBB0EE0E476728 /* NotificationCategories.swift in Sources */,
 				C53DB60CA9E95907A2CBF2C0 /* NotificationService.swift in Sources */,
 				842E955B0ED4DC5255816199 /* NowScore.swift in Sources */,
 				61951D68523CF51B987F4385 /* NowScoreEngine.swift in Sources */,
@@ -1957,6 +2063,7 @@
 				2FFDD120FE87D1EE121EAB40 /* SkeletonBadgeView.swift in Sources */,
 				F84389464D54A5F5BEB866D0 /* SkeletonView.swift in Sources */,
 				7382FC6B271BA4FE4D24B389 /* SolarEvents.swift in Sources */,
+				14CEE4C5885B0643A52E0DA3 /* SoloCompassActivityAttributes.swift in Sources */,
 				E5F463CE3CE822F7F96CA82C /* SoloCompassApp.swift in Sources */,
 				13E5AEAEE5194DDB79AE92AC /* SoloCompassModelContainer.swift in Sources */,
 				86F4628473C2D520D4C2FFFB /* SoloScoreBadge.swift in Sources */,
@@ -2001,6 +2108,11 @@
 			target = 54773438FB1E1E9F2C8DF91C /* SoloCompass */;
 			targetProxy = 2C6D32C9538461241D786D7D /* PBXContainerItemProxy */;
 		};
+		64205F3B6070D95056B8C7DE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 718021C20FBE1F1F9A85A7D4 /* SoloCompassWidgets */;
+			targetProxy = 74F1616ACCE95887E9338A47 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -2025,6 +2137,46 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		4A829C0F9F10F04A2D837373 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = 6RG2F8YY59;
+				INFOPLIST_FILE = SoloCompassWidgets/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.solocompass.app.widgets;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		84A4043009900070C9536CE7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = 6RG2F8YY59;
+				INFOPLIST_FILE = SoloCompassWidgets/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.solocompass.app.widgets;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		96CB10D8184006DA8310F30A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2244,6 +2396,15 @@
 			buildConfigurations = (
 				FC84E6D80723B23534997CFF /* Debug */,
 				EC82903E674DB84F696F9BD1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		9FD3781E06E3513BAD79B567 /* Build configuration list for PBXNativeTarget "SoloCompassWidgets" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4A829C0F9F10F04A2D837373 /* Debug */,
+				84A4043009900070C9536CE7 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/apps/ios/SoloCompass/App/SoloCompassApp.swift
+++ b/apps/ios/SoloCompass/App/SoloCompassApp.swift
@@ -48,8 +48,17 @@ final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
         let userInfo = response.notification.request.content.userInfo
+        let actionId = response.actionIdentifier
         Task { @MainActor in
-            NotificationService.shared.handleRemotePayload(userInfo)
+            // US-026: a quick-action tap ("我已出发 / 查看路线 / 接受 / 查看申请")
+            // routes through handleActionResponse; a plain banner tap
+            // (UNNotificationDefaultActionIdentifier) keeps the prior behavior.
+            if actionId == UNNotificationDefaultActionIdentifier
+                || actionId == UNNotificationDismissActionIdentifier {
+                NotificationService.shared.handleRemotePayload(userInfo)
+            } else {
+                NotificationService.shared.handleActionResponse(actionIdentifier: actionId, userInfo: userInfo)
+            }
             completionHandler()
         }
     }
@@ -75,6 +84,10 @@ struct SoloCompassApp: App {
         // US-023: own the notification-center delegate so a tapped friend-request
         // banner routes to the inbox deep link (and foreground banners still show).
         UNUserNotificationCenter.current().delegate = NotificationDelegate.shared
+
+        // US-026: register the departure / join-request categories so their quick
+        // actions ("我已出发 / 查看路线", "接受 / 查看申请") attach to the banners.
+        SCNotificationCategory.registerAll()
     }
 
     @State private var locationService = LocationService.shared
@@ -90,6 +103,9 @@ struct SoloCompassApp: App {
     @State private var aiService = AIService(useSharedCache: true)
     @State private var preferences = UserPreferences()
     @State private var notificationService = NotificationService.shared
+    // US-026: Live Activities / Dynamic Island controller. Started/ended from
+    // the route, companion-countdown, recording, and AI-compile flows.
+    @State private var liveActivityService = LiveActivityService.shared
     @State private var subscriptionService = SubscriptionService()
     @State private var languageService = LanguageService.shared
     @State private var companionService = CompanionService.shared
@@ -109,6 +125,7 @@ struct SoloCompassApp: App {
                 .environment(aiService)
                 .environment(preferences)
                 .environment(notificationService)
+                .environment(liveActivityService)
                 .environment(subscriptionService)
                 .environment(languageService)
                 .environment(companionService)

--- a/apps/ios/SoloCompass/Resources/Info.plist
+++ b/apps/ios/SoloCompass/Resources/Info.plist
@@ -57,6 +57,8 @@
 	<string>Solo Compass needs access to your photos so you can attach an image to a place you add.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Solo Compass uses speech recognition so you can describe what you're looking for by voice.</string>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>location</string>

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -640,6 +640,20 @@
 "notification.route.join.title" = "You're in!";
 "notification.route.join.body" = "%1$@ added you to “%2$@”. Tap to see the route.";
 
+/* US-026 — Live Activity (Dynamic Island) copy */
+"island.compile.title" = "Composing today's page";
+"island.compile.subtitle" = "%d signals · synthesizing";
+
+/* US-026 — Notification quick actions */
+"notification.action.departed" = "I'm on my way";
+"notification.action.viewRoute" = "View route";
+"notification.action.accept" = "Accept";
+"notification.action.viewRequest" = "View request";
+
+/* US-026 — Departure reminder (time-sensitive) */
+"notification.departure.title" = "Meet up in 30 minutes";
+"notification.departure.body" = "Heading out soon — meet at %@.";
+
 /* US-020 — Invite friends into a recruiting route (no approval) */
 "invite.friends.button" = "Invite Friends";
 "invite.friends.button.a11y" = "Invite friends into this route";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -326,6 +326,20 @@
 "notification.route.join.title" = "你已加入！";
 "notification.route.join.body" = "%1$@ 把你加入了「%2$@」。点按查看路线。";
 
+/* US-026 — 灵动岛（实时活动）文案 */
+"island.compile.title" = "正在编排今日页面";
+"island.compile.subtitle" = "%d 条 signal · 编排中";
+
+/* US-026 — 通知快捷操作 */
+"notification.action.departed" = "我已出发";
+"notification.action.viewRoute" = "查看路线";
+"notification.action.accept" = "接受";
+"notification.action.viewRequest" = "查看申请";
+
+/* US-026 — 出发提醒（时效） */
+"notification.departure.title" = "30 分钟后集合";
+"notification.departure.body" = "即将出发 · 在 %@ 集合。";
+
 /* US-020 — 邀请好友直接加入招募中的路线（无需审批） */
 "invite.friends.button" = "邀请好友";
 "invite.friends.button.a11y" = "邀请好友加入此路线";

--- a/apps/ios/SoloCompass/Services/LiveActivityService.swift
+++ b/apps/ios/SoloCompass/Services/LiveActivityService.swift
@@ -1,0 +1,238 @@
+import Foundation
+import ActivityKit
+import Observation
+
+/// Starts, updates, and ends the four SoloCompass Live Activities (US-026):
+/// route / countdown / recording / compile. All activities are **local** —
+/// `Activity.request` + `activity.update` drive the Dynamic Island without any
+/// APNs push token, so this stays clear of the disabled push provisioning.
+///
+/// One activity runs at a time (the app never overlaps these scenarios). The
+/// service keeps a single `Activity<SoloCompassActivityAttributes>` handle plus
+/// its `kind`, so callers can start one and end it without juggling references.
+///
+/// Each `start*` reads from real app models (Route / RouteCompanion /
+/// VoiceService / AIService) and maps them onto `SoloCompassActivityState`. The
+/// widget extension renders that state — see `SoloCompassLiveActivity`.
+@MainActor
+@Observable
+public final class LiveActivityService {
+    public static let shared = LiveActivityService()
+
+    /// The currently running activity, if any. Read-only to callers.
+    public private(set) var current: Activity<SoloCompassActivityAttributes>?
+    /// Which scenario `current` represents (mirrors `current.attributes.kind`).
+    public private(set) var currentKind: SoloCompassActivityAttributes.Kind?
+
+    private init() {}
+
+    /// Whether the user has Live Activities enabled for the app. Surfaces in UI
+    /// so a "show in Dynamic Island" affordance can hide when off.
+    public var isEnabled: Bool {
+        ActivityAuthorizationInfo().areActivitiesEnabled
+    }
+
+    // MARK: - Route — 路线进行中
+
+    /// Begin a route Live Activity. `nextStopName` should be a short place name
+    /// (Experience.placeNameRomanized ?? placeNameLocal ?? title) — never the
+    /// long `title` sentence — so the island reads cleanly.
+    @discardableResult
+    public func startRoute(
+        routeTitle: String,
+        nextStopName: String,
+        nextStopMeta: String,
+        etaText: String,
+        currentStopIndex: Int,
+        totalStops: Int
+    ) -> Bool {
+        let state = SoloCompassActivityState(
+            routeTitle: routeTitle,
+            nextStopName: nextStopName,
+            nextStopMeta: nextStopMeta,
+            etaText: etaText,
+            currentStopIndex: currentStopIndex,
+            totalStops: totalStops
+        )
+        return start(kind: .route, state: state)
+    }
+
+    /// Advance the route activity to a new stop / ETA.
+    public func updateRoute(
+        nextStopName: String,
+        nextStopMeta: String,
+        etaText: String,
+        currentStopIndex: Int,
+        totalStops: Int
+    ) async {
+        guard currentKind == .route, var state = current?.content.state else { return }
+        state.nextStopName = nextStopName
+        state.nextStopMeta = nextStopMeta
+        state.etaText = etaText
+        state.currentStopIndex = currentStopIndex
+        state.totalStops = totalStops
+        await update(state)
+    }
+
+    // MARK: - Countdown — 出发倒计时
+
+    /// Begin a companion-group departure countdown. The widget renders a live
+    /// timer against `departureDate`, so the OS ticks the seconds for us.
+    @discardableResult
+    public func startCountdown(
+        groupTitle: String,
+        meetPointName: String,
+        departureDate: Date,
+        memberInitials: [String],
+        memberSummary: String
+    ) -> Bool {
+        let state = SoloCompassActivityState(
+            departureDate: departureDate,
+            meetPointName: meetPointName,
+            groupTitle: groupTitle,
+            memberInitials: memberInitials,
+            memberSummary: memberSummary
+        )
+        return start(kind: .countdown, state: state)
+    }
+
+    // MARK: - Recording — 录制语音 signal
+
+    /// Begin a voice-recording activity. Call `updateRecording(amplitude:)` from
+    /// the capture loop (e.g. observing `VoiceService.amplitude`) to feed the
+    /// waveform; the duration ticks itself from `startDate`.
+    @discardableResult
+    public func startRecording(
+        startDate: Date = Date(),
+        locality: String
+    ) -> Bool {
+        let state = SoloCompassActivityState(
+            recordingStartDate: startDate,
+            waveformSamples: [],
+            recordingLocality: locality
+        )
+        return start(kind: .recording, state: state)
+    }
+
+    /// Push a new amplitude sample into the rolling waveform window. Keeps the
+    /// last `window` samples so the bars scroll without growing the ContentState.
+    public func updateRecording(amplitude: Double, window: Int = 26) async {
+        guard currentKind == .recording, var state = current?.content.state else { return }
+        var samples = state.waveformSamples
+        samples.append(min(max(amplitude, 0), 1))
+        if samples.count > window { samples.removeFirst(samples.count - window) }
+        state.waveformSamples = samples
+        await update(state)
+    }
+
+    /// Background sampler that polls a live amplitude source a few times a
+    /// second and feeds the waveform. `VoiceService.amplitude` updates at ~60fps,
+    /// but ActivityKit throttles (and drains battery) if you push every frame —
+    /// so we sample at a calm cadence instead of mirroring every tick.
+    private var recordingSampler: Task<Void, Never>?
+
+    /// Begin a recording activity AND start sampling its waveform from
+    /// `amplitudeProvider` (e.g. `{ voiceService.amplitude }`). Both ChatSheet
+    /// and VoiceButton call this single entry so the island/lifecycle logic
+    /// lives in one place. The sampler stops when `endRecordingSession()` (or any
+    /// other activity start, or `end()`) runs.
+    public func beginRecordingSession(
+        locality: String,
+        amplitudeProvider: @escaping @MainActor () -> Double
+    ) {
+        guard startRecording(locality: locality) else { return }
+        recordingSampler?.cancel()
+        recordingSampler = Task { @MainActor [weak self] in
+            // ~3 samples/sec keeps the bars lively while staying well under
+            // ActivityKit's update budget.
+            while !Task.isCancelled, self?.currentKind == .recording {
+                await self?.updateRecording(amplitude: amplitudeProvider())
+                try? await Task.sleep(nanoseconds: 330_000_000)
+            }
+        }
+    }
+
+    /// End the recording activity and stop the waveform sampler.
+    public func endRecordingSession() async {
+        recordingSampler?.cancel()
+        recordingSampler = nil
+        if currentKind == .recording { await end() }
+    }
+
+    // MARK: - Compile — AI 编排中
+
+    /// Begin an AI-synthesis activity (evening page/route compile). Pass
+    /// `progress` 0–1, or -1 for an indeterminate shimmer.
+    @discardableResult
+    public func startCompile(
+        title: String,
+        subtitle: String,
+        progress: Double = -1
+    ) -> Bool {
+        let state = SoloCompassActivityState(
+            compileTitle: title,
+            compileSubtitle: subtitle,
+            compileProgress: progress
+        )
+        return start(kind: .compile, state: state)
+    }
+
+    /// Update compile progress (0–1).
+    public func updateCompile(progress: Double) async {
+        guard currentKind == .compile, var state = current?.content.state else { return }
+        state.compileProgress = progress
+        await update(state)
+    }
+
+    // MARK: - End
+
+    /// End the running activity immediately and drop the handle.
+    public func end() async {
+        guard let activity = current else { return }
+        await activity.end(nil, dismissalPolicy: .immediate)
+        current = nil
+        currentKind = nil
+    }
+
+    // MARK: - Core start / update
+
+    /// Request a new activity, ending any prior one first (one-at-a-time). Returns
+    /// false when Live Activities are disabled or the request throws.
+    @discardableResult
+    private func start(
+        kind: SoloCompassActivityAttributes.Kind,
+        state: SoloCompassActivityState
+    ) -> Bool {
+        guard isEnabled else { return false }
+
+        // Tear down any prior activity so we never stack two — fire-and-forget
+        // the async end, then request the new one.
+        if let prior = current {
+            current = nil
+            currentKind = nil
+            Task { await prior.end(nil, dismissalPolicy: .immediate) }
+        }
+
+        do {
+            let activity = try Activity.request(
+                attributes: SoloCompassActivityAttributes(kind: kind),
+                content: .init(state: state, staleDate: nil),
+                pushType: nil   // local-only; no APNs
+            )
+            current = activity
+            currentKind = kind
+            return true
+        } catch {
+            // Non-critical — the in-app UI is the primary surface; the island is
+            // an enhancement. Swallow (e.g. user disabled activities mid-flight).
+            current = nil
+            currentKind = nil
+            return false
+        }
+    }
+
+    private func update(_ state: SoloCompassActivityState) async {
+        guard let activity = current else { return }
+        await activity.update(.init(state: state, staleDate: nil))
+    }
+}

--- a/apps/ios/SoloCompass/Services/NotificationCategories.swift
+++ b/apps/ios/SoloCompass/Services/NotificationCategories.swift
@@ -1,0 +1,63 @@
+import Foundation
+import UserNotifications
+
+/// Notification categories + quick actions for the SoloCompass companion /
+/// route flows (US-026). Registered once at launch so the system attaches the
+/// "我已出发 / 查看路线" and "接受 / 查看申请" buttons to the matching banners.
+///
+/// Design source: the lock-screen stack in `island_notif.jsx` — a time-sensitive
+/// departure reminder with two actions, and a host-facing join request with an
+/// inline accept. Tapping an action routes through `NotificationService`'s
+/// userInfo handling just like a banner tap.
+public enum SCNotificationCategory {
+    /// 出发提醒 (time-sensitive) — "我已出发" / "查看路线".
+    public static let departure = "sc.departure"
+    /// 加入申请 (host view) — "接受" / "查看申请".
+    public static let joinRequest = "sc.joinRequest"
+
+    // Action identifiers (handled in NotificationService.handleActionResponse).
+    public static let actionDeparted    = "sc.action.departed"
+    public static let actionViewRoute   = "sc.action.viewRoute"
+    public static let actionAccept      = "sc.action.accept"
+    public static let actionViewRequest = "sc.action.viewRequest"
+
+    /// Build and register all categories. Idempotent — safe to call on every
+    /// launch; the last `setNotificationCategories` wins.
+    public static func registerAll(on center: UNUserNotificationCenter = .current()) {
+        let departed = UNNotificationAction(
+            identifier: actionDeparted,
+            title: NSLocalizedString("notification.action.departed", comment: "I'm on my way"),
+            options: []
+        )
+        let viewRoute = UNNotificationAction(
+            identifier: actionViewRoute,
+            title: NSLocalizedString("notification.action.viewRoute", comment: "View route"),
+            options: [.foreground]
+        )
+        let accept = UNNotificationAction(
+            identifier: actionAccept,
+            title: NSLocalizedString("notification.action.accept", comment: "Accept join request"),
+            options: [.authenticationRequired]
+        )
+        let viewRequest = UNNotificationAction(
+            identifier: actionViewRequest,
+            title: NSLocalizedString("notification.action.viewRequest", comment: "View request"),
+            options: [.foreground]
+        )
+
+        let departureCategory = UNNotificationCategory(
+            identifier: departure,
+            actions: [departed, viewRoute],
+            intentIdentifiers: [],
+            options: []
+        )
+        let joinCategory = UNNotificationCategory(
+            identifier: joinRequest,
+            actions: [accept, viewRequest],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        center.setNotificationCategories([departureCategory, joinCategory])
+    }
+}

--- a/apps/ios/SoloCompass/Services/NotificationService.swift
+++ b/apps/ios/SoloCompass/Services/NotificationService.swift
@@ -158,6 +158,125 @@ public final class NotificationService {
         await center.removePendingNotificationRequests(withIdentifiers: [identifier])
     }
 
+    // MARK: - US-026: companion / route lock-screen notifications
+    //
+    // The five scenarios from the design's lock-screen stack (island_notif.jsx).
+    // All local — no APNs. DayPage voice: structured, sentence-case, no emoji,
+    // the result stated in one line.
+
+    /// ① AI「此刻」提示 — e.g. "日落将至 · 步行 7 分钟可达 湄公河观景点". Default
+    /// interruption level; this is a gentle nudge, not urgent.
+    public func scheduleAINowHint(title: String, body: String, deepLinkExperienceId: String? = nil) async {
+        guard isAuthorized else { return }
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+        if let id = deepLinkExperienceId { content.userInfo = ["experienceId": id] }
+        await deliver(content, id: "ai-now-\(deepLinkExperienceId ?? UUID().uuidString)", after: 2)
+    }
+
+    /// ② 出发提醒 (time-sensitive) — "30 分钟后集合" with "我已出发 / 查看路线"
+    /// quick actions. Time-sensitive so it can break through Focus when the
+    /// group is about to set off. Fires at `fireDate` (e.g. 30 min before the
+    /// group's departure); a past/imminent `fireDate` is clamped to ~now.
+    public func scheduleDepartureReminder(
+        routeId: String,
+        title: String,
+        body: String,
+        fireDate: Date
+    ) async {
+        guard isAuthorized else { return }
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+        content.interruptionLevel = .timeSensitive
+        content.categoryIdentifier = SCNotificationCategory.departure
+        content.userInfo = ["routeId": routeId, "kind": "departure"]
+        let seconds = max(1, fireDate.timeIntervalSinceNow)
+        await deliver(content, id: "departure-\(routeId)", after: seconds)
+    }
+
+    /// ③ 加入申请 (host view) — "Yuna 想加入你的路线" with "接受 / 查看申请".
+    public func scheduleJoinRequestNotification(
+        routeId: String,
+        requestId: String,
+        title: String,
+        body: String
+    ) async {
+        guard isAuthorized else { return }
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+        content.categoryIdentifier = SCNotificationCategory.joinRequest
+        content.userInfo = ["routeId": routeId, "requestId": requestId, "kind": "joinRequest"]
+        await deliver(content, id: "join-\(requestId)", after: 2)
+    }
+
+    /// ④ 群聊新消息 — "Lin: 中午 11:30 我们转场 Sapa…". Routes to the chat thread.
+    public func scheduleGroupMessage(
+        conversationId: String,
+        senderName: String,
+        preview: String
+    ) async {
+        guard isAuthorized else { return }
+        let content = UNMutableNotificationContent()
+        content.title = senderName
+        content.body = preview
+        content.sound = .default
+        // Group by conversation so threads stack on the lock screen (the design's
+        // "+2 条" stacked notification).
+        content.threadIdentifier = "conv-\(conversationId)"
+        content.userInfo = ["type": "message", "conversationId": conversationId]
+        await deliver(content, id: "msg-\(conversationId)-\(UUID().uuidString)", after: 1)
+    }
+
+    /// ⑤ 已成团 — low-priority result confirmation, one line.
+    public func scheduleGroupFormed(routeId: String, title: String, body: String) async {
+        guard isAuthorized else { return }
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+        content.interruptionLevel = .passive
+        content.userInfo = ["routeId": routeId, "kind": "groupFormed"]
+        await deliver(content, id: "formed-\(routeId)", after: 2)
+    }
+
+    /// US-026: route a quick-action tap. "我已出发" is fire-and-forget (no nav);
+    /// "查看路线" / "接受" / "查看申请" deep-link into the matching surface via the
+    /// existing pendingDeepLink mechanism.
+    public func handleActionResponse(actionIdentifier: String, userInfo: [AnyHashable: Any]) {
+        switch actionIdentifier {
+        case SCNotificationCategory.actionDeparted:
+            // Acknowledged — no navigation. (A future story can mark the member
+            // as en route in the group thread.)
+            break
+        case SCNotificationCategory.actionAccept, SCNotificationCategory.actionViewRequest:
+            let requestId = userInfo["requestId"] as? String
+            pendingDeepLink = .friendRequestInbox(requestId: requestId)
+        case SCNotificationCategory.actionViewRoute:
+            // The map observes pendingDeepLink; a route deep link reuses the
+            // chat-conversation channel when a group thread exists, else falls
+            // through to a plain tap (handled by handleRemotePayload).
+            handleRemotePayload(userInfo)
+        default:
+            handleRemotePayload(userInfo)
+        }
+    }
+
+    /// Shared scheduling tail — removes any prior request with the same id, then
+    /// adds a short-delay one-shot trigger. Errors are non-critical (the in-app
+    /// surface is primary).
+    private func deliver(_ content: UNMutableNotificationContent, id: String, after seconds: TimeInterval) async {
+        await center.removePendingNotificationRequests(withIdentifiers: [id])
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: max(1, seconds), repeats: false)
+        let request = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
+        try? await center.add(request)
+    }
+
     // MARK: - Helpers
 
     private func secondsUntilMorning(quietHoursEnd: Int) -> TimeInterval {

--- a/apps/ios/SoloCompass/Shared/SoloCompassActivityAttributes.swift
+++ b/apps/ios/SoloCompass/Shared/SoloCompassActivityAttributes.swift
@@ -1,0 +1,140 @@
+import Foundation
+import ActivityKit
+
+/// Live Activity attributes shared between the main app (which starts and
+/// updates activities) and the `SoloCompassWidgets` extension (which renders
+/// them on the Lock Screen and in the Dynamic Island).
+///
+/// One attributes type carries all four scenarios via a `kind` discriminator on
+/// the dynamic `ContentState`, instead of four separate Activity types. iOS only
+/// surfaces one Live Activity in the compact Dynamic Island at a time, and the
+/// app never runs two of these scenarios concurrently — so a single attributes
+/// type keeps the widget's `ActivityConfiguration` to one declaration while the
+/// `ContentState.kind` switch drives which layout renders.
+///
+/// Design source: `island_notif.jsx` / `island_notif.css` from the
+/// claude.ai/design handoff (DayPage warm-amber system). Five island scenarios
+/// were specced; four are wired to real app state here (route / countdown /
+/// recording / compile). Navigation is omitted — the app has no turn-by-turn
+/// engine yet, so a live nav activity would have nothing real to update.
+///
+/// This file is compiled into BOTH targets. Keep it dependency-free (Foundation
+/// + ActivityKit only) so it never pulls SwiftUI or app services into the
+/// extension.
+public struct SoloCompassActivityAttributes: ActivityAttributes {
+    public typealias ContentState = SoloCompassActivityState
+
+    /// Which scenario this activity represents. Fixed for the lifetime of the
+    /// activity — the `kind` never changes once started, so the widget can pick
+    /// its layout from `attributes.kind` and read scenario-specific fields off
+    /// `ContentState`.
+    public let kind: Kind
+
+    public enum Kind: String, Codable, Hashable, Sendable {
+        case route       // 路线进行中 — following a route, next stop + walking ETA + progress
+        case countdown   // 出发倒计时 — companion group nearing its meet time
+        case recording   // 录制语音 signal — capturing a voice signal, live waveform + duration
+        case compile     // AI 编排中 — synthesizing today's page from the day's signals
+    }
+
+    public init(kind: Kind) {
+        self.kind = kind
+    }
+}
+
+/// The mutable per-frame state pushed via `activity.update(...)`.
+///
+/// A single flat struct holds the union of all four scenarios' fields; only the
+/// subset relevant to `attributes.kind` is populated. ActivityKit budgets the
+/// serialized `ContentState` to ~4KB, which this stays comfortably under.
+public struct SoloCompassActivityState: Codable, Hashable, Sendable {
+
+    // MARK: route — 路线进行中
+
+    /// Route title, e.g. "湄公河日落散步". Shown as the expanded header.
+    public var routeTitle: String
+    /// Short name of the next stop, e.g. "昭阿努翁雕像". Use Experience.shortName,
+    /// never the long `title` sentence.
+    public var nextStopName: String
+    /// Free-form walking-distance meta, e.g. "步行 7 分 · 540 m · 河堤一带".
+    public var nextStopMeta: String
+    /// Wall-clock arrival estimate as a display string, e.g. "17:49".
+    public var etaText: String
+    /// 1-based index of the current stop and total stop count (e.g. 2 / 3).
+    public var currentStopIndex: Int
+    public var totalStops: Int
+
+    // MARK: countdown — 出发倒计时
+
+    /// The absolute instant the group sets off. The widget renders a live
+    /// `Text(timerInterval:)` against this, so the OS ticks the countdown for
+    /// us without the app pushing every second.
+    public var departureDate: Date?
+    /// Meet-point short name, e.g. "昭阿努翁雕像".
+    public var meetPointName: String
+    /// Group title, e.g. "同伴团 · 30 分钟后集合".
+    public var groupTitle: String
+    /// Up to ~3 member initials for the avatar stack (e.g. ["M", "你", "T"]).
+    public var memberInitials: [String]
+    /// Human roster line, e.g. "Maya(主理) · 你 · Tomas".
+    public var memberSummary: String
+
+    // MARK: recording — 录制语音 signal
+
+    /// The instant recording began. Drives the live duration via
+    /// `Text(timerInterval:)`.
+    public var recordingStartDate: Date?
+    /// Latest normalized amplitude 0–1 from `VoiceService.amplitude`, sampled
+    /// for the waveform. A short rolling window keeps the bars lively without
+    /// flooding `update(...)`.
+    public var waveformSamples: [Double]
+    /// Locality hint shown under the title, e.g. "万象 河堤".
+    public var recordingLocality: String
+
+    // MARK: compile — AI 编排中
+
+    /// Headline for the synthesis, e.g. "正在编排今日页面".
+    public var compileTitle: String
+    /// Mono sub-line, e.g. "12 条 signal · 3 个地点".
+    public var compileSubtitle: String
+    /// 0–1 progress; drives the shimmer skeleton fill. -1 means indeterminate.
+    public var compileProgress: Double
+
+    public init(
+        routeTitle: String = "",
+        nextStopName: String = "",
+        nextStopMeta: String = "",
+        etaText: String = "",
+        currentStopIndex: Int = 0,
+        totalStops: Int = 0,
+        departureDate: Date? = nil,
+        meetPointName: String = "",
+        groupTitle: String = "",
+        memberInitials: [String] = [],
+        memberSummary: String = "",
+        recordingStartDate: Date? = nil,
+        waveformSamples: [Double] = [],
+        recordingLocality: String = "",
+        compileTitle: String = "",
+        compileSubtitle: String = "",
+        compileProgress: Double = -1
+    ) {
+        self.routeTitle = routeTitle
+        self.nextStopName = nextStopName
+        self.nextStopMeta = nextStopMeta
+        self.etaText = etaText
+        self.currentStopIndex = currentStopIndex
+        self.totalStops = totalStops
+        self.departureDate = departureDate
+        self.meetPointName = meetPointName
+        self.groupTitle = groupTitle
+        self.memberInitials = memberInitials
+        self.memberSummary = memberSummary
+        self.recordingStartDate = recordingStartDate
+        self.waveformSamples = waveformSamples
+        self.recordingLocality = recordingLocality
+        self.compileTitle = compileTitle
+        self.compileSubtitle = compileSubtitle
+        self.compileProgress = compileProgress
+    }
+}

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -1351,6 +1351,17 @@ public final class MapViewModel {
             preferredCategories: preferences.preferredCategories,
             dislikedCategories: preferences.dislikedCategories
         )
+        // US-026: surface the synthesis as an "AI 编排中" Live Activity — the
+        // skeleton-shimmer island that stands in for "正在编排今日页面". Ended in
+        // the defer so it always tears down, success or failure.
+        LiveActivityService.shared.startCompile(
+            title: NSLocalizedString("island.compile.title", comment: "AI compile island title"),
+            subtitle: String(
+                format: NSLocalizedString("island.compile.subtitle", comment: "AI compile island subtitle — count of candidates"),
+                candidates.count
+            )
+        )
+        defer { Task { await LiveActivityService.shared.end() } }
         do {
             let ranked = try await aiService.recommendExperiences(from: candidates, context: context)
             let rank = Dictionary(uniqueKeysWithValues: ranked.enumerated().map { ($0.element, $0.offset) })

--- a/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
@@ -1316,6 +1316,11 @@ public struct ChatSheet: View {
                 liveTranscript = ""
                 let stream = try voiceService.startListening()
                 if !reduceMotion { recordingPulse = true }
+                // US-026: surface the capture as a Live Activity (录制语音 signal)
+                // with a live waveform sampled from VoiceService.amplitude.
+                LiveActivityService.shared.beginRecordingSession(
+                    locality: ""
+                ) { voiceService.amplitude }
                 Haptics.impact(.light)
                 voiceStreamTask = Task { @MainActor in
                     do {
@@ -1341,6 +1346,7 @@ public struct ChatSheet: View {
 
     private func endPushToTalk(send: Bool) {
         voiceService.stopListening()
+        Task { await LiveActivityService.shared.endRecordingSession() }
         recordingPulse = false
         voiceStreamTask?.cancel()
         voiceStreamTask = nil
@@ -1364,6 +1370,7 @@ public struct ChatSheet: View {
         if voiceService.isListening {
             voiceService.stopListening()
         }
+        Task { await LiveActivityService.shared.endRecordingSession() }
         recordingPulse = false
         liveTranscript = ""
     }

--- a/apps/ios/SoloCompass/Views/Companion/ApprovalQueueView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ApprovalQueueView.swift
@@ -385,6 +385,67 @@ public struct ApprovalQueueView: View {
         }
 
         routeState = updated
+
+        // US-026: when this accept closes the group (成团), start a departure
+        // countdown Live Activity if the departure time parses to a real clock
+        // time. A vague hint like "morning" can't drive a live timer, so we skip
+        // it rather than invent a fake countdown.
+        if companion.status == .closed {
+            startCountdownActivity(for: companion, routeTitle: updated.title)
+        }
+    }
+
+    /// Map a closed companion slot onto a countdown Live Activity. Resolves
+    /// `departureWindow.time` ("HH:mm") to today's instant and builds the member
+    /// avatar stack from confirmed members (host first).
+    private func startCountdownActivity(for companion: RouteCompanion, routeTitle: String) {
+        guard let departure = Self.nextDeparture(from: companion.departureWindow.time) else { return }
+
+        let memberIds = ([companion.hostId] + companion.confirmedMembers)
+            .reduce(into: [String]()) { acc, id in if !acc.contains(id) { acc.append(id) } }
+        let initials = memberIds.map { id -> String in
+            let name = UserDirectory.displayName(forId: id)
+            return String(name.prefix(1)).uppercased()
+        }
+        let summary = memberIds.map { UserDirectory.displayName(forId: $0) }
+            .joined(separator: " · ")
+
+        LiveActivityService.shared.startCountdown(
+            groupTitle: routeTitle,
+            meetPointName: companion.departureLabel.isEmpty ? routeTitle : companion.departureLabel,
+            departureDate: departure,
+            memberInitials: initials,
+            memberSummary: summary
+        )
+
+        // US-026: also schedule a time-sensitive departure reminder 30 min before
+        // the group sets off (the design's "30 分钟后集合" banner). Local-only, so
+        // it nudges this device's owner — cross-device social pushes await APNs.
+        let meetLabel = companion.departureLabel.isEmpty ? routeTitle : companion.departureLabel
+        Task {
+            await NotificationService.shared.scheduleDepartureReminder(
+                routeId: route.id.rawValue,
+                title: NSLocalizedString("notification.departure.title", comment: "Departure reminder title"),
+                body: String(
+                    format: NSLocalizedString("notification.departure.body", comment: "Departure reminder body — meet point"),
+                    meetLabel
+                ),
+                fireDate: departure.addingTimeInterval(-30 * 60)
+            )
+        }
+    }
+
+    /// Parse a "HH:mm" departure hint into the next occurrence of that time
+    /// (today if still ahead, otherwise tomorrow). Returns nil for non-clock
+    /// hints like "morning".
+    private static func nextDeparture(from time: String) -> Date? {
+        let parts = time.split(separator: ":")
+        guard parts.count == 2, let h = Int(parts[0]), let m = Int(parts[1]),
+              (0..<24).contains(h), (0..<60).contains(m) else { return nil }
+        let cal = Calendar.current
+        let now = Date()
+        guard let today = cal.date(bySettingHour: h, minute: m, second: 0, of: now) else { return nil }
+        return today > now ? today : cal.date(byAdding: .day, value: 1, to: today)
     }
 
     private func decline(_ request: JoinRequest) {

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -852,6 +852,8 @@ struct CompassMapContentView: View {
                             stopCount: active.coordinates.count,
                             onEnd: {
                                 withAnimation(.easeInOut(duration: 0.25)) { activeRoute = nil }
+                                // US-026: tear down the route Live Activity too.
+                                Task { await LiveActivityService.shared.end() }
                             }
                         )
                         .padding(.horizontal, 16)
@@ -1145,7 +1147,34 @@ struct CompassMapContentView: View {
         activeRoute = ActiveRoute(route: route, coordinates: coords)
         viewModel.cameraPosition = .region(Self.region(enclosing: coords))
         HapticService.shared.impact(style: .medium)
+
+        // US-026: start the "路线进行中" Live Activity so the next stop, walking
+        // ETA, and overall progress live in the Dynamic Island. The first stop's
+        // short place name (never its long title sentence) heads the card.
+        let firstStop = route.experienceIds.first.flatMap { experienceService.getExperience(id: $0) }
+        let firstStopName = firstStop.map { $0.location.placeNameRomanized ?? $0.location.placeNameLocal ?? $0.title }
+            ?? route.title
+        // Rough first-leg ETA: ~1/N of the route's estimated duration from now.
+        let legMinutes = max(1, route.estimatedDuration / max(coords.count, 1))
+        let eta = Date().addingTimeInterval(Double(legMinutes) * 60)
+        let etaText = Self.islandTimeFormatter.string(from: eta)
+        LiveActivityService.shared.startRoute(
+            routeTitle: route.title,
+            nextStopName: firstStopName,
+            nextStopMeta: "步行约 \(legMinutes) 分 · 共 \(coords.count) 站",
+            etaText: etaText,
+            currentStopIndex: 1,
+            totalStops: coords.count
+        )
     }
+
+    /// HH:mm formatter for Live Activity ETAs — fixed 24h so the island reads
+    /// the same regardless of the device's 12/24-hour setting.
+    private static let islandTimeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm"
+        return f
+    }()
 
     /// Radius (meters) of the translucent circle drawn around the traveler's
     /// own location marker. ~120m reads as a comfortable "right here" bubble at

--- a/apps/ios/SoloCompassWidgets/Info.plist
+++ b/apps/ios/SoloCompassWidgets/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>SoloCompass</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/apps/ios/SoloCompassWidgets/IslandComponents.swift
+++ b/apps/ios/SoloCompassWidgets/IslandComponents.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+
+/// Small reusable pieces shared across the Live Activity layouts. Direct ports
+/// of the corresponding bits in `island_notif.css` (.wave / .av-stack /
+/// .exp-stops / .exp-pill / .compile-dots).
+
+// MARK: - Waveform (录制语音)
+
+/// Amplitude bars for the recording scenario. `samples` are 0–1 magnitudes
+/// (newest last). Mirrors `.wave` — amber-red bars, rounded, min 14% height so a
+/// silent moment still reads as "live".
+struct IslandWaveform: View {
+    let samples: [Double]
+    var barCount: Int = 22
+    var height: CGFloat = 30
+    var tint: Color = IP.rec
+
+    var body: some View {
+        GeometryReader { geo in
+            let bars = normalized()
+            let gap: CGFloat = 3
+            let barW = max(2, (geo.size.width - gap * CGFloat(bars.count - 1)) / CGFloat(bars.count))
+            HStack(alignment: .center, spacing: gap) {
+                ForEach(Array(bars.enumerated()), id: \.offset) { _, v in
+                    Capsule(style: .continuous)
+                        .fill(tint.opacity(0.55 + 0.45 * v))
+                        .frame(width: barW, height: max(height * 0.14, height * CGFloat(v)))
+                }
+            }
+            .frame(width: geo.size.width, height: geo.size.height, alignment: .center)
+        }
+        .frame(height: height)
+    }
+
+    /// Resample / pad the incoming samples to a fixed bar count so the bar width
+    /// stays stable as the rolling window fills.
+    private func normalized() -> [Double] {
+        guard !samples.isEmpty else { return Array(repeating: 0.12, count: barCount) }
+        if samples.count == barCount { return samples }
+        if samples.count > barCount {
+            return Array(samples.suffix(barCount))
+        }
+        // Left-pad with low bars so new audio scrolls in from the right.
+        return Array(repeating: 0.12, count: barCount - samples.count) + samples
+    }
+}
+
+// MARK: - Avatar stack (出发倒计时 members)
+
+/// Overlapping initial-circles, capped, with a black ring like the spec
+/// (`.av-stack .av { box-shadow: 0 0 0 2px #000 }`).
+struct IslandAvatarStack: View {
+    let initials: [String]
+    var size: CGFloat = 26
+    var cap: Int = 3
+
+    private static let palette: [Color] = [IP.avatarAmber, IP.accent, IP.avatarBlue]
+
+    var body: some View {
+        HStack(spacing: -size * 0.31) {
+            ForEach(Array(initials.prefix(cap).enumerated()), id: \.offset) { idx, name in
+                Text(name)
+                    .font(.islandDisplay(size * 0.46, .semibold))
+                    .foregroundStyle(IP.cream)
+                    .frame(width: size, height: size)
+                    .background(Circle().fill(Self.palette[idx % Self.palette.count]))
+                    .overlay(Circle().stroke(.black, lineWidth: 2))
+            }
+        }
+    }
+}
+
+// MARK: - Stop progress (路线进度)
+
+/// The dotted progress rail under the route's next-stop block
+/// (`.exp-stops` — done dots gold, the current dot a haloed cream).
+struct IslandStopProgress: View {
+    let current: Int   // 1-based current stop
+    let total: Int
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(0..<safeTotal, id: \.self) { i in
+                dot(for: i)
+                if i < safeTotal - 1 {
+                    Rectangle()
+                        .fill(i < current - 1 ? IP.sunGold : IP.cream(0.16))
+                        .frame(height: 2)
+                }
+            }
+        }
+        .frame(height: 11)
+    }
+
+    private var safeTotal: Int { Swift.max(total, 1) }
+
+    @ViewBuilder private func dot(for i: Int) -> some View {
+        let stop = i + 1
+        if stop < current {
+            Circle().fill(IP.sunGold).frame(width: 11, height: 11)
+        } else if stop == current {
+            Circle().fill(IP.sunGoldSoft).frame(width: 11, height: 11)
+                .overlay(Circle().stroke(IP.sunGold.opacity(0.25), lineWidth: 4))
+        } else {
+            Circle().fill(IP.cream(0.2)).frame(width: 11, height: 11)
+        }
+    }
+}
+
+// MARK: - Pill (status / count chip)
+
+/// The gold mono pill in expanded headers (`.exp-pill`).
+struct IslandPill: View {
+    let text: String
+    var tint: Color = IP.sunGoldSoft
+    var fill: Color = IP.goldPill
+    var stroke: Color = IP.goldBorder
+
+    var body: some View {
+        Text(text)
+            .font(.islandMono(11, .medium))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(fill))
+            .overlay(Capsule().stroke(stroke, lineWidth: 1))
+    }
+}
+
+// MARK: - Compile dots (AI 编排)
+
+/// The three gold dots used as the compact trailing accessory for the compile
+/// scenario (`.compile-dots`). Static here (Live Activities can't run keyframe
+/// loops), so it reads as a settled three-dot glyph.
+struct IslandCompileDots: View {
+    var body: some View {
+        HStack(spacing: 3) {
+            ForEach(0..<3, id: \.self) { i in
+                Circle()
+                    .fill(IP.sunGold.opacity(i == 1 ? 1 : 0.5))
+                    .frame(width: 4, height: 4)
+            }
+        }
+    }
+}
+
+// MARK: - Icon tile
+
+/// Rounded amber-tinted square that hosts an SF Symbol in expanded headers
+/// (`.exp-ic`). `recording` swaps to the red tint.
+struct IslandIconTile: View {
+    let systemName: String
+    var fill: Color = IP.goldTile
+    var tint: Color = IP.sunGold
+    var size: CGFloat = 30
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 9, style: .continuous)
+            .fill(fill)
+            .frame(width: size, height: size)
+            .overlay(
+                Image(systemName: systemName)
+                    .font(.system(size: size * 0.5, weight: .semibold))
+                    .foregroundStyle(tint)
+            )
+    }
+}

--- a/apps/ios/SoloCompassWidgets/IslandPalette.swift
+++ b/apps/ios/SoloCompassWidgets/IslandPalette.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+/// Warm-amber palette for the Live Activity / Dynamic Island surfaces.
+///
+/// The main app owns the full `CT` token set (`Views/Shared/CompareTokens.swift`),
+/// but `CT` lives in the app target and leans on SwiftUI semantic colors. Rather
+/// than drag the whole `Views/Shared` tree into the extension, this mirrors only
+/// the handful of tokens the island needs, sourced verbatim from the same hex
+/// values in `island_notif.css` (DayPage warm-amber system):
+///
+///   --accent #5D3000 · --sun-gold #C9A677 · --sun-gold-soft #F5E9D2 · --rec #C0492F
+///   plus the cream tones used for text on the black island glass.
+///
+/// Keep this in lockstep with `CT` if those hex values ever change.
+enum IP {
+    // Brand / now-semantic ambers (= CT.accent / CT.sunGold* / styles.css --sun-gold*)
+    static let accent       = hex(0x5D3000)
+    static let sunGold      = hex(0xC9A677)
+    static let sunGoldDeep  = hex(0xA07F4B)
+    static let sunGoldSoft  = hex(0xF5E9D2)
+    static let rec          = hex(0xC0492F)   // recording red
+
+    // Cream tones for text/lines on the black island (styles.css --cream*)
+    static let cream        = hex(0xF5EFE6)
+    static func cream(_ a: Double) -> Color { hex(0xF5EFE6).opacity(a) }
+
+    // Avatar fallback colors used by the countdown member stack
+    // (mirror styles.css inline avatar colors: #E89530 / #2F7DD1 + accent).
+    static let avatarAmber = hex(0xE89530)
+    static let avatarBlue  = hex(0x2F7DD1)
+
+    // Amber-tinted icon-tile fills / pill backgrounds (styles.css .exp-ic / .exp-pill).
+    static let goldTile    = hex(0xC9A677).opacity(0.18)
+    static let goldPill    = hex(0xC9A677).opacity(0.16)
+    static let goldBorder  = hex(0xC9A677).opacity(0.24)
+    static let recTile     = hex(0xC0492F).opacity(0.20)
+
+    static func hex(_ v: Int) -> Color {
+        Color(
+            .sRGB,
+            red: Double((v >> 16) & 0xFF) / 255,
+            green: Double((v >> 8) & 0xFF) / 255,
+            blue: Double(v & 0xFF) / 255,
+            opacity: 1
+        )
+    }
+}
+
+extension Font {
+    /// Monospaced digits — the island spec puts every number in JetBrains Mono;
+    /// SF Mono is the system stand-in. Used for countdowns, ETAs, durations.
+    static func islandMono(_ size: CGFloat, _ weight: Font.Weight = .medium) -> Font {
+        .system(size: size, weight: weight, design: .monospaced)
+    }
+    /// Rounded geometric sans for place names / titles (≈ Space Grotesk).
+    static func islandDisplay(_ size: CGFloat, _ weight: Font.Weight = .semibold) -> Font {
+        .system(size: size, weight: weight, design: .rounded)
+    }
+}

--- a/apps/ios/SoloCompassWidgets/LockScreenLiveActivityView.swift
+++ b/apps/ios/SoloCompassWidgets/LockScreenLiveActivityView.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+import WidgetKit
+
+/// The Lock Screen / banner presentation of the Live Activity (shown when the
+/// device has no Dynamic Island, or below the clock on any device). Reuses the
+/// same warm-amber chrome as the expanded island: a black glass card with a
+/// gold-tinted icon tile, cream text, and mono numbers.
+struct LockScreenLiveActivityView: View {
+    let kind: SoloCompassActivityAttributes.Kind
+    let state: SoloCompassActivityState
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            leadingTile
+            VStack(alignment: .leading, spacing: 6) {
+                header
+                detail
+            }
+            Spacer(minLength: 0)
+            trailing
+        }
+        .padding(14)
+    }
+
+    // MARK: leading icon tile
+
+    @ViewBuilder private var leadingTile: some View {
+        switch kind {
+        case .recording:
+            IslandIconTile(systemName: "mic.fill", fill: IP.recTile, tint: IP.rec, size: 38)
+        case .route:
+            IslandIconTile(systemName: "location.north.circle.fill", size: 38)
+        case .countdown:
+            IslandIconTile(systemName: "person.2.fill", size: 38)
+        case .compile:
+            IslandIconTile(systemName: "sparkles", size: 38)
+        }
+    }
+
+    // MARK: header (app label + title)
+
+    @ViewBuilder private var header: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("SOLOCOMPASS")
+                .font(.islandMono(10, .medium))
+                .tracking(1.4)
+                .foregroundStyle(IP.cream(0.5))
+            Text(titleText)
+                .font(.islandDisplay(15, .semibold))
+                .foregroundStyle(IP.cream)
+                .lineLimit(1)
+        }
+    }
+
+    private var titleText: String {
+        switch kind {
+        case .route:     return state.routeTitle
+        case .countdown: return state.groupTitle
+        case .recording: return "正在录制语音 signal"
+        case .compile:   return state.compileTitle
+        }
+    }
+
+    // MARK: detail line(s)
+
+    @ViewBuilder private var detail: some View {
+        switch kind {
+        case .route:
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    Text("下一站")
+                        .font(.islandMono(9.5, .medium)).textCase(.uppercase)
+                        .foregroundStyle(IP.sunGold)
+                    Text(state.nextStopName)
+                        .font(.islandDisplay(13, .semibold))
+                        .foregroundStyle(IP.cream)
+                        .lineLimit(1)
+                }
+                Text(state.nextStopMeta)
+                    .font(.islandMono(11))
+                    .foregroundStyle(IP.cream(0.5))
+                    .lineLimit(1)
+                IslandStopProgress(current: state.currentStopIndex, total: state.totalStops)
+                    .frame(maxWidth: 160)
+            }
+        case .countdown:
+            VStack(alignment: .leading, spacing: 6) {
+                Label(state.meetPointName, systemImage: "mappin.and.ellipse")
+                    .font(.islandMono(11))
+                    .foregroundStyle(IP.cream(0.5))
+                    .lineLimit(1)
+                HStack(spacing: 8) {
+                    IslandAvatarStack(initials: state.memberInitials, size: 22)
+                    Text(state.memberSummary)
+                        .font(.islandDisplay(11.5))
+                        .foregroundStyle(IP.cream(0.5))
+                        .lineLimit(1)
+                }
+            }
+        case .recording:
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 6) {
+                    Circle().fill(IP.rec).frame(width: 6, height: 6)
+                    Text("REC · \(state.recordingLocality)")
+                        .font(.islandMono(10.5, .medium)).textCase(.uppercase)
+                        .foregroundStyle(IP.cream(0.5))
+                }
+                IslandWaveform(samples: state.waveformSamples, barCount: 22, height: 22)
+                    .frame(maxWidth: 180)
+            }
+        case .compile:
+            Text(state.compileSubtitle)
+                .font(.islandMono(11.5, .medium)).textCase(.uppercase)
+                .foregroundStyle(IP.cream(0.5))
+                .lineLimit(1)
+        }
+    }
+
+    // MARK: trailing (live number)
+
+    @ViewBuilder private var trailing: some View {
+        switch kind {
+        case .route:
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(state.etaText)
+                    .font(.islandMono(20, .medium))
+                    .foregroundStyle(IP.sunGoldSoft)
+                Text("ETA")
+                    .font(.islandMono(9)).textCase(.uppercase)
+                    .foregroundStyle(IP.cream(0.5))
+            }
+        case .countdown:
+            CountdownText(date: state.departureDate, font: .islandMono(22, .medium))
+                .foregroundStyle(IP.sunGoldSoft)
+        case .recording:
+            DurationText(since: state.recordingStartDate, font: .islandMono(18, .medium))
+                .foregroundStyle(IP.cream)
+        case .compile:
+            IslandCompileDots()
+        }
+    }
+}

--- a/apps/ios/SoloCompassWidgets/SoloCompassLiveActivity.swift
+++ b/apps/ios/SoloCompassWidgets/SoloCompassLiveActivity.swift
@@ -1,0 +1,408 @@
+import SwiftUI
+import WidgetKit
+import ActivityKit
+
+/// The Live Activity widget — one `ActivityConfiguration` driving all four
+/// scenarios (route / countdown / recording / compile) via `attributes.kind`.
+///
+/// Layout maps the design's three island states onto ActivityKit's regions:
+///   · minimal      → `.minimal` (one glyph)
+///   · compact      → `.compactLeading` + `.compactTrailing`
+///   · expanded     → the `.expanded` regions (the long-press big card)
+///   · lock screen  → the configuration's `content` closure (the banner card)
+///
+/// Visual language is a direct port of `island_notif.css`: black island glass,
+/// cream text, JetBrains-Mono numbers (SF Mono stand-in), sun-gold accents, and
+/// the warm-amber DayPage system throughout.
+struct SoloCompassLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: SoloCompassActivityAttributes.self) { context in
+            // Lock Screen / banner presentation.
+            LockScreenLiveActivityView(kind: context.attributes.kind, state: context.state)
+                .activityBackgroundTint(Color.black.opacity(0.92))
+                .activitySystemActionForegroundColor(IP.sunGoldSoft)
+        } dynamicIsland: { context in
+            let kind = context.attributes.kind
+            let state = context.state
+            return DynamicIsland {
+                expandedRegions(kind: kind, state: state)
+            } compactLeading: {
+                CompactLeading(kind: kind, state: state)
+            } compactTrailing: {
+                CompactTrailing(kind: kind, state: state)
+            } minimal: {
+                MinimalGlyph(kind: kind, state: state)
+            }
+            .keylineTint(IP.sunGold)
+        }
+    }
+
+    // MARK: - Expanded regions
+
+    /// `DynamicIslandExpandedContentBuilder` is a restricted result builder with
+    /// no `buildEither`, so it can't host a `switch` directly. Keep the four
+    /// regions fixed and push the per-scenario branching down into ordinary
+    /// `@ViewBuilder` views (`ExpandedLeading` / `…Trailing` / `…Center` /
+    /// `…Bottom`), which each `switch` on `kind` freely.
+    @DynamicIslandExpandedContentBuilder
+    private func expandedRegions(
+        kind: SoloCompassActivityAttributes.Kind,
+        state: SoloCompassActivityState
+    ) -> DynamicIslandExpandedContent<some View> {
+        DynamicIslandExpandedRegion(.leading) {
+            ExpandedLeading(kind: kind)
+        }
+        DynamicIslandExpandedRegion(.trailing) {
+            ExpandedTrailing(kind: kind, state: state)
+        }
+        DynamicIslandExpandedRegion(.center) {
+            ExpandedCenter(kind: kind, state: state)
+        }
+        DynamicIslandExpandedRegion(.bottom) {
+            ExpandedBottom(kind: kind, state: state)
+        }
+    }
+}
+
+// MARK: - Expanded region dispatchers (per-scenario @ViewBuilder switches)
+
+private struct ExpandedLeading: View {
+    let kind: SoloCompassActivityAttributes.Kind
+    var body: some View {
+        switch kind {
+        case .route:     IslandIconTile(systemName: "location.north.circle.fill")
+        case .countdown: IslandIconTile(systemName: "person.2.fill")
+        case .recording: IslandIconTile(systemName: "mic.fill", fill: IP.recTile, tint: IP.rec)
+        case .compile:   IslandIconTile(systemName: "sparkles")
+        }
+    }
+}
+
+private struct ExpandedTrailing: View {
+    let kind: SoloCompassActivityAttributes.Kind
+    let state: SoloCompassActivityState
+    var body: some View {
+        switch kind {
+        case .route:     IslandPill(text: "\(state.currentStopIndex) / \(state.totalStops) 站")
+        case .countdown: CountdownPill(date: state.departureDate)
+        case .recording: RecPill(start: state.recordingStartDate)
+        case .compile:   IslandCompileDots()
+        }
+    }
+}
+
+private struct ExpandedCenter: View {
+    let kind: SoloCompassActivityAttributes.Kind
+    let state: SoloCompassActivityState
+    var body: some View {
+        switch kind {
+        case .route:
+            ExpandedTitle(title: state.routeTitle, sub: "进行中 · 第 \(state.currentStopIndex) 站")
+        case .countdown:
+            ExpandedTitle(title: state.groupTitle, sub: state.meetPointName, subIcon: "mappin.and.ellipse")
+        case .recording:
+            RecordingTitle(locality: state.recordingLocality)
+        case .compile:
+            ExpandedTitle(title: state.compileTitle, sub: state.compileSubtitle)
+        }
+    }
+}
+
+private struct ExpandedBottom: View {
+    let kind: SoloCompassActivityAttributes.Kind
+    let state: SoloCompassActivityState
+    var body: some View {
+        switch kind {
+        case .route:
+            RouteBottom(state: state)
+        case .countdown:
+            CountdownBottom(state: state)
+        case .recording:
+            IslandWaveform(samples: state.waveformSamples, barCount: 26, height: 34)
+                .padding(.top, 4)
+        case .compile:
+            CompileSkeleton(progress: state.compileProgress)
+                .padding(.top, 6)
+        }
+    }
+}
+
+// MARK: - Shared expanded header
+
+/// Title + uppercase mono subtitle used by route / countdown / compile centers.
+struct ExpandedTitle: View {
+    let title: String
+    let sub: String
+    var subIcon: String? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.islandDisplay(14, .semibold))
+                .foregroundStyle(IP.cream)
+                .lineLimit(1)
+            HStack(spacing: 5) {
+                if let subIcon {
+                    Image(systemName: subIcon).font(.system(size: 9))
+                }
+                Text(sub)
+                    .lineLimit(1)
+            }
+            .font(.islandMono(10.5, .medium))
+            .foregroundStyle(IP.cream(0.5))
+            .textCase(.uppercase)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct RecordingTitle: View {
+    let locality: String
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("正在录制语音 signal")
+                .font(.islandDisplay(14, .semibold))
+                .foregroundStyle(IP.cream)
+                .lineLimit(1)
+            HStack(spacing: 6) {
+                Circle().fill(IP.rec).frame(width: 6, height: 6)
+                Text("REC · \(locality)")
+                    .font(.islandMono(10.5, .medium))
+                    .foregroundStyle(IP.cream(0.5))
+                    .textCase(.uppercase)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Compact + minimal accessories
+
+private struct CompactLeading: View {
+    let kind: SoloCompassActivityAttributes.Kind
+    let state: SoloCompassActivityState
+
+    var body: some View {
+        switch kind {
+        case .route:
+            Image(systemName: "location.north.circle.fill")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(IP.sunGold)
+        case .countdown:
+            Image(systemName: "person.2.fill")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(IP.sunGold)
+        case .recording:
+            Image(systemName: "mic.fill")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(IP.rec)
+        case .compile:
+            Image(systemName: "sparkles")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(IP.sunGold)
+        }
+    }
+}
+
+private struct CompactTrailing: View {
+    let kind: SoloCompassActivityAttributes.Kind
+    let state: SoloCompassActivityState
+
+    var body: some View {
+        switch kind {
+        case .route:
+            HStack(spacing: 3) {
+                Image(systemName: "figure.walk").font(.system(size: 11)).foregroundStyle(IP.cream(0.5))
+                Text(state.etaText)
+                    .font(.islandMono(13, .medium))
+                    .foregroundStyle(IP.cream)
+            }
+        case .countdown:
+            CountdownText(date: state.departureDate, font: .islandMono(13, .medium))
+                .foregroundStyle(IP.sunGoldSoft)
+        case .recording:
+            DurationText(since: state.recordingStartDate, font: .islandMono(13, .medium))
+                .foregroundStyle(IP.cream)
+        case .compile:
+            IslandCompileDots()
+        }
+    }
+}
+
+private struct MinimalGlyph: View {
+    let kind: SoloCompassActivityAttributes.Kind
+    let state: SoloCompassActivityState
+
+    var body: some View {
+        switch kind {
+        case .route:
+            Image(systemName: "location.north.circle.fill").foregroundStyle(IP.sunGold)
+        case .countdown:
+            Image(systemName: "person.2.fill").foregroundStyle(IP.sunGold)
+        case .recording:
+            Circle().fill(IP.rec).frame(width: 9, height: 9)
+        case .compile:
+            Image(systemName: "sparkles").foregroundStyle(IP.sunGold)
+        }
+    }
+}
+
+// MARK: - Expanded bottoms
+
+private struct RouteBottom: View {
+    let state: SoloCompassActivityState
+
+    var body: some View {
+        VStack(spacing: 12) {
+            HStack(alignment: .center, spacing: 12) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("下一站")
+                        .font(.islandMono(10, .medium)).textCase(.uppercase)
+                        .foregroundStyle(IP.sunGold)
+                    Text(state.nextStopName)
+                        .font(.islandDisplay(16, .semibold))
+                        .foregroundStyle(IP.cream)
+                        .lineLimit(1)
+                    Text(state.nextStopMeta)
+                        .font(.islandMono(11.5))
+                        .foregroundStyle(IP.cream(0.5))
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 8)
+                VStack(alignment: .trailing, spacing: 3) {
+                    Text(state.etaText)
+                        .font(.islandMono(22, .medium))
+                        .foregroundStyle(IP.sunGoldSoft)
+                    Text("预计到达")
+                        .font(.islandMono(10)).textCase(.uppercase)
+                        .foregroundStyle(IP.cream(0.5))
+                }
+            }
+            IslandStopProgress(current: state.currentStopIndex, total: state.totalStops)
+        }
+    }
+}
+
+private struct CountdownBottom: View {
+    let state: SoloCompassActivityState
+
+    var body: some View {
+        VStack(spacing: 12) {
+            HStack(alignment: .bottom) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("距集合")
+                        .font(.islandMono(10, .medium)).textCase(.uppercase)
+                        .foregroundStyle(IP.sunGold)
+                    CountdownText(date: state.departureDate, font: .islandMono(38, .medium))
+                        .foregroundStyle(IP.cream)
+                }
+                Spacer()
+                Label("已到达", systemImage: "checkmark")
+                    .font(.islandDisplay(13, .semibold))
+                    .foregroundStyle(IP.sunGoldSoft)
+                    .padding(.horizontal, 16).padding(.vertical, 10)
+                    .background(Capsule().fill(IP.cream(0.1)))
+                    .overlay(Capsule().stroke(IP.cream(0.16), lineWidth: 0.5))
+            }
+            HStack(spacing: 9) {
+                IslandAvatarStack(initials: state.memberInitials)
+                Text(state.memberSummary)
+                    .font(.islandDisplay(12, .regular))
+                    .foregroundStyle(IP.cream(0.5))
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+        }
+    }
+}
+
+/// Shimmer skeleton rows for the compile scenario. Three rows of decreasing
+/// width; when `progress >= 0` a gold fill shows how far synthesis has reached.
+private struct CompileSkeleton: View {
+    let progress: Double
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            ShimmerRow(widthFraction: 0.9, progress: progress)
+            ShimmerRow(widthFraction: 0.7, progress: progress)
+            ShimmerRow(widthFraction: 0.5, progress: progress)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct ShimmerRow: View {
+    let widthFraction: CGFloat
+    let progress: Double
+
+    var body: some View {
+        GeometryReader { geo in
+            let trackW = geo.size.width * widthFraction
+            ZStack(alignment: .leading) {
+                Capsule().fill(IP.cream(0.1)).frame(width: trackW)
+                if progress >= 0 {
+                    Capsule().fill(IP.sunGold.opacity(0.55))
+                        .frame(width: trackW * CGFloat(min(max(progress, 0), 1)))
+                }
+            }
+        }
+        .frame(height: 8)
+    }
+}
+
+// MARK: - Live timer helpers
+
+/// Live count-DOWN to a future date, rendered as a mono mm:ss the OS ticks for us.
+struct CountdownText: View {
+    let date: Date?
+    let font: Font
+
+    var body: some View {
+        if let date {
+            Text(timerInterval: Date.now...max(date, Date.now.addingTimeInterval(1)),
+                 countsDown: true)
+                .font(font)
+                .monospacedDigit()
+        } else {
+            Text("--:--").font(font)
+        }
+    }
+}
+
+/// Live count-UP from a start date (recording duration).
+struct DurationText: View {
+    let since: Date?
+    let font: Font
+
+    var body: some View {
+        if let since {
+            Text(timerInterval: since...Date.distantFuture, countsDown: false)
+                .font(font)
+                .monospacedDigit()
+        } else {
+            Text("0:00").font(font)
+        }
+    }
+}
+
+private struct CountdownPill: View {
+    let date: Date?
+    var body: some View {
+        CountdownText(date: date, font: .islandMono(11, .medium))
+            .foregroundStyle(IP.sunGoldSoft)
+            .padding(.horizontal, 9).padding(.vertical, 3)
+            .background(Capsule().fill(IP.goldPill))
+            .overlay(Capsule().stroke(IP.goldBorder, lineWidth: 1))
+    }
+}
+
+private struct RecPill: View {
+    let start: Date?
+    var body: some View {
+        DurationText(since: start, font: .islandMono(11, .medium))
+            .foregroundStyle(IP.sunGoldSoft)
+            .padding(.horizontal, 9).padding(.vertical, 3)
+            .background(Capsule().fill(IP.rec.opacity(0.18)))
+            .overlay(Capsule().stroke(IP.rec.opacity(0.3), lineWidth: 1))
+    }
+}

--- a/apps/ios/SoloCompassWidgets/SoloCompassWidgetsBundle.swift
+++ b/apps/ios/SoloCompassWidgets/SoloCompassWidgetsBundle.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+import WidgetKit
+
+/// The widget extension's entry point. Holds only the Live Activity for now
+/// (US-026). Home Screen / Lock Screen widgets can be added to this bundle later
+/// without touching the activity.
+@main
+struct SoloCompassWidgetsBundle: WidgetBundle {
+    var body: some Widget {
+        SoloCompassLiveActivity()
+    }
+}

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -44,6 +44,11 @@ targets:
         CFBundleLocalizations:
           - en
           - zh-Hans
+        # US-026: opt the app into Live Activities so LiveActivityService can
+        # start Dynamic Island activities. This is local-only — it needs no APNs
+        # / aps-environment entitlement (activities update via ActivityKit, not
+        # remote push), so it stays clear of the disabled push provisioning.
+        NSSupportsLiveActivities: true
         UILaunchScreen: {}
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
@@ -117,6 +122,40 @@ targets:
         product: Sentry
       - package: swift-markdown-ui
         product: MarkdownUI
+      # Embed the Live Activities widget extension into the app bundle. Without
+      # this dependency the extension builds but is never copied into
+      # SoloCompass.app/PlugIns, so iOS can't surface the Dynamic Island UI.
+      - target: SoloCompassWidgets
+
+  # Live Activities / Dynamic Island widget extension (US-026). Renders the four
+  # Live Activity scenarios (route / countdown / recording / compile) on the
+  # Lock Screen and in the Dynamic Island. The main app drives state via
+  # LiveActivityService; this extension only renders ContentState — it has no
+  # app services, no network, and no APNs (activities update locally).
+  SoloCompassWidgets:
+    type: app-extension
+    platform: iOS
+    deploymentTarget: "17.0"
+    sources:
+      # The extension's own SwiftUI widget code.
+      - path: SoloCompassWidgets
+      # The ActivityAttributes contract, compiled into BOTH targets so the app
+      # and the widget agree on the ContentState shape. Single source of truth.
+      - path: SoloCompass/Shared/SoloCompassActivityAttributes.swift
+    info:
+      path: SoloCompassWidgets/Info.plist
+      properties:
+        CFBundleDisplayName: SoloCompass
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.widgetkit-extension
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.solocompass.app.widgets
+        INFOPLIST_FILE: SoloCompassWidgets/Info.plist
+        CODE_SIGN_STYLE: Manual
+        CODE_SIGN_IDENTITY: "Apple Distribution"
+        DEVELOPMENT_TEAM: "6RG2F8YY59"
+        SKIP_INSTALL: NO
 
   SoloCompassTests:
     type: bundle.unit-test


### PR DESCRIPTION
## 概要

落地 claude.ai/design 的 **「Live Activities & Notifications」** 设计稿（DayPage 暖琥珀系统 · iOS 26）。设计稿两大块：5 个灵动岛场景 ×3 态 + 5 条锁屏通知 —— 全部转译为真实 iOS 实现并接通真实业务链路。

## 灵动岛 / Dynamic Island（US-026）

新建 `SoloCompassWidgets` app-extension target（xcodegen 管理），一个 `ActivityConfiguration` 通过 `kind` 判别驱动 4 个场景：

| 场景 | 业务链路 | 三态 |
| --- | --- | --- |
| 路线进行中 | `startRouteOnMap`（下一站短名 + 步行 ETA + 进度条 2/3） | minimal / compact / expanded + 锁屏 |
| 出发倒计时 | 成团（`ApprovalQueueView`）· `departureWindow.time` 解析 · 成员头像堆叠 + `Text(timerInterval:)` 走秒 | ✓ |
| 录制语音 signal | ChatSheet push-to-talk · 节流采样 `VoiceService.amplitude` 喂波形 | ✓ |
| AI 编排中 | `runAIRanking` · 骨架占位 shimmer | ✓ |

- **共享 `SoloCompassActivityAttributes`** 同时编进 app + extension，单一 ContentState 契约。
- **`LiveActivityService`**（@MainActor）本地 `ActivityKit` start/update/end —— **不走 APNs**，绕开已禁用的 push 配置；`NSSupportsLiveActivities` 经 Info.plist 开启。
- 视觉 1:1 复刻 `island_notif.css`：黑玻璃岛、cream 文字、mono 数字（JetBrains Mono → SF Mono）、sun-gold 强调。

## 通知

- `NotificationService` 新增设计稿的 5 类锁屏通知（AI 此刻 / **time-sensitive** 出发提醒 / 加入申请 / 群聊分组堆叠 / 已成团），全本地。
- `NotificationCategories` 加快捷操作（我已出发·查看路线 / 接受·查看申请），经 `NotificationDelegate` 路由；出发提醒在解析出的出发时间前 30 分钟触发。
- 双语 Localizable（`island.*` / `notification.action.*` / `notification.departure.*`）。

## 范围说明（诚实交付）

- **导航场景刻意未做**：app 无 turn-by-turn 引擎，做了也无真实数据可更新。
- **跨设备社交推送**（A 申请 → B 设备通知）本质需 APNs（当前禁用）；`schedule*` API 已就位，待 APNs 恢复后由后端触发。本地可真实触发的是「出发提醒（给本机）」。

## 验证

- ✅ 主 app + widget extension 全量构建通过（iPhone 17 Pro 模拟器，零 error）。
- ⏳ 灵动岛真机渲染视觉验证留待真机/TestFlight（模拟器 Live Activity 渲染需真触发）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)