### PR TITLE
fix(ci): provision widget extension for TestFlight archive

### DIFF
--- a/.github/workflows/regen-profiles.yml
+++ b/.github/workflows/regen-profiles.yml
@@ -1,11 +1,13 @@
 name: Regenerate Signing Profiles
 
-# Manually re-issue the App Store provisioning profile and push it to the
-# solo-compass-certs repo. Run this after changing the App ID's capabilities in
-# the Apple Developer portal (e.g. enabling Push Notifications for US-021): the
-# existing profile is invalidated by Apple and must be regenerated so it carries
-# the new entitlements. Uses the same secrets as the TestFlight deploy — nothing
-# is needed locally.
+# Manually re-issue the App Store provisioning profiles and push them to the
+# solo-compass-certs repo. Run this when the set of signed bundles or their
+# capabilities change — e.g. enabling Push Notifications for US-021, or adding
+# the Live Activities widget extension (US-026, com.solocompass.app.widgets):
+# the existing profiles are invalidated/missing and must be regenerated so they
+# carry the new entitlements and cover every bundle the archive signs. The
+# regen_profiles lane provisions both the main app and the widget extension.
+# Uses the same secrets as the TestFlight deploy — nothing is needed locally.
 on:
   workflow_dispatch:
     inputs:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,6 +10,62 @@ end
 
 default_platform(:ios)
 
+# App Store distribution covers two signed bundles: the main app and the
+# Live Activities widget extension (US-026). Each needs its own App ID and
+# provisioning profile — the widget can't ride on the main app's profile, so
+# the archive fails with "profile … has app ID com.solocompass.app, which does
+# not match the bundle ID com.solocompass.app.widgets" if it isn't provisioned
+# separately.
+APP_IDENTIFIER    = "com.solocompass.app".freeze
+WIDGET_IDENTIFIER = "com.solocompass.app.widgets".freeze
+SIGNED_IDENTIFIERS = [APP_IDENTIFIER, WIDGET_IDENTIFIER].freeze
+
+XCODEPROJ_PATH = "apps/ios/SoloCompass.xcodeproj".freeze
+
+# Map each signed bundle ID to the Xcode target that produces it. Used to write
+# the matching provisioning profile into each target's build settings.
+TARGET_FOR_IDENTIFIER = {
+  APP_IDENTIFIER    => "SoloCompass",
+  WIDGET_IDENTIFIER => "SoloCompassWidgets"
+}.freeze
+
+def certs_git_url
+  ENV["MATCH_GIT_URL"] || "git@github-solo-compass-certs:getyak/solo-compass-certs.git"
+end
+
+# match exports the resolved profile name per identifier as
+# `sigh_<bundle-id>_appstore_profile-name`. Fall back to match's default naming
+# convention if the env var isn't set (e.g. a dry parse of the lane).
+def profile_name_for(app_id)
+  ENV["sigh_#{app_id}_appstore_profile-name"] || "match AppStore #{app_id}"
+end
+
+# Pin each target to its own provisioning profile in the generated pbxproj.
+# xcodebuild's `archive` applies a single global PROVISIONING_PROFILE_SPECIFIER
+# xcarg to *every* target, so the only way to sign the app and its widget with
+# different profiles is to bake per-target specifiers into the project before
+# build_app runs.
+def apply_manual_signing(team_id)
+  SIGNED_IDENTIFIERS.each do |app_id|
+    update_code_signing_settings(
+      path:                  XCODEPROJ_PATH,
+      use_automatic_signing: false,
+      team_id:               team_id,
+      targets:               [TARGET_FOR_IDENTIFIER.fetch(app_id)],
+      code_sign_identity:    "Apple Distribution",
+      profile_name:          profile_name_for(app_id)
+    )
+  end
+end
+
+# provisioningProfiles map for gym's export_options — both bundles must be
+# present or `-exportArchive` can't sign the embedded widget.
+def export_provisioning_profiles
+  SIGNED_IDENTIFIERS.each_with_object({}) do |app_id, map|
+    map[app_id] = profile_name_for(app_id)
+  end
+end
+
 def api_key
   return nil unless ENV["APP_STORE_CONNECT_API_KEY_ID"]
 
@@ -64,14 +120,14 @@ platform :ios do
     match(
       type:              "appstore",
       readonly:          true,
-      git_url:           ENV["MATCH_GIT_URL"] || "git@github-solo-compass-certs:getyak/solo-compass-certs.git",
-      app_identifier:    "com.solocompass.app",
+      git_url:           certs_git_url,
+      app_identifier:    SIGNED_IDENTIFIERS,
       keychain_name:     "ci_keychain",
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"] || "ci_temp_password"
     )
 
-    profile_name = ENV["sigh_com.solocompass.app_appstore_profile-name"] || "match AppStore com.solocompass.app"
     team_id = ENV["DEVELOPMENT_TEAM"] || "6RG2F8YY59"
+    apply_manual_signing(team_id)
     build_app(
       scheme:           "SoloCompass",
       project:          "apps/ios/SoloCompass.xcodeproj",
@@ -80,12 +136,12 @@ platform :ios do
       clean:            true,
       output_directory: "build",
       output_name:      "SoloCompass.ipa",
-      xcargs:           "CODE_SIGN_STYLE=Manual CODE_SIGNING_REQUIRED=YES CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM=#{team_id} PROVISIONING_PROFILE_SPECIFIER='#{profile_name}' OTHER_CODE_SIGN_FLAGS='--keychain /Users/runner/Library/Keychains/ci_keychain-db'",
+      xcargs:           "CODE_SIGN_STYLE=Manual CODE_SIGNING_REQUIRED=YES CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM=#{team_id} OTHER_CODE_SIGN_FLAGS='--keychain /Users/runner/Library/Keychains/ci_keychain-db'",
       export_options:   {
         method:               "app-store",
         signingStyle:         "manual",
         teamID:               team_id,
-        provisioningProfiles: { "com.solocompass.app" => profile_name }
+        provisioningProfiles: export_provisioning_profiles
       }
     )
 
@@ -117,14 +173,14 @@ platform :ios do
     match(
       type:              "appstore",
       readonly:          true,
-      git_url:           ENV["MATCH_GIT_URL"] || "git@github-solo-compass-certs:getyak/solo-compass-certs.git",
-      app_identifier:    "com.solocompass.app",
+      git_url:           certs_git_url,
+      app_identifier:    SIGNED_IDENTIFIERS,
       keychain_name:     "ci_keychain",
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"] || "ci_temp_password"
     )
 
-    profile_name = ENV["sigh_com.solocompass.app_appstore_profile-name"] || "match AppStore com.solocompass.app"
     team_id = ENV["DEVELOPMENT_TEAM"] || "6RG2F8YY59"
+    apply_manual_signing(team_id)
     build_app(
       scheme:           "SoloCompass",
       project:          "apps/ios/SoloCompass.xcodeproj",
@@ -133,12 +189,12 @@ platform :ios do
       clean:            true,
       output_directory: "build",
       output_name:      "SoloCompass.ipa",
-      xcargs:           "CODE_SIGN_STYLE=Manual CODE_SIGNING_REQUIRED=YES CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM=#{team_id} PROVISIONING_PROFILE_SPECIFIER='#{profile_name}' OTHER_CODE_SIGN_FLAGS='--keychain /Users/runner/Library/Keychains/ci_keychain-db'",
+      xcargs:           "CODE_SIGN_STYLE=Manual CODE_SIGNING_REQUIRED=YES CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM=#{team_id} OTHER_CODE_SIGN_FLAGS='--keychain /Users/runner/Library/Keychains/ci_keychain-db'",
       export_options:   {
         method:               "app-store",
         signingStyle:         "manual",
         teamID:               team_id,
-        provisioningProfiles: { "com.solocompass.app" => profile_name }
+        provisioningProfiles: export_provisioning_profiles
       }
     )
 
@@ -191,23 +247,25 @@ platform :ios do
     UI.message "Build number set to #{build_number} (git commit count)"
   end
 
-  # Regenerate the App Store provisioning profile and push it to the certs repo.
-  # Run this (via the "Regenerate Signing Profiles" workflow) after changing the
-  # App ID's capabilities in the Apple Developer portal — e.g. enabling Push
-  # Notifications for US-021. `force: true` + `readonly: false` re-issues the
-  # profile so it includes the new entitlements, then match encrypts and pushes
-  # it to solo-compass-certs. The next TestFlight build picks it up automatically.
-  desc "Regenerate App Store signing profiles (writes to certs repo)"
+  # Regenerate the App Store provisioning profiles and push them to the certs
+  # repo. Run this (via the "Regenerate Signing Profiles" workflow) when the set
+  # of signed bundles or their capabilities change — e.g. enabling Push
+  # Notifications for US-021, or adding the Live Activities widget extension
+  # (US-026, bundle id com.solocompass.app.widgets). `force: true` +
+  # `readonly: false` (with the ASC API key) creates any missing App ID, re-issues
+  # the profile, then match encrypts and pushes it to solo-compass-certs. The next
+  # TestFlight build picks the new profiles up automatically.
+  desc "Regenerate App Store signing profiles for all signed bundles (writes to certs repo)"
   lane :regen_profiles do
     match(
       type:           "appstore",
       readonly:       false,
       force:          true,
-      git_url:        ENV["MATCH_GIT_URL"] || "git@github-solo-compass-certs:getyak/solo-compass-certs.git",
-      app_identifier: "com.solocompass.app",
+      git_url:        certs_git_url,
+      app_identifier: SIGNED_IDENTIFIERS,
       api_key:        api_key
     )
-    UI.success "App Store profile regenerated and pushed to certs repo."
+    UI.success "App Store profiles regenerated and pushed to certs repo: #{SIGNED_IDENTIFIERS.join(', ')}"
   end
 
   error do |lane, exception|

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,5 +1,5 @@
 git_url(ENV["MATCH_GIT_URL"] || "git@github-solo-compass-certs:getyak/solo-compass-certs.git")
 storage_mode("git")
 type("appstore")
-app_identifier("com.solocompass.app")
+app_identifier(["com.solocompass.app", "com.solocompass.app.widgets"])
 git_branch(ENV["MATCH_GIT_BRANCH"] || "main")


### PR DESCRIPTION
## Problem

The TestFlight deploy workflow has been **failing on every `main` push since #553** (Live Activities, US-026). The archive step fails:

```
error: Provisioning profile "match AppStore com.solocompass.app 1778651136"
has app ID "com.solocompass.app", which does not match the bundle ID
"com.solocompass.app.widgets". (in target 'SoloCompassWidgets')
** ARCHIVE FAILED **
```

PR #553 added a WidgetKit extension target `SoloCompassWidgets` (bundle id `com.solocompass.app.widgets`) to render the Live Activity / Dynamic Island UI. But the signing setup only ever provisioned `com.solocompass.app`, and `build_app` forced that single profile onto **every** target via a global `PROVISIONING_PROFILE_SPECIFIER` xcarg. The widget extension had no profile matching its own bundle id, so the archive failed.

## Fix

- **`fastlane/Fastfile` (`beta` / `release`)** — `match` now fetches profiles for **both** bundle ids. Per-target signing is written into the generated project with `update_code_signing_settings` (xcodebuild `archive` only honors per-target `PROVISIONING_PROFILE_SPECIFIER` build settings, not a single global xcarg — so the global override is removed). Both bundles are mapped in `export_options.provisioningProfiles`.
- **`fastlane/Fastfile` (`regen_profiles`)** + **`fastlane/Matchfile`** — provision both app ids, so a one-time `regen_profiles` run creates the widget App ID and its App Store profile in `solo-compass-certs`.
- **`.github/workflows/regen-profiles.yml`** — comment updated to note it now covers the widget bundle.

## ⚠️ One-time action required before the next deploy

`beta` uses `match` in **readonly** mode, so the widget's App Store profile must already exist in the `solo-compass-certs` repo. Run the **"Regenerate Signing Profiles"** workflow (`workflow_dispatch`, type `regenerate`) once — `regen_profiles` runs `match` with `readonly: false, force: true` and the ASC API key, which auto-creates the `com.solocompass.app.widgets` App ID + profile and pushes them to the certs repo. After that, TestFlight deploys pick the new profile up automatically.

## Validation

- `ruby -c fastlane/Fastfile` → Syntax OK
- `bundle exec fastlane lanes` loads all lanes (`build_only`, `beta`, `release`, `regen_profiles`) without error.
- The signed archive itself can only be verified on a macOS runner after the one-time regen above.

https://claude.ai/code/session_019EPYQeUE7qZJ31Jv1L6jnW

---
_Generated by [Claude Code](https://claude.ai/code/session_019EPYQeUE7qZJ31Jv1L6jnW)_