### PR TITLE
fix(ios): produce widget App ID before regen_profiles

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -247,16 +247,40 @@ platform :ios do
     UI.message "Build number set to #{build_number} (git commit count)"
   end
 
+  # Register an App ID on the Developer Portal if it doesn't exist yet. match
+  # can only *issue a profile* for an existing App ID — it does NOT create the
+  # identifier — so a brand-new bundle id (e.g. the widget extension) fails with
+  # "Could not find App ID with bundle identifier …" until `produce` registers
+  # it. produce is idempotent: it's a no-op when the App ID already exists.
+  def ensure_app_id(app_id)
+    produce(
+      app_identifier: app_id,
+      app_name:       app_id,
+      team_id:        ENV["DEVELOPMENT_TEAM"] || "6RG2F8YY59",
+      skip_itc:       true,   # Developer Portal only; the widget has no ASC app record
+      api_key:        api_key
+    )
+  rescue => e
+    # produce raises if the App ID already exists in some fastlane versions;
+    # treat "already exists" as success and let match proceed.
+    raise unless e.message =~ /already (exists|registered|taken)/i
+    UI.message "App ID #{app_id} already exists on the Developer Portal — skipping create."
+  end
+
   # Regenerate the App Store provisioning profiles and push them to the certs
   # repo. Run this (via the "Regenerate Signing Profiles" workflow) when the set
   # of signed bundles or their capabilities change — e.g. enabling Push
   # Notifications for US-021, or adding the Live Activities widget extension
-  # (US-026, bundle id com.solocompass.app.widgets). `force: true` +
-  # `readonly: false` (with the ASC API key) creates any missing App ID, re-issues
-  # the profile, then match encrypts and pushes it to solo-compass-certs. The next
-  # TestFlight build picks the new profiles up automatically.
+  # (US-026, bundle id com.solocompass.app.widgets). It first registers any
+  # missing App ID via `produce`, then `force: true` + `readonly: false` (with
+  # the ASC API key) re-issues each profile and match encrypts and pushes it to
+  # solo-compass-certs. The next TestFlight build picks the new profiles up.
   desc "Regenerate App Store signing profiles for all signed bundles (writes to certs repo)"
   lane :regen_profiles do
+    # Ensure every signed bundle id has an App ID on the Developer Portal before
+    # match tries to issue a profile for it.
+    SIGNED_IDENTIFIERS.each { |app_id| ensure_app_id(app_id) }
+
     match(
       type:           "appstore",
       readonly:       false,


### PR DESCRIPTION
## Why

PR #555 merged the widget **version-match** fix but was merged *before* this **App ID registration** commit was pushed, so it never reached `main`. This PR carries that remaining commit.

## Root cause

The Regenerate Signing Profiles workflow ([run 27392448611](https://github.com/getyak/solo-compass/actions/runs/27392448611)) failed with:

```
Could not find App ID with bundle identifier 'com.solocompass.app.widgets'
An app with that bundle ID needs to exist in order to create a provisioning profile for it
```

`match` only **issues a profile** for an App ID that already exists on the Developer Portal — it does **not** create the identifier. `com.solocompass.app` was registered long ago; `com.solocompass.app.widgets` (the new Live Activities widget extension, US-026) never was. The old comment in `regen_profiles` wrongly claimed match "creates any missing App ID".

## Fix

`regen_profiles` now calls `produce` for each signed bundle id **before** `match`:
- idempotent (no-op when the App ID already exists)
- authenticates with the same ASC API key
- registers a Developer-Portal-only identifier (`skip_itc`) — the widget needs no ASC app record

`ruby -c fastlane/Fastfile` → Syntax OK. `produce` is a core fastlane action (2.233.1 in Gemfile, no extra gem).

## After merge

Re-run **Regenerate Signing Profiles** (Actions → Run workflow → type `regenerate`). It now produces the widget App ID, then issues + pushes both profiles to `solo-compass-certs`. Then a tagged release can deploy to TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)