### PR TITLE
fix(ios): keep explicit city pick over GPS-anchored auto-explore

### DIFF
--- a/apps/ios/SoloCompass/Services/LocationService.swift
+++ b/apps/ios/SoloCompass/Services/LocationService.swift
@@ -13,15 +13,6 @@ public final class LocationService: NSObject {
     public private(set) var lastError: Error?
     public private(set) var heading: CLHeading?
 
-    #if DEBUG
-    /// Test hook: inject a GPS fix without a live CLLocationManager, so logic
-    /// that branches on `currentLocation` (e.g. `MapViewModel.bindToLocation`)
-    /// is unit-testable. DEBUG-only — never compiled into Release.
-    public func setTestLocation(_ coordinate: CLLocationCoordinate2D) {
-        currentLocation = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
-    }
-    #endif
-
     /// Geohash precision-6 (~600m×600m) of `currentLocation`. Nil when
     /// no location is known. Precise coordinates are never exposed — only
     /// the coarse cell string computed locally on device.

--- a/apps/ios/SoloCompass/Services/LocationService.swift
+++ b/apps/ios/SoloCompass/Services/LocationService.swift
@@ -13,6 +13,15 @@ public final class LocationService: NSObject {
     public private(set) var lastError: Error?
     public private(set) var heading: CLHeading?
 
+    #if DEBUG
+    /// Test hook: inject a GPS fix without a live CLLocationManager, so logic
+    /// that branches on `currentLocation` (e.g. `MapViewModel.bindToLocation`)
+    /// is unit-testable. DEBUG-only — never compiled into Release.
+    public func setTestLocation(_ coordinate: CLLocationCoordinate2D) {
+        currentLocation = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+    }
+    #endif
+
     /// Geohash precision-6 (~600m×600m) of `currentLocation`. Nil when
     /// no location is known. Precise coordinates are never exposed — only
     /// the coarse cell string computed locally on device.

--- a/apps/ios/SoloCompass/Tests/MapViewModelCityRegionSyncTests.swift
+++ b/apps/ios/SoloCompass/Tests/MapViewModelCityRegionSyncTests.swift
@@ -108,4 +108,92 @@ final class MapViewModelCityRegionSyncTests: XCTestCase {
             "Unknown, unseeded city must fall back to the default center"
         )
     }
+
+    // MARK: - V-007: a GPS fix must not override an explicit city pick
+
+    /// Regression (V-007): when the user has picked a preset city, the first GPS
+    /// fix at a far-away real location (e.g. picking a SF/China city while
+    /// physically in Laos) must NOT snap the camera back to the GPS location.
+    ///
+    /// Before the fix, `bindToLocation` skipped the camera recenter for a preset
+    /// city but still ran `autoExploreIfEmpty(at: gps)`, whose `exploreNearby`
+    /// tail called `selectCity(discoveredCity)` + `recenter(gps)` — silently
+    /// overriding the pick. The fix moves `autoExploreIfEmpty` inside the
+    /// "no city selected" branch so a preset city is left untouched.
+    func testGPSFixDoesNotOverridePresetCity() throws {
+        let locationService = LocationService()
+        let prefs = UserPreferences(defaults: makeIsolatedDefaults())
+        prefs.lastSelectedCity = "san-francisco"
+        let vm = MapViewModel(
+            locationService: locationService,
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: prefs
+        )
+        XCTAssertEqual(vm.selectedCity, "san-francisco")
+        let sf = try XCTUnwrap(MapViewModel.knownCityCenters["san-francisco"])
+
+        // Simulate the traveler being physically in Vientiane, Laos — ~12,000 km
+        // from the picked San Francisco.
+        let laos = CLLocationCoordinate2D(latitude: 17.9757, longitude: 102.6331)
+        locationService.setTestLocation(laos)
+
+        // The first GPS fix fires bindToLocation (CompassMapView's onChange).
+        vm.bindToLocation()
+
+        // Core regression assertion: a preset city must NOT trigger GPS-anchored
+        // auto-explore at all. (`exploreNearby`'s tail — selectCity + recenter —
+        // is async, so asserting on the count is the deterministic way to prove
+        // the override path is never entered; reverting the fix makes this fail.)
+        XCTAssertEqual(
+            vm.autoExploreInvocationCount, 0,
+            "A preset-city GPS fix must not run GPS-anchored auto-explore"
+        )
+        // The pick must survive: city unchanged, camera still on SF.
+        XCTAssertEqual(
+            vm.selectedCity, "san-francisco",
+            "A GPS fix must not change an explicit preset-city pick"
+        )
+        let region = try XCTUnwrap(vm.cameraPosition.region)
+        XCTAssertLessThan(
+            distanceKm(region.center, sf), 1.0,
+            "Camera must stay on the picked city, not snap to the GPS location"
+        )
+        XCTAssertGreaterThan(
+            distanceKm(region.center, laos), 1000.0,
+            "Camera must NOT be anywhere near the real GPS location"
+        )
+    }
+
+    /// Complement to the above: with NO city selected (pure GPS-follow mode), the
+    /// first GPS fix SHOULD recenter the camera on the user — the auto-recenter
+    /// path the fix must preserve.
+    func testGPSFixRecentersWhenNoCitySelected() throws {
+        let locationService = LocationService()
+        let prefs = UserPreferences(defaults: makeIsolatedDefaults())
+        prefs.lastSelectedCity = nil
+        let vm = MapViewModel(
+            locationService: locationService,
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: prefs
+        )
+        vm.selectedCity = nil
+
+        let laos = CLLocationCoordinate2D(latitude: 17.9757, longitude: 102.6331)
+        locationService.setTestLocation(laos)
+        vm.bindToLocation()
+
+        let region = try XCTUnwrap(vm.cameraPosition.region)
+        XCTAssertLessThan(
+            distanceKm(region.center, laos), 5.0,
+            "With no city selected, the first GPS fix must recenter on the user"
+        )
+        // GPS-follow mode must still run auto-explore (the behavior the fix
+        // preserves) — so a genuinely data-sparse landing still fetches places.
+        XCTAssertEqual(
+            vm.autoExploreInvocationCount, 1,
+            "With no city selected, the GPS fix must still run auto-explore"
+        )
+    }
 }

--- a/apps/ios/SoloCompass/Tests/MapViewModelCityRegionSyncTests.swift
+++ b/apps/ios/SoloCompass/Tests/MapViewModelCityRegionSyncTests.swift
@@ -136,7 +136,7 @@ final class MapViewModelCityRegionSyncTests: XCTestCase {
         // Simulate the traveler being physically in Vientiane, Laos — ~12,000 km
         // from the picked San Francisco.
         let laos = CLLocationCoordinate2D(latitude: 17.9757, longitude: 102.6331)
-        locationService.setTestLocation(laos)
+        locationService.simulate(location: CLLocation(latitude: laos.latitude, longitude: laos.longitude))
 
         // The first GPS fix fires bindToLocation (CompassMapView's onChange).
         vm.bindToLocation()
@@ -181,7 +181,7 @@ final class MapViewModelCityRegionSyncTests: XCTestCase {
         vm.selectedCity = nil
 
         let laos = CLLocationCoordinate2D(latitude: 17.9757, longitude: 102.6331)
-        locationService.setTestLocation(laos)
+        locationService.simulate(location: CLLocation(latitude: laos.latitude, longitude: laos.longitude))
         vm.bindToLocation()
 
         let region = try XCTUnwrap(vm.cameraPosition.region)

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -221,16 +221,23 @@ public final class MapViewModel {
         // city (persisted or `-startCity`) must not be yanked to the first GPS
         // fix. In the simulator that fix defaults to San Francisco, so without
         // this guard a `cmi` cold start shows the "Chiang Mai" header over a San
-        // Francisco map with an empty nearby list. We skip only the *camera
-        // recenter* for a preset (non-custom) city; the auto-explore check below
-        // still runs so a data-sparse landing can offer to fetch nearby places.
-        // The user can still pull to their real location via the explicit
-        // recenter button (`recenterOnUser`), which bypasses `hasAutoCentered`.
+        // Francisco map with an empty nearby list. The user can still pull to
+        // their real location via the explicit recenter button
+        // (`recenterOnUser`), which bypasses `hasAutoCentered`.
+        //
+        // Bugfix (V-007): when a preset city owns the camera we must ALSO skip
+        // `autoExploreIfEmpty`, not just the recenter. The auto-explore runs at
+        // the *GPS* coordinate, and on success `exploreNearby` ends with both
+        // `selectCity(discoveredCity)` and `recenter(gpsCoord)` — which silently
+        // overrode the user's explicit city pick (e.g. picking a China city
+        // while physically in Laos snapped the map + nearby list back to Laos).
+        // A user who picked a city wants that city; GPS-anchored auto-explore is
+        // only appropriate when we're actually following GPS (no city selected).
         let cityOwnsCamera = (selectedCity.map { !$0.hasPrefix("custom_") }) ?? false
         if !cityOwnsCamera {
             recenter(on: coordinate)
+            autoExploreIfEmpty(at: coordinate)
         }
-        autoExploreIfEmpty(at: coordinate)
     }
 
     /// Whether a GPS fix is available right now — drives the custom recenter
@@ -248,12 +255,24 @@ public final class MapViewModel {
         recenter(on: coordinate)
     }
 
+    #if DEBUG
+    /// Test-only counter: how many times `autoExploreIfEmpty` has been entered.
+    /// Lets the V-007 regression test assert that a preset-city `bindToLocation`
+    /// does NOT trigger GPS-anchored auto-explore (the path whose `exploreNearby`
+    /// tail overrode the user's city pick). Synchronous + deterministic, so it
+    /// catches the regression without racing the async `exploreNearby` Task.
+    @ObservationIgnored public private(set) var autoExploreInvocationCount = 0
+    #endif
+
     /// Auto-trigger Explore when the user lands in a data-sparse area
     /// (e.g. Vientiane with zero seed data). Fires once after the first
     /// GPS fix. Skips when there's already ≥3 experiences within 5 km,
     /// or when a recent (<7 day) offline region cache covers the spot.
     /// `exploreNearby` handles the paywall + consent gates internally.
     private func autoExploreIfEmpty(at coordinate: CLLocationCoordinate2D) {
+        #if DEBUG
+        autoExploreInvocationCount += 1
+        #endif
         let nearby = experienceService.getExperiences(near: coordinate, radiusKm: 5.0)
         guard nearby.count < 3 else { return }
 


### PR DESCRIPTION
## 现象

在老挝（真实 GPS）手动选一个中国城市后，**地图镜头跳回老挝 + 附近列表也变老挝** —— 选城被真实位置覆盖。

## 根因

`MapViewModel.bindToLocation()`（首个 GPS fix 触发）在选了预设城市时**跳过了相机 recenter，但仍无条件执行 `autoExploreIfEmpty(at: GPS坐标)`**。

数据稀疏的 GPS 点会触发 `exploreNearby(老挝)`，而它的结尾：
- `selectCity(discoveredCity)` → 把 `selectedCity` 切到老挝
- `recenter(gpsCoord)` → 相机跳回老挝

→ 用户选的中国城市被静默覆盖，相机/数据/列表全变老挝。

`824ed8d`（"keep cold-start camera on selected city over default GPS"）只修了**直接的 recenter**，漏了这条 **explore 间接路径**。

## 修复

把 `autoExploreIfEmpty` 移进 `if !cityOwnsCamera` 分支。用户显式选城 = 明确意图查看那个城市；GPS 锚定的 auto-explore 只在**真正跟随 GPS（无选城）**时才合理。

```swift
let cityOwnsCamera = (selectedCity.map { !$0.hasPrefix("custom_") }) ?? false
if !cityOwnsCamera {
    recenter(on: coordinate)
    autoExploreIfEmpty(at: coordinate)   // ← 移进来
}
```

## 回归测试（`MapViewModelCityRegionSyncTests`）

- **`testGPSFixDoesNotOverridePresetCity`** — 选 SF + 注入老挝 GPS → 城市/相机不变，`autoExploreInvocationCount == 0`。
- **`testGPSFixRecentersWhenNoCitySelected`** — 无选城 → GPS 正常 recenter **且**仍 auto-explore（修复保留的行为）。

**验证测试有意义**：回退 fix 后第一个测试失败 —— `XCTAssertEqual failed: ("1") is not equal to ("0")`。恢复 fix 后 7/7 通过。

## 测试基础设施

- DEBUG `autoExploreInvocationCount` 计数器：`exploreNearby` 是 async Task，用 `selectedCity` 同步断言抓不到；计数器同步、确定性。
- DEBUG `LocationService.setTestLocation`：注入 GPS fix 让 `bindToLocation` 这类依赖定位的逻辑可单测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)