### PR TITLE
feat(ios): long-press context menu on place cards

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		1917588F1289C48C928ACF6C /* CompanionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8062A7E6BA3EE88C6DAF02 /* CompanionService.swift */; };
 		193FE8EBE03520DF740EE78D /* PaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92F9A65ACFD3B9518A364B0 /* PaywallView.swift */; };
 		1961D53326B8AF67585215F7 /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CD4C674431C0702AD8AED3 /* Color+Hex.swift */; };
+		19AAF9D13B929174D04ADF84 /* ExperiencePreviewCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF52264EDAC06D283132721 /* ExperiencePreviewCard.swift */; };
 		1AB73ECFECC13F149F971563 /* SettingsViewQuerySortTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7112C1C0DEDB8C518D83CC18 /* SettingsViewQuerySortTest.swift */; };
 		1BF34EAE036021423C1ACE2D /* ExploreCacheRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F76E8EBB87A2F70FEA1BB0 /* ExploreCacheRecord.swift */; };
 		1C87BA1A3EB6B4D7FFCE3EA0 /* CreateExperienceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C7C2D7BA51FFDDF53242A3 /* CreateExperienceSheet.swift */; };
@@ -683,6 +684,7 @@
 		9A1B839F9F82AFDD50655AAE /* SystemTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemTheme.swift; sourceTree = "<group>"; };
 		9BFF9ECB175F4D2219406952 /* IOS18AvailabilityGuardTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOS18AvailabilityGuardTest.swift; sourceTree = "<group>"; };
 		9DA531A7BAD8A34652BA4801 /* CompanionCrossTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionCrossTests.swift; sourceTree = "<group>"; };
+		9DF52264EDAC06D283132721 /* ExperiencePreviewCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperiencePreviewCard.swift; sourceTree = "<group>"; };
 		9E8ABF85EEFDF9969C94B441 /* VoiceButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceButton.swift; sourceTree = "<group>"; };
 		9EDF4F9F84F50797290FF9E0 /* VoiceProcessingToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceProcessingToast.swift; sourceTree = "<group>"; };
 		9F0DD079D640DF68659C6483 /* NowSignalCompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowSignalCompositionTests.swift; sourceTree = "<group>"; };
@@ -865,6 +867,7 @@
 				53F836182A03FC067C4A9AB9 /* CompareTokens.swift */,
 				2294AF173D063B1F55894696 /* CompletionCelebrationView.swift */,
 				EC8F9EFD56A2C839428AA92D /* ConfidenceBadge.swift */,
+				9DF52264EDAC06D283132721 /* ExperiencePreviewCard.swift */,
 				C5C3BA25EFA9F149FB4FAAB3 /* FavoritesListView.swift */,
 				B39F3D5F813E5C3B23C7EE30 /* FlowLayout.swift */,
 				5933575E731D8AC09356AB9F /* GlassmorphismCapsule.swift */,
@@ -1933,6 +1936,7 @@
 				CF8B2BDE6D707CE2537C8688 /* ExperienceDetailView.swift in Sources */,
 				A84320715E7CBDA91FC3F26F /* ExperienceDetailViewModel.swift in Sources */,
 				9E0C778CF1FD76DB9E0CEB9D /* ExperienceImageService.swift in Sources */,
+				19AAF9D13B929174D04ADF84 /* ExperiencePreviewCard.swift in Sources */,
 				116FF0278F882D45402B0E78 /* ExperienceRecord.swift in Sources */,
 				7C14629A3FAB31975BFBB0A6 /* ExperienceRepository.swift in Sources */,
 				E7B5B022519434F7C07818CF /* ExperienceService.swift in Sources */,

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -352,6 +352,14 @@
 /* Experience card accessibility */
 "experience.card.hint" = "Double tap to view details";
 "experience.card.preview.a11y" = "Show quick preview";
+
+/* Long-press context menu on a place card */
+"menu.viewDetails" = "View details";
+"menu.showOnMap" = "Show on map";
+"menu.askSolo" = "Ask Solo";
+"menu.favorite" = "Save";
+"menu.unfavorite" = "Remove from saved";
+"menu.navigate" = "Directions";
 "card.favorite.add" = "Add to favorites";
 "card.favorite.remove" = "Remove from favorites";
 "card.favorite.added.a11y" = "Saved to favorites";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -191,6 +191,14 @@
 "experience.card.hint" = "双击查看详情";
 "experience.card.preview.a11y" = "显示快速预览";
 
+/* 地点卡片长按上下文菜单 */
+"menu.viewDetails" = "查看详情";
+"menu.showOnMap" = "在地图上显示";
+"menu.askSolo" = "问 Solo";
+"menu.favorite" = "收藏";
+"menu.unfavorite" = "取消收藏";
+"menu.navigate" = "导航前往";
+
 /* Voice recognition error alert */
 "voice.error.title" = "语音识别错误";
 "voice.error.permission" = "麦克风或语音识别权限被拒绝。请在「设置」中允许。";

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -752,11 +752,15 @@ struct NearbyExperienceRow: View {
     /// Long-pressing the card floats the quick preview card instead. Optional so
     /// existing callers that only want a tap action keep compiling.
     var onLongPress: (() -> Void)? = nil
+    /// "问 Solo" context-menu action — opens a chat scoped to this experience.
+    /// Optional so callers that don't wire chat keep compiling.
+    var onAskSolo: (() -> Void)? = nil
 
     @State private var pressed = false
     @State private var pulsing = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(LocationService.self) private var locationService
+    @Environment(UserPreferences.self) private var preferences
 
     private var isNearby: Bool {
         guard let m = distanceMeters else { return false }
@@ -882,15 +886,77 @@ struct NearbyExperienceRow: View {
         }
         .buttonStyle(.plain)
         .scaleEffect(pressed ? 0.97 : 1.0)
-        // Long-press floats the quick preview card; the tap (above) opens detail.
-        // Attached only when a handler is provided so non-long-press callers are
-        // unaffected.
-        .modifier(LongPressCardModifier(onLongPress: onLongPress))
+        // Long-press now raises the native context menu: a warm-amber preview
+        // card (key info + hero image) floating over a blurred backdrop, plus a
+        // quick-action menu (details · show on map · favorite · navigate · 问
+        // Solo). This replaces the former custom floating-card long-press —
+        // `onLongPress` is still wired as the "show on map" action so that
+        // behavior is preserved, just relocated into the menu.
+        .contextMenu {
+            cardContextMenu
+        } preview: {
+            ExperiencePreviewCard(
+                experience: experience,
+                distanceMeters: distanceMeters,
+                bestNowChipState: bestNowChipState
+            )
+        }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint(Text(NSLocalizedString("experience.card.hint", comment: "Double tap to view details")))
         .accessibilityAction(named: Text(NSLocalizedString("experience.card.preview.a11y", comment: "Preview action: float the quick preview card"))) {
             onLongPress?()
+        }
+    }
+
+    /// Quick actions for the long-press context menu. Favorite + navigate act
+    /// inline (preferences / NavigationLauncher); details, show-on-map, and 问
+    /// Solo route through the caller's handlers.
+    @ViewBuilder
+    private var cardContextMenu: some View {
+        Button {
+            onTap()
+        } label: {
+            Label(NSLocalizedString("menu.viewDetails", comment: "View details"), systemImage: "doc.text.magnifyingglass")
+        }
+
+        if let onLongPress {
+            Button {
+                onLongPress()
+            } label: {
+                Label(NSLocalizedString("menu.showOnMap", comment: "Show on map"), systemImage: "mappin.and.ellipse")
+            }
+        }
+
+        if let onAskSolo {
+            Button {
+                onAskSolo()
+            } label: {
+                Label(NSLocalizedString("menu.askSolo", comment: "Ask Solo about this place"), systemImage: "sparkles")
+            }
+        }
+
+        Divider()
+
+        let favorited = preferences.isFavorited(experience.id)
+        Button {
+            Haptics.impact(.light)
+            preferences.toggleFavorite(experience.id)
+        } label: {
+            Label(
+                favorited
+                    ? NSLocalizedString("menu.unfavorite", comment: "Remove from saved")
+                    : NSLocalizedString("menu.favorite", comment: "Save place"),
+                systemImage: favorited ? "heart.slash" : "heart"
+            )
+        }
+
+        if let coord = experience.coordinate {
+            Button {
+                NavigationLauncher.open(app: .appleMaps, coordinate: coord, name: experience.title)
+            } label: {
+                Label(NSLocalizedString("menu.navigate", comment: "Navigate there"), systemImage: "arrow.triangle.turn.up.right.diamond")
+            }
         }
     }
 
@@ -1250,6 +1316,8 @@ struct NearbySection: View {
     /// Long-pressing a row floats the quick preview card instead. Optional so
     /// callers that only wire a tap keep compiling.
     let onLongPressExperience: ((Experience) -> Void)?
+    /// "问 Solo" context-menu action — opens a chat scoped to the experience.
+    let onAskSoloExperience: ((Experience) -> Void)?
     /// When non-nil, passed through to EmptySheetListView to render the
     /// 'Explore another area' CTA that zooms the map out.
     let onExploreElsewhere: (() -> Void)?
@@ -1265,7 +1333,8 @@ struct NearbySection: View {
         showsSectionDivider: Bool = false,
         onExploreElsewhere: (() -> Void)? = nil,
         onSelectExperience: @escaping (Experience) -> Void,
-        onLongPressExperience: ((Experience) -> Void)? = nil
+        onLongPressExperience: ((Experience) -> Void)? = nil,
+        onAskSoloExperience: ((Experience) -> Void)? = nil
     ) {
         self.experiences = experiences
         self.smartPickIds = smartPickIds
@@ -1275,6 +1344,7 @@ struct NearbySection: View {
         self.onExploreElsewhere = onExploreElsewhere
         self.onSelectExperience = onSelectExperience
         self.onLongPressExperience = onLongPressExperience
+        self.onAskSoloExperience = onAskSoloExperience
     }
 
     /// US-036: When true, the Nearby header is preceded by an inset divider so a
@@ -1323,7 +1393,8 @@ struct NearbySection: View {
                             isOpenNow: openNow,
                             bestNowChipState: openNow ? chipState : nil,
                             onTap: { onSelectExperience(exp) },
-                            onLongPress: onLongPressExperience.map { handler in { handler(exp) } }
+                            onLongPress: onLongPressExperience.map { handler in { handler(exp) } },
+                            onAskSolo: onAskSoloExperience.map { handler in { handler(exp) } }
                         )
                     }
                 }

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -771,12 +771,24 @@ struct CompassMapContentView: View {
                                         }
                                     },
                                     onLongPressExperience: { exp in
-                                        // Long-press → float the quick preview
-                                        // card (the former tap behavior). Backing
-                                        // out of detail still lands on this card.
+                                        // Context-menu "show on map" → float the
+                                        // quick preview card (the former tap
+                                        // behavior). Backing out of detail still
+                                        // lands on this card.
                                         withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
                                             viewModel.selectExperience(exp)
                                         }
+                                    },
+                                    onAskSoloExperience: { exp in
+                                        // Context-menu "问 Solo" → open a chat
+                                        // scoped to this place (same path as the
+                                        // detail sheet's Ask-Solo button): ensure
+                                        // the orchestrator, then inject the
+                                        // <experience_context> block before the
+                                        // sheet content evaluates.
+                                        chatStartMode = .text
+                                        ensureOrchestrator(viewModel: viewModel)
+                                        voiceOrchestrator?.rebindContext(exp)
                                     }
                                 )
                             }

--- a/apps/ios/SoloCompass/Views/Shared/ExperiencePreviewCard.swift
+++ b/apps/ios/SoloCompass/Views/Shared/ExperiencePreviewCard.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+
+/// The floating preview shown above the native `.contextMenu` when a traveler
+/// long-presses a place card. Surfaces the decision-relevant essentials —
+/// a hero image (or category fallback), the short place name, its one-liner,
+/// the Solo score, the live "best now" state, and walking distance — so they can
+/// judge a spot without opening the full detail sheet.
+///
+/// Read-only by design: a context-menu preview must not contain its own tap
+/// targets (the menu items below own the actions), so every badge here is static.
+/// DayPage warm-amber system (CT tokens).
+struct ExperiencePreviewCard: View {
+    let experience: Experience
+    let distanceMeters: Double?
+    /// Live best-now / closing-soon chip state, resolved by the caller from the
+    /// shared clock. Nil hides the chip.
+    var bestNowChipState: BestNowChipState? = nil
+
+    /// Short, human place name — never the long `title` sentence.
+    private var placeName: String {
+        experience.location.placeNameRomanized
+            ?? experience.location.placeNameLocal
+            ?? experience.title
+    }
+
+    private var walkMinutes: Int? {
+        guard let m = distanceMeters else { return nil }
+        // ~80 m/min walking pace, floored to a sensible minimum of 1.
+        return max(1, Int((m / 80).rounded()))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            hero
+            details
+        }
+        .frame(width: 260)
+        .background(CT.surfaceWhite)
+    }
+
+    // MARK: - Hero image (or category fallback)
+
+    private var hero: some View {
+        ZStack(alignment: .topLeading) {
+            heroImage
+                .frame(width: 260, height: 146)
+                .clipped()
+
+            // Category chip (top-left) + best-now chip (top-right) float over the
+            // image so they stay legible on any photo.
+            HStack(alignment: .top) {
+                categoryChip
+                Spacer()
+                if let chip = bestNowChipState {
+                    bestNowChip(chip)
+                }
+            }
+            .padding(10)
+        }
+    }
+
+    @ViewBuilder
+    private var heroImage: some View {
+        if let urlString = experience.location.photoUrls?.first,
+           let url = URL(string: urlString) {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill()
+                case .empty:
+                    ZStack {
+                        experience.category.color.opacity(0.16)
+                        ProgressView().tint(experience.category.color)
+                    }
+                case .failure:
+                    categoryFallback
+                @unknown default:
+                    categoryFallback
+                }
+            }
+        } else {
+            categoryFallback
+        }
+    }
+
+    /// A warm category-tinted panel with a large glyph when no photo is available.
+    private var categoryFallback: some View {
+        ZStack {
+            LinearGradient(
+                colors: [experience.category.color.opacity(0.28), experience.category.color.opacity(0.12)],
+                startPoint: .topLeading, endPoint: .bottomTrailing
+            )
+            Image(systemName: experience.category.symbol)
+                .font(.system(size: 38, weight: .semibold))
+                .foregroundStyle(experience.category.color)
+        }
+    }
+
+    private var categoryChip: some View {
+        HStack(spacing: 5) {
+            Image(systemName: experience.category.symbol)
+                .font(.system(size: 10, weight: .bold))
+            Text(experience.category.localizedTitle)
+                .font(CT.body(11, .semibold))
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 8).padding(.vertical, 4)
+        .background(Capsule().fill(experience.category.color.opacity(0.92)))
+    }
+
+    private func bestNowChip(_ chip: BestNowChipState) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: chip.symbol).font(.system(size: 9, weight: .bold))
+            Text(chip.label).font(CT.body(10.5, .semibold))
+        }
+        .foregroundStyle(chip.foreground)
+        .padding(.horizontal, 7).padding(.vertical, 3)
+        .background(Capsule().fill(chip.background))
+    }
+
+    // MARK: - Details
+
+    private var details: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(placeName)
+                .font(CT.displayRounded(17, .semibold))
+                .foregroundStyle(CT.fgPrimary)
+                .lineLimit(1)
+
+            if !experience.oneLiner.isEmpty {
+                Text(experience.oneLiner)
+                    .font(CT.body(13))
+                    .foregroundStyle(CT.fgMuted)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            keyInfoRow
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 13)
+    }
+
+    /// Solo score · walking distance — the two numbers a traveler scans first.
+    private var keyInfoRow: some View {
+        HStack(spacing: 8) {
+            HStack(spacing: 4) {
+                Image(systemName: "figure.stand")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(CT.verifiedGreen)
+                Text(String(format: "Solo %.1f", experience.soloScore.overall))
+                    .font(CT.mono(12, .medium))
+                    .foregroundStyle(CT.verifiedGreen)
+            }
+            .padding(.horizontal, 8).padding(.vertical, 4)
+            .background(Capsule().fill(CT.verifiedGreen.opacity(0.1)))
+
+            if let mins = walkMinutes {
+                HStack(spacing: 4) {
+                    Image(systemName: "figure.walk")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(CT.fgMuted)
+                    Text(String(format: NSLocalizedString("nearby.chip.walkMin", comment: "Walk minutes chip, e.g. '4 min'"), mins))
+                        .font(CT.mono(12, .medium))
+                        .foregroundStyle(CT.fgMuted)
+                }
+                .padding(.horizontal, 8).padding(.vertical, 4)
+                .background(Capsule().fill(CT.surfaceSunken))
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+}


### PR DESCRIPTION
## 概要

给底部 sheet 的地点卡片加 **iOS 原生长按 Context Menu**——长按弹出暖琥珀悬浮预览卡（背景虚化）+ 快捷操作菜单，取代旧的自定义浮卡长按。把**关键信息 + 常用操作**放到一次长按之内，就是地图类 app 该有的「peek」交互。

## 悬浮预览卡（`ExperiencePreviewCard` · DayPage 暖琥珀）

- Hero 预览图（`location.photoUrls`），无图降级为分类色渐变 + 大图标
- 悬浮分类 chip + 实时「此刻最佳/即将关闭」chip
- 短地名（`placeNameRomanized`，非长 title 句）+ 一句话 + Solo 评分 + 步行距离

## 快捷操作（`NearbyExperienceRow.cardContextMenu`）

- **查看详情**（复用 onTap）· **在地图上显示**（复用原长按行为）
- **问 Solo** — 起一个锚定该地点的聊天，走详情页 Ask-Solo 同款 `ensureOrchestrator + rebindContext(experience)` 链路（新 `onAskSolo` 回调经 NearbySection → CompassMapView 透传）
- **收藏/取消收藏**（`UserPreferences.toggleFavorite`，行内）
- **导航前往**（`NavigationLauncher.open`，行内）

## 视觉验证

ImageRenderer 渲染预览卡，跨分类色核对暖琥珀对齐：

| 分类 | chip 色 | 图标 |
| --- | --- | --- |
| 文化 | 橙 | 神庙 |
| 身心 | 青 | 爱心 |
| 咖啡 | 棕 | 咖啡杯 |
| 美食 | 红 | 刀叉 |

短地名、mono 数字（Solo 评分/步行分钟）、一句话布局都对。

## 范围说明

`LongPressCardModifier`（旧自定义浮卡）仍被 `FavoritesListView` + 地图 pin 长按使用——只有 Nearby 行迁到原生菜单。双语 `menu.*` 文案齐。构建绿（iPhone 17 Pro 模拟器）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)