### PR TITLE
feat(ios): Amap POI source for mainland-China explore

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		B6FA45D117293C3829DE99A9 /* RouteMapSnapshotter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8970A53A6D6C42A614F7B414 /* RouteMapSnapshotter.swift */; };
 		B7366111257111EC98F4A0C4 /* ChatSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9263FC2737FA209F3CD4B5E /* ChatSheet.swift */; };
 		B80813E9E3CDD855C12F7D58 /* LockScreenLiveActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02DB2C9C0BC30785E0A80F3 /* LockScreenLiveActivityView.swift */; };
+		B9AFA2FC4C9102AF0B27DFFF /* AmapLiveIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D22DBF50B6C3FABE64A9DE2 /* AmapLiveIntegrationTests.swift */; };
 		B9EDA827F7E00B19DF97512C /* ConversationRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12888843433B2A00D7CAB18 /* ConversationRecord.swift */; };
 		BA0DD7D5C46016E81A23B2B4 /* ChatInputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88D9F377D7AF634DAE07A3E /* ChatInputBar.swift */; };
 		BA870AD09C34F9B1E703086D /* DiscoverFriendGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820F9980B60883E879851303 /* DiscoverFriendGate.swift */; };
@@ -617,6 +618,7 @@
 		69C8C17C79CD2B4EAE72F385 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		6C5CA5533D846B39EF16CDFA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6CE165B6335EEBF5DDED2C47 /* AmapPOIServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmapPOIServiceTests.swift; sourceTree = "<group>"; };
+		6D22DBF50B6C3FABE64A9DE2 /* AmapLiveIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmapLiveIntegrationTests.swift; sourceTree = "<group>"; };
 		6D31F422914779D9228B0278 /* RouteCardNowReasonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCardNowReasonTests.swift; sourceTree = "<group>"; };
 		6DFBC1C003B8745713588A23 /* City.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = City.swift; sourceTree = "<group>"; };
 		7022B4362225428DCEB74D59 /* SettingsAdminUnlockTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAdminUnlockTest.swift; sourceTree = "<group>"; };
@@ -998,6 +1000,7 @@
 				88DFC61CD1B433E92301FB18 /* AddFriendSheetTests.swift */,
 				E5DB59261DB471FD587F4134 /* AgentTests.swift */,
 				D9CF57D3342E9C609CD56801 /* AISynthesisQualityTests.swift */,
+				6D22DBF50B6C3FABE64A9DE2 /* AmapLiveIntegrationTests.swift */,
 				6CE165B6335EEBF5DDED2C47 /* AmapPOIServiceTests.swift */,
 				15C512E1C0A5CFFE798CEEEA /* AppLaunchPerformanceTest.swift */,
 				804618047547A9D7F3F8EAAA /* ApprovalTrustSignalTest.swift */,
@@ -1740,6 +1743,7 @@
 				2C15829741157EA5A2EC8A5C /* AddFriendButtonRenderTest.swift in Sources */,
 				217F30D0C177D27828B5661E /* AddFriendSheetTests.swift in Sources */,
 				8632F83028F07E07435FE075 /* AgentTests.swift in Sources */,
+				B9AFA2FC4C9102AF0B27DFFF /* AmapLiveIntegrationTests.swift in Sources */,
 				5A0A16C0E997E1C0A8FD8BFE /* AmapPOIServiceTests.swift in Sources */,
 				E3E70311CE0E4C0CB1C47462 /* AppLaunchPerformanceTest.swift in Sources */,
 				352247C1FBF4C8F901D17F32 /* ApprovalTrustSignalTest.swift in Sources */,

--- a/apps/ios/SoloCompass/Tests/AmapLiveIntegrationTests.swift
+++ b/apps/ios/SoloCompass/Tests/AmapLiveIntegrationTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+import CoreLocation
+@testable import SoloCompass
+
+/// Live integration test: hits the real Amap API with the compiled-in key
+/// to verify Shenzhen POI data retrieval end-to-end.
+///
+/// Skipped in CI (no key), runs locally with `swift test` / Xcode when the
+/// AMAP_API_KEY is baked into GeneratedSecrets.
+@MainActor
+final class AmapLiveIntegrationTests: XCTestCase {
+
+    private let shenzhen = CLLocationCoordinate2D(latitude: 22.5431, longitude: 114.0579)
+
+    private func skipIfNoKey() throws {
+        let key = Secrets.resolvedAmapKey
+        try XCTSkipIf(key.isEmpty, "AMAP_API_KEY not configured — skipping live test")
+    }
+
+    // MARK: - Live Amap fetch
+
+    func testFetchShenzhenCoffeePOIs() async throws {
+        try skipIfNoKey()
+
+        let service = AmapPOIService()
+        let pois = try await service.fetchPOIs(
+            near: shenzhen,
+            radiusMeters: 3000,
+            category: .coffee
+        )
+
+        print("=== Amap Shenzhen coffee POIs: \(pois.count) ===")
+        for poi in pois.prefix(10) {
+            print("  [\(poi.id)] \(poi.name) @ (\(poi.lat), \(poi.lon)) tags=\(poi.tags)")
+        }
+
+        XCTAssertGreaterThan(pois.count, 0, "Shenzhen CBD should have coffee shops")
+
+        for poi in pois {
+            let dist = CLLocation(latitude: poi.lat, longitude: poi.lon)
+                .distance(from: CLLocation(latitude: shenzhen.latitude, longitude: shenzhen.longitude))
+            XCTAssertLessThan(dist, 10_000, "POI \(poi.name) should be within 10km of Shenzhen center")
+        }
+
+        for poi in pois {
+            XCTAssertEqual(poi.tags["source"], "amap")
+        }
+    }
+
+    func testFetchShenzhenAllCategories() async throws {
+        try skipIfNoKey()
+
+        let service = AmapPOIService()
+        let pois = try await service.fetchPOIs(
+            near: shenzhen,
+            radiusMeters: 3000,
+            category: nil
+        )
+
+        print("=== Amap Shenzhen all-category POIs: \(pois.count) ===")
+        for poi in pois.prefix(15) {
+            let category = poi.tags["amenity"] ?? poi.tags["tourism"] ?? poi.tags["leisure"] ?? "unknown"
+            print("  [\(poi.id)] \(poi.name) category=\(category) @ (\(poi.lat), \(poi.lon))")
+        }
+
+        XCTAssertGreaterThan(pois.count, 5, "Shenzhen CBD broad search should return many POIs")
+    }
+
+    func testFetchShenzhenFoodPOIs() async throws {
+        try skipIfNoKey()
+
+        let service = AmapPOIService()
+        let pois = try await service.fetchPOIs(
+            near: shenzhen,
+            radiusMeters: 3000,
+            category: .food
+        )
+
+        print("=== Amap Shenzhen food POIs: \(pois.count) ===")
+        for poi in pois.prefix(10) {
+            print("  [\(poi.id)] \(poi.name) @ (\(poi.lat), \(poi.lon))")
+        }
+
+        XCTAssertGreaterThan(pois.count, 0, "Shenzhen CBD should have restaurants")
+    }
+
+    func testShenzhenIsInsideMainland() {
+        XCTAssertTrue(
+            CoordinateConverter.isInsideChinaMainland(shenzhen),
+            "Shenzhen should be classified as mainland China"
+        )
+    }
+
+    func testShenzhenGCJRoundTrip() {
+        let gcj = CoordinateConverter.wgs84ToGcj02(shenzhen)
+        let back = CoordinateConverter.gcj02ToWgs84(gcj)
+        let dist = CLLocation(latitude: back.latitude, longitude: back.longitude)
+            .distance(from: CLLocation(latitude: shenzhen.latitude, longitude: shenzhen.longitude))
+        XCTAssertLessThan(dist, 1.0, "Round-trip should be sub-metre")
+        print("=== GCJ-02 offset for Shenzhen: \(CLLocation(latitude: gcj.latitude, longitude: gcj.longitude).distance(from: CLLocation(latitude: shenzhen.latitude, longitude: shenzhen.longitude)))m ===")
+    }
+}


### PR DESCRIPTION
## Summary

- Add `AmapPOIService` — mainland-China POI source via Amap `/v5/place/around`, returning canonical `OverpassService.POI` with WGS-84 coordinates
- Add `CoordinateConverter` — WGS-84 ↔ GCJ-02 conversion with sub-metre round-trip accuracy; `isInsideChinaMainland` gate carves out HK/Macau/Taiwan
- Route `EnrichmentAgent` through Amap when the explore coordinate falls inside mainland China; falls back to Overpass on empty key or error
- Wire `AMAP_API_KEY` through `generate_secrets.sh` → `GeneratedSecrets` → `SecretsRuntime.resolvedAmapKey`
- ADR documenting the hybrid routing decision, coordinate boundary, and no-persistence constraint (Amap ToS)

**Shenzhen live test results**: coffee 25, food 25, all-category 25 POIs — real shops like 瑞幸, 星巴克, MANNER, 小杨生煎 correctly located in Futian CBD.

## Test plan

- [x] `AmapPOIServiceTests` — 10 unit tests: category mapping, URL building, POI projection, stable ID, empty-key gating
- [x] `CoordinateConverterTests` — 11 unit tests: mainland/HK/Macau/Taiwan boundaries, round-trip accuracy, offset range
- [x] `AmapLiveIntegrationTests` — 5 live tests: real API calls for Shenzhen coffee/food/all + coordinate verification (skipped in CI)
- [x] 26 total tests, 0 failures
- [x] Simulator visual: city "深圳市", 6 AI-synthesized experiences on map, "小杨生煎（岗厦北店）" card visible