### PR TITLE
feat(ios): Shenzhen Amap 5km experience + clustering fix

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -1746,13 +1746,14 @@
 /* Begin PBXShellScriptBuildPhase section */
 		64D3462D348FFD483BDEABFE /* Generate Secrets from .env */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/../../.env",
+				"$(SRCROOT)/../../scripts/generate_secrets.sh",
 			);
 			name = "Generate Secrets from .env";
 			outputFileListPaths = (

--- a/apps/ios/SoloCompass/Models/MapCluster.swift
+++ b/apps/ios/SoloCompass/Models/MapCluster.swift
@@ -36,10 +36,17 @@ enum MapItem: Identifiable {
 }
 
 enum MapClusterEngine {
+    /// Below this pin count, clustering is skipped — a handful of pins never
+    /// visually overlap enough to justify collapsing into a numbered circle.
+    static let skipClusteringThreshold = 15
+
     static func cluster(
         _ experiences: [Experience],
         spanLatitudeDelta: Double
     ) -> [MapItem] {
+        if experiences.count <= skipClusteringThreshold {
+            return experiences.map { .single($0) }
+        }
         let cellSize = cellSize(for: spanLatitudeDelta)
         guard cellSize > 0 else {
             return experiences.map { .single($0) }
@@ -70,7 +77,7 @@ enum MapClusterEngine {
     }
 
     private static func cellSize(for spanLatitudeDelta: Double) -> Double {
-        if spanLatitudeDelta < 0.01 { return 0 }
-        return spanLatitudeDelta / 6.0
+        if spanLatitudeDelta < 0.05 { return 0 }
+        return spanLatitudeDelta / 10.0
     }
 }

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1902,6 +1902,34 @@
 "mood.hardToFind" = "Hard to find";
 "mood.veryFew" = "Very few people";
 
+/* Actions — route favorite */
+"action.favorited" = "Favorited";
+"action.notFavorited" = "Not favorited";
+
+/* Chat attachments */
+"chat.attachment.add.a11y" = "Add attachment";
+"chat.attachment.add.title" = "Add attachment";
+"chat.attachment.close.a11y" = "Close attachment";
+"chat.attachment.remove.a11y" = "Remove attachment";
+"chat.attachment.source.camera" = "Camera";
+"chat.attachment.source.cancel" = "Cancel";
+"chat.attachment.source.files" = "Files";
+"chat.attachment.source.photos" = "Photo Library";
+
+/* Foursquare errors */
+"foursquare.error.missingKey" = "Foursquare API key is missing";
+"foursquare.error.request" = "Foursquare request failed (status %d)";
+"foursquare.error.url" = "Invalid Foursquare URL";
+
+/* Friends list — preview */
+"friends.list.error.preview" = "Preview error";
+
+/* Location picker */
+"locationPicker.map.pin" = "Selected location";
+
+/* Preview */
+"preview.raiseScore" = "Raise Score";
+
 /* Map style picker */
 "map.style.standard" = "Standard";
 "map.style.satellite" = "Satellite";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -394,9 +394,9 @@
 "explore.aiBadge" = "AI 生成 · 来自 OpenStreetMap";
 "explore.osmBadge" = "来自 OpenStreetMap · 未增强";
 "explore.error.nothingFound" = "附近没找到公共场所。试试拖动地图。";
-“location.error.banner” = “无法获取你的位置 — 已显示默认区域。请在”设置”中检查定位权限。”;
-“location.banner.openSettings” = “打开设置”;
-“explore.skeleton.oneLiner” = “一处来自 OpenStreetMap 的真实地点。”;
+"location.error.banner" = "无法获取你的位置 — 已显示默认区域。请在「设置」中检查定位权限。";
+"location.banner.openSettings" = "打开设置";
+"explore.skeleton.oneLiner" = "一处来自 OpenStreetMap 的真实地点。";
 "explore.skeleton.why" = "我们还没有这个地方的精选故事。去看看，然后告诉我们你发现了什么。";
 "explore.quota.dailyLimit" = "今日 AI 调用次数已达上限。明天恢复前会展示真实地点但不再增强。";
 "explore.toast.addedNamed" = "正在探索 %1$@ · 新增 %2$d 处地点";
@@ -1629,7 +1629,7 @@
 "solo.radar.replay.hint" = "点击重播";
 "solo.safety.desc" = "在多数旅行者前往的时段独自待在这里是安全的。";
 "solo.seating.desc" = "吧台、高脚凳或小桌，独行者可自在落座而不尴尬。";
-"solo.staff.desc" = "店员不打扰你 — 不盯着、不追问“还有别人来吗”、不催促服务。";
+"solo.staff.desc" = "店员不打扰你 — 不盯着、不追问「还有别人来吗」、不催促服务。";
 "solo.weakest" = "注意：%@";
 "solo.weakest.a11y" = "注意：%@ 是该地点最弱的维度。";
 "solo.strongest" = "亮点：%@";
@@ -1815,6 +1815,132 @@
 "mood.worthFinding" = "值得找";
 "mood.hardToFind" = "不太好找";
 "mood.veryFew" = "人很少";
+
+/* Actions */
+"action.done" = "完成";
+"action.favorited" = "已收藏";
+"action.notFavorited" = "未收藏";
+
+/* Avatar stack */
+"avatarstack.count" = "%d 人";
+"avatarstack.members.title" = "成员";
+"avatarstack.one" = "1 人";
+"avatarstack.overflow.hint" = "显示全部成员";
+
+/* Card distance */
+"card.distance.recenter.hint" = "双击以地图居中至此处";
+
+/* Chat attachments */
+"chat.attachment.add.a11y" = "添加附件";
+"chat.attachment.add.title" = "添加附件";
+"chat.attachment.close.a11y" = "关闭附件";
+"chat.attachment.remove.a11y" = "移除附件";
+"chat.attachment.source.camera" = "相机";
+"chat.attachment.source.cancel" = "取消";
+"chat.attachment.source.files" = "文件";
+"chat.attachment.source.photos" = "相册";
+
+/* Chat history */
+"chat.history.empty.title" = "暂无对话记录";
+
+/* Explore skeleton */
+"explore.skeleton.oneLiner" = "来自 OpenStreetMap 的真实地点。";
+
+/* Favorites journey */
+"favorites.journey.halfway" = "完成一半 — 已探索 %1$d / %2$d";
+"favorites.journey.milestone.a11y" = "已探索收藏的 %d%%";
+"favorites.search.noResults.a11y" = "没有匹配「%@」的收藏";
+"favorites.search.resultCount.a11y" = "%d 个匹配的收藏";
+
+/* Foursquare errors */
+"foursquare.error.missingKey" = "缺少 Foursquare API 密钥";
+"foursquare.error.request" = "Foursquare 请求失败（状态 %d）";
+"foursquare.error.url" = "Foursquare URL 无效";
+
+/* Friend add */
+"friend.add.state.add" = "添加好友";
+"friend.add.state.friends" = "已是好友";
+"friend.add.state.pending" = "等待中";
+"friend.error.disabled" = "好友功能暂不可用。";
+"friend.error.encoding" = "出了点问题，请重试。";
+"friend.error.self" = "不能添加自己为好友。";
+
+/* Friend profile */
+"friend.profile.action.addFriend" = "添加好友";
+"friend.profile.action.invite" = "邀请见面";
+"friend.profile.action.message" = "发消息";
+"friend.profile.action.requestPending" = "请求已发送";
+"friend.profile.bio.header" = "简介";
+"friend.profile.handle.placeholder" = "旅行者";
+"friend.profile.languages.header" = "会说";
+"friend.profile.stat.friends" = "好友";
+"friend.profile.stat.placesWalked" = "走过的地方";
+"friend.profile.stat.routesJoined" = "加入的路线";
+
+/* Friends list */
+"friends.add.open.a11y" = "显示我的好友码";
+"friends.connected.a11y" = "你已与 %@ 建立连接";
+"friends.connected.label" = "已连接！";
+"friends.list.empty.cta" = "添加好友";
+"friends.list.empty.description" = "遇到同路人并添加后，他们会出现在这里。";
+"friends.list.empty.friends" = "还没有好友。";
+"friends.list.empty.title" = "还没有好友";
+"friends.list.error.preview" = "预览错误";
+"friends.list.error.retry" = "重试";
+"friends.list.error.title" = "无法加载好友";
+"friends.list.friend.a11y" = "好友 %@。点击查看资料。";
+"friends.list.friends.section" = "好友";
+"friends.list.pending.count" = "%d 个待处理";
+"friends.list.pending.count.a11y" = "%d 个待处理的好友请求";
+"friends.list.refresh.a11y" = "刷新好友和请求";
+"friends.list.remove.confirm.action" = "移除好友";
+"friends.list.remove.confirm.title" = "移除 %@？";
+"friends.list.request.from" = "来自";
+"friends.list.requests.section" = "好友请求";
+"friends.list.row.remove" = "移除";
+"friends.list.strip.a11y" = "你的好友";
+"friends.list.title" = "好友";
+"friends.removed.a11y" = "%@ 已从好友中移除";
+"friends.request.accept" = "接受";
+"friends.request.decline" = "拒绝";
+
+/* Location */
+"location.banner.openSettings" = "打开设置";
+"location.error.banner" = "无法获取你的位置，正在显示默认区域。请在设置中检查定位权限。";
+
+/* Location picker */
+"locationPicker.map.pin" = "选定位置";
+
+/* Map loading */
+"map.loadingPOIs.done" = "附近 %d 个地点";
+
+/* My hosted routes */
+"my.hosted.routes.empty.cta" = "创建路线";
+"my.hosted.routes.empty.hint" = "创建路线并邀请同伴加入你的旅程。";
+"my.hosted.routes.empty.title" = "还没有主持的路线";
+
+/* Preview */
+"preview.raiseScore" = "提高评分";
+
+/* Profile */
+"profile.edit.title" = "我的资料";
+"profile.handle.footer" = "%d–%d 个字符，无需唯一。";
+"profile.handle.header" = "昵称";
+"profile.handle.invalid" = "昵称须为 %d–%d 个字符。";
+"profile.handle.placeholder" = "别人看到的名字（如 wanderer）";
+
+/* Settings — haptics */
+"settings.haptics.toggle" = "触觉反馈";
+"settings.haptics.toggle.a11y" = "开关触觉反馈";
+
+/* Solo safety */
+"solo.safety.caution" = "独行安全信号较低";
+"solo.safety.caution.a11y" = "安全提醒：独行安全信号较低";
+
+/* Voice recording */
+"voice.recording.empty" = "没听清 — 长按说话";
+"voice.recording.secondsLeft" = "剩余 %d 秒";
+"voice.recording.tooShort" = "长按麦克风说话";
 
 /* Map style picker */
 "map.style.standard" = "标准";

--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -1101,8 +1101,12 @@ public final class AIService {
                     sources: [
                         InformationSource(
                             type: .user,
-                            url: URL(string: "https://www.openstreetmap.org/node/\(poi.osmId)"),
-                            attribution: "© OpenStreetMap contributors + AI",
+                            url: poi.tags["source"] == "amap"
+                                ? nil
+                                : URL(string: "https://www.openstreetmap.org/node/\(poi.osmId)"),
+                            attribution: poi.tags["source"] == "amap"
+                                ? "© AutoNavi (Amap) + AI"
+                                : "© OpenStreetMap contributors + AI",
                             verifiedAt: now
                         )
                     ],

--- a/apps/ios/SoloCompass/Services/AmapPOIService.swift
+++ b/apps/ios/SoloCompass/Services/AmapPOIService.swift
@@ -78,7 +78,7 @@ public final class AmapPOIService {
     /// `public` default argument may not reference internal symbols.
     public init(
         session: URLSession = .shared,
-        maxResults: Int = 25,
+        maxResults: Int = 75,
         keyProvider: (() -> String)? = nil
     ) {
         self.session = session
@@ -105,46 +105,58 @@ public final class AmapPOIService {
             return cached.pois
         }
 
-        // Convert the query center WGS84 → GCJ-02 for Amap. `location` is
-        // "lon,lat" with 6 decimals per the Amap spec.
         let gcj = CoordinateConverter.wgs84ToGcj02(coordinate)
-        guard let url = Self.buildURL(
-            key: key,
-            gcjCenter: gcj,
-            radiusMeters: radiusMeters,
-            category: category,
-            pageSize: maxResults
-        ) else {
-            throw AmapError.requestFailed(status: -1)
-        }
 
         isFetching = true
         defer { isFetching = false }
 
-        var request = URLRequest(url: url)
-        request.timeoutInterval = 20
-        request.setValue("SoloCompass-iOS/1.0", forHTTPHeaderField: "User-Agent")
+        // Amap caps page_size at 25. Paginate up to maxResults (default 75).
+        let pageSize = 25
+        let maxPages = max(1, (maxResults + pageSize - 1) / pageSize)
+        var allPois: [OverpassService.POI] = []
+        var seenIds = Set<Int64>()
 
-        let (data, response) = try await session.data(for: request)
-        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
-            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
-            throw AmapError.requestFailed(status: status)
+        for page in 1...maxPages {
+            guard let url = Self.buildURL(
+                key: key,
+                gcjCenter: gcj,
+                radiusMeters: radiusMeters,
+                category: category,
+                pageSize: pageSize,
+                pageNum: page
+            ) else {
+                throw AmapError.requestFailed(status: -1)
+            }
+
+            var request = URLRequest(url: url)
+            request.timeoutInterval = 20
+            request.setValue("SoloCompass-iOS/1.0", forHTTPHeaderField: "User-Agent")
+
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+                let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+                throw AmapError.requestFailed(status: status)
+            }
+
+            let decoded = try JSONDecoder().decode(AroundResponse.self, from: data)
+            guard decoded.status == "1" else {
+                Self.logger.info("Amap non-success status=\(decoded.status, privacy: .public) info=\(decoded.info ?? "nil", privacy: .public)")
+                break
+            }
+
+            let pagePois = (decoded.pois ?? []).compactMap { Self.poi(from: $0) }
+            for poi in pagePois where !seenIds.contains(poi.osmId) {
+                seenIds.insert(poi.osmId)
+                allPois.append(poi)
+            }
+
+            // Stop if this page returned fewer than pageSize (no more data).
+            if pagePois.count < pageSize { break }
+            if allPois.count >= maxResults { break }
         }
 
-        let decoded = try JSONDecoder().decode(AroundResponse.self, from: data)
-        // status "1" = success. Anything else (quota, invalid key, no result)
-        // degrades to empty so the merge step still proceeds with other sources.
-        // Log the `info` field (e.g. "DAILY_QUERY_OVER_LIMIT", "INVALID_USER_KEY")
-        // so a quota/auth failure is observable instead of silently looking like
-        // "no POIs here" — the operator needs to see why China quality dropped.
-        guard decoded.status == "1" else {
-            Self.logger.info("Amap non-success status=\(decoded.status, privacy: .public) info=\(decoded.info ?? "nil", privacy: .public)")
-            return []
-        }
-
-        let pois = (decoded.pois ?? []).compactMap { Self.poi(from: $0) }
-        memoryCache.setObject(CachedPOIs(pois), forKey: cacheKey)
-        return pois
+        memoryCache.setObject(CachedPOIs(allPois), forKey: cacheKey)
+        return allPois
     }
 
     // MARK: - URL building
@@ -154,7 +166,8 @@ public final class AmapPOIService {
         gcjCenter: CLLocationCoordinate2D,
         radiusMeters: Int,
         category: ExperienceCategory?,
-        pageSize: Int
+        pageSize: Int,
+        pageNum: Int = 1
     ) -> URL? {
         var comps = URLComponents(string: "https://restapi.amap.com/v5/place/around")
         // Amap caps radius at 50 km and page_size at 25.
@@ -165,7 +178,7 @@ public final class AmapPOIService {
             URLQueryItem(name: "location", value: String(format: "%.6f,%.6f", gcjCenter.longitude, gcjCenter.latitude)),
             URLQueryItem(name: "radius", value: String(radius)),
             URLQueryItem(name: "page_size", value: String(size)),
-            URLQueryItem(name: "page_num", value: "1"),
+            URLQueryItem(name: "page_num", value: String(pageNum)),
             // Sort by distance so the closest, most relevant POIs survive the cap.
             URLQueryItem(name: "sortrule", value: "distance"),
             // Ask for the richer field set (business hours, rating, etc.) so

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -913,7 +913,40 @@ public final class MapViewModel {
         aiSmartPickIds = []
         recomputeNowCount()
         updateBottomInfo()
+        fitCameraToPinsIfNeeded(nearby)
         scheduleColdStartEmptyWatchdog()
+    }
+
+    /// When pins are clustered in a tight area relative to the current camera
+    /// span, zoom in so every pin is individually visible instead of stacking
+    /// into a single dot at city-overview zoom.
+    private func fitCameraToPinsIfNeeded(_ experiences: [Experience]) {
+        let coords = experiences.compactMap(\.coordinate)
+        guard coords.count >= 2 else { return }
+
+        let lats = coords.map(\.latitude)
+        let lons = coords.map(\.longitude)
+        let minLat = lats.min()!, maxLat = lats.max()!
+        let minLon = lons.min()!, maxLon = lons.max()!
+        let latSpread = maxLat - minLat
+        let lonSpread = maxLon - minLon
+
+        // Only auto-fit when pins are much tighter than the current camera.
+        guard latSpread < currentSpanLatitudeDelta * 0.3 else { return }
+        guard lonSpread < currentSpanLatitudeDelta * 0.3 else { return }
+
+        let padding = max(latSpread, lonSpread, 0.005) * 1.8
+        let newSpan = MKCoordinateSpan(
+            latitudeDelta: max(latSpread + padding, 0.01),
+            longitudeDelta: max(lonSpread + padding, 0.01)
+        )
+        let center = CLLocationCoordinate2D(
+            latitude: (minLat + maxLat) / 2,
+            longitude: (minLon + maxLon) / 2
+        )
+        withAnimation(Self.cameraAnimation) {
+            cameraPosition = .region(MKCoordinateRegion(center: center, span: newSpan))
+        }
     }
 
     /// V-004: origin for the nearby query. A *preset* city selection drives the
@@ -2017,7 +2050,17 @@ public final class MapViewModel {
             }
 
             if added > 0 {
-                selectCity(cityCode)
+                // V-007 extension: when the user has an explicit city
+                // selection (non-custom), preserve it — don't let an
+                // explore result at the GPS coordinate hijack the camera.
+                let userOwnsCity = (selectedCity.map { !$0.hasPrefix("custom_") }) ?? false
+                let discoveredMatchesSelected = selectedCity == cityCode
+                    || Self.cityCodeAliases[cityCode] == selectedCity
+                    || Self.cityCodeAliases.first(where: { $0.value == selectedCity })?.key == cityCode
+                if !userOwnsCity || discoveredMatchesSelected {
+                    selectCity(cityCode)
+                    recenter(on: coordinate)
+                }
                 let outerKm = effectiveRadius / 1000
                 if progressiveExpanded, let finalKm = progressiveFinalRadiusKm {
                     // US-006: progressive run that widened past 5 km — show final radius.
@@ -2054,8 +2097,6 @@ public final class MapViewModel {
                                  added)
                 }
             }
-
-            recenter(on: coordinate)
         } catch {
             // US-022: on network failure, look for a recent nearby region and
             // surface its cached SwiftData pins instead of showing an error.

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -112,9 +112,12 @@ targets:
           else
             echo "[generate_secrets] script not found at ${SRCROOT}/../../scripts/generate_secrets.sh — skipping" >&2
           fi
+        inputFiles:
+          - $(SRCROOT)/../../.env
+          - $(SRCROOT)/../../scripts/generate_secrets.sh
         outputFiles:
           - $(SRCROOT)/SoloCompass/Config/GeneratedSecrets.swift
-        basedOnDependencyAnalysis: false
+        basedOnDependencyAnalysis: true
     dependencies:
       - package: Supabase
         product: Supabase


### PR DESCRIPTION
## Summary

- **Amap POI pagination**: fetch up to 75 results (3 pages) instead of 25, with cross-page dedup — gives Shenzhen and other mainland China cities real POI density
- **Clustering fix**: skip grid-based clustering when pin count ≤ 15 and raise the no-cluster zoom threshold so sparse pin sets always show individual markers instead of a single numbered circle
- **Auto-fit camera**: when all pins cluster within 30% of the current camera span, auto-zoom to their bounding box so they spread apart visually instead of stacking into one dot
- **Attribution compliance**: Amap-sourced POIs now show "© AutoNavi" instead of an invalid OSM node URL
- **Localization**: add missing en/zh-Hans keys for chat attachments, friends UI, location picker, foursquare errors, and misc strings; fix Chinese typographic quotes
- **Build optimization**: add inputFiles to the Generate Secrets build phase for incremental builds

Prior commits on this branch add: search bar, empty-state cards, onboarding steps, clustering, city-aware proximity thresholds, sub-view extraction, map style toggle, photo thumbnails, Dynamic Type scaling, dark mode contrast, and many other polish items.

## Test plan

- [x] `xcodebuild build` — BUILD SUCCEEDED
- [x] MapDensityLODTests — 11/11 passed
- [x] ColdStartExperienceLoadTests — 6/6 passed
- [x] MapViewModelCityRegionSyncTests — 7/7 passed
- [x] Visual: Shenzhen cold start shows individual pins (not a "6" circle)
- [x] Visual: Chiang Mai unaffected (pins remain spread across map)