### PR TITLE
feat(ios): autonomous UX polish — warm-amber + cold-start TTFV (R0→R14)

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -2342,6 +2342,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = SoloCompass/Resources/SoloCompass.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
@@ -2423,6 +2424,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = SoloCompass/Resources/SoloCompass.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;

--- a/apps/ios/SoloCompass/Models/UserPreferences.swift
+++ b/apps/ios/SoloCompass/Models/UserPreferences.swift
@@ -25,7 +25,13 @@ public final class UserPreferences {
         var preferredCategories: [ExperienceCategory] = []
         var dislikedCategories: [ExperienceCategory] = []
         var soloTravelStyle: SoloTravelStyle = .explorer
-        var maxDistanceKm: Double = 5.0
+        // First-launch default raised 5 → 8 km so a cold start in a seeded city
+        // (e.g. Chiang Mai, where Doi Suthep sits at ~7.8 km from the centroid)
+        // surfaces all curated Experiences instead of showing an "empty within
+        // 5 km" peek. 8 km matches the practical radius a solo traveler covers
+        // on foot + tuk-tuk in a half day, and remains well under the 25 km
+        // auto-expand fallback. Persisted users keep their stored value.
+        var maxDistanceKm: Double = 8.0
         var visitHistory: [String: Date] = [:]
         var completedExperiences: Set<String> = []
         var favoritedExperiences: Set<String> = []
@@ -187,7 +193,7 @@ public final class UserPreferences {
             self.preferredCategories = try container.decodeIfPresent([ExperienceCategory].self, forKey: .preferredCategories) ?? []
             self.dislikedCategories = try container.decodeIfPresent([ExperienceCategory].self, forKey: .dislikedCategories) ?? []
             self.soloTravelStyle = try container.decodeIfPresent(SoloTravelStyle.self, forKey: .soloTravelStyle) ?? .explorer
-            self.maxDistanceKm = try container.decodeIfPresent(Double.self, forKey: .maxDistanceKm) ?? 5.0
+            self.maxDistanceKm = try container.decodeIfPresent(Double.self, forKey: .maxDistanceKm) ?? 8.0
             self.visitHistory = try container.decodeIfPresent([String: Date].self, forKey: .visitHistory) ?? [:]
             self.completedExperiences = try container.decodeIfPresent(Set<String>.self, forKey: .completedExperiences) ?? []
             self.favoritedExperiences = try container.decodeIfPresent(Set<String>.self, forKey: .favoritedExperiences) ?? []
@@ -399,6 +405,21 @@ public final class UserPreferences {
         self.companionConsentGivenAt = snapshot.companionConsentGivenAt
         self.companionEnabled = snapshot.companionEnabled
         self.companionModuleStrengthRaw = snapshot.companionModuleStrengthRaw
+
+        // One-time migration: bump the historical 5 km default to the new 8 km
+        // cold-start default for users who never touched the distance slider.
+        // Without this, returning users who installed a build before the 8 km
+        // change keep seeing "Quiet patch of map." in a seeded city like
+        // Chiang Mai where a hero seed (Doi Suthep) sits at 7.83 km. The flag
+        // guards against re-running so users who explicitly chose 5 km again
+        // aren't surprised.
+        let migrationFlagKey = "SoloCompass.didMigrateRadius8"
+        if !defaults.bool(forKey: migrationFlagKey) {
+            if self.maxDistanceKm == 5.0 {
+                self.maxDistanceKm = 8.0
+            }
+            defaults.set(true, forKey: migrationFlagKey)
+        }
     }
 
     private static func load(from defaults: UserDefaults) -> Snapshot {

--- a/apps/ios/SoloCompass/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apps/ios/SoloCompass/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x30",
+          "red" : "0x5D"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x77",
+          "green" : "0xA6",
+          "red" : "0xC9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -337,6 +337,7 @@
 
 /* City picker */
 "city.all" = "All Cities";
+"city.nearby" = "Nearby";
 "city.picker.title" = "Choose a city";
 "city.experienceCount" = "%d experiences";
 "city.empty.title" = "No cities yet";

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -314,9 +314,9 @@
 "me.empty.cta" = "Back to the map";
 
 /* Map empty / loading */
-"map.empty.title" = "No experiences nearby";
-"map.empty.hint" = "Try clearing filters or moving the map.";
-"map.empty.radius" = "No experiences within %.0fkm";
+"map.empty.title" = "Quiet patch of map.";
+"map.empty.hint" = "Pan to a busier corner, or clear filters.";
+"map.empty.radius" = "Showing within %.0f km — try a wider radius.";
 "map.empty.expand" = "Expand to 25km";
 "map.empty.browse" = "Browse %@";
 "map.empty.clearFilters" = "Clear filters";
@@ -1674,11 +1674,11 @@
 "a11y.empty.list" = "No experiences to show";
 
 /* Empty Nearby two-tier empty state (headline + subtitle) */
-"empty.nearby.headline" = "Nothing here — yet";
-"empty.nearby.subtitle" = "Pan the map or widen the view to find experiences around you.";
+"empty.nearby.headline" = "Quiet patch of map.";
+"empty.nearby.subtitle" = "Pan, or widen the radius to see what's around.";
 
 /* Empty Nearby CTA — nudges the traveler to recenter/zoom out */
-"empty.nearby.cta" = "Explore another area";
+"empty.nearby.cta" = "Take me somewhere alive";
 
 /* Empty Nearby — city has no data, suggest switching */
 "empty.nearby.subtitle.nocity" = "This area doesn't have experiences yet. Try a city we've curated for you.";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -154,9 +154,9 @@
 "map.userLocation.label" = "你的位置";
 
 /* Map empty / loading */
-"map.empty.title" = "附近暂无体验";
-"map.empty.hint" = "试试清除筛选或拖动地图。";
-"map.empty.radius" = "%.0f 公里内暂无体验";
+"map.empty.title" = "这片地图还很安静。";
+"map.empty.hint" = "拖到更热闹的一角，或清除筛选。";
+"map.empty.radius" = "目前在 %.0f 公里内 — 试试更大半径。";
 "map.empty.expand" = "扩展到 25 公里";
 "map.empty.browse" = "浏览 %@";
 "map.empty.clearFilters" = "清除筛选";
@@ -522,7 +522,7 @@
 "chat.error.network" = "网络连接出错 — 请检查网络后重试。";
 "chat.error.apiKey" = "API 密钥无效 — 请在设置中检查你的密钥。";
 "chat.error.permission" = "需要麦克风权限 — 请在设置中启用。";
-"chat.error.unknown" = "出现错误 — 请重试。";
+"chat.error.unknown" = "没发出去。再试一次。";
 
 /* Send-rejected hints + unconfigured banner shown above the chat input bar */
 "chat.send.hint.notReady" = "稍等片刻 — Solo 正在唤醒，请再次点击发送。";
@@ -1396,9 +1396,9 @@
 "detail.nearby.open.hint" = "打开体验详情";
 
 /* Empty states */
-"empty.nearby.headline" = "这附近还没有体验";
-"empty.nearby.subtitle" = "移动地图或拉远视野，看看周围有什么。";
-"empty.nearby.cta" = "探索其他区域";
+"empty.nearby.headline" = "这片地图还很安静。";
+"empty.nearby.subtitle" = "拖动地图，或拉大半径看看周围。";
+"empty.nearby.cta" = "带我去热闹一点的地方";
 
 /* Empty Nearby — city has no data, suggest switching */
 "empty.nearby.subtitle.nocity" = "这个区域暂时还没有体验。试试我们精选的城市吧。";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -172,6 +172,7 @@
 
 /* City picker */
 "city.all" = "全部城市";
+"city.nearby" = "附近";
 "city.picker.title" = "选择城市";
 "city.experienceCount" = "%d 处体验";
 "city.empty.title" = "暂无城市";

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -500,6 +500,11 @@ public final class MapViewModel {
     /// consults this table both directions so either form selects the city.
     static let cityCodeAliases: [String: String] = [
         "chiang-mai": "cmi",
+        // PascalCase variants people actually type when launching with
+        // `-startCity ChiangMai` from the command line / Xcode scheme. Without
+        // these the alias lookup falls through to `Self.defaultCenter` and the
+        // cold-start map silently lands on SF.
+        "chiangmai": "cmi",
         "vientiane": "VTE",
         "shenzhen": "cn-深圳市",
         "szx": "cn-深圳市",
@@ -552,6 +557,10 @@ public final class MapViewModel {
         customLocationLabel = nil
         selectedCity = cityCode
         preferences.lastSelectedCity = cityCode
+        // Reset the one-shot auto-recovery flag so a freshly selected city gets
+        // its own chance at the empty-state widen — without this, jumping to a
+        // second seeded city in the same session would silently render empty.
+        didAutoRecoverEmpty = false
         let center = defaultCenterForSelectedCity
         cameraPosition = .region(MKCoordinateRegion(
             center: center,
@@ -1001,12 +1010,19 @@ public final class MapViewModel {
     /// Recompute the experiences shown on the map for the current origin,
     /// distance, and active filters, refreshing markers and the info bar.
     public func loadNearbyExperiences() {
+        loadNearbyExperiences(overrideRadiusKm: nil)
+    }
+
+    /// Internal load that lets the cold-start auto-recovery widen the radius
+    /// in-memory (without persisting the change to `preferences.maxDistanceKm`).
+    /// Pass `nil` for the normal preference-driven path.
+    private func loadNearbyExperiences(overrideRadiusKm: Double?) {
         // US-017: the experience set (and thus discovered cities) may have
         // changed since the last load — e.g. after an Explore added pins.
         // Drop the city cache so the next `availableCities` read recomputes.
         invalidateCityCache()
         let center = nearbyQueryOrigin
-        let radiusKm = max(1.0, preferences.maxDistanceKm)
+        let radiusKm = max(1.0, overrideRadiusKm ?? preferences.maxDistanceKm)
         let nearby = applyFilters(near: center, radiusKm: radiusKm)
         withAnimation(Self.markerSetAnimation) {
             visibleExperiences = nearby
@@ -1067,12 +1083,22 @@ public final class MapViewModel {
 
     // MARK: - Cold-start empty-state watchdog (V-004 / US-033)
 
-    /// Seconds a selected city may stay empty before we report it to Sentry.
-    static let coldStartEmptyWatchdogSeconds: UInt64 = 5
+    /// Seconds a selected city may stay empty before we report it to Sentry
+    /// AND auto-recover. Was 5; tightened to 1 because the user-visible
+    /// "Quiet patch of map." panel renders within the first frame, so a
+    /// 5-second wait felt like the app was broken to anyone watching. The
+    /// auto-recovery path only widens the radius in-memory and only once.
+    static let coldStartEmptyWatchdogSeconds: UInt64 = 1
 
     /// Set true once we've reported a given empty cold start so the watchdog
     /// doesn't spam Sentry on every subsequent reload while the map stays empty.
     @ObservationIgnored private var reportedColdStartEmpty = false
+
+    /// Set true after the watchdog has auto-recovered an empty cold start
+    /// once by widening the radius in-memory to 25 km. Prevents oscillation
+    /// when the user later returns to a genuinely empty area in the same
+    /// session. Reset by `selectCity` so a fresh city pick gets a fresh shot.
+    @ObservationIgnored private var didAutoRecoverEmpty = false
 
     /// In-flight watchdog so repeated `loadNearbyExperiences` calls don't pile
     /// up parallel timers. `@ObservationIgnored` — pure bookkeeping.
@@ -1114,6 +1140,19 @@ public final class MapViewModel {
                     "totalExperiences": self.experienceService.allExperiences.count
                 ]
             )
+            // R8 auto-recovery: a selected city that lands 0 nearby after the
+            // grace window is almost always a too-tight radius (seeded city,
+            // user's preferred 5–8 km vs a hero pin at 7–10 km). Widen the
+            // radius in-memory to 25 km exactly once per session so the user
+            // sees the city's curated set instead of "Quiet patch of map."
+            // Persisted preference is intentionally left alone — this is a
+            // recovery, not a re-configuration.
+            if !self.didAutoRecoverEmpty {
+                self.didAutoRecoverEmpty = true
+                await MainActor.run {
+                    self.loadNearbyExperiences(overrideRadiusKm: 25)
+                }
+            }
         }
     }
 

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -1640,7 +1640,12 @@ public struct ExperienceDetailView: View {
         }
         .padding(.horizontal, 16)
         .padding(.top, 11)
-        .padding(.bottom, 12)
+        // Bottom padding raised 12 → 26 pt so the Mark-done pill no longer
+        // visually crashes into the home-indicator area on iPhone 17. The
+        // background ZStack below already ignoresSafeArea(.bottom), so the
+        // bar's blur extends to the screen edge; this extra inner padding is
+        // what gives the row breathing room above the indicator strip.
+        .padding(.bottom, 26)
         .background(
             // Opaque warm bar: reserves its own space via safeAreaInset (no manual
             // bottom padding), so content never scrolls behind it. Warm-white blur

--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -564,8 +564,12 @@ public struct FilterBarView: View {
                 Image(systemName: category.symbol)
                     .font(.caption.weight(.semibold))
                     // Keep category identity in the glyph so users still scan
-                    // the row by color, while text + border stay neutral.
-                    .foregroundStyle(isSelected ? .white : category.color)
+                    // the row by color, while text + border stay neutral. The
+                    // opacity is held to 0.85 on unselected pills so the row
+                    // reads as quiet color hints rather than five competing
+                    // category beacons — the previous full-saturation chips
+                    // pulled the eye away from the active selection.
+                    .foregroundStyle(isSelected ? .white : category.color.opacity(0.85))
 
                 Text(category.localizedTitle)
                     .font(.subheadline.weight(.medium))

--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -436,18 +436,15 @@ public struct FilterBarView: View {
                 Text(label)
                     .font(.subheadline.weight(.medium))
 
-                // Inline result count — mirrors the Now pill's inline badge so
-                // every filter chip speaks one visual language. Replaces the old
-                // floating topTrailing badge, which read as a stray dot hovering
-                // off the chip's corner.
+                // Inline result count — slimmed to a plain number (no inner
+                // capsule background, no extra padding) so the chip stops
+                // visually swelling on count change and the row reads as one
+                // even cadence rather than "All 5" suddenly twice as wide.
                 if isSelected && resultCount > 0 {
                     Text(Self.compactCount(resultCount))
                         .font(.caption2.monospacedDigit().weight(.semibold))
                         .contentTransition(reduceMotion ? .identity : .numericText(value: Double(resultCount)))
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 2)
-                        .background(Capsule().fill(Color.white.opacity(0.28)))
-                        .opacity(countBadgeOpacity)
+                        .opacity(countBadgeOpacity * 0.85)
                         .transition(.scale.combined(with: .opacity))
                 }
             }
@@ -536,7 +533,11 @@ public struct FilterBarView: View {
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 8)
-            .foregroundStyle(isSelected ? .white : tint)
+            // Unselected pills now share a single neutral text color across the
+            // bar (Now/All/Saved/category) so the row reads as one component
+            // instead of a parade of red/orange/green outlines. The category
+            // identity color survives as the inline glyph tint (heart icon).
+            .foregroundStyle(isSelected ? .white : CT.fgPrimary)
             .background {
                 if isSelected {
                     Capsule()
@@ -545,7 +546,7 @@ public struct FilterBarView: View {
                 }
             }
             .overlay(
-                Capsule().stroke(isSelected ? Color.clear : tint.opacity(0.7), lineWidth: 1)
+                Capsule().stroke(isSelected ? Color.clear : CT.borderDefault, lineWidth: 1)
             )
             .animation(.spring(response: 0.3, dampingFraction: 0.65), value: resultCount)
         }
@@ -562,6 +563,9 @@ public struct FilterBarView: View {
             HStack(spacing: 5) {
                 Image(systemName: category.symbol)
                     .font(.caption.weight(.semibold))
+                    // Keep category identity in the glyph so users still scan
+                    // the row by color, while text + border stay neutral.
+                    .foregroundStyle(isSelected ? .white : category.color)
 
                 Text(category.localizedTitle)
                     .font(.subheadline.weight(.medium))
@@ -579,7 +583,11 @@ public struct FilterBarView: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
-            .foregroundStyle(isSelected ? .white : category.color)
+            // Same unification as favoritePill: unselected = neutral text +
+            // neutral border. Category identity color stays as the inline glyph
+            // tint (the `category.symbol` Image keeps its colored stroke via the
+            // base foregroundStyle, but text and border read as one system.
+            .foregroundStyle(isSelected ? .white : CT.fgPrimary)
             .background {
                 if isSelected {
                     Capsule()
@@ -588,7 +596,7 @@ public struct FilterBarView: View {
                 }
             }
             .overlay(
-                Capsule().stroke(isSelected ? Color.clear : category.color, lineWidth: 1)
+                Capsule().stroke(isSelected ? Color.clear : CT.borderDefault, lineWidth: 1)
             )
             .animation(.spring(response: 0.3, dampingFraction: 0.65), value: resultCount)
         }

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -460,12 +460,16 @@ public struct BottomInfoSheet<Content: View>: View {
     // MARK: - Drag Handle
 
     private var dragHandleArea: some View {
-        // ≥44pt hit area (60×44) containing a 36×4 visible pill so VoiceOver /
+        // ≥44pt hit area (60×44) containing a 36×5 visible pill so VoiceOver /
         // Switch Control users can reliably grab the handle (Apple HIG).
+        // Pill widened slightly (4→5pt) and opacity bumped (0.5→0.7) so the
+        // grabber actually reads as a drag affordance against the warm peek
+        // background — the previous spec was so subtle the peek looked like a
+        // stranded toast rather than a pull-up sheet.
         ZStack {
             Capsule()
-                .fill(Color.secondary.opacity(0.5))
-                .frame(width: 36, height: 4)
+                .fill(Color.secondary.opacity(0.7))
+                .frame(width: 36, height: 5)
         }
         .frame(
             minWidth: BottomSheetMetrics.handleHitTargetWidth,

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -2261,6 +2261,14 @@ private struct MapOverlayView: View {
             if viewModel.isCustomLocation, let label = viewModel.customLocationLabel {
                 return label
             }
+            // Friendly fallback for the synthetic `osm_<lat>_<lon>` code that
+            // MapViewModel emits when reverse-geocoding misses on an Explore
+            // jump. Rendering "osm_18.8_99.0" in the city pill exposes an
+            // internal sentinel to the user — we'd rather show a localized
+            // "Nearby" and let the chevron offer the picker as the recovery.
+            if let code = viewModel.selectedCity, code.hasPrefix("osm_") {
+                return NSLocalizedString("city.nearby", comment: "Fallback city label for synthetic osm_ codes")
+            }
             if let code = viewModel.selectedCity,
                let city = viewModel.availableCities.first(where: { $0.code == code }) {
                 return city.name

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -408,8 +408,15 @@ struct CompassMapContentView: View {
                 // `viewModel == nil` guard.
                 if !hasRunFirstAppear {
                     hasRunFirstAppear = true
-                    // On first launch with no saved city and no GPS, prompt city picker.
-                    if preferences.lastSelectedCity == nil && locationService.currentLocation == nil {
+                    // On first launch with no resolved city and no GPS, prompt city
+                    // picker. We consult `viewModel.selectedCity` (not just persisted
+                    // `lastSelectedCity`) so the DEBUG `-startCity` launch arg — which
+                    // never writes back to preferences — actually suppresses the
+                    // picker. Without this guard a cold launch with `-startCity` still
+                    // unexpectedly opens the picker over the consent gate.
+                    if viewModel.selectedCity == nil
+                        && preferences.lastSelectedCity == nil
+                        && locationService.currentLocation == nil {
                         isShowingCityPicker = true
                     }
                     // Populate the Routes section for the initial city. `selectedCity`
@@ -2289,6 +2296,11 @@ private struct MapOverlayView: View {
     }
 
     private var mapStyleButton: some View {
+        // Demoted to secondary affordance (32pt + reduced opacity) so the
+        // top-right cluster reads as a hierarchy — Recenter (44pt primary) >
+        // Avatar (40pt identity) > MapStyle (32pt secondary). The previous
+        // three-equal-circles layout pushed the city pill off-center and made
+        // the column feel cluttered on cold-start screenshots.
         Button {
             Haptics.impact(.light)
             withAnimation(.easeInOut(duration: 0.2)) {
@@ -2296,13 +2308,13 @@ private struct MapOverlayView: View {
             }
         } label: {
             Image(systemName: mapStyleChoice.icon)
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(CT.accent)
-                .frame(width: 36, height: 36)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(CT.accent.opacity(0.75))
+                .frame(width: 32, height: 32)
                 .background(
                     Circle()
                         .fill(.ultraThinMaterial)
-                        .shadow(color: .black.opacity(0.12), radius: 4, y: 2)
+                        .shadow(color: .black.opacity(0.08), radius: 3, y: 1)
                 )
         }
         .accessibilityLabel(Text(mapStyleChoice.label))
@@ -2625,7 +2637,12 @@ private struct PlusActionButton: View {
                 )
 
             Circle()
-                .fill(Color.black.opacity(0.85))
+                // Amber-fill the Ask Solo FAB so it reads as the brand's own
+                // primary action (matched to consent / onboarding CTAs) rather
+                // than a generic "system action" black puck. The previous
+                // .black.opacity(0.85) made the right side of the map look like
+                // an Apple-default control sat next to red pin markers.
+                .fill(CT.accent)
                 .frame(width: 56, height: 56)
                 .shadow(color: .black.opacity(0.2), radius: 6, y: 3)
                 .scaleEffect(isPressed ? 1.08 : 1.0)

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -99,6 +99,7 @@ targets:
         CODE_SIGN_IDENTITY: "Apple Distribution"
         DEVELOPMENT_TEAM: "6RG2F8YY59"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
     entitlements:
       path: SoloCompass/Resources/SoloCompass.entitlements
       properties:


### PR DESCRIPTION
## Summary
Autonomous, evaluator-driven UX polish across 14 rounds. **Net 4-lens score 3.7 → 7.8 (+110%)** on the cold-start flow, measured before/after on the same 3-screenshot panel by an independent PM + Visual + Microcopy + Interaction agent team.

**Net diff**: 11 files / +190 / −41 across 2 commits (`17c0118` main sweep + `b3e07e8` follow-up polish).

## What changed

### Brand color sweep (one-line fix, huge surface)
- Added `AccentColor` asset (`#5D3000` warm amber) + `ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME` in project.yml. Onboarding, consent gate, "Ask Solo" FAB, and all `.borderedProminent` CTAs flip to amber in one stroke — no more system blue mid-flow.
- Ask Solo FAB filled `CT.accent` (was `.black.opacity(0.85)`).

### Cold-start TTFV (30s+ → <8s)
- City picker guard now consults `viewModel.selectedCity`, not just `preferences.lastSelectedCity` — `-startCity` no longer leaks the picker over the consent gate.
- `cityCodeAliases` resolves PascalCase variants (`ChiangMai` → `cmi`) so the launch arg routes through `defaultCenterForSelectedCity` instead of `Self.defaultCenter`.
- Default `maxDistanceKm` raised 5 → 8 km so Chiang Mai's Doi Suthep seed (7.83 km) is in-radius on cold start. One-time UserDefaults-flagged migration (`SoloCompass.didMigrateRadius8`) bumps existing 5.0 users.
- Cold-start empty watchdog tightened 5s → 1s and now auto-recovers in-memory: city-selected + 0 nearby + 1s timeout → widen radius to 25 km once per session (`didAutoRecoverEmpty`), reset by `selectCity`. Never persists.

### Empty-state copy (brand voice)
- `map.empty.title`: "No experiences nearby" → "Quiet patch of map." / "这片地图还很安静。"
- `map.empty.radius`: "...暂无体验" → "Showing within %.0f km — try a wider radius." / "目前在 %.0f 公里内 — 试试更大半径。"
- `empty.nearby.headline` + `.subtitle` + `.cta` rewritten in same voice
- `chat.error.unknown` zh: "出现错误 — 请重试" → "没发出去。再试一次。"

### Sheet + FilterBar polish
- Bottom-sheet drag handle 4×36 / 0.5 → 5×36 / 0.7 — peek now reads as a pull-up affordance, not a stranded toast.
- FilterBar pills share a single neutral border + neutral text on unselected. Category color survives only in the inline glyph (held at `opacity(0.85)` for additional quiet).
- Inline result count slimmed to plain digits — chip stops swelling when "All 5" appears.

### Top-right cluster hierarchy
- `mapStyleButton` demoted 36pt full-opacity → 32pt at 0.75 opacity. Right rail now reads as Recenter (44pt primary) > Avatar (40pt identity) > MapStyle (32pt secondary).

### Detail page
- `ExperienceDetailView.actionBar` bottom padding 12 → 26 pt so the Mark-done pill no longer crashes into the home-indicator strip on iPhone 17.

### City pill leak guard
- `osm_<lat>_<lon>` reverse-geocode-miss sentinel intercepted in `cityPill`; renders localized "Nearby" / "附近" instead of exposing the internal code.

## Test plan
- [x] `xcodebuild build` — green on iPhone 17 / iOS 26.1
- [x] `xcodebuild test` — 1140 passed / 28 failed / 1 skipped; the 28 failures match the main-branch baseline (DocComments / closingSoon / AskSoloCTA / LanguageService / Voice) — **0 regression introduced**
- [x] Live cold-start verified: `-startCity ChiangMai` lands on 5 pins + "Backstreet Books" peek card in ~6 s after consent agree (vs 30 s+ empty before)
- [x] Onboarding (1, 2) + consent gate visually verified warm-amber end-to-end (R2 screenshots)
- [ ] Suggested follow-up review: someone re-runs the 4-lens scoring panel to confirm 7.8 net (screenshots in `scratchpad/ux-rounds/R0..R6/`)

## Multi-lens scoring (independent agent panel)
| Dimension | Before | After | Δ |
|---|---:|---:|---:|
| Brand color coherence | 4 | 8.5 | +4.5 |
| Cold-start TTFV | 3 | 8 | +5 |
| Empty-state recovery | 4 | 8 | +4 |
| FilterBar visual unity | 3 | 6.5 | +3.5 |
| Onboarding warmth | 3 | 8.5 | +5.5 |
| Sheet affordance | 5 | 7 | +2 |
| Overall delight | 4 | 8 | +4 |
| **Weighted net** | **3.7** | **7.8** | **+4.1** |

## Known follow-ups (out of scope here)
1. SwiftUI Map has no `preferredLanguage` API → Thai admin labels on Chiang Mai tiles need MKMapView migration to fix.
2. `AvatarBubble` glyph reads as a second compass control next to the right-rail compass — refresh to a distinct identity mark.
3. `-openExperience` deep-link occasionally leaves the map in a white-tile state after sheet dismiss; needs a separate investigation.