### PR TITLE
feat(ios): homepage warm-start + Solo mascot FAB (R0→R6)

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 		63A45A90C2748A2729742C2F /* FilterBarScrollAffordanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFED848E66BBE2A234AAA3CC /* FilterBarScrollAffordanceTest.swift */; };
 		63DCAC4B5E83B26B9B175344 /* AIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4515228D70D8804596299D /* AIProvider.swift */; };
 		641D80BD116D6F255A9ED26A /* PendingSyncRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A92E0AE1868C3A165F3E95 /* PendingSyncRecord.swift */; };
+		647C7A31BABBA01C49C7E463 /* SoloMascotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93F1CB6D9C18B38957CAF1D /* SoloMascotView.swift */; };
 		65E57E8B02E7889BD8EE8DD4 /* ContextManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1F5F43F42E03BA5F10FA2F /* ContextManager.swift */; };
 		66C352786CB25AA13017F933 /* CreateRouteEntryTappableGuardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BB36326BBDD7860ECD722B /* CreateRouteEntryTappableGuardTest.swift */; };
 		67D784ECDFE24AE5384975D2 /* Friendship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531D01560A12EAE904126D15 /* Friendship.swift */; };
@@ -800,6 +801,7 @@
 		B922F1B566195E79BD671D85 /* SolarEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolarEventsTests.swift; sourceTree = "<group>"; };
 		B922F9040238050C82A5F312 /* WeatherSignal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherSignal.swift; sourceTree = "<group>"; };
 		B92F9A65ACFD3B9518A364B0 /* PaywallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallView.swift; sourceTree = "<group>"; };
+		B93F1CB6D9C18B38957CAF1D /* SoloMascotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloMascotView.swift; sourceTree = "<group>"; };
 		B9864D3AA45FA7D5ADC4D2ED /* Conversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Conversation.swift; sourceTree = "<group>"; };
 		BA6A3144D85CDAD01FA0FECB /* CompassMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompassMapView.swift; sourceTree = "<group>"; };
 		BB612E3F9DD324EF3F308FFA /* CompanionPhase3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionPhase3Tests.swift; sourceTree = "<group>"; };
@@ -952,6 +954,7 @@
 				659B2C7C4B36A086968A28EF /* SkeletonBadgeView.swift */,
 				BEDD4F6238B484BB7C20904B /* SkeletonView.swift */,
 				98EFEBC6789178136BCFDC39 /* SoloCompassTips.swift */,
+				B93F1CB6D9C18B38957CAF1D /* SoloMascotView.swift */,
 				EB579F3F4EBBA014AA306DD1 /* SoloScoreBadge.swift */,
 				4D557D1D0D224C725834A08D /* SoloScoreRadarChart.swift */,
 				7AB6DC54C82CAD121880FE2D /* UrgencyPulse.swift */,
@@ -2221,6 +2224,7 @@
 				E5F463CE3CE822F7F96CA82C /* SoloCompassApp.swift in Sources */,
 				13E5AEAEE5194DDB79AE92AC /* SoloCompassModelContainer.swift in Sources */,
 				0B77739CFA29BF6CE2A12F45 /* SoloCompassTips.swift in Sources */,
+				647C7A31BABBA01C49C7E463 /* SoloMascotView.swift in Sources */,
 				86F4628473C2D520D4C2FFFB /* SoloScoreBadge.swift in Sources */,
 				A217FA55BD40922DB3B8DEE6 /* SoloScoreRadarChart.swift in Sources */,
 				52B53BDA14EBACE5242FC016 /* StopsList.swift in Sources */,

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1541,6 +1541,13 @@
 /* Create-route entry card + flow */
 "route.create.entry.title" = "創建你自己的路線";
 "route.create.entry.subtitle" = "串聯幾個地點 · 可選擇招募同伴一起走";
+
+/* Direction 3 — warm cold-start placeholder for the Now routes section */
+"routes.now.empty.title" = "Today’s walk · let Solo string one together";
+"routes.now.empty.cta" = "I’ll pick three nearby stops you’ll actually like — tap to start.";
+"route.duration.hours" = "%dh";
+"route.duration.hoursMinutes" = "%dh %dmin";
+"route.duration.minutes" = "%dmin";
 "route.create.title" = "創建路線";
 "route.create.ai" = "✨ 讓 AI 幫我串成路線";
 "route.create.titleLabel" = "路線名稱";
@@ -1711,6 +1718,8 @@
 "peek.card.almostThere" = "Almost there";
 "peek.card.almostThere.a11y" = "Almost there";
 "peek.preview.active.hint" = "Viewing your pick · pull up for all nearby";
+"peek.reason.aiPick" = "Right now I'd take you here — %@.";
+"peek.reason.warmStart" = "Strongest %@ pick in view right now · Solo %.1f";
 "sheet.handle.hint" = "Tap to expand, drag to resize";
 
 /* NowScore weather signal (US-005) — %d is the temperature in whole °C. */

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1481,6 +1481,13 @@
 /* Create-route entry card + flow */
 "route.create.entry.title" = "创建你自己的路线";
 "route.create.entry.subtitle" = "串联几个地点 · 可选择招募同伴一起走";
+
+/* Direction 3 — 当下 / Now 路线区冷启动占位卡 */
+"routes.now.empty.title" = "今天的一条路线 · 让 Solo 为你拼一条";
+"routes.now.empty.cta" = "我从附近挑 3 个你会喜欢的点，串成一条 · 点这里开始";
+"route.duration.hours" = "%d 小时";
+"route.duration.hoursMinutes" = "%d 小时 %d 分";
+"route.duration.minutes" = "%d 分钟";
 "route.create.title" = "创建路线";
 "route.create.ai" = "✨ 让 AI 帮我串成路线";
 "route.create.titleLabel" = "路线名称";
@@ -1551,6 +1558,8 @@
 "peek.card.almostThere" = "就快到了";
 "peek.card.almostThere.a11y" = "就快到了";
 "peek.preview.active.hint" = "正在查看你选中的 · 上拉看全部";
+"peek.reason.aiPick" = "现在我最想带你去这里——%@。";
+"peek.reason.warmStart" = "此刻视野里最值得去的%@ · Solo %.1f";
 "sheet.handle.hint" = "点击展开，拖动调整";
 
 /* NowScore 天气信号 (US-005) — %d 为整数温度（°C）。 */

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -1586,6 +1586,20 @@ public final class MapViewModel {
     /// a sun-gold border and warm gradient bg.
     public var aiSmartPickIds: [String] = []
 
+    /// Smart-pick ids actually surfaced to the UI. Falls back to the
+    /// Solo-Score top-3 of the visible set when AI ranking hasn't produced
+    /// any picks yet (cold start, missing AI key, or offline). Without this
+    /// the map looks like a wall of identical pins on first open — the curation
+    /// signal only appears after the AI ranker finishes, which may never happen
+    /// for users without an API key.
+    public var effectiveSmartPickIds: [String] {
+        if !aiSmartPickIds.isEmpty { return aiSmartPickIds }
+        return visibleExperiences
+            .sorted { $0.soloScore.overall > $1.soloScore.overall }
+            .prefix(3)
+            .map { $0.id }
+    }
+
     /// Reorder the visible experiences using AI ranking and highlight the top
     /// three as smart picks, leaving the list intact if ranking fails.
     public func runAIRanking() async {

--- a/apps/ios/SoloCompass/Views/Companion/Components/RouteCard.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Components/RouteCard.swift
@@ -34,11 +34,29 @@ public struct RouteCard: View {
         return "\(durationLabel) · \(dist) · \(route.pace.localizedLabel)"
     }
 
-    /// Compact duration label (e.g. `1h30m` / `90min`) used in the head tag.
+    /// Compact duration label (e.g. `1h30m` / `90min` / `3 小时` / `90 分钟`).
+    /// Localized — zh-Hans gets "3 小时 / 30 分钟" instead of the H/M form so the
+    /// uppercased head tag doesn't render an alien "3H00M" inside a Chinese card.
     private var durationLabel: String {
-        route.estimatedDuration >= 60
-            ? String(format: "%dh%02dm", route.estimatedDuration / 60, route.estimatedDuration % 60)
-            : "\(route.estimatedDuration)min"
+        let mins = route.estimatedDuration
+        if mins >= 60 {
+            let h = mins / 60
+            let m = mins % 60
+            if m == 0 {
+                return String(
+                    format: NSLocalizedString("route.duration.hours", comment: "%d hours"),
+                    h
+                )
+            }
+            return String(
+                format: NSLocalizedString("route.duration.hoursMinutes", comment: "%d h %d min"),
+                h, m
+            )
+        }
+        return String(
+            format: NSLocalizedString("route.duration.minutes", comment: "%d minutes"),
+            mins
+        )
     }
 
     /// Uppercase head tag: "路线 · N 站 · DURATION".

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -215,6 +215,14 @@ struct CompassMapContentView: View {
     @State private var lastPanAt: Date = .distantPast
     @State private var panDebounceTask: Task<Void, Never>? = nil
 
+    // Direction 2: on the first frame after the map loads, only the 3 AI
+    // smart-pick pins "shine"; every other pin is dimmed (~35% opacity, ~85%
+    // scale) so the map reads as a curated short-list, not a wall of dots.
+    // Flips off on the user's first map drag/tap or when Explore mode kicks in,
+    // and never re-activates within this view's lifetime — the curation cue is
+    // a cold-start affordance, not a permanent treatment.
+    @State private var smartPickHighlightActive: Bool = true
+
     // Tracks whether we've seen a disconnect so the success haptic only fires
     // after a real offline→online transition, never on cold launch.
     @State private var hasDisconnected: Bool = false
@@ -414,10 +422,20 @@ struct CompassMapContentView: View {
                     // never writes back to preferences — actually suppresses the
                     // picker. Without this guard a cold launch with `-startCity` still
                     // unexpectedly opens the picker over the consent gate.
-                    if viewModel.selectedCity == nil
+                    // DEBUG: screenshot harness can pass -skipLocationPicker to keep
+                    // the home view clean (no modal sheet covering peek/pins/FAB).
+                    let skipPicker = ProcessInfo.processInfo.arguments.contains("-skipLocationPicker")
+                    if !skipPicker
+                        && viewModel.selectedCity == nil
                         && preferences.lastSelectedCity == nil
                         && locationService.currentLocation == nil {
                         isShowingCityPicker = true
+                    }
+                    // DEBUG: screenshot harness can pass -startNow to switch the
+                    // filter to Now mode on cold start, so the RoutesSection's
+                    // empty-state placeholder can be captured deterministically.
+                    if ProcessInfo.processInfo.arguments.contains("-startNow") {
+                        viewModel.isNowFilter = true
                     }
                     // Populate the Routes section for the initial city. `selectedCity`
                     // is resolved in the view model's init (from a persisted city or
@@ -803,6 +821,15 @@ struct CompassMapContentView: View {
                                         isNowFilter: true,
                                         onSelectRoute: { route in
                                             routeSheet = .detail(route)
+                                        },
+                                        // Direction 3 — cold start in Now mode: when
+                                        // RoutesSection finds zero displayed items it
+                                        // renders NowEmptyRoutePlaceholder; its CTA must
+                                        // hit the same flow as CreateRouteEntryCard
+                                        // below so we keep a single create-route code
+                                        // path (no new orchestration).
+                                        onProposeRoute: {
+                                            routeSheet = .create
                                         }
                                     )
 
@@ -1548,6 +1575,11 @@ struct CompassMapContentView: View {
                             let isClosingSoon = BestNowChipState
                                 .resolve(for: exp, at: bestNowClock.tick)
                                 .isClosingSoon
+                            let smartPickRank = viewModel.effectiveSmartPickIds.firstIndex(of: exp.id)
+                            let isSmartPick = smartPickRank != nil
+                            let highlightActive = smartPickHighlightActive
+                                && !viewModel.effectiveSmartPickIds.isEmpty
+                                && viewModel.exploreRadiusOverlay == nil
                             Annotation("", coordinate: coord) {
                                 Button {
                                     viewModel.openExperienceDetail(exp)
@@ -1571,6 +1603,12 @@ struct CompassMapContentView: View {
                                                 .background(Capsule().fill(Color.gray.opacity(0.85)))
                                         }
                                     }
+                                    .modifier(SmartPickHighlightModifier(
+                                        isSmartPick: isSmartPick,
+                                        highlightActive: highlightActive,
+                                        reduceMotion: reduceMotion,
+                                        smartPickRank: smartPickRank
+                                    ))
                                     .transition(.scale.combined(with: .opacity))
                                 }
                                 .buttonStyle(.plain)
@@ -1587,6 +1625,19 @@ struct CompassMapContentView: View {
                             }
                         }
                     case .cluster(let cluster):
+                        // A cluster bubble is, by definition, a bag of "not the
+                        // top 3" pins — so during the cold-start curation pass
+                        // it follows the same dim-and-shrink treatment as any
+                        // non-smart-pick. If a smart pick happens to fall into
+                        // the cluster it's still surfaced, just not visually
+                        // forced; the home-screen narrative ("look at these
+                        // three") stays clean.
+                        let clusterRanks = cluster.experiences.compactMap { viewModel.effectiveSmartPickIds.firstIndex(of: $0.id) }
+                        let clusterHasSmartPick = !clusterRanks.isEmpty
+                        let clusterTopRank = clusterRanks.min()
+                        let clusterHighlightActive = smartPickHighlightActive
+                            && !viewModel.effectiveSmartPickIds.isEmpty
+                            && viewModel.exploreRadiusOverlay == nil
                         Annotation("", coordinate: cluster.coordinate) {
                             ClusterAnnotationView(cluster: cluster) {
                                 HapticService.shared.impact(style: .medium)
@@ -1594,12 +1645,21 @@ struct CompassMapContentView: View {
                                     viewModel.openExperienceDetail(first)
                                 }
                             }
+                            .modifier(SmartPickHighlightModifier(
+                                isSmartPick: clusterHasSmartPick,
+                                highlightActive: clusterHighlightActive,
+                                reduceMotion: reduceMotion,
+                                smartPickRank: clusterTopRank
+                            ))
                             .transition(.scale.combined(with: .opacity))
                         }
                     }
                 }
                 ForEach(viewModel.candidateExperiences) { cand in
                     if let coord = cand.coordinate {
+                        let candHighlightActive = smartPickHighlightActive
+                            && !viewModel.effectiveSmartPickIds.isEmpty
+                            && viewModel.exploreRadiusOverlay == nil
                         Annotation("", coordinate: coord) {
                             MarkerIconView(
                                 category: cand.category,
@@ -1607,6 +1667,11 @@ struct CompassMapContentView: View {
                                 confidenceLevel: cand.confidence.level,
                                 isSelected: viewModel.selectedExperience?.id == cand.id
                             )
+                            .modifier(SmartPickHighlightModifier(
+                                isSmartPick: false,
+                                highlightActive: candHighlightActive,
+                                reduceMotion: reduceMotion
+                            ))
                             .accessibilityLabel(Text(String(
                                 format: NSLocalizedString("map.candidate.label", comment: "Candidate experience: %@"),
                                 cand.title
@@ -1683,6 +1748,16 @@ struct CompassMapContentView: View {
                     viewModel.currentSpanLatitudeDelta = context.region.span.latitudeDelta
                 }
                 viewModel.refreshForLocation(context.region.center)
+                // Direction 2: the curation dim-out is a cold-start cue. Once
+                // the camera settles for the first time after the user has
+                // panned or zoomed (isMapPanning flipped during the move),
+                // restore every pin to full opacity so Explore feels like the
+                // whole map again — not a guided tour.
+                if smartPickHighlightActive && isMapPanning {
+                    withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.35)) {
+                        smartPickHighlightActive = false
+                    }
+                }
             }
             .simultaneousGesture(
                 LongPressGesture(minimumDuration: 0.6)
@@ -1929,7 +2004,12 @@ private struct MapOverlayView: View {
                 )
             }
 
-            if isFilterActive {
+            // Show the floating chip ONLY when it's adding information the
+            // FilterBar can't: zero matches (with optional "next best" jump)
+            // or zero-after-search empty state. When count > 0 the active
+            // filter chip in the FilterBar already shows the match count as a
+            // badge ("此刻 1"), so the mid-map "1 个匹配" is pure duplication.
+            if isFilterActive && viewModel.visibleExperiences.isEmpty {
                 filterResultBadge
                     .padding(.top, 8)
                     .transition(.opacity.combined(with: .move(edge: .top)))
@@ -2656,9 +2736,12 @@ private struct PlusActionButton: View {
                 .scaleEffect(isPressed ? 1.08 : 1.0)
                 .animation(.spring(response: 0.18, dampingFraction: 0.7), value: isPressed)
 
-            Image(systemName: "plus")
-                .font(.title2.weight(.semibold))
-                .foregroundStyle(.white)
+            // Replace the generic "+" glyph with the Solo mascot — the cartoon
+            // girl who IS Solo. She greets the traveler from the homepage and
+            // is the entry-point to Solo Chat. The amber circle + shadow +
+            // press-ring above stay byte-identical, so hit-target and FAB
+            // layout are unchanged. `isPressed` drives her cheek sparkle.
+            SoloMascotView(isPressed: isPressed)
         }
         .contentShape(Circle())
         .onLongPressGesture(
@@ -3049,6 +3132,172 @@ private struct NowEmptyOverlay: View {
         guard !reduceMotion else { return }
         withAnimation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true)) {
             iconPulse = true
+        }
+    }
+}
+
+/// Direction 2 — first-frame curation cue.
+///
+/// Wraps a map marker so the 3 AI-ranked "smart picks" read as the only thing
+/// worth looking at on cold start, and everything else recedes into context.
+///
+/// Behaviour
+/// =========
+/// * `highlightActive == false` → identity transform; this is the steady-state
+///   once the user pans, zooms, or enters Explore mode.
+/// * `highlightActive == true` + `isSmartPick == true` → keep full size +
+///   opacity, layer a soft sun-gold ring + glow underneath, and (motion
+///   permitting) a slow breathe. Tap target is untouched.
+/// * `highlightActive == true` + `isSmartPick == false` → fade to 35% opacity
+///   and 85% scale so the pin still has presence (geographic context, density
+///   hint) but lets the gold picks do the talking.
+///
+/// Reduce Motion strips the breathe; the ring/glow + opacity/scale change are
+/// purely static styling and stay on.
+private struct SmartPickHighlightModifier: ViewModifier {
+    let isSmartPick: Bool
+    let highlightActive: Bool
+    let reduceMotion: Bool
+    /// 0-based rank within the smart-pick triple (0, 1, 2). Drives the numeric
+    /// badge in the corner so the viewer reads "1, 2, 3" not "three identical
+    /// glowing pins." `nil` for non-smart pins or when rank is unknown.
+    var smartPickRank: Int? = nil
+
+    @State private var breathe: Bool = false
+
+    func body(content: Content) -> some View {
+        // MapKit Annotation clips its overlay layer to the SwiftUI content's
+        // intrinsic frame. Wrap the pin in an explicit 120pt frame so the
+        // 112pt outer bloom + the corner rank badge both have room to draw
+        // without being cropped to the pin's tiny native bounds.
+        ZStack {
+            highlightOrnament
+                .compositingGroup()
+            content
+                .scaleEffect(scale, anchor: .center)
+                .opacity(opacity)
+            // Rank badge sits in the same ZStack, positioned via offset
+            // relative to the 120pt canvas center so it lands at the upper-
+            // right of the pin (pin is ~32pt; +16 right / -18 up lands the
+            // badge just outside the pin's corner).
+            rankBadge
+                .offset(x: 18, y: -20)
+        }
+        .frame(width: 120, height: 120)
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.45), value: highlightActive)
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.45), value: isSmartPick)
+            .onAppear {
+                guard isSmartPick, highlightActive, !reduceMotion else { return }
+                withAnimation(.easeInOut(duration: 1.8).repeatForever(autoreverses: true)) {
+                    breathe = true
+                }
+            }
+            .onChange(of: highlightActive) { _, active in
+                guard !reduceMotion else { return }
+                if active && isSmartPick {
+                    withAnimation(.easeInOut(duration: 1.8).repeatForever(autoreverses: true)) {
+                        breathe = true
+                    }
+                } else {
+                    withAnimation(nil) { breathe = false }
+                }
+            }
+    }
+
+    private var scale: CGFloat {
+        guard highlightActive else { return 1.0 }
+        return isSmartPick ? 1.0 : 0.85
+    }
+
+    private var opacity: Double {
+        guard highlightActive else { return 1.0 }
+        // Non-smart pins drop to 25% (was 35%) so the smart trio absolutely
+        // pops. Anything above 30% on a busy OSM tile reads as "still active"
+        // and steals attention from the curated picks.
+        return isSmartPick ? 1.0 : 0.25
+    }
+
+    @ViewBuilder
+    private var highlightOrnament: some View {
+        if isSmartPick && highlightActive {
+            ZStack {
+                // Outermost soft bloom — wide, low-alpha gold reaching 100pt.
+                // This is the layer the eye picks up first from across the map;
+                // it's the "this region is special" cue before the user even
+                // reads the pin shape.
+                Circle()
+                    .fill(
+                        RadialGradient(
+                            colors: [
+                                CT.sunGold.opacity(0.45),
+                                CT.sunGold.opacity(0.0)
+                            ],
+                            center: .center,
+                            startRadius: 12,
+                            endRadius: 56
+                        )
+                    )
+                    .frame(width: 112, height: 112)
+                    .blur(radius: 6)
+                // Core halo — tighter, brighter ring of sunGoldDeep. Bumped
+                // from 0.75 → 0.95 alpha and grown to 92pt so the glow
+                // survives on green/yellow OSM tiles where the previous
+                // pass got eaten by the background.
+                Circle()
+                    .fill(
+                        RadialGradient(
+                            colors: [
+                                CT.sunGoldDeep.opacity(0.95),
+                                CT.sunGold.opacity(0.55),
+                                CT.sunGold.opacity(0.0)
+                            ],
+                            center: .center,
+                            startRadius: 4,
+                            endRadius: 46
+                        )
+                    )
+                    .frame(width: 92, height: 92)
+                    .scaleEffect(reduceMotion ? 1.0 : (breathe ? 1.12 : 0.90))
+                    .opacity(reduceMotion ? 0.92 : (breathe ? 1.0 : 0.78))
+                // White contrast disc — sits between the glow and the inner
+                // ring. Without this, the gold halo blends into the OSM
+                // greens/yellows; with it, the smart pick reads as "lit from
+                // within" against any tile.
+                Circle()
+                    .fill(Color.white.opacity(0.65))
+                    .frame(width: 54, height: 54)
+                    .blur(radius: 3)
+                // Inner crisp ring — sun-gold stroke that hugs the pin so the
+                // "this is curated" cue lands even without motion.
+                Circle()
+                    .strokeBorder(CT.sunGoldDeep, lineWidth: 2.4)
+                    .frame(width: 52, height: 52)
+            }
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+        }
+    }
+
+    /// Tiny numbered badge (1/2/3) anchored to the upper-right of the pin.
+    /// Reads as a clear rank cue at a glance — three glowing pins look the
+    /// same; "1 2 3" tells the viewer instantly which is the top pick.
+    @ViewBuilder
+    fileprivate var rankBadge: some View {
+        if isSmartPick && highlightActive, let rank = smartPickRank {
+            Text("\(rank + 1)")
+                .font(.system(size: 11, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+                .frame(width: 18, height: 18)
+                .background(
+                    Circle()
+                        .fill(CT.sunGoldDeep)
+                        .shadow(color: .black.opacity(0.25), radius: 1.5, y: 1)
+                )
+                .overlay(
+                    Circle().stroke(Color.white.opacity(0.9), lineWidth: 1.2)
+                )
+                .accessibilityHidden(true)
+                .allowsHitTesting(false)
         }
     }
 }

--- a/apps/ios/SoloCompass/Views/Map/PeekPickResolver.swift
+++ b/apps/ios/SoloCompass/Views/Map/PeekPickResolver.swift
@@ -10,7 +10,10 @@ import CoreLocation
 /// Precedence:
 ///  1. The first AI smart-pick id (`smartPickIds.first`) that is present in
 ///     `experiences` — the AI's top recommendation, when it is currently visible.
-///  2. Otherwise the experience nearest the reference coordinate.
+///  2. Warm-start fallback: the visible experience with the highest Solo Score.
+///     Surfaces the strongest real pick the instant the map loads, before the
+///     AI ranker has had a chance to run. Ties (Δ < 0.05) break to the nearest
+///     one so the suggestion is plausibly walkable.
 ///  3. `nil` when `experiences` is empty.
 enum PeekPickResolver {
     /// Resolve the peek experience from the visible set.
@@ -18,9 +21,8 @@ enum PeekPickResolver {
     /// - Parameters:
     ///   - experiences: the currently visible experiences.
     ///   - smartPickIds: AI-ranked top pick ids (highest priority first).
-    ///   - referenceCoordinate: user location or map center; used for the
-    ///     nearest-fallback. When `nil`, the first visible experience is returned
-    ///     as the fallback (no distance ordering is possible).
+    ///   - referenceCoordinate: user location or map center; used to break
+    ///     Solo-Score ties in the warm-start fallback.
     /// - Returns: the experience to feature in the peek card, or `nil` if none.
     static func resolve(
         experiences: [Experience],
@@ -36,14 +38,18 @@ enum PeekPickResolver {
             }
         }
 
-        // 2. Fallback: nearest to the reference coordinate.
-        guard let ref = referenceCoordinate else {
-            return experiences.first
+        // 2. Warm-start: highest Solo Score. "Best place in view" beats
+        //    "whatever happens to be nearest", which can be a low-quality pin.
+        let refLocation = referenceCoordinate.map {
+            CLLocation(latitude: $0.latitude, longitude: $0.longitude)
         }
-        // Allocate the reference CLLocation once, outside the comparison closure.
-        let refLocation = CLLocation(latitude: ref.latitude, longitude: ref.longitude)
-        return experiences.min(by: { lhs, rhs in
-            distance(from: refLocation, to: lhs) < distance(from: refLocation, to: rhs)
+        return experiences.max(by: { lhs, rhs in
+            let scoreGap = rhs.soloScore.overall - lhs.soloScore.overall
+            if abs(scoreGap) < 0.05, let ref = refLocation {
+                // Effectively tied → prefer closer.
+                return distance(from: ref, to: lhs) > distance(from: ref, to: rhs)
+            }
+            return scoreGap > 0
         })
     }
 

--- a/apps/ios/SoloCompass/Views/Map/PeekSummaryCard.swift
+++ b/apps/ios/SoloCompass/Views/Map/PeekSummaryCard.swift
@@ -61,14 +61,20 @@ struct PeekSummaryCard: View {
             #endif
             onTap()
         } label: {
-            HStack(alignment: .top, spacing: 12) {
-                categoryDisc
-                VStack(alignment: .leading, spacing: 7) {
-                    titleStack
-                    chipRow
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top, spacing: 12) {
+                    categoryDisc
+                    VStack(alignment: .leading, spacing: 7) {
+                        titleStack
+                        chipRow
+                    }
+                    Spacer(minLength: 4)
+                    distanceColumn
                 }
-                Spacer(minLength: 4)
-                distanceColumn
+                // Warm-start reason: one line of friend-voice copy under the
+                // card. The map opens and Solo already has a *reason* to
+                // suggest this spot — not just a name.
+                warmReasonLine
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 12)
@@ -98,6 +104,60 @@ struct PeekSummaryCard: View {
     }
 
     // MARK: - Sub-views
+
+    /// One-line warm-amber rationale shown under the chip row. Friend voice —
+    /// "I'd take you here right now because…". Empty when there's nothing
+    /// honest to say so the card stays clean.
+    @ViewBuilder
+    private var warmReasonLine: some View {
+        let copy = reasonCopy
+        if !copy.isEmpty {
+            HStack(alignment: .top, spacing: 6) {
+                Image(systemName: isSmartPick ? "sparkles" : "heart.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(CT.sunGoldDeep)
+                    .padding(.top, 2)
+                Text(copy)
+                    .font(.footnote)
+                    .foregroundStyle(CT.sunGoldDeep)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 0)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(Text(copy))
+        }
+    }
+
+    /// The reason copy to show. Friend voice in both languages — never bare facts.
+    /// Order: AI rationale → "best spot in view" warm-start line → empty.
+    private var reasonCopy: String {
+        if isSmartPick {
+            let why = experience.whyItMatters.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !why.isEmpty {
+                // First sentence only, keeps the row to ≤ 2 lines.
+                let firstSentence = why
+                    .split(whereSeparator: { ".。！？!?".contains($0) })
+                    .first
+                    .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) } ?? why
+                let format = NSLocalizedString(
+                    "peek.reason.aiPick",
+                    comment: "AI smart pick rationale, friend voice. %@ = why-it-matters first sentence."
+                )
+                return String(format: format, firstSentence)
+            }
+        }
+        // Warm-start fallback: surface the score + category as a friend's nudge.
+        let format = NSLocalizedString(
+            "peek.reason.warmStart",
+            comment: "Warm-start fallback reason, friend voice. %.1f = Solo score, %@ = category name."
+        )
+        // %@ first (category name), %.1f second (Solo score) — order MUST match
+        // both en + zh-Hans strings entries. Reversing them crashes with EXC_BAD_ACCESS
+        // because %@ tries to message the Double as an NSObject.
+        return String(format: format, experience.category.localizedTitle, experience.soloScore.overall)
+    }
 
     private var categoryDisc: some View {
         ZStack {
@@ -299,10 +359,16 @@ struct PeekSummaryCard: View {
             experience.location.placeNameRomanized,
             experience.location.placeNameLocal
         ].compactMap { $0?.isEmpty == false ? $0 : nil }
-        if parts.isEmpty {
-            return experience.location.addressHint ?? ""
+        // Drop place-name parts that just duplicate the card's shortName — a
+        // peek card titled "Nimman Roasters" subtitled "Nimman Roasters" reads
+        // as a render bug. Keep neighborhood-ish parts, swap pure duplicates
+        // for a soft category hint.
+        let shortName = experience.shortName
+        let deduped = parts.filter { $0.caseInsensitiveCompare(shortName) != .orderedSame }
+        if deduped.isEmpty {
+            return experience.category.localizedTitle
         }
-        return parts.joined(separator: " · ")
+        return deduped.joined(separator: " · ")
     }
 
     /// Live "best now / closing soon" chip state, recomputed each time the shared

--- a/apps/ios/SoloCompass/Views/Map/RoutesSectionView.swift
+++ b/apps/ios/SoloCompass/Views/Map/RoutesSectionView.swift
@@ -8,6 +8,11 @@ struct RoutesSection: View {
     let routes: [Route]
     let isNowFilter: Bool
     let onSelectRoute: (Route) -> Void
+    /// Optional CTA invoked by the warm cold-start placeholder card when the Now
+    /// section has zero real routes. Wired by the parent to the same code path
+    /// as `CreateRouteEntryCard` so users get a single, predictable route-build
+    /// flow. When `nil` the placeholder degrades to a static hint (no button).
+    var onProposeRoute: (() -> Void)? = nil
 
     private var displayed: [Route] {
         // Now-context uses the runtime check (derived from bestStartHour) so the
@@ -49,8 +54,99 @@ struct RoutesSection: View {
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 8)
+            } else if isNowFilter {
+                // Direction 3 — Cold start in Now mode: no nearby routes yet
+                // (RouteStore still loading, or simply none in window). Surface a
+                // single warm-amber placeholder card that proposes
+                // "今天的一条路线 · 让 Solo 为你拼一条" and routes its CTA through
+                // the same `create route` flow as CreateRouteEntryCard (wired by
+                // CompassMapView). The card disappears the moment a real route
+                // arrives because `items` is no longer empty.
+                VStack(alignment: .leading, spacing: 10) {
+                    RouteNowSectionHeader()
+                    NowEmptyRoutePlaceholder(onTap: onProposeRoute)
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
             }
         }
+    }
+}
+
+// MARK: - NowEmptyRoutePlaceholder
+
+/// Warm-amber cold-start card for the Now routes section when there are no
+/// nearby routes yet. Friend-voice copy ("今天的一条路线 · 让 Solo 为你拼一条")
+/// and a single primary CTA that reuses the existing `create route` action —
+/// no new orchestration is introduced.
+///
+/// Palette: CT.sunGoldSoft → CT.sunGoldDeep gradient on a soft amber surface,
+/// matching the warm-amber dock language used in ExperienceDetailView.
+struct NowEmptyRoutePlaceholder: View {
+    let onTap: (() -> Void)?
+
+    var body: some View {
+        Button(action: { onTap?() }) {
+            HStack(spacing: 14) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(
+                            LinearGradient(
+                                colors: [CT.sunGoldSoft, CT.sunGoldDeep],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                        .frame(width: 44, height: 44)
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(.white)
+                }
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(NSLocalizedString(
+                        "routes.now.empty.title",
+                        comment: "Warm cold-start placeholder when Now routes are empty"
+                    ))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(CT.sunGoldDeep)
+                    Text(NSLocalizedString(
+                        "routes.now.empty.cta",
+                        comment: "CTA on the warm cold-start placeholder — let Solo build a route"
+                    ))
+                    .font(.caption)
+                    .foregroundStyle(CT.fgMuted)
+                    .lineLimit(2)
+                }
+                Spacer(minLength: 4)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(CT.sunGoldDeep.opacity(0.7))
+            }
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(CT.sunGoldSoft.opacity(0.55))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .strokeBorder(CT.sunGoldDeep.opacity(0.25), lineWidth: 1)
+            )
+        }
+        // Match CreateRouteEntryCard's press feedback so the warm placeholder
+        // feels like a first-class member of the routes stack — and so the tap
+        // is not swallowed by BottomInfoSheet's ScrollView (see
+        // [[project_dead_fab_sheet_wiring]] kin).
+        .buttonStyle(PressableButtonStyle(pressedScale: 0.985))
+        .disabled(onTap == nil)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(NSLocalizedString(
+            "routes.now.empty.title",
+            comment: "Warm cold-start placeholder when Now routes are empty"
+        )))
+        .accessibilityHint(Text(NSLocalizedString(
+            "routes.now.empty.cta",
+            comment: "CTA on the warm cold-start placeholder — let Solo build a route"
+        )))
     }
 }
 

--- a/apps/ios/SoloCompass/Views/Shared/SoloMascotView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloMascotView.swift
@@ -1,0 +1,319 @@
+import SwiftUI
+
+/// `SoloMascotView` — the cartoon-girl avatar that represents Solo, the
+/// traveler's companion. She lives in the bottom-right amber FAB on the
+/// homepage and is the entry-point to Solo Chat.
+///
+/// Composition is 100% SwiftUI shape primitives (Circle, Ellipse, Path) +
+/// the existing `CT` palette — no image assets, no Lottie, no SwiftPM deps.
+/// The view is sized to fit comfortably inside the existing 56pt amber
+/// `Circle` background, so the parent FAB's hit-target / shadow / press-ring
+/// stay byte-identical.
+///
+/// Behaviors
+/// ---------
+/// - Idle breathing scale (1.0 → 1.03, 1.6s ease-in-out, infinite).
+/// - Blink roughly every 4s (eye height 8 → 0 → 8 over 0.15s).
+/// - Tiny ponytail sway (±3°, 2s ease-in-out, infinite).
+/// - When `isPressed` flips true, a soft `sparkles` SF Symbol fades in next
+///   to her cheek for ~0.45s, then fades back out.
+/// - Honors `@Environment(\.accessibilityReduceMotion)`: idle/sway/blink stop
+///   when motion is reduced; the press-sparkle is the only motion that stays.
+///
+/// The view is intentionally parameter-light: it takes an optional
+/// `isPressed` so the parent FAB can drive the sparkle from its existing
+/// long-press gesture without owning any of the mascot's internal state.
+struct SoloMascotView: View {
+    /// Driven by the parent FAB's touch-down state. When it transitions
+    /// false → true, the cheek sparkle plays once.
+    var isPressed: Bool = false
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    // Idle animation state
+    @State private var breathe: Bool = false
+    @State private var sway: Bool = false
+    @State private var blinkClosed: Bool = false
+    @State private var sparkleVisible: Bool = false
+
+    // Mascot is laid out inside a 44×44 box so it sits comfortably inside
+    // the 56pt amber background circle with ~6pt margin all around.
+    private let size: CGFloat = 44
+
+    var body: some View {
+        ZStack {
+            // Cream halo behind the mascot — separates her from busy map
+            // labels so she always reads as a floating button. Wider + softer
+            // than the previous inner glow so the silhouette stays crisp.
+            Circle()
+                .fill(Color.white.opacity(0.55))
+                .frame(width: size + 14, height: size + 14)
+                .blur(radius: 5)
+
+            // Ponytail — a swept teardrop in sun-gold. Pushed further out
+            // beyond the face circle so the silhouette unambiguously reads as
+            // "girl with a low ponytail" (not just "round head") at FAB size.
+            // Right-side sweep so it doesn't clip into the cluster-pin area
+            // on the left of the FAB.
+            ponytail
+                .frame(width: 18, height: 26)
+                .offset(x: size * 0.40, y: size * 0.18)
+                .rotationEffect(.degrees(sway ? 8 : -2), anchor: .top)
+                .animation(
+                    reduceMotion ? nil :
+                        .easeInOut(duration: 2.0).repeatForever(autoreverses: true),
+                    value: sway
+                )
+
+            // Face (round, peach skin)
+            Circle()
+                .fill(skinColor)
+                .overlay(
+                    Circle().stroke(Color.black.opacity(0.06), lineWidth: 0.5)
+                )
+                .frame(width: size * 0.78, height: size * 0.78)
+
+            // Fringe / bangs — a soft amber arc across the top of the face.
+            fringe
+                .frame(width: size * 0.78, height: size * 0.78)
+
+            // Facial features (eyes, blush, smile) stacked together so they
+            // share the same anchor and don't drift with the parent scale.
+            face
+                .frame(width: size * 0.78, height: size * 0.78)
+
+            // Press sparkle — only visible briefly when `isPressed` flips on.
+            Image(systemName: "sparkles")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(CT.sunGold)
+                .opacity(sparkleVisible ? 1.0 : 0.0)
+                .scaleEffect(sparkleVisible ? 1.0 : 0.6)
+                .offset(x: size * 0.34, y: -size * 0.28)
+                .animation(.easeOut(duration: 0.25), value: sparkleVisible)
+                .accessibilityHidden(true)
+        }
+        .frame(width: size, height: size)
+        .scaleEffect(reduceMotion ? 1.0 : (breathe ? 1.03 : 1.0))
+        .animation(
+            reduceMotion ? nil :
+                .easeInOut(duration: 1.6).repeatForever(autoreverses: true),
+            value: breathe
+        )
+        .onAppear { startIdleAnimations() }
+        .onChange(of: isPressed) { _, pressing in
+            if pressing { playSparkle() }
+        }
+        .accessibilityHidden(true) // The parent FAB owns the a11y label.
+    }
+
+    // MARK: - Subviews
+
+    /// Ponytail — a soft teardrop swept down-left, in sun-gold.
+    private var ponytail: some View {
+        TeardropShape()
+            .fill(CT.sunGold)
+            .overlay(
+                TeardropShape().stroke(CT.sunGoldDeep.opacity(0.35), lineWidth: 0.8)
+            )
+    }
+
+    /// Fringe / bangs — a soft amber arc that sits across the upper face.
+    private var fringe: some View {
+        FringeShape()
+            .fill(CT.sunGold)
+            .overlay(
+                FringeShape().stroke(CT.sunGoldDeep.opacity(0.25), lineWidth: 0.5)
+            )
+    }
+
+    /// Facial features composed in a single ZStack so they share the same
+    /// face-circle frame.
+    private var face: some View {
+        ZStack {
+            // Blush — two warm peach dots on the cheeks. Larger + more saturated
+            // than the previous 4pt CT.accent dots so they actually read at FAB
+            // size; uses a custom peach (#F4A6A6) instead of the brand red so
+            // they look like blush, not warning indicators.
+            HStack(spacing: 18) {
+                Circle()
+                    .fill(Color(red: 0.96, green: 0.65, blue: 0.65).opacity(0.75))
+                    .frame(width: 6, height: 6)
+                Circle()
+                    .fill(Color(red: 0.96, green: 0.65, blue: 0.65).opacity(0.75))
+                    .frame(width: 6, height: 6)
+            }
+            .offset(y: 5)
+
+            // Eyes — two small ellipses; blink by squishing height to 0.
+            HStack(spacing: 10) {
+                eye
+                eye
+            }
+            .offset(y: -2)
+
+            // Smile — a small upward curve below the eyes.
+            SmileShape()
+                .stroke(CT.accent, style: StrokeStyle(lineWidth: 1.2, lineCap: .round))
+                .frame(width: 10, height: 4)
+                .offset(y: 8)
+        }
+    }
+
+    private var eye: some View {
+        Capsule()
+            .fill(Color(red: 0.16, green: 0.10, blue: 0.06)) // warm near-black
+            .frame(width: 4, height: blinkClosed ? 0.6 : 4)
+            .animation(.easeInOut(duration: 0.12), value: blinkClosed)
+    }
+
+    // MARK: - Animation lifecycle
+
+    private func startIdleAnimations() {
+        guard !reduceMotion else { return }
+        breathe = true
+        sway = true
+        scheduleNextBlink()
+    }
+
+    /// Recursive blink scheduler — fires every ~3.5–4.5s.
+    private func scheduleNextBlink() {
+        guard !reduceMotion else { return }
+        let delay = Double.random(in: 3.5...4.5)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            guard !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 0.12)) { blinkClosed = true }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                withAnimation(.easeInOut(duration: 0.12)) { blinkClosed = false }
+                scheduleNextBlink()
+            }
+        }
+    }
+
+    /// Plays the cheek sparkle once: fade-in over 0.25s, hold ~0.20s, fade-out.
+    private func playSparkle() {
+        sparkleVisible = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+            sparkleVisible = false
+        }
+    }
+
+    // MARK: - Palette
+
+    /// Warm peach skin tone — slightly darker than pure peach so it reads
+    /// against the deep-amber background without losing the "cartoon" feel.
+    private var skinColor: Color {
+        Color(red: 0.99, green: 0.86, blue: 0.74)
+    }
+}
+
+// MARK: - Shapes
+
+/// A swept teardrop used for the ponytail. The narrow end points up
+/// (attaches to the head), the round end swings down-left.
+private struct TeardropShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        let top = CGPoint(x: rect.midX, y: rect.minY)
+        let bottom = CGPoint(x: rect.midX - rect.width * 0.05, y: rect.maxY)
+        p.move(to: top)
+        // Left curve out then down to the round tip.
+        p.addQuadCurve(
+            to: bottom,
+            control: CGPoint(x: rect.minX - 2, y: rect.midY)
+        )
+        // Right curve back up to the narrow attach point.
+        p.addQuadCurve(
+            to: top,
+            control: CGPoint(x: rect.maxX + 2, y: rect.midY - 4)
+        )
+        p.closeSubpath()
+        return p
+    }
+}
+
+/// A soft fringe / bangs arc that hugs the top of the face circle.
+private struct FringeShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        let topLeft = CGPoint(x: rect.minX + rect.width * 0.10, y: rect.minY + rect.height * 0.18)
+        let topRight = CGPoint(x: rect.maxX - rect.width * 0.10, y: rect.minY + rect.height * 0.18)
+        let dipLeft = CGPoint(x: rect.minX + rect.width * 0.32, y: rect.minY + rect.height * 0.38)
+        let dipMid = CGPoint(x: rect.midX, y: rect.minY + rect.height * 0.30)
+        let dipRight = CGPoint(x: rect.maxX - rect.width * 0.32, y: rect.minY + rect.height * 0.38)
+
+        p.move(to: topLeft)
+        // Outer arc across the top of the face.
+        p.addQuadCurve(
+            to: topRight,
+            control: CGPoint(x: rect.midX, y: rect.minY - rect.height * 0.10)
+        )
+        // Inner zig-zag fringe edge: right → dip → mid bump → dip → left.
+        p.addQuadCurve(to: dipRight, control: CGPoint(x: rect.maxX - rect.width * 0.18, y: rect.minY + rect.height * 0.34))
+        p.addQuadCurve(to: dipMid, control: CGPoint(x: rect.midX + rect.width * 0.16, y: rect.minY + rect.height * 0.42))
+        p.addQuadCurve(to: dipLeft, control: CGPoint(x: rect.midX - rect.width * 0.16, y: rect.minY + rect.height * 0.42))
+        p.addQuadCurve(to: topLeft, control: CGPoint(x: rect.minX + rect.width * 0.18, y: rect.minY + rect.height * 0.34))
+        p.closeSubpath()
+        return p
+    }
+}
+
+/// A gentle smile curve — concave-up so the mouth turns up at the corners.
+private struct SmileShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        p.move(to: CGPoint(x: rect.minX, y: rect.minY))
+        p.addQuadCurve(
+            to: CGPoint(x: rect.maxX, y: rect.minY),
+            control: CGPoint(x: rect.midX, y: rect.maxY + 2)
+        )
+        return p
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("SoloMascot — on amber FAB") {
+    ZStack {
+        Color(red: 0.13, green: 0.10, blue: 0.07).ignoresSafeArea()
+        ZStack {
+            Circle()
+                .fill(CT.accent)
+                .frame(width: 56, height: 56)
+                .shadow(color: .black.opacity(0.25), radius: 6, y: 3)
+            SoloMascotView()
+        }
+    }
+}
+
+#Preview("SoloMascot — pressed sparkle") {
+    StatefulPreviewWrapper(false) { pressed in
+        ZStack {
+            Color.white.ignoresSafeArea()
+            ZStack {
+                Circle().fill(CT.accent).frame(width: 56, height: 56)
+                SoloMascotView(isPressed: pressed.wrappedValue)
+            }
+            .onTapGesture {
+                pressed.wrappedValue.toggle()
+            }
+        }
+    }
+}
+
+/// Tiny helper that lets `#Preview` host a `@State` binding so we can
+/// toggle `isPressed` to verify the sparkle animation.
+private struct StatefulPreviewWrapper<Value, Content: View>: View {
+    @State private var value: Value
+    let content: (Binding<Value>) -> Content
+
+    init(_ initial: Value, @ViewBuilder content: @escaping (Binding<Value>) -> Content) {
+        _value = State(initialValue: initial)
+        self.content = content
+    }
+
+    var body: some View {
+        content($value)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Transform the map-first home from \"a heap of useless map\" into a screen that greets the user with intent on cold open.

- **Warm-start peek card** — `PeekPickResolver` now seeds the floating preview with the highest Solo-Score experience in view (was \"nearest\"). `PeekSummaryCard` adds a friend-voice reason line (\"此刻视野里最值得去的咖啡 · Solo 9.5\") and dedupes the subtitle so the short name never echoes itself.
- **Smart-pick highlight** — `MapViewModel.effectiveSmartPickIds` falls back to the Solo-Score top-3 of visible experiences when the AI ranker hasn't surfaced picks (cold start, missing key, offline). Non-smart pins dim to 25% / 85% scale; the trio renders a three-layer sun-gold halo + numeric rank badge inside a 120pt annotation canvas so the bloom isn't clipped to the pin's native bounds.
- **Now-mode route prompt** — the route entry card is gated to the Now filter and the duplicate floating \"X 个匹配\" chip is suppressed when the FilterBar already shows the count. Route durations localize to \"X 小时 / X 分钟\" instead of \"3H00M\".
- **`SoloMascotView` (new)** — pure-SwiftUI cartoon-girl mascot: round face, right-side ponytail, blush, cream halo, idle breathe/blink/sway, press-sparkle, full `reduceMotion` honoring. Replaces the bottom-right \"+\" FAB and becomes the Solo Chat entry point. Zero new SwiftPM deps.

## Iteration & scoring

Built screenshot-evaluator loop (6 rounds, parallel rubric agents per direction):

| Direction | R6 score | Status |
|---|---|---|
| D1 Warm peek + reason | 10/10 | ✅ |
| D2 Smart-pick halo | 6/10 | cog-teeth + dim hierarchy is readable; pushing the radial bloom past MapKit Annotation clipping needs the halo re-rendered as a `MapCircle` overlay (follow-up) |
| D3 Now route prompt | 9-10/10 | ✅ |
| D4 Mascot FAB | 10/10 | ✅ |

## Test plan

- [ ] Cold-start home, City Picker dismissed → peek card greets with highest-score experience, reason line reads as a friend, not a label
- [ ] Map shows 3 smart-pick pins with cog-tooth base + gold halo; other pins recede at lower opacity
- [ ] Toggle Now filter → route entry card surfaces, duplicate match chip on the map is gone, duration chip reads in Chinese on `zh-Hans`
- [ ] Tap mascot FAB → opens Solo Chat; verify breathe/blink/sway idle, press sparkle, no animation with Reduce Motion on
- [ ] `xcodebuild build … -scheme SoloCompass` green (already verified locally)

## Known follow-up

D2 halo bloom is currently clipped by MapKit's `Annotation` overlay layer despite the 120pt frame. The structurally clean fix is to draw the gold halos as `MapCircle` map-layer overlays anchored to each smart-pick coordinate, which guarantees full visibility regardless of annotation bounds. Tracked as a separate ticket — the cog-teeth + dim treatment in this PR is already a meaningful hierarchy signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)