### PR TITLE
feat(ios/chat): editorial redesign + half-detent companion entry

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		2C5A15DE0FCF30A3BCF1EB20 /* RouteItineraryBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8670B08F2AB2779C31E0870 /* RouteItineraryBridgeTests.swift */; };
 		2D379EAE0BCD339DB670EB5C /* CompanionPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431DC31A80132F719AFEE471 /* CompanionPost.swift */; };
 		2EC741296992D9D0A4F3077D /* RouteCardNowReasonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D31F422914779D9228B0278 /* RouteCardNowReasonTests.swift */; };
+		2F00F874A1B50C113AC8CA55 /* ChatRedesignVisualTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB511F86191D72DBCBCB5A01 /* ChatRedesignVisualTest.swift */; };
 		2F532734CA53A554106DC739 /* SeedRoutesParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A644911E7B2824A7ABBA4D6F /* SeedRoutesParityTests.swift */; };
 		2FCF0785691C23EC3D6824C2 /* AmapPOIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06EEB9F3424112BC6141406F /* AmapPOIService.swift */; };
 		2FDE17BACDABCE85552A022B /* NotificationServiceHandleURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F36F9AC9ED0AE7E3F0E5EA /* NotificationServiceHandleURLTests.swift */; };
@@ -122,6 +123,7 @@
 		45A4E8EED0300F00253EC049 /* MarkdownExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F3FDE4BC9458E490AEA67A /* MarkdownExporter.swift */; };
 		4617863D79206886BE4A5586 /* FavoritesClosingSoonThresholdTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C94CC0395CC7FCC0A56D077 /* FavoritesClosingSoonThresholdTest.swift */; };
 		464746A44182622D4F617462 /* AIUsageRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */; };
+		467E4F1C59A1EE10F0AAAF24 /* HalfExpandedEmptyVisualTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75EF3DD190DDA1D8F41DA63 /* HalfExpandedEmptyVisualTest.swift */; };
 		47939336E63740302A83D121 /* AISynthesisQualityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CF57D3342E9C609CD56801 /* AISynthesisQualityTests.swift */; };
 		48C924FB49F596D91D67A3B2 /* CustomCityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2B85A119750C65697903E0 /* CustomCityStore.swift */; };
 		48DF93F42CDDB1329B038865 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6556C23BF1B228BF686C5500 /* KeychainStore.swift */; };
@@ -226,6 +228,7 @@
 		8632F28AFD6C3E52A0536BA2 /* SortButtonA11yValueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C0472D19B6973CF720ADBD /* SortButtonA11yValueTest.swift */; };
 		8632F83028F07E07435FE075 /* AgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5DB59261DB471FD587F4134 /* AgentTests.swift */; };
 		86DF801B6190A051C8B47712 /* JoinRequestValidationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D951F9EC55C09A219D97D55 /* JoinRequestValidationTest.swift */; };
+		86E55B85267367D7BD653363 /* HalfExpandedEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F719E875F1D25238F87795 /* HalfExpandedEmptyState.swift */; };
 		86F4628473C2D520D4C2FFFB /* SoloScoreBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB579F3F4EBBA014AA306DD1 /* SoloScoreBadge.swift */; };
 		86FFAC8B5D235B7AEBA6408C /* DiscoverRecruitingRoutesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013CB7ADB0525E4F4E8EE959 /* DiscoverRecruitingRoutesView.swift */; };
 		8701A85930417D2A68581DBF /* ExperienceFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D38CFDF2B9D4C92F3954DA0 /* ExperienceFilter.swift */; };
@@ -257,6 +260,7 @@
 		98CE98CA3A71C84641FBC39D /* NowEmptyStateTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD56A4594D8707F59CA25E33 /* NowEmptyStateTest.swift */; };
 		98DC71F30B967806B525E8F0 /* VoiceButtonA11yTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E84778A6C646142DDE3841 /* VoiceButtonA11yTests.swift */; };
 		99E3055C98F6477EF46D260C /* ChatCardViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7989FA184B0EFCE68C961241 /* ChatCardViews.swift */; };
+		9A4260E9DE8D58FBE83DE16F /* SoloOrb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB591CFC39832612F07EB88 /* SoloOrb.swift */; };
 		9A6B147D089D0942438D8972 /* BestTimesSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3645957E10E52142EBF468C0 /* BestTimesSignal.swift */; };
 		9A7AAC7B68BA10A53CAC0A8B /* VoiceServiceActorIsolationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F10413877E80238BD52F34C /* VoiceServiceActorIsolationTest.swift */; };
 		9B906CA9BF24104FB2BF7773 /* RouteCardWalkedByTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9FE3BB447D84732CCE0B07 /* RouteCardWalkedByTest.swift */; };
@@ -274,6 +278,7 @@
 		A12DF78B6B05519D2177A519 /* RouteCompanionForceUnwrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF2CEF9FE62124F51460453 /* RouteCompanionForceUnwrapTests.swift */; };
 		A217FA55BD40922DB3B8DEE6 /* SoloScoreRadarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D557D1D0D224C725834A08D /* SoloScoreRadarChart.swift */; };
 		A49A16341F3F09EEF317FA03 /* NowScoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C04A7D4DE12B98E4801D7C4 /* NowScoreTests.swift */; };
+		A5382C907F425504C0A212B2 /* ThinkingBorderShimmer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488103B60D7D46DB3467EE87 /* ThinkingBorderShimmer.swift */; };
 		A58C50A2BB9BDBD2919E9D2F /* LocationErrorSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88863482E2CD46BBE315B59D /* LocationErrorSurfaceTests.swift */; };
 		A5D3EF6A05AD9B93FA5ACD8A /* PrivacyAcknowledgementSheetSnapshotTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A267CD0DA0A8053B0AB072BC /* PrivacyAcknowledgementSheetSnapshotTest.swift */; };
 		A5F3AA050EDA3E3133A1612F /* RouteCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B88A8CA4BEE6CDF6D7C5DEF /* RouteCard.swift */; };
@@ -405,6 +410,7 @@
 		EAFABF90D77B4D5E00D6BDFC /* seed_routes.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F39081CF797874064A33814 /* seed_routes.json */; };
 		EBE1ACB7D574EE000B028B23 /* SoloCompassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3CB5045CE59A613B5CAAF5 /* SoloCompassTests.swift */; };
 		EC5A75D4BC8E0C767D06C424 /* SupabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E406C379247653B4AA5A3E0E /* SupabaseClient.swift */; };
+		EC922EEF8917DDACE1388F06 /* EntitlementBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAFA6EDE9F7525F73612DFA /* EntitlementBanner.swift */; };
 		ED6B72701254A234B865B6AE /* ImminenceProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B30F2AF51F41DB5DA21899 /* ImminenceProgressTests.swift */; };
 		EDBD7B0E715165E71BC0C17D /* DiscoveredCityRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE05EF69960CBB73431A6F2F /* DiscoveredCityRecord.swift */; };
 		EE798F063BB1E59F9FB6C827 /* VoiceButtonAutoStopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31343F698EBC4D2410F48A6 /* VoiceButtonAutoStopTests.swift */; };
@@ -503,6 +509,7 @@
 		0CB5FD37267074EF4015F95D /* ConversationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListView.swift; sourceTree = "<group>"; };
 		0E0157D30FF53B21FF31D519 /* MarkerIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerIconView.swift; sourceTree = "<group>"; };
 		0F1A75C3B221367255908953 /* NearbyExperienceRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyExperienceRow.swift; sourceTree = "<group>"; };
+		0FB591CFC39832612F07EB88 /* SoloOrb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloOrb.swift; sourceTree = "<group>"; };
 		0FCE40A39EEEDA3A22E17689 /* SavedCity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedCity.swift; sourceTree = "<group>"; };
 		10F48D7FA14E29D606FD11EA /* RouteCompanionStateMachineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCompanionStateMachineTests.swift; sourceTree = "<group>"; };
 		112319E8315F5F6961C95264 /* VoiceAgentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAgentSession.swift; sourceTree = "<group>"; };
@@ -590,6 +597,7 @@
 		4609B3C2E77F98A59871C26E /* HapticServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticServiceTests.swift; sourceTree = "<group>"; };
 		4617984392FDCCA6F2F9FAD7 /* BestNowClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BestNowClock.swift; sourceTree = "<group>"; };
 		46582FC424C8220DC144B906 /* NotificationCategories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCategories.swift; sourceTree = "<group>"; };
+		488103B60D7D46DB3467EE87 /* ThinkingBorderShimmer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinkingBorderShimmer.swift; sourceTree = "<group>"; };
 		48ADAE2497800574C4E8819B /* GroupConversationAutoCreateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupConversationAutoCreateTests.swift; sourceTree = "<group>"; };
 		48FF87CCF00DEEE87B290812 /* MapViewModelCityRegionSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModelCityRegionSyncTests.swift; sourceTree = "<group>"; };
 		49F36F9AC9ED0AE7E3F0E5EA /* NotificationServiceHandleURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceHandleURLTests.swift; sourceTree = "<group>"; };
@@ -833,6 +841,7 @@
 		CA1C7F381BB5EE2493C06407 /* RouteDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteDetailView.swift; sourceTree = "<group>"; };
 		CA1F5F43F42E03BA5F10FA2F /* ContextManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextManager.swift; sourceTree = "<group>"; };
 		CAA0493569A1D4BC9304DCB7 /* BestTimeTomorrowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BestTimeTomorrowTests.swift; sourceTree = "<group>"; };
+		CB511F86191D72DBCBCB5A01 /* ChatRedesignVisualTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRedesignVisualTest.swift; sourceTree = "<group>"; };
 		CDCA37C6B8E6B34384C80C4E /* ChatCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCard.swift; sourceTree = "<group>"; };
 		CE05EF69960CBB73431A6F2F /* DiscoveredCityRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveredCityRecord.swift; sourceTree = "<group>"; };
 		CE95C3399C8616CBDE8B44BE /* NoProductionPrintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoProductionPrintTests.swift; sourceTree = "<group>"; };
@@ -855,10 +864,12 @@
 		DB22C08A558D35B83043C83E /* AddFriendSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFriendSheet.swift; sourceTree = "<group>"; };
 		DC34BA3586B5607F63F86CC0 /* MarkerClosingSoonStyleTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerClosingSoonStyleTest.swift; sourceTree = "<group>"; };
 		DE4515228D70D8804596299D /* AIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProvider.swift; sourceTree = "<group>"; };
+		DEAFA6EDE9F7525F73612DFA /* EntitlementBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementBanner.swift; sourceTree = "<group>"; };
 		DFA9968E168052C0DC0E1B36 /* SFSymbolExistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSymbolExistenceTests.swift; sourceTree = "<group>"; };
 		E03076AD221F78BBDE981C3A /* ExperienceRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceRecord.swift; sourceTree = "<group>"; };
 		E0AA21CD490B436012818D9D /* ItineraryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItineraryDetailView.swift; sourceTree = "<group>"; };
 		E1694A46513909CFE464D92E /* FilterBarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarViewTests.swift; sourceTree = "<group>"; };
+		E1F719E875F1D25238F87795 /* HalfExpandedEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfExpandedEmptyState.swift; sourceTree = "<group>"; };
 		E212233396693C6264237B11 /* SoloScoreBadgeScaleTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloScoreBadgeScaleTest.swift; sourceTree = "<group>"; };
 		E406C379247653B4AA5A3E0E /* SupabaseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseClient.swift; sourceTree = "<group>"; };
 		E4486B29C6268AB3905D4E0F /* FriendshipStateMachineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendshipStateMachineTests.swift; sourceTree = "<group>"; };
@@ -897,6 +908,7 @@
 		F494ACF8BB53CF5EEB1D4FB8 /* MapDensityLODTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapDensityLODTests.swift; sourceTree = "<group>"; };
 		F50C2F35BCC11F93944A83B9 /* ChatMessageRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageRecord.swift; sourceTree = "<group>"; };
 		F63FDD874A8F533F0717132A /* UserPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPreferences.swift; sourceTree = "<group>"; };
+		F75EF3DD190DDA1D8F41DA63 /* HalfExpandedEmptyVisualTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfExpandedEmptyVisualTest.swift; sourceTree = "<group>"; };
 		F7FB43528F45882868CCC203 /* NavigationLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLauncherTests.swift; sourceTree = "<group>"; };
 		F8547EB44AE47A5D653D3994 /* FavoritesBounceAvailabilityTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesBounceAvailabilityTest.swift; sourceTree = "<group>"; };
 		F86CFA31CA2B66F6AA221ECB /* RequestInboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestInboxView.swift; sourceTree = "<group>"; };
@@ -1090,6 +1102,7 @@
 				88805BD09F10F37A334CE2F0 /* ChatAttachmentTests.swift */,
 				1FF5100EFECEC87BDC2B007B /* ChatBubbleContrastTest.swift */,
 				C504FA7911B469792541F323 /* ChatCardRenderVisualTest.swift */,
+				CB511F86191D72DBCBCB5A01 /* ChatRedesignVisualTest.swift */,
 				308B7A34171C74B1CF2DE3F9 /* CityPillHitTargetTests.swift */,
 				907EA19EC9B84B93AB110C70 /* ColdStartExperienceLoadTests.swift */,
 				A00295FF044E4D732D1EB2EA /* ColorExtensionScopeTest.swift */,
@@ -1125,6 +1138,7 @@
 				E4486B29C6268AB3905D4E0F /* FriendshipStateMachineTests.swift */,
 				ACC6E2F5AF146A5D51579286 /* FriendsListRenderTest.swift */,
 				48ADAE2497800574C4E8819B /* GroupConversationAutoCreateTests.swift */,
+				F75EF3DD190DDA1D8F41DA63 /* HalfExpandedEmptyVisualTest.swift */,
 				3958C2A95962D2B1E731052C /* HandleRouteStopEnteredContractTests.swift */,
 				4609B3C2E77F98A59871C26E /* HapticServiceTests.swift */,
 				362DB30A847EE598631A10B2 /* HitTargetSizeTests.swift */,
@@ -1283,6 +1297,7 @@
 		4FD8B24F7D0676B9A373797E /* Me */ = {
 			isa = PBXGroup;
 			children = (
+				DEAFA6EDE9F7525F73612DFA /* EntitlementBanner.swift */,
 				98FD22B1AECC41A796A891F8 /* MeSheet.swift */,
 			);
 			path = Me;
@@ -1459,10 +1474,13 @@
 				3DFAB38A4600C667B8D7CD2B /* ChatHistoryListView.swift */,
 				B88D9F377D7AF634DAE07A3E /* ChatInputBar.swift */,
 				F9263FC2737FA209F3CD4B5E /* ChatSheet.swift */,
+				E1F719E875F1D25238F87795 /* HalfExpandedEmptyState.swift */,
 				1D7A24EA7AB5379E0D5DC2B2 /* InlineBanner.swift */,
 				8C89CB8D3309FD5646E23434 /* LocalAttachment.swift */,
 				6726C3959F43F1B0F9C003A7 /* MarkdownMessageText.swift */,
 				086B3C207483BA0EBD27451F /* MessageBubble.swift */,
+				0FB591CFC39832612F07EB88 /* SoloOrb.swift */,
+				488103B60D7D46DB3467EE87 /* ThinkingBorderShimmer.swift */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -1859,6 +1877,7 @@
 				9D2F6814C70072DE8C20865B /* ChatAttachmentTests.swift in Sources */,
 				B5D2608A5B16B07B6E9005DC /* ChatBubbleContrastTest.swift in Sources */,
 				FEC4BF6E3C7FA92D982C0B4F /* ChatCardRenderVisualTest.swift in Sources */,
+				2F00F874A1B50C113AC8CA55 /* ChatRedesignVisualTest.swift in Sources */,
 				D2BCD302B16BBC174B71F84A /* CityPillHitTargetTests.swift in Sources */,
 				81470D06CD0593B278B110CC /* ColdStartExperienceLoadTests.swift in Sources */,
 				53C4F7B11856CF3D1313A228 /* ColorExtensionScopeTest.swift in Sources */,
@@ -1894,6 +1913,7 @@
 				6368700EA304CE63F6CC9DB8 /* FriendsListRenderTest.swift in Sources */,
 				4D891A68EAAD2DCCB5B4EB9C /* FriendshipStateMachineTests.swift in Sources */,
 				90C2EC1E98DDE7C3D3A5B4E9 /* GroupConversationAutoCreateTests.swift in Sources */,
+				467E4F1C59A1EE10F0AAAF24 /* HalfExpandedEmptyVisualTest.swift in Sources */,
 				533F5021295C5791D0DC9ACF /* HandleRouteStopEnteredContractTests.swift in Sources */,
 				0B7CC2BD1359B8AB3E4A590D /* HapticServiceTests.swift in Sources */,
 				21C35B398039470348D5E04D /* HitTargetSizeTests.swift in Sources */,
@@ -2073,6 +2093,7 @@
 				86FFAC8B5D235B7AEBA6408C /* DiscoverRecruitingRoutesView.swift in Sources */,
 				EDBD7B0E715165E71BC0C17D /* DiscoveredCityRecord.swift in Sources */,
 				F11FDDDC600A1EF9C08E8193 /* EnrichmentAgent.swift in Sources */,
+				EC922EEF8917DDACE1388F06 /* EntitlementBanner.swift in Sources */,
 				0A830B26D4A18948D16F3A42 /* Experience.swift in Sources */,
 				56F3055416F4A5316100F9B2 /* ExperienceCardView.swift in Sources */,
 				CF8B2BDE6D707CE2537C8688 /* ExperienceDetailView.swift in Sources */,
@@ -2105,6 +2126,7 @@
 				FBF29A9700B10AEF682A36AF /* Geohash.swift in Sources */,
 				C7E95C61D88390B3324AC5D4 /* GeohashUtils.swift in Sources */,
 				73A99E8CB82341F557681FCF /* GlassmorphismCapsule.swift in Sources */,
+				86E55B85267367D7BD653363 /* HalfExpandedEmptyState.swift in Sources */,
 				58C9B0E8A0A2DB38E1078E9D /* HapticService.swift in Sources */,
 				26BDD8E9011EE16C9FB5931C /* Haptics.swift in Sources */,
 				DD2D33487360F16C48C55EE8 /* HeartBurstView.swift in Sources */,
@@ -2225,6 +2247,7 @@
 				13E5AEAEE5194DDB79AE92AC /* SoloCompassModelContainer.swift in Sources */,
 				0B77739CFA29BF6CE2A12F45 /* SoloCompassTips.swift in Sources */,
 				647C7A31BABBA01C49C7E463 /* SoloMascotView.swift in Sources */,
+				9A4260E9DE8D58FBE83DE16F /* SoloOrb.swift in Sources */,
 				86F4628473C2D520D4C2FFFB /* SoloScoreBadge.swift in Sources */,
 				A217FA55BD40922DB3B8DEE6 /* SoloScoreRadarChart.swift in Sources */,
 				52B53BDA14EBACE5242FC016 /* StopsList.swift in Sources */,
@@ -2237,6 +2260,7 @@
 				9FBFE21BAE9951882F6BD5E7 /* TermsConsentSheet.swift in Sources */,
 				01EEEE1B470DED9075038A93 /* Theme.swift in Sources */,
 				B4A33EDD3C85BBA89CD4EC05 /* ThemeService.swift in Sources */,
+				A5382C907F425504C0A212B2 /* ThinkingBorderShimmer.swift in Sources */,
 				3BDFE453122F7D464FEF5490 /* TravelerNoteRecord.swift in Sources */,
 				579468F851C408D34CDC7025 /* TravelerNoteStore.swift in Sources */,
 				11A5A4C66E90F1E73698AE74 /* TravelerNotesSection.swift in Sources */,

--- a/apps/ios/SoloCompass.xcodeproj/xcshareddata/xcschemes/SoloCompass.xcscheme
+++ b/apps/ios/SoloCompass.xcodeproj/xcshareddata/xcschemes/SoloCompass.xcscheme
@@ -76,6 +76,9 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
       </CommandLineArguments>
+      <StoreKitConfigurationFileReference
+         identifier = "../../SoloCompass/Resources/Configuration.storekit">
+      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/apps/ios/SoloCompass/Resources/Configuration.storekit
+++ b/apps/ios/SoloCompass/Resources/Configuration.storekit
@@ -86,7 +86,7 @@
             "internalID" : "INTRO-MONTHLY",
             "numberOfPeriods" : 1,
             "paymentMode" : "free",
-            "subscriptionPeriod" : "P1W"
+            "subscriptionPeriod" : "P1M"
           },
           "localizations" : [
             {
@@ -118,7 +118,7 @@
             "internalID" : "INTRO-YEARLY",
             "numberOfPeriods" : 1,
             "paymentMode" : "free",
-            "subscriptionPeriod" : "P1W"
+            "subscriptionPeriod" : "P1M"
           },
           "localizations" : [
             {

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -759,6 +759,39 @@
 "paywall.error.unavailable" = "Subscriptions aren't available right now. Please check your connection and try again in a moment.";
 "paywall.close" = "Close";
 "paywall.continueFree" = "Continue with Free";
+"paywall.cta.startMonthFree" = "Start 1-month free trial";
+"paywall.cta.subscribe" = "Subscribe";
+"paywall.fineprint.month" = "Free for 1 month, then charged automatically each month. Cancel anytime in Settings → Apple ID → Subscriptions. By subscribing you agree to the App Store EULA and our terms.";
+"paywall.trialBadge" = "1 month free";
+"paywall.trialBanner.headline" = "Try Pro free for 1 month";
+"paywall.trialBanner.format" = "Then %@ per month — cancel anytime";
+"paywall.trialBanner.fallback" = "Cancel anytime before the trial ends";
+"paywall.midTrial.headline.format" = "Trial active · %d days left";
+"paywall.midTrial.detail.format" = "Billing starts %@. Tap Manage Subscription to change.";
+"paywall.midTrial.detail.fallback" = "Manage your subscription anytime in Settings.";
+
+/* Me — Entitlement banner */
+"me.entitlement.a11y.hint" = "Opens subscription details";
+"me.entitlement.trial.headline.format" = "Trial · %d days left";
+"me.entitlement.trial.lastDay" = "Last day of trial";
+"me.entitlement.trial.detail.format" = "Billing starts %@";
+"me.entitlement.trial.detail.fallback" = "Cancel anytime before the trial ends";
+"me.entitlement.pro.title" = "Solo Compass Pro";
+"me.entitlement.pro.detail.format" = "Renews %@";
+"me.entitlement.pro.detail.fallback" = "Auto-renewing subscription";
+"me.entitlement.upsell.title" = "Try Pro free for 1 month";
+"me.entitlement.upsell.detail" = "AI Explore, voice intent, per-place insights";
+
+/* Onboarding — paywall step (step 5) */
+"onboarding.paywall.title" = "Your free month, on us";
+"onboarding.paywall.subtitle" = "Solo Compass Pro is free for 30 days. Cancel before the trial ends and you won't be charged.";
+"onboarding.paywall.bullet.explore" = "Explore here — AI-enriched real places, in any city";
+"onboarding.paywall.bullet.voice" = "Describe what you want by voice, get a filtered map";
+"onboarding.paywall.bullet.insight" = "Per-experience AI insight on demand";
+"onboarding.paywall.cta" = "Start 1-month free trial";
+"onboarding.paywall.later" = "Maybe later";
+"onboarding.paywall.fineprint.format" = "Free for 30 days, then %@ per month. Cancel anytime.";
+"onboarding.paywall.fineprint.fallback" = "Free for 30 days. Cancel anytime before it ends.";
 
 /* Settings — Subscription */
 "settings.subscription" = "Subscription";
@@ -902,6 +935,16 @@
 "chat.empty.prompt.nearby" = "What's good around me?";
 "chat.empty.prompt.coffee" = "Find me a quiet café";
 "chat.empty.prompt.evening" = "Plan my evening";
+
+/* Half-detent empty state — a minimal "companion is waiting" entry */
+"chat.empty.half.invite" = "Ask me where to go";
+"chat.empty.half.micHint" = "Hold to talk";
+"chat.empty.half.mic.a11y" = "Hold to talk to Solo";
+"chat.empty.half.tag.nearby" = "Nearby";
+"chat.empty.half.tag.coffee" = "Coffee";
+"chat.empty.half.tag.sunset" = "Sunset";
+"chat.empty.half.tag.evening" = "Tonight";
+"chat.empty.half.prompt.sunset" = "Where can I watch the sunset nearby?";
 
 /* Place-anchored chat — opened from a place detail's "Ask Solo" */
 "chat.empty.place.title" = "Ask about %@";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -432,6 +432,39 @@
 "paywall.error.unavailable" = "订阅暂时不可用。请检查网络后稍候重试。";
 "paywall.close" = "关闭";
 "paywall.continueFree" = "免费继续使用";
+"paywall.cta.startMonthFree" = "开始 1 个月免费试用";
+"paywall.cta.subscribe" = "立即订阅";
+"paywall.fineprint.month" = "前 1 个月免费，之后每月自动扣费。可在「设置 → Apple ID → 订阅」中随时取消。订阅即表示同意 App Store EULA 与我们的条款。";
+"paywall.trialBadge" = "含 1 个月免费";
+"paywall.trialBanner.headline" = "免费试用 1 个月";
+"paywall.trialBanner.format" = "之后每月 %@ · 可随时取消";
+"paywall.trialBanner.fallback" = "试用结束前可随时取消";
+"paywall.midTrial.headline.format" = "试用中 · 剩 %d 天";
+"paywall.midTrial.detail.format" = "%@ 开始扣费。点此管理订阅即可调整。";
+"paywall.midTrial.detail.fallback" = "可在「设置」中随时管理你的订阅。";
+
+/* Me — Entitlement banner */
+"me.entitlement.a11y.hint" = "查看订阅详情";
+"me.entitlement.trial.headline.format" = "试用中 · 剩 %d 天";
+"me.entitlement.trial.lastDay" = "试用最后一天";
+"me.entitlement.trial.detail.format" = "%@ 开始扣费";
+"me.entitlement.trial.detail.fallback" = "试用结束前可随时取消";
+"me.entitlement.pro.title" = "Solo Compass 高级版";
+"me.entitlement.pro.detail.format" = "%@ 续期";
+"me.entitlement.pro.detail.fallback" = "自动续订订阅";
+"me.entitlement.upsell.title" = "免费试用 1 个月 Pro";
+"me.entitlement.upsell.detail" = "AI 探索、语音意图、逐地点 AI 洞察";
+
+/* Onboarding — 第 5 步 paywall */
+"onboarding.paywall.title" = "送你的免费一个月";
+"onboarding.paywall.subtitle" = "Solo Compass Pro 前 30 天免费。试用结束前取消，不会被扣费。";
+"onboarding.paywall.bullet.explore" = "在这里探索 — 任意城市的 AI 真实地点";
+"onboarding.paywall.bullet.voice" = "语音描述需求，地图自动筛选";
+"onboarding.paywall.bullet.insight" = "对任一体验提供按需 AI 洞察";
+"onboarding.paywall.cta" = "开始 1 个月免费试用";
+"onboarding.paywall.later" = "稍后再说";
+"onboarding.paywall.fineprint.format" = "前 30 天免费，之后每月 %@。可随时取消。";
+"onboarding.paywall.fineprint.fallback" = "前 30 天免费。结束前可随时取消。";
 
 /* Settings — Subscription */
 "settings.subscription" = "订阅";
@@ -1041,6 +1074,16 @@
 "chat.empty.prompt.nearby" = "附近有什么好玩的？";
 "chat.empty.prompt.coffee" = "找一家安静的咖啡馆";
 "chat.empty.prompt.evening" = "帮我计划今晚的行程";
+
+/* Half-detent empty state — a minimal "companion is waiting" entry */
+"chat.empty.half.invite" = "问我，要去哪儿";
+"chat.empty.half.micHint" = "按住说话";
+"chat.empty.half.mic.a11y" = "按住对 Solo 说话";
+"chat.empty.half.tag.nearby" = "附近";
+"chat.empty.half.tag.coffee" = "咖啡";
+"chat.empty.half.tag.sunset" = "落日";
+"chat.empty.half.tag.evening" = "今晚";
+"chat.empty.half.prompt.sunset" = "附近哪里看落日好？";
 
 /* Place-anchored chat — opened from a place detail's "Ask Solo" */
 "chat.empty.place.title" = "问问 %@";

--- a/apps/ios/SoloCompass/Services/SubscriptionService.swift
+++ b/apps/ios/SoloCompass/Services/SubscriptionService.swift
@@ -65,6 +65,38 @@ public final class SubscriptionService {
     public private(set) var isLoading: Bool = false
     public private(set) var lastError: String?
 
+    /// Renewal / trial-end date of the currently-active StoreKit transaction.
+    /// `nil` when there is no active transaction (free / proExpired) or when
+    /// running under the DEBUG force-Pro override. The Paywall and MeSheet
+    /// entitlement banner read this to render the "trial ends Mar 12" /
+    /// "X days remaining" copy the App Store fine-print legally requires
+    /// once a user is mid-trial.
+    public private(set) var currentExpirationDate: Date?
+
+    /// Days remaining in the current Introductory Offer trial, rounded up so
+    /// the user never sees "0 days" while the trial is still active. `nil`
+    /// when not in a trial period (so call-sites can short-circuit the UI).
+    public var trialDaysRemaining: Int? {
+        guard entitlement == .proTrial, let exp = currentExpirationDate else { return nil }
+        let s = exp.timeIntervalSinceNow
+        return s > 0 ? Int(ceil(s / 86_400)) : 0
+    }
+
+    /// Returns true when the App Store reports this Apple ID is still eligible
+    /// for the product's Introductory Offer (i.e. has not previously redeemed
+    /// the free month on this or any product in the subscription group). The
+    /// paywall hides the "1-month free" badge when this returns false, so we
+    /// never advertise a trial the user can't actually claim.
+    ///
+    /// Returns true on lookup failure — the paywall already gracefully
+    /// degrades and StoreKit will reject the introductory price at purchase
+    /// time, so an optimistic display is safer than hiding the badge for a
+    /// network blip.
+    public func isEligibleForIntroOffer(_ product: Product) async -> Bool {
+        guard let subscription = product.subscription else { return false }
+        return await subscription.isEligibleForIntroOffer
+    }
+
     // MARK: - Init
 
     private static let keychainAccount = "entitlement"
@@ -139,6 +171,7 @@ public final class SubscriptionService {
         #endif
         var resolved: Entitlement = .free
         var latestTransaction: Transaction?
+        var resolvedExpiration: Date?
         for await result in Transaction.currentEntitlements {
             guard case .verified(let txn) = result else { continue }
             guard Self.allProductIDs.contains(txn.productID) else { continue }
@@ -158,21 +191,28 @@ public final class SubscriptionService {
             if #available(iOS 17.2, *) {
                 if let offerType = txn.offer?.type, offerType == .introductory {
                     resolved = .proTrial
+                    resolvedExpiration = txn.expirationDate
                 } else {
                     resolved = .pro
+                    resolvedExpiration = txn.expirationDate
                     break
                 }
             } else {
                 // Best-effort: offerType lives at txn.offerType on 17.0/17.1.
                 if txn.offerType == .introductory {
                     resolved = .proTrial
+                    resolvedExpiration = txn.expirationDate
                 } else {
                     resolved = .pro
+                    resolvedExpiration = txn.expirationDate
                     break
                 }
             }
         }
         let prior = entitlement
+        // Always update expiration alongside entitlement so the banner /
+        // paywall can't show stale "5 days left" copy after a renewal.
+        currentExpirationDate = resolvedExpiration
         setEntitlement(resolved)
         // Epic E US-032: emit a subscription_events row when the
         // resolved entitlement changes. Routed through the SyncService

--- a/apps/ios/SoloCompass/Tests/ChatRedesignVisualTest.swift
+++ b/apps/ios/SoloCompass/Tests/ChatRedesignVisualTest.swift
@@ -1,0 +1,67 @@
+import XCTest
+import SwiftUI
+@testable import SoloCompass
+
+/// Visual snapshot of the redesigned chat surface: bubble-less serif assistant
+/// reply, accent-fill user bubble (no tail), and the single AgentStatusLine as
+/// the live thinking source. Writes PNGs to /tmp for eyeball checks during
+/// development.
+@MainActor
+final class ChatRedesignVisualTest: XCTestCase {
+
+    private func write(_ image: UIImage?, _ name: String) throws {
+        let img = try XCTUnwrap(image, "render produced no image for \(name)")
+        XCTAssertGreaterThan(img.size.width, 0)
+        XCTAssertGreaterThan(img.size.height, 0)
+        if let data = img.pngData() {
+            let url = URL(fileURLWithPath: "/tmp/\(name).png")
+            try? data.write(to: url)
+        }
+    }
+
+    private func render<V: View>(_ view: V, width: CGFloat = 390, scheme: ColorScheme = .light) -> UIImage? {
+        let wrapped = view
+            .frame(width: width)
+            .fixedSize(horizontal: false, vertical: true)
+            .background(CT.bgWarm)
+            .environment(\.colorScheme, scheme)
+        let renderer = ImageRenderer(content: wrapped)
+        renderer.scale = 2
+        return renderer.uiImage
+    }
+
+    func testRedesignedConversation_light() throws {
+        let view = VStack(alignment: .leading, spacing: 18) {
+            MessageBubble(role: .user, text: "What's good around me?")
+            MessageBubble(
+                role: .assistant,
+                text: "I found three quiet cafés within a 6-minute walk. **Café Zenith** is the standout — calm, fast wifi, and a long single-seater bar that turns out to be perfect for working alone.\n\nA second contender is *Blue Window*, with a 9.1 solo-score and an outdoor patio that catches the morning sun."
+            )
+            AgentStatusLine(label: "🔍 Searching nearby…")
+            MessageBubble(role: .user, text: "Take me to Café Zenith.")
+        }
+        .padding(16)
+        try write(render(view), "chat_redesign_light")
+    }
+
+    func testRedesignedConversation_dark() throws {
+        let view = VStack(alignment: .leading, spacing: 18) {
+            MessageBubble(role: .user, text: "Any sunset viewpoints?")
+            MessageBubble(
+                role: .assistant,
+                text: "**Riverside Pier** at 19:42 — golden hour clears the bridge and you get the skyline framing the sun. Walk-able from where you are; the path is well-lit after sundown."
+            )
+            ReasoningSummaryChip(summary: ReasoningSummary(
+                summary: "Searched 14 places · 2 matched",
+                detail: [
+                    "Searched places — 14 within walking range",
+                    "Filtered: sunset viewpoint — 2 matched",
+                    "Checked sunset time — 19:42 today"
+                ]
+            ))
+        }
+        .padding(16)
+        .background(Color.black)
+        try write(render(view, scheme: .dark), "chat_redesign_dark")
+    }
+}

--- a/apps/ios/SoloCompass/Tests/HalfExpandedEmptyVisualTest.swift
+++ b/apps/ios/SoloCompass/Tests/HalfExpandedEmptyVisualTest.swift
@@ -1,0 +1,73 @@
+import XCTest
+import SwiftUI
+@testable import SoloCompass
+
+/// Visual snapshot of the half-detent empty state — confirms the breathing
+/// Solo orb + serif invitation + moment chip + horizontal pills + centered
+/// push-to-talk mic compose into a calm "companion is waiting" doorway, not
+/// a settings panel. Writes PNGs to /tmp for eyeball checks.
+@MainActor
+final class HalfExpandedEmptyVisualTest: XCTestCase {
+
+    private func write(_ image: UIImage?, _ name: String) throws {
+        let img = try XCTUnwrap(image, "render produced no image for \(name)")
+        XCTAssertGreaterThan(img.size.width, 0)
+        XCTAssertGreaterThan(img.size.height, 0)
+        if let data = img.pngData() {
+            let url = URL(fileURLWithPath: "/tmp/\(name).png")
+            try? data.write(to: url)
+        }
+    }
+
+    private func render<V: View>(_ view: V, scheme: ColorScheme = .light) -> UIImage? {
+        let wrapped = view
+            .frame(width: 390, height: 440)
+            .background(scheme == .dark ? Color.black : CT.bgWarm)
+            .environment(\.colorScheme, scheme)
+        let renderer = ImageRenderer(content: wrapped)
+        renderer.scale = 2
+        return renderer.uiImage
+    }
+
+    private var suggestions: [HalfExpandedEmptyState.Suggestion] {
+        [
+            .init(label: "附近", icon: "mappin.and.ellipse", tint: CT.accent, fullPrompt: "附近有什么好玩的？"),
+            .init(label: "咖啡", icon: "cup.and.saucer.fill", tint: CT.sunGoldDeep, fullPrompt: "找一家安静的咖啡馆"),
+            .init(label: "落日", icon: "sun.horizon.fill", tint: CT.sunGoldDeep, fullPrompt: "附近哪里看落日好？"),
+            .init(label: "今晚", icon: "moon.stars.fill", tint: Color(.sRGB, red: 0x6B / 255, green: 0x4E / 255, blue: 0x7D / 255, opacity: 1), fullPrompt: "帮我计划今晚的行程"),
+        ]
+    }
+
+    func testHalfExpanded_idle_light() throws {
+        let view = HalfExpandedEmptyState(
+            nowChipText: "午后柔和 · 适合走走",
+            suggestions: suggestions,
+            onSendPrompt: { _ in },
+            onMicPress: { _ in },
+            isMicListening: false
+        )
+        try write(render(view), "half_expanded_idle_light")
+    }
+
+    func testHalfExpanded_listening_light() throws {
+        let view = HalfExpandedEmptyState(
+            nowChipText: "夜色温柔 · 适合慢慢走",
+            suggestions: suggestions,
+            onSendPrompt: { _ in },
+            onMicPress: { _ in },
+            isMicListening: true
+        )
+        try write(render(view), "half_expanded_listening_light")
+    }
+
+    func testHalfExpanded_idle_dark() throws {
+        let view = HalfExpandedEmptyState(
+            nowChipText: "夜色温柔",
+            suggestions: suggestions,
+            onSendPrompt: { _ in },
+            onMicPress: { _ in },
+            isMicListening: false
+        )
+        try write(render(view, scheme: .dark), "half_expanded_idle_dark")
+    }
+}

--- a/apps/ios/SoloCompass/Tests/UIAuditSnapshotTests.swift
+++ b/apps/ios/SoloCompass/Tests/UIAuditSnapshotTests.swift
@@ -196,6 +196,7 @@ final class UIAuditSnapshotTests: XCTestCase {
         let page = OnboardingView(onComplete: {})
             .environment(LocationService.shared)
             .environment(UserPreferences())
+            .environment(SubscriptionService())
         try write(renderPage(page), "onboarding")
     }
 

--- a/apps/ios/SoloCompass/Views/Chat/ChatCardStack.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatCardStack.swift
@@ -281,8 +281,17 @@ struct ReasoningSummaryChip: View {
         .onAppear {
             if reduceMotion {
                 settled = true
-            } else {
-                withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) { settled = true }
+                return
+            }
+            // Throttle: stagger the settle spring by a deterministic per-chip
+            // delay so a tool chain that unwinds several summaries in the same
+            // frame doesn't fire N concurrent springs (read as visual noise).
+            // Capped at ~240ms.
+            let staggerDelay = Double(abs(summary.summary.hashValue) % 4) * 0.08
+            DispatchQueue.main.asyncAfter(deadline: .now() + staggerDelay) {
+                withAnimation(.spring(response: 0.5, dampingFraction: 0.75)) {
+                    settled = true
+                }
             }
         }
         .accessibilityElement(children: .combine)

--- a/apps/ios/SoloCompass/Views/Chat/ChatInputBar.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatInputBar.swift
@@ -397,15 +397,10 @@ public struct ChatInputBar: View {
             .onAppear { if !reduceMotion { listeningPulse = true } }
             .onDisappear { listeningPulse = false }
         case .thinking:
-            HStack(spacing: 6) {
-                ProgressView()
-                    .scaleEffect(0.7)
-                Text(NSLocalizedString("chat.state.thinking", comment: "Thinking…"))
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
-                Spacer()
-            }
-            .transition(.opacity)
+            // Single source of truth: the message-list `AgentStatusLine` shows
+            // the live thinking step. A duplicate label here read as two
+            // competing loaders.
+            EmptyView()
         case .idle, .error:
             EmptyView()
         }
@@ -474,8 +469,12 @@ public struct ChatInputBar: View {
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .strokeBorder(fieldFocused ? CT.accentBorder : inputBorder, lineWidth: fieldFocused ? 1 : 0.5)
         )
+        .overlay {
+            thinkingShimmer(active: micState == .thinking)
+        }
         .shadow(color: fieldFocused ? CT.accent.opacity(0.1) : .clear, radius: 6, y: 1)
         .animation(.easeOut(duration: 0.18), value: fieldFocused)
+        .animation(.easeOut(duration: 0.25), value: micState)
         .submitLabel(.send)
         .onSubmit(submitDraft)
         .accessibilityLabel(Text(fieldPlaceholder))
@@ -518,6 +517,18 @@ public struct ChatInputBar: View {
         }
         .buttonStyle(PressableButtonStyle(pressedScale: 0.88))
         .accessibilityLabel(Text(NSLocalizedString("chat.input.send.a11y", comment: "Send")))
+    }
+
+    /// Animated 1.4s sweep that traces the input field border while the agent
+    /// is thinking — a calm GPT-5-style cue that the composer is "busy" without
+    /// adding a second label. Static (no animation) when reduceMotion is on.
+    @ViewBuilder
+    private func thinkingShimmer(active: Bool) -> some View {
+        if active {
+            ThinkingBorderShimmer()
+                .allowsHitTesting(false)
+                .transition(.opacity)
+        }
     }
 
     private var micButton: some View {

--- a/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
@@ -330,7 +330,11 @@ public struct ChatSheet: View {
         } else {
             ScrollViewReader { proxy in
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 10) {
+                    // Editorial rhythm: 18pt between turns reads as paragraphs,
+                    // not chat-density. Serif assistant text and bubble-less
+                    // replies need the breathing room (Claude.ai / GPT-5
+                    // standard ~16-20pt).
+                    LazyVStack(alignment: .leading, spacing: 18) {
                         ForEach(visibleMessages) { msg in
                             MessageBubble(
                                 role: msg.role,
@@ -376,15 +380,17 @@ public struct ChatSheet: View {
                             // user bubble so the chat shows what's being
                             // captured in real time, with a small sun-gold
                             // pulse dot marking that the mic is still hot.
+                            // Slight transparency reads as "not yet committed".
                             MessageBubble(
                                 role: .user,
                                 text: liveTranscript
                             )
                             .id(Self.liveTranscriptID)
-                            .opacity(0.85)
+                            .opacity(0.82)
                             .overlay(alignment: .topLeading) {
                                 recordingPulseDot
                             }
+                            .transition(.opacity)
                         }
 
                         if isAgentWorking {
@@ -556,10 +562,62 @@ public struct ChatSheet: View {
     private var emptyState: some View {
         if let place = orchestrator.scopedExperience {
             placeEmptyState(place)
+        } else if detent == .medium {
+            // Half-expanded: a minimal doorway — orb + invitation + pills +
+            // centered push-to-talk mic. Reads as "a companion is waiting"
+            // rather than a settings panel.
+            halfExpandedGenericEmptyState
         } else {
             genericEmptyState
         }
     }
+
+    /// The minimal half-detent layout. Wires `starterPrompts` into the
+    /// `HalfExpandedEmptyState` pills so taps still produce the same full
+    /// question the large state would have sent, and routes push-to-talk
+    /// through the existing `handleMicPress` so the orchestrator handlers
+    /// stay one path. The fourth pill ("sunset") is half-detent-only —
+    /// there's room for one more punchy tag and it nudges a moment-aware
+    /// question without crowding the large state.
+    private var halfExpandedGenericEmptyState: some View {
+        HalfExpandedEmptyState(
+            nowChipText: Self.nowContextCopy(hour: nowHour),
+            suggestions: Self.halfExpandedSuggestions,
+            onSendPrompt: { handleSend($0) },
+            onMicPress: handleMicPress,
+            isMicListening: voiceService.isListening
+        )
+    }
+
+    /// Punchy 2-4 char tags + the full sentence they expand to on tap. The
+    /// short tag is what reads on the pill; the full sentence is what the
+    /// orchestrator receives, so the answer quality matches the large state.
+    private static let halfExpandedSuggestions: [HalfExpandedEmptyState.Suggestion] = [
+        .init(
+            label: NSLocalizedString("chat.empty.half.tag.nearby", comment: "Nearby short tag"),
+            icon: "mappin.and.ellipse",
+            tint: CT.accent,
+            fullPrompt: NSLocalizedString("chat.empty.prompt.nearby", comment: "Starter chip — what's good around me")
+        ),
+        .init(
+            label: NSLocalizedString("chat.empty.half.tag.coffee", comment: "Coffee short tag"),
+            icon: "cup.and.saucer.fill",
+            tint: CT.sunGoldDeep,
+            fullPrompt: NSLocalizedString("chat.empty.prompt.coffee", comment: "Starter chip — find a quiet café")
+        ),
+        .init(
+            label: NSLocalizedString("chat.empty.half.tag.sunset", comment: "Sunset short tag"),
+            icon: "sun.horizon.fill",
+            tint: CT.sunGoldDeep,
+            fullPrompt: NSLocalizedString("chat.empty.half.prompt.sunset", comment: "Where to watch the sunset")
+        ),
+        .init(
+            label: NSLocalizedString("chat.empty.half.tag.evening", comment: "Evening short tag"),
+            icon: "moon.stars.fill",
+            tint: Color(.sRGB, red: 0x6B / 255, green: 0x4E / 255, blue: 0x7D / 255, opacity: 1),
+            fullPrompt: NSLocalizedString("chat.empty.prompt.evening", comment: "Starter chip — plan my evening")
+        ),
+    ]
 
     /// Hour-aware global empty state (the "+" entry). Sequence: hero glyph →
     /// title → subtitle → NOW banner → starter cards. Rebuilt for a single warm

--- a/apps/ios/SoloCompass/Views/Chat/HalfExpandedEmptyState.swift
+++ b/apps/ios/SoloCompass/Views/Chat/HalfExpandedEmptyState.swift
@@ -1,0 +1,223 @@
+import SwiftUI
+
+/// Minimal, breathing entry shown when the chat sheet is parked at the medium
+/// detent. The full empty state (large hero + three full-width starter cards)
+/// looks crowded at half-height — it reads as a settings panel instead of a
+/// doorway to a companion. This layout strips it down to:
+///
+///   - a slow-breathing `SoloOrb` (the "someone is here"-feeling)
+///   - a single serif invitation
+///   - a tiny moment chip
+///   - four ultra-short suggestion pills (taps fill the full prompt + send)
+///   - a centered push-to-talk mic (the primary voice-mode handle)
+///
+/// Tapping a pill calls `onSendPrompt(fullPrompt)` with the full sentence so
+/// the orchestrator gets a complete question. Long-pressing the mic is
+/// push-to-talk — `onMicPress(true)` on touch-down, `onMicPress(false)` on
+/// release — mirroring `ChatInputBar` so the orchestrator handlers can stay.
+@MainActor
+struct HalfExpandedEmptyState: View {
+    /// Short pill label + the full sentence it expands to when tapped.
+    struct Suggestion: Identifiable {
+        let id = UUID()
+        let label: String       // 2-4 char punchy tag, e.g. "咖啡"
+        let icon: String        // SF symbol
+        let tint: Color
+        let fullPrompt: String  // the actual question to send
+    }
+
+    let nowChipText: String
+    let suggestions: [Suggestion]
+    let onSendPrompt: (String) -> Void
+    let onMicPress: (Bool) -> Void
+    /// Whether the mic is currently held — drives the orb-style pulse on the
+    /// mic button so the user can see they're recording without looking away.
+    let isMicListening: Bool
+
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var appeared = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 18)
+
+            SoloOrb(size: 60)
+                .padding(.bottom, 18)
+
+            Text(NSLocalizedString(
+                "chat.empty.half.invite",
+                comment: "Half-detent serif invitation — Ask me where to go"
+            ))
+                .font(.system(size: 19, weight: .semibold, design: .serif))
+                .foregroundStyle(titleColor)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+                .padding(.bottom, 10)
+
+            momentChip
+                .padding(.bottom, 18)
+
+            suggestionRow
+                .padding(.bottom, 22)
+
+            micHandle
+                .padding(.bottom, 6)
+
+            Text(NSLocalizedString(
+                "chat.empty.half.micHint",
+                comment: "Micro caption under push-to-talk mic"
+            ))
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(.secondary)
+                .opacity(isMicListening ? 0 : 1)
+
+            Spacer(minLength: 14)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .opacity(appeared ? 1 : 0)
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.45), value: appeared)
+        .onAppear { appeared = true }
+    }
+
+    // MARK: - Moment chip
+
+    private var momentChip: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "sun.haze.fill")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(CT.sunGoldDeep)
+            Text(nowChipText)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(CT.sunGoldDeep)
+        }
+        .padding(.horizontal, 11)
+        .padding(.vertical, 5)
+        .background(Capsule().fill(CT.sunGoldSoft))
+    }
+
+    // MARK: - Suggestion row (horizontal pills)
+    //
+    // Plain HStack — at 4 short tags + 22pt side padding the row fits well
+    // under 360pt on every supported width, so the ScrollView's bounce was
+    // never used. Removing it also makes the row visible to `ImageRenderer`
+    // (which silently drops ScrollView content in snapshot tests).
+    private var suggestionRow: some View {
+        HStack(spacing: 8) {
+            ForEach(suggestions) { s in
+                Button {
+                    Haptics.impact(.light)
+                    onSendPrompt(s.fullPrompt)
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: s.icon)
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(s.tint)
+                        Text(s.label)
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(pillTextColor)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(pillFill, in: Capsule())
+                    .overlay(Capsule().strokeBorder(pillBorder, lineWidth: 0.5))
+                }
+                .buttonStyle(PressableButtonStyle(pressedScale: 0.92))
+                .accessibilityLabel(s.fullPrompt)
+            }
+        }
+        .padding(.horizontal, 22)
+    }
+
+    // MARK: - Push-to-talk mic
+
+    private var micHandle: some View {
+        ZStack {
+            // Outer breathing halo while listening — the user's confirmation
+            // they're being heard without breaking attention away from speaking.
+            if isMicListening {
+                Circle()
+                    .fill(CT.accent.opacity(0.18))
+                    .frame(width: 84, height: 84)
+                    .scaleEffect(isMicListening ? 1.18 : 0.9)
+                    .opacity(isMicListening ? 0.0 : 0.9)
+                    .animation(
+                        reduceMotion ? nil : .easeOut(duration: 1.0).repeatForever(autoreverses: false),
+                        value: isMicListening
+                    )
+            }
+
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: isMicListening
+                            ? [CT.sunGoldDeep, CT.accent]
+                            : [CT.accent, CT.accentHover],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: 56, height: 56)
+                .overlay(
+                    Circle().strokeBorder(Color.white.opacity(0.22), lineWidth: 0.75)
+                )
+                .overlay(
+                    Image(systemName: isMicListening ? "waveform" : "mic.fill")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(.white)
+                )
+                .shadow(color: CT.accent.opacity(0.28), radius: 10, y: 4)
+                .scaleEffect(isMicListening ? 1.06 : 1.0)
+                .animation(reduceMotion ? nil : .spring(response: 0.32, dampingFraction: 0.7), value: isMicListening)
+        }
+        .contentShape(Circle())
+        .onLongPressGesture(
+            minimumDuration: 0.0,
+            maximumDistance: .infinity,
+            perform: {},
+            onPressingChanged: { pressing in
+                onMicPress(pressing)
+            }
+        )
+        .accessibilityLabel(Text(NSLocalizedString(
+            "chat.empty.half.mic.a11y",
+            comment: "Push and hold to talk to Solo"
+        )))
+        .accessibilityAddTraits(.isButton)
+    }
+
+    // MARK: - Colors
+
+    private var titleColor: Color {
+        colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary
+    }
+
+    private var pillTextColor: Color {
+        colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary
+    }
+
+    private var pillFill: Color {
+        colorScheme == .dark ? Color(.secondarySystemBackground) : CT.surfaceWhite
+    }
+
+    private var pillBorder: Color {
+        colorScheme == .dark ? Color(.separator) : CT.borderSubtle
+    }
+}
+
+#Preview("Half-Expanded Empty — light") {
+    HalfExpandedEmptyState(
+        nowChipText: "午后柔和 · 适合走走",
+        suggestions: [
+            .init(label: "附近", icon: "mappin.and.ellipse", tint: CT.accent, fullPrompt: "附近有什么好玩的？"),
+            .init(label: "咖啡", icon: "cup.and.saucer.fill", tint: CT.sunGoldDeep, fullPrompt: "找一家安静的咖啡馆"),
+            .init(label: "落日", icon: "sun.horizon.fill", tint: CT.sunGoldDeep, fullPrompt: "推荐一个看落日的地方"),
+            .init(label: "今晚", icon: "moon.stars.fill", tint: Color(.sRGB, red: 0x6B / 255, green: 0x4E / 255, blue: 0x7D / 255, opacity: 1), fullPrompt: "帮我计划今晚的行程"),
+        ],
+        onSendPrompt: { _ in },
+        onMicPress: { _ in },
+        isMicListening: false
+    )
+    .frame(height: 440)
+    .background(CT.bgWarm)
+}

--- a/apps/ios/SoloCompass/Views/Chat/MarkdownMessageText.swift
+++ b/apps/ios/SoloCompass/Views/Chat/MarkdownMessageText.swift
@@ -17,18 +17,23 @@ private typealias MarkdownTheme = MarkdownUI.Theme
 @MainActor
 struct MarkdownMessageText: View {
     let text: String
+    let bodyFont: Font
+    let bodyLineSpacing: CGFloat
 
     @Environment(\.colorScheme) private var colorScheme
 
-    init(text: String) {
+    init(text: String, bodyFont: Font = .body, bodyLineSpacing: CGFloat = 0) {
         self.text = text
+        self.bodyFont = bodyFont
+        self.bodyLineSpacing = bodyLineSpacing
     }
 
     var body: some View {
         Markdown(text)
             .markdownTheme(chatTheme)
-            // Body text matches the surrounding bubble: system body, primary fg.
-            .font(.body)
+            // Body text matches the surrounding bubble: caller picks font + leading.
+            .font(bodyFont)
+            .lineSpacing(bodyLineSpacing)
             .foregroundStyle(.primary)
     }
 

--- a/apps/ios/SoloCompass/Views/Chat/MessageBubble.swift
+++ b/apps/ios/SoloCompass/Views/Chat/MessageBubble.swift
@@ -60,18 +60,18 @@ public struct MessageBubble: View {
 
     private var userBubble: some View {
         HStack {
-            Spacer(minLength: 48)
+            Spacer(minLength: 56)
             VStack(alignment: .trailing, spacing: 5) {
                 if let voiceDuration {
                     voiceBadge(voiceDuration)
                 }
                 Text(text)
-                    .font(.system(size: 14.5))
+                    .font(.system(size: 15))
                     .foregroundStyle(.white)
-                    .padding(.horizontal, 15)
-                    .padding(.vertical, 10)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 11)
                     .background(CT.accent, in: userBubbleShape)
-                    .shadow(color: CT.accent.opacity(0.22), radius: 8, y: 3)
+                    .shadow(color: CT.accent.opacity(0.18), radius: 6, y: 2)
                     .accessibilityLabel(Text(String(
                     format: NSLocalizedString("chat.bubble.user.a11y", comment: "You said: %@"),
                     text
@@ -113,27 +113,24 @@ public struct MessageBubble: View {
     }
 
     private var assistantBubble: some View {
-        // No per-message avatar — the compass mark used to repeat on every
-        // single reply, which read as generic "AI assistant" chrome. The reply
-        // simply sits left-aligned in a warm, low-contrast bubble that belongs
-        // to the app's parchment palette rather than a stark white card.
+        // Editorial voice — no bubble, no border. The assistant reply sits
+        // directly on the warm sheet in a serif body face with generous
+        // leading, so a long answer reads like a letter rather than a chat
+        // chrome block. Tokens fade in (handled in ChatSheet via .transition);
+        // no blinking caret — the cursor was visual noise at scale.
         HStack(spacing: 0) {
-            // Assistant replies render Markdown (code/lists/links/quotes).
-            // Streaming throttle (batched ~50–80 chars / ~80ms) lives in the
-            // orchestrator (Phase D) so this view re-renders smoothly.
-            MarkdownMessageText(text: MessageBubble.renderCitations(text.isEmpty ? " " : text))
-                .padding(.horizontal, 15)
-                .padding(.vertical, 10)
-                .background {
-                    assistantBubbleShape.fill(MessageBubble.assistantFill(colorScheme))
-                }
-                .overlay(assistantBubbleShape.strokeBorder(CT.borderSubtle, lineWidth: 0.5))
-                .overlay(alignment: .trailing) {
-                    if isStreaming {
-                        StreamingCursor()
-                            .padding(.trailing, 10)
-                    }
-                }
+            MarkdownMessageText(
+                text: MessageBubble.renderCitations(text.isEmpty ? " " : text),
+                bodyFont: .system(size: 16, design: .serif),
+                bodyLineSpacing: 6
+            )
+                .foregroundStyle(MessageBubble.assistantTextColor(colorScheme))
+                .padding(.horizontal, 4)
+                .padding(.vertical, 2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .id(isStreaming ? "streaming-\(text.count)" : "final")
+                .transition(.opacity)
+                .animation(.easeOut(duration: 0.18), value: text)
                 .contextMenu {
                     if !text.isEmpty && !isStreaming {
                         Button {
@@ -146,7 +143,7 @@ public struct MessageBubble: View {
                         }
                     }
                 }
-            Spacer(minLength: 48)
+            Spacer(minLength: 24)
         }
         .accessibilityLabel(Text(String(
             format: NSLocalizedString("chat.bubble.assistant.a11y", comment: "Solo said: %@"),
@@ -157,12 +154,17 @@ public struct MessageBubble: View {
         }
     }
 
-    /// AI bubble fill: clean surface-white with a hairline in light mode (the
-    /// design-handoff voice — a soft card that floats on the warm sheet, not a
-    /// muddy parchment block), and the dark token in dark mode so it doesn't
-    /// glare on a near-black sheet.
+    /// AI bubble fill — kept for `TypingIndicatorBubble` compatibility. The main
+    /// assistant message no longer uses a bubble; it sits directly on the warm
+    /// sheet in serif body text.
     static func assistantFill(_ scheme: ColorScheme) -> Color {
         scheme == .dark ? CT.chatAIBubbleBgDark : CT.surfaceWhite
+    }
+
+    /// Editorial body color for the bubble-less assistant text. Slightly softer
+    /// than pure primary so long passages read like newsprint instead of headlines.
+    static func assistantTextColor(_ scheme: ColorScheme) -> Color {
+        scheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary
     }
 
     private var toolIndicator: some View {
@@ -182,29 +184,12 @@ public struct MessageBubble: View {
         .accessibilityElement(children: .combine)
     }
 
-    /// User bubble: 18pt rounded, but the bottom-trailing corner tucks to 5pt so
-    /// the bubble "points" back toward the sender — a quiet directional cue that
-    /// reads as a tail without drawing one (design `border-bottom-right-radius`).
+    /// User bubble: even 18pt rounded rectangle. The old tucked corner pointed
+    /// toward the sender, but top-tier chat apps (Claude / ChatGPT / iMessage
+    /// 2025) settled on symmetric rounded rects — the alignment + color already
+    /// signal authorship, no tail required.
     private var userBubbleShape: some InsettableShape {
-        UnevenRoundedRectangle(
-            topLeadingRadius: 18,
-            bottomLeadingRadius: 18,
-            bottomTrailingRadius: 5,
-            topTrailingRadius: 18,
-            style: .continuous
-        )
-    }
-
-    /// Assistant bubble: mirror image — the bottom-leading corner tucks to 5pt
-    /// so the reply points toward Solo on the left.
-    private var assistantBubbleShape: some InsettableShape {
-        UnevenRoundedRectangle(
-            topLeadingRadius: 18,
-            bottomLeadingRadius: 5,
-            bottomTrailingRadius: 18,
-            topTrailingRadius: 18,
-            style: .continuous
-        )
+        RoundedRectangle(cornerRadius: 18, style: .continuous)
     }
 
     // MARK: - Actions
@@ -400,29 +385,6 @@ private struct BouncingDot: View {
                 value: bouncing
             )
             .onAppear { if !reduceMotion { bouncing = true } }
-            .accessibilityHidden(true)
-    }
-}
-
-/// Blinking caret rendered on the trailing edge of a streaming bubble, echoing
-/// a text-cursor so the live response reads as "still typing". Pure visual —
-/// no semantic meaning for VoiceOver.
-private struct StreamingCursor: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var visible = true
-
-    var body: some View {
-        RoundedRectangle(cornerRadius: 1, style: .continuous)
-            .fill(CT.accent)
-            .frame(width: 2, height: 14)
-            .opacity(visible ? 1.0 : 0.15)
-            .animation(
-                reduceMotion
-                    ? nil
-                    : .easeInOut(duration: 0.55).repeatForever(autoreverses: true),
-                value: visible
-            )
-            .onAppear { if !reduceMotion { visible = false } }
             .accessibilityHidden(true)
     }
 }

--- a/apps/ios/SoloCompass/Views/Chat/SoloOrb.swift
+++ b/apps/ios/SoloCompass/Views/Chat/SoloOrb.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+/// The "living" entry orb used at the top of the chat sheet's half-expanded
+/// empty state. Replaces the static sparkles disc with a soft, slowly-breathing
+/// circle so the sheet reads as a doorway to a present, attentive companion —
+/// not a feature panel. Two halos + a gradient core scale-pulse on a 3.2s
+/// cycle; reduceMotion lands it static.
+///
+/// Purely decorative — hidden from VoiceOver.
+@MainActor
+struct SoloOrb: View {
+    /// Diameter of the inner gradient core. Halos scale relative to this.
+    var size: CGFloat = 64
+
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var breathing = false
+
+    var body: some View {
+        ZStack {
+            // Outer ambient bloom — barely-there warmth that softens the edge.
+            Circle()
+                .fill(CT.accent.opacity(colorScheme == .dark ? 0.18 : 0.10))
+                .frame(width: size * 1.75, height: size * 1.75)
+                .blur(radius: size * 0.22)
+                .scaleEffect(breathing ? 1.06 : 0.94)
+                .opacity(breathing ? 1.0 : 0.78)
+
+            // Mid ring — a thin warm border floating just outside the core.
+            Circle()
+                .strokeBorder(
+                    CT.sunGold.opacity(colorScheme == .dark ? 0.34 : 0.42),
+                    lineWidth: 1
+                )
+                .frame(width: size * 1.26, height: size * 1.26)
+                .scaleEffect(breathing ? 1.03 : 0.98)
+
+            // Core — gradient amber fill with a hairline highlight + sparkles.
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: colorScheme == .dark
+                            ? [CT.accent, CT.accentHover]
+                            : [CT.sunGoldSoft, CT.accentSoft],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: size, height: size)
+                .overlay(
+                    Circle().strokeBorder(
+                        Color.white.opacity(colorScheme == .dark ? 0.10 : 0.55),
+                        lineWidth: 0.75
+                    )
+                )
+                .overlay(
+                    Image(systemName: "sparkles")
+                        .font(.system(size: size * 0.38, weight: .semibold))
+                        .foregroundStyle(colorScheme == .dark ? Color.white : CT.accent)
+                )
+                .shadow(color: CT.accent.opacity(colorScheme == .dark ? 0.45 : 0.18), radius: size * 0.18, y: 4)
+                .scaleEffect(breathing ? 1.02 : 0.98)
+        }
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 3.2).repeatForever(autoreverses: true)) {
+                breathing = true
+            }
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+#Preview("Solo Orb — light") {
+    VStack(spacing: 40) {
+        SoloOrb(size: 48)
+        SoloOrb(size: 64)
+        SoloOrb(size: 80)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(CT.bgWarm)
+}
+
+#Preview("Solo Orb — dark") {
+    VStack(spacing: 40) {
+        SoloOrb(size: 64)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.black)
+    .preferredColorScheme(.dark)
+}

--- a/apps/ios/SoloCompass/Views/Chat/ThinkingBorderShimmer.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ThinkingBorderShimmer.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// A calm, accent-tinted highlight that sweeps around the input field's border
+/// while Solo is thinking — the GPT-5 "composer is busy" cue. Adds visual
+/// presence without a second text label, keeping the AgentStatusLine as the
+/// single source of thinking-state truth in the message list.
+///
+/// Implementation: an `AngularGradient` rotates inside an 18pt rounded-rect
+/// stroke. Strictly decorative — hidden from VoiceOver. Respects
+/// `accessibilityReduceMotion` (renders static).
+@MainActor
+struct ThinkingBorderShimmer: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var phase: Double = 0
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .strokeBorder(gradient, lineWidth: 1.1)
+            .opacity(0.85)
+            .rotationEffect(.degrees(reduceMotion ? 0 : phase))
+            .onAppear {
+                guard !reduceMotion else { return }
+                withAnimation(.linear(duration: 1.4).repeatForever(autoreverses: false)) {
+                    phase = 360
+                }
+            }
+            .accessibilityHidden(true)
+    }
+
+    private var gradient: AngularGradient {
+        AngularGradient(
+            gradient: Gradient(stops: [
+                .init(color: CT.accent.opacity(0.0), location: 0.0),
+                .init(color: CT.accent.opacity(0.0), location: 0.55),
+                .init(color: CT.accent.opacity(0.55), location: 0.75),
+                .init(color: CT.sunGold.opacity(0.7), location: 0.85),
+                .init(color: CT.accent.opacity(0.0), location: 1.0),
+            ]),
+            center: .center
+        )
+    }
+}
+
+#Preview("Thinking Shimmer") {
+    VStack(spacing: 24) {
+        RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .fill(CT.surfaceWhite)
+            .frame(height: 46)
+            .overlay {
+                ThinkingBorderShimmer()
+            }
+            .padding(.horizontal)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(CT.bgWarm)
+}

--- a/apps/ios/SoloCompass/Views/Map/ExploreConsentSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/ExploreConsentSheet.swift
@@ -21,10 +21,18 @@ struct ExploreConsentSheet: View {
     var body: some View {
         VStack(spacing: 0) {
             VStack(spacing: 12) {
+                // Hero icon — sized + framed to render fully inside the sheet's
+                // safe area. The previous 44pt glyph + 32pt top padding caused
+                // the icon to be clipped by the sheet's rounded top corners
+                // on `.medium` detent (the user reported "half-icon" rendering).
+                // 36pt glyph in a 56pt frame + 28pt top padding keeps the full
+                // optical bounds below the grabber on every device class.
                 Image(systemName: "sparkle.magnifyingglass")
-                    .font(.system(size: 44, weight: .light))
+                    .font(.system(size: 36, weight: .light))
                     .foregroundStyle(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255))
-                    .padding(.top, 32)
+                    .frame(width: 56, height: 56)
+                    .padding(.top, 28)
+                    .accessibilityHidden(true)
 
                 Text(NSLocalizedString("explore.consent.title", comment: "Title for explore consent sheet"))
                     .font(.title2.bold())

--- a/apps/ios/SoloCompass/Views/Me/EntitlementBanner.swift
+++ b/apps/ios/SoloCompass/Views/Me/EntitlementBanner.swift
@@ -1,0 +1,216 @@
+import SwiftUI
+
+/// Subscription-state strip rendered at the top of `MeSheet`. Three faces:
+///
+/// - **proTrial** — progress bar + "X days left · billing starts MMM d".
+///   Tapping pushes PaywallView so the user can see/manage the upcoming
+///   charge (Apple's settings link lives there).
+/// - **pro** — confident green-check + "Pro · renews MMM d". Tapping pushes
+///   PaywallView (which routes to App Store subscription management).
+/// - **free / proExpired** — amber CTA card: "Try free for 1 month".
+///   Tapping pushes PaywallView in upsell mode.
+///
+/// The banner is intentionally tappable in every state so the user has a
+/// single, predictable affordance for "manage my subscription" — no hidden
+/// settings-deep-link discovery.
+struct EntitlementBanner: View {
+    @Environment(SubscriptionService.self) private var subscription
+
+    var body: some View {
+        NavigationLink {
+            PaywallView()
+        } label: {
+            content
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(14)
+                .background(
+                    RoundedRectangle(cornerRadius: 14)
+                        .fill(backgroundFill)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .stroke(borderColor, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityHint(NSLocalizedString("me.entitlement.a11y.hint",
+                                             comment: "Opens subscription details"))
+    }
+
+    // MARK: - Content variants
+
+    @ViewBuilder
+    private var content: some View {
+        switch subscription.entitlement {
+        case .proTrial:
+            trialContent
+        case .pro:
+            proContent
+        case .free, .proExpired:
+            upsellContent
+        }
+    }
+
+    /// Mid-trial: progress + days remaining + billing date.
+    private var trialContent: some View {
+        let days = subscription.trialDaysRemaining ?? 0
+        let progress = trialProgress
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
+                Image(systemName: "sparkles")
+                    .font(.headline)
+                    .foregroundStyle(amber)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(headlineText(days: days))
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.primary)
+                    Text(detailText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            // Progress bar — full at trial start, drains to zero on the
+            // last day. tint=amber for trial, intentionally not red so we
+            // don't make the user feel they're being rushed.
+            ProgressView(value: progress)
+                .tint(amber)
+                .progressViewStyle(.linear)
+        }
+    }
+
+    /// Steady-state Pro: clean badge + renewal date.
+    private var proContent: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.headline)
+                .foregroundStyle(amber)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(NSLocalizedString("me.entitlement.pro.title",
+                                       comment: "Pro headline"))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                Text(proRenewalDetail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Free / proExpired: warm CTA card.
+    private var upsellContent: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "gift.fill")
+                .font(.headline)
+                .foregroundStyle(amber)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(NSLocalizedString("me.entitlement.upsell.title",
+                                       comment: "Try free for 1 month"))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                Text(NSLocalizedString("me.entitlement.upsell.detail",
+                                       comment: "Pro features hint"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Derived values
+
+    /// Headline copy resolves on days-remaining boundary so users see
+    /// "Last day of trial" specifically on the final day — a quiet but
+    /// honest nudge that beats the generic "1 day left" plural.
+    private func headlineText(days: Int) -> String {
+        if days <= 0 {
+            return NSLocalizedString("me.entitlement.trial.lastDay",
+                                     comment: "Last day of trial")
+        }
+        let fmt = NSLocalizedString("me.entitlement.trial.headline.format",
+                                    comment: "Trial headline (%d days)")
+        return String(format: fmt, days)
+    }
+
+    /// Detail row: "Billing starts on MMM d" — only renders the date if
+    /// we have one; falls back to a generic copy so the row is never empty.
+    private var detailText: String {
+        guard let exp = subscription.currentExpirationDate else {
+            return NSLocalizedString("me.entitlement.trial.detail.fallback",
+                                     comment: "Trial detail without date")
+        }
+        let df = DateFormatter()
+        df.dateStyle = .medium
+        df.timeStyle = .none
+        let fmt = NSLocalizedString("me.entitlement.trial.detail.format",
+                                    comment: "Trial detail with date")
+        return String(format: fmt, df.string(from: exp))
+    }
+
+    private var proRenewalDetail: String {
+        guard let exp = subscription.currentExpirationDate else {
+            return NSLocalizedString("me.entitlement.pro.detail.fallback",
+                                     comment: "Pro detail without date")
+        }
+        let df = DateFormatter()
+        df.dateStyle = .medium
+        df.timeStyle = .none
+        let fmt = NSLocalizedString("me.entitlement.pro.detail.format",
+                                    comment: "Pro detail with renewal date")
+        return String(format: fmt, df.string(from: exp))
+    }
+
+    /// Drain progress over the 30-day trial. Defensively bounded so a
+    /// missing expiration date doesn't show an empty bar and a far-future
+    /// one doesn't render past the trough.
+    private var trialProgress: Double {
+        guard let exp = subscription.currentExpirationDate else { return 0 }
+        let remaining = exp.timeIntervalSinceNow
+        let trialSeconds: TimeInterval = 30 * 86_400
+        let consumed = max(0, trialSeconds - remaining)
+        return max(0, min(1, consumed / trialSeconds))
+    }
+
+    // MARK: - Styling
+
+    private var amber: Color {
+        Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)
+    }
+
+    private var backgroundFill: Color {
+        switch subscription.entitlement {
+        case .proTrial, .free, .proExpired:
+            return amber.opacity(0.10)
+        case .pro:
+            return amber.opacity(0.06)
+        }
+    }
+
+    private var borderColor: Color {
+        switch subscription.entitlement {
+        case .proTrial: return amber.opacity(0.35)
+        case .pro:      return amber.opacity(0.20)
+        case .free, .proExpired: return amber.opacity(0.30)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        List {
+            Section { EntitlementBanner() }
+        }
+    }
+    .environment(SubscriptionService())
+}

--- a/apps/ios/SoloCompass/Views/Me/MeSheet.swift
+++ b/apps/ios/SoloCompass/Views/Me/MeSheet.swift
@@ -57,6 +57,17 @@ struct MeSheet: View {
                     .listRowBackground(Color.clear)
                 }
 
+                // Subscription status banner — shows trial progress for
+                // mid-trial users, Pro renewal date for paying users, and
+                // the "start free month" CTA for free users. Tappable in
+                // every state: routes to PaywallView (handles its own
+                // mid-trial vs upsell rendering).
+                Section {
+                    EntitlementBanner()
+                        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                        .listRowBackground(Color.clear)
+                }
+
                 if preferences.favoritedExperiences.isEmpty {
                     Section {
                         MeEmptyStateCard()

--- a/apps/ios/SoloCompass/Views/Onboarding/OnboardingView.swift
+++ b/apps/ios/SoloCompass/Views/Onboarding/OnboardingView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import StoreKit
 
 /// Documented VoiceOver focus order for every onboarding page.
 ///
@@ -28,11 +29,23 @@ public struct OnboardingView: View {
     @Environment(LocationService.self) private var locationService
     @Environment(UserPreferences.self) private var preferences
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Optional — when present, the final paywall step uses real StoreKit
+    /// purchases. When absent (e.g. previews/tests that don't inject the
+    /// service), the paywall step renders but the CTA falls back to skip.
+    @Environment(SubscriptionService.self) private var subscription
     let onComplete: () -> Void
 
     @State private var step: Int = 0
+    @State private var paywallPurchaseInFlight: Bool = false
 
-    private static let totalSteps = 4
+    /// UserDefaults flag set the first time the user finishes (or skips) the
+    /// onboarding paywall step. We never re-show the onboarding paywall after
+    /// this is true — returning users hit the SettingsView paywall entry
+    /// point instead, which is intentional (the Apple HIG requirement is one
+    /// non-modal post-onboarding paywall, not repeated wall-of-trial popups).
+    private static let onboardingPaywallSeenKey = "hasSeenOnboardingPaywall"
+
+    private static let totalSteps = 5
 
     private var slideTransition: AnyTransition {
         reduceMotion
@@ -60,10 +73,14 @@ public struct OnboardingView: View {
                 scoringStep
                     .transition(slideTransition)
                     .id(2)
-            default:
+            case 3:
                 styleStep
                     .transition(slideTransition)
                     .id(3)
+            default:
+                paywallStep
+                    .transition(slideTransition)
+                    .id(4)
             }
         }
         .overlay(alignment: .topTrailing) {
@@ -75,8 +92,13 @@ public struct OnboardingView: View {
     // MARK: - Skip the whole flow
 
     /// Completes onboarding immediately from any step (returning users / QA).
+    /// If the user is already on the paywall step, also mark it as seen so a
+    /// future onboarding re-entry doesn't re-pitch the trial.
     private var skipButton: some View {
         Button {
+            if step == 4 {
+                UserDefaults.standard.set(true, forKey: Self.onboardingPaywallSeenKey)
+            }
             preferences.completeOnboarding()
             onComplete()
         } label: {
@@ -367,8 +389,16 @@ public struct OnboardingView: View {
 
             VStack(spacing: 12) {
                 Button {
-                    preferences.completeOnboarding()
-                    onComplete()
+                    // Onboarding-paywall gating: returning Pro users (or anyone
+                    // who already saw the trial pitch and dismissed it) skip the
+                    // paywall step entirely so re-entering onboarding via the
+                    // mid-flow recovery path doesn't feel like nagging.
+                    if shouldSkipOnboardingPaywall {
+                        preferences.completeOnboarding()
+                        onComplete()
+                    } else {
+                        withAnimation { step = 4 }
+                    }
                 } label: {
                     Text(NSLocalizedString("onboarding.style.cta", comment: "Start exploring"))
                         .font(.headline)
@@ -380,8 +410,12 @@ public struct OnboardingView: View {
                 .accessibilitySortPriority(OnboardingA11ySortPriority.primaryCTA)
 
                 Button {
-                    preferences.completeOnboarding()
-                    onComplete()
+                    if shouldSkipOnboardingPaywall {
+                        preferences.completeOnboarding()
+                        onComplete()
+                    } else {
+                        withAnimation { step = 4 }
+                    }
                 } label: {
                     Text(NSLocalizedString("onboarding.style.skip", comment: "Decide later"))
                         .font(.subheadline)
@@ -393,6 +427,189 @@ public struct OnboardingView: View {
             .padding(.bottom, 48)
         }
         .accessibilityElement(children: .contain)
+    }
+
+    // MARK: - Step 4: Paywall (1-month free trial via StoreKit)
+
+    /// True if we should bypass the onboarding paywall and finish immediately.
+    /// Covers three cases that all share the same UX rule: the user has
+    /// already seen the trial pitch, so nagging them again on warm re-entry
+    /// would be hostile.
+    ///
+    /// 1. Already Pro / mid-trial: they're paying customers, the paywall is
+    ///    a regression.
+    /// 2. Previously dismissed: opening onboarding again for any reason
+    ///    (mid-flow kill recovery, QA replay) shouldn't re-trigger the upsell.
+    /// 3. Test/preview env without a SubscriptionService injected: degrade
+    ///    cleanly to completion rather than crashing on missing env.
+    private var shouldSkipOnboardingPaywall: Bool {
+        if subscription.entitlement.isActive { return true }
+        if UserDefaults.standard.bool(forKey: Self.onboardingPaywallSeenKey) { return true }
+        return false
+    }
+
+    /// Marks the onboarding paywall as seen and finishes the flow. Called both
+    /// after a successful purchase and after the user taps "Maybe later" —
+    /// the seen flag is independent of whether they actually subscribed.
+    private func finishOnboardingPaywall() {
+        UserDefaults.standard.set(true, forKey: Self.onboardingPaywallSeenKey)
+        preferences.completeOnboarding()
+        onComplete()
+    }
+
+    private var paywallStep: some View {
+        VStack(spacing: 0) {
+            stepIndicator
+                .padding(.top, 24)
+
+            Spacer(minLength: 0)
+
+            VStack(spacing: 20) {
+                // Hero glyph — sparkles in warm amber, matches PaywallView so
+                // the user sees one visual identity for "Pro" across surfaces.
+                Image(systemName: "sparkles")
+                    .font(.system(size: 44, weight: .regular))
+                    .foregroundStyle(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255))
+                    .accessibilityHidden(true)
+
+                Text(NSLocalizedString("onboarding.paywall.title", comment: "Trial step title"))
+                    .font(.title.bold())
+                    .multilineTextAlignment(.center)
+                    .accessibilitySortPriority(OnboardingA11ySortPriority.title)
+
+                Text(NSLocalizedString("onboarding.paywall.subtitle", comment: "Trial step subtitle"))
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+                    .accessibilitySortPriority(OnboardingA11ySortPriority.subtitle)
+
+                // Trial-benefit bullets. Kept to three so the page feels
+                // confident, not a feature dump.
+                VStack(alignment: .leading, spacing: 12) {
+                    onboardingPaywallBullet("sparkle.magnifyingglass",
+                                            key: "onboarding.paywall.bullet.explore")
+                    onboardingPaywallBullet("mic.fill",
+                                            key: "onboarding.paywall.bullet.voice")
+                    onboardingPaywallBullet("brain.head.profile",
+                                            key: "onboarding.paywall.bullet.insight")
+                }
+                .padding(.horizontal, 28)
+                .accessibilitySortPriority(OnboardingA11ySortPriority.content)
+            }
+
+            Spacer(minLength: 0)
+            Spacer(minLength: 0)
+
+            VStack(spacing: 12) {
+                Button {
+                    Task { await runOnboardingPurchase() }
+                } label: {
+                    HStack(spacing: 8) {
+                        if paywallPurchaseInFlight {
+                            ProgressView()
+                                .progressViewStyle(.circular)
+                                .tint(Color(red: 0x3A/255, green: 0x2A/255, blue: 0x05/255))
+                        }
+                        Text(NSLocalizedString("onboarding.paywall.cta", comment: "Start free month CTA"))
+                            .font(.headline)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .background(
+                        Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255),
+                        in: RoundedRectangle(cornerRadius: 14)
+                    )
+                    .foregroundStyle(Color(red: 0x3A/255, green: 0x2A/255, blue: 0x05/255))
+                }
+                .disabled(paywallPurchaseInFlight)
+                .accessibilitySortPriority(OnboardingA11ySortPriority.primaryCTA)
+                .accessibilityIdentifier("onboarding.paywall.cta")
+
+                // Apple legally requires the trial price disclosure to be
+                // visible near the CTA, not buried in fine print. Resolved
+                // from the live StoreKit product when available; falls back
+                // to a generic copy when products haven't loaded yet.
+                Text(trialFinePrintCopy)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+                    .accessibilityLabel(Text(trialFinePrintCopy))
+
+                Button {
+                    finishOnboardingPaywall()
+                } label: {
+                    Text(NSLocalizedString("onboarding.paywall.later", comment: "Skip trial"))
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilitySortPriority(OnboardingA11ySortPriority.skip)
+                .accessibilityIdentifier("onboarding.paywall.later")
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 40)
+        }
+        .accessibilityElement(children: .contain)
+        .task {
+            // Eager product load so the price is rendered before the user
+            // even reads the bullets — no "loading…" flash on tap.
+            if subscription.products.isEmpty {
+                await subscription.loadProducts()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func onboardingPaywallBullet(_ icon: String, key: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.body)
+                .foregroundStyle(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255))
+                .frame(width: 24)
+            Text(NSLocalizedString(key, comment: ""))
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    /// Resolves the StoreKit-driven fine-print copy. Falls back to a
+    /// localized generic line when products haven't loaded yet — never
+    /// shows an empty string, which would let the CTA float without
+    /// disclosure (App Store 3.1.2 requirement).
+    private var trialFinePrintCopy: String {
+        let monthly = subscription.products.first(where: { $0.id == SubscriptionService.monthlyProductID })
+        if let monthly {
+            let fmt = NSLocalizedString("onboarding.paywall.fineprint.format",
+                                        comment: "Trial fineprint with %@ price")
+            return String(format: fmt, monthly.displayPrice)
+        }
+        return NSLocalizedString("onboarding.paywall.fineprint.fallback",
+                                 comment: "Trial fineprint without price")
+    }
+
+    private func runOnboardingPurchase() async {
+        guard let product = subscription.products.first(where: { $0.id == SubscriptionService.monthlyProductID })
+                ?? subscription.products.first
+        else {
+            // StoreKit catalog empty (sandbox not configured / offline). In
+            // DEBUG SubscriptionService._setEntitlementForTesting could be
+            // called here, but the cleaner UX in Release is to finish
+            // onboarding silently so the user isn't trapped on a dead button.
+            #if DEBUG
+            subscription._setEntitlementForTesting(.proTrial)
+            #endif
+            finishOnboardingPaywall()
+            return
+        }
+        paywallPurchaseInFlight = true
+        defer { paywallPurchaseInFlight = false }
+        let unlocked = await subscription.purchase(product)
+        // Whether purchase succeeded or the user cancelled at the StoreKit
+        // sheet, the onboarding paywall is "done" — we don't re-prompt.
+        finishOnboardingPaywall()
+        _ = unlocked  // status reflected via subscription.entitlement everywhere else
     }
 
     @ViewBuilder
@@ -458,4 +675,5 @@ public struct OnboardingView: View {
     OnboardingView(onComplete: {})
         .environment(LocationService.shared)
         .environment(UserPreferences())
+        .environment(SubscriptionService())
 }

--- a/apps/ios/SoloCompass/Views/Paywall/PaywallView.swift
+++ b/apps/ios/SoloCompass/Views/Paywall/PaywallView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import StoreKit
 
 /// First user-visible paid moment. Shows the two product cards (yearly
-/// emphasized as "Best value"), the 7-day free trial CTA, restore link,
+/// emphasized as "Best value"), the 1-month free trial CTA, restore link,
 /// and fine-print legal copy.
 ///
 /// Driven by `SubscriptionService` from the environment. On a successful
@@ -12,9 +12,21 @@ public struct PaywallView: View {
     @Environment(SubscriptionService.self) private var subscription
     @Environment(\.dismiss) private var dismiss
 
-    @State private var selectedProductID: String = SubscriptionService.yearlyProductID
+    // Default selection = monthly because the Introductory Offer (1-month
+    // free trial) is configured on the monthly SKU. Pre-selecting yearly
+    // would suppress the trial pitch — bad funnel design even though yearly
+    // has higher LTV.
+    @State private var selectedProductID: String = SubscriptionService.monthlyProductID
     @State private var purchaseInFlight = false
     @State private var purchaseError: String?
+    /// Whether the App Store Apple ID currently looking at this paywall is
+    /// still eligible for the monthly Introductory Offer (1 month free).
+    /// Defaults to `true` so the trial banner is visible while we're still
+    /// resolving — false positives are recoverable (StoreKit will fall back
+    /// to the regular price at purchase time and the user will see it in
+    /// Apple's own purchase sheet); false negatives would silently hide our
+    /// most important hook.
+    @State private var introOfferEligible: Bool = true
 
     /// Called after a successful purchase or restore so callers can
     /// resume the action that triggered the paywall.
@@ -26,8 +38,16 @@ public struct PaywallView: View {
 
     public var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 24) {
+            VStack(alignment: .leading, spacing: 20) {
                 hero
+                // Mid-trial state takes precedence: a paying-trial user
+                // re-opening the paywall (from MeSheet) should see "X days
+                // left" + manage, not the upsell pitch again.
+                if subscription.entitlement == .proTrial {
+                    midTrialBanner
+                } else if introOfferEligible {
+                    trialBanner
+                }
                 bullets
                 productCards
                 ctaButton
@@ -53,6 +73,16 @@ public struct PaywallView: View {
             if subscription.products.isEmpty {
                 await subscription.loadProducts()
             }
+            // Refresh intro-offer eligibility after products are in hand.
+            // Done in a separate Task so a slow StoreKit call doesn't block
+            // the bullets/CTA from rendering — if it's late, the optimistic
+            // default keeps the banner visible until the truth lands.
+            if let monthly = subscription.products.first(where: { $0.id == SubscriptionService.monthlyProductID }) {
+                introOfferEligible = await subscription.isEligibleForIntroOffer(monthly)
+            }
+            // Make sure the mid-trial banner reads from a fresh
+            // currentExpirationDate. refreshEntitlement is idempotent.
+            await subscription.refreshEntitlement()
         }
         .alert(
             NSLocalizedString("paywall.error.title", comment: "Purchase error"),
@@ -79,6 +109,94 @@ public struct PaywallView: View {
                 .font(.body)
                 .foregroundStyle(.secondary)
         }
+    }
+
+    /// "Get 1 month free" pitch banner shown to eligible Apple IDs.
+    /// Pulls live monthly displayPrice so the price disclosure satisfies
+    /// App Store 3.1.2 without us hard-coding currency-localized strings.
+    private var trialBanner: some View {
+        let amber = Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)
+        let monthly = subscription.products.first(where: { $0.id == SubscriptionService.monthlyProductID })
+        let priceCopy: String = {
+            if let monthly {
+                let fmt = NSLocalizedString("paywall.trialBanner.format",
+                                            comment: "Trial banner with %@ monthly price")
+                return String(format: fmt, monthly.displayPrice)
+            }
+            return NSLocalizedString("paywall.trialBanner.fallback",
+                                     comment: "Trial banner without price")
+        }()
+        return HStack(alignment: .center, spacing: 12) {
+            Image(systemName: "gift.fill")
+                .font(.title3)
+                .foregroundStyle(amber)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(NSLocalizedString("paywall.trialBanner.headline",
+                                       comment: "Trial banner headline"))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                Text(priceCopy)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(amber.opacity(0.12))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(amber.opacity(0.35), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+    }
+
+    /// Status banner for users already inside the trial period — replaces
+    /// the "Get 1 month free" pitch with renewal context and a manage link.
+    private var midTrialBanner: some View {
+        let amber = Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)
+        let days = subscription.trialDaysRemaining ?? 0
+        let headline: String = {
+            let fmt = NSLocalizedString("paywall.midTrial.headline.format",
+                                        comment: "Trial-active headline (%d days)")
+            return String(format: fmt, days)
+        }()
+        let detail: String = {
+            guard let exp = subscription.currentExpirationDate else {
+                return NSLocalizedString("paywall.midTrial.detail.fallback",
+                                         comment: "Trial-active detail without date")
+            }
+            let df = DateFormatter()
+            df.dateStyle = .medium
+            df.timeStyle = .none
+            let fmt = NSLocalizedString("paywall.midTrial.detail.format",
+                                        comment: "Trial-active detail with renewal date")
+            return String(format: fmt, df.string(from: exp))
+        }()
+        return HStack(alignment: .center, spacing: 12) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.title3)
+                .foregroundStyle(amber)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(headline)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(amber.opacity(0.12))
+        )
+        .accessibilityElement(children: .combine)
     }
 
     private var bullets: some View {
@@ -117,7 +235,12 @@ public struct PaywallView: View {
 
     private func productCard(_ product: Product) -> some View {
         let isYearly = product.id == SubscriptionService.yearlyProductID
+        let isMonthly = product.id == SubscriptionService.monthlyProductID
         let isSelected = selectedProductID == product.id
+        let showTrialBadge = isMonthly && introOfferEligible && subscription.entitlement != .proTrial
+        // Dark brown for badge text — same WCAG-AA-clear pairing the CTA uses
+        // on the amber fill.
+        let badgeText = Color(red: 0x3A/255, green: 0x2A/255, blue: 0x05/255)
         return Button {
             selectedProductID = product.id
         } label: {
@@ -126,13 +249,21 @@ public struct PaywallView: View {
                     HStack(spacing: 6) {
                         Text(product.displayName)
                             .font(.headline)
-                        if isYearly {
+                        if showTrialBadge {
+                            Text(NSLocalizedString("paywall.trialBadge",
+                                                   comment: "1-month free trial badge"))
+                                .font(.caption2.weight(.bold))
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Capsule().fill(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)))
+                                .foregroundStyle(badgeText)
+                        } else if isYearly {
                             Text(NSLocalizedString("paywall.bestValue", comment: "Best value badge"))
                                 .font(.caption2.weight(.bold))
                                 .padding(.horizontal, 6)
                                 .padding(.vertical, 2)
                                 .background(Capsule().fill(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)))
-                                .foregroundStyle(.white)
+                                .foregroundStyle(badgeText)
                         }
                     }
                     Text(product.description)
@@ -179,6 +310,20 @@ public struct PaywallView: View {
         }
     }
 
+    /// Dynamic CTA copy: emphasize the free month when eligible, fall back
+    /// to "Subscribe" for ineligible Apple IDs (returning users who already
+    /// burned the introductory offer) so we don't promise what StoreKit
+    /// won't deliver.
+    private var ctaTitle: String {
+        let isMonthly = selectedProductID == SubscriptionService.monthlyProductID
+        if isMonthly && introOfferEligible && subscription.entitlement != .proTrial {
+            return NSLocalizedString("paywall.cta.startMonthFree",
+                                     comment: "Start 1-month free trial CTA")
+        }
+        return NSLocalizedString("paywall.cta.subscribe",
+                                 comment: "Plain subscribe CTA")
+    }
+
     private var ctaButton: some View {
         // The CTA must always be tappable (except mid-purchase). Previously
         // Release builds disabled it whenever `products.isEmpty`, which made
@@ -199,7 +344,7 @@ public struct PaywallView: View {
                 if purchaseInFlight {
                     ProgressView().tint(ctaText)
                 } else {
-                    Text(NSLocalizedString("paywall.cta.startTrial", comment: "Start 7-day free trial"))
+                    Text(ctaTitle)
                         .font(.headline)
                 }
             }
@@ -225,7 +370,17 @@ public struct PaywallView: View {
     }
 
     private var fineprint: some View {
-        Text(NSLocalizedString("paywall.fineprint", comment: "Subscription fine print"))
+        // Re-resolve copy by trial vs no-trial so the legal disclosure
+        // matches what the CTA actually offers — Apple's Reviewer #1 thing.
+        let key: String
+        if selectedProductID == SubscriptionService.monthlyProductID
+            && introOfferEligible
+            && subscription.entitlement != .proTrial {
+            key = "paywall.fineprint.month"
+        } else {
+            key = "paywall.fineprint"
+        }
+        return Text(NSLocalizedString(key, comment: "Subscription fine print"))
             .font(.caption2)
             .foregroundStyle(.secondary)
             .multilineTextAlignment(.leading)

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -225,6 +225,11 @@ schemes:
         SoloCompass: all
     run:
       config: Debug
+      # The Run action also needs the .storekit config wired in (the
+      # STOREKIT_CONFIGURATION build setting alone is not honored by Run on
+      # iOS 17+), or the simulator's StoreKit returns zero products and the
+      # onboarding paywall lands on a dead button with no price disclosure.
+      storeKitConfiguration: SoloCompass/Resources/Configuration.storekit
     test:
       config: Debug
       # StoreKit unit tests need the local .storekit config wired into the

--- a/docs/SUBSCRIPTION_SETUP.md
+++ b/docs/SUBSCRIPTION_SETUP.md
@@ -1,0 +1,156 @@
+# Solo Compass — Subscription Setup
+
+Solo Compass Pro is delivered via **StoreKit Introductory Offer**: a 1-month
+free trial attached to the monthly auto-renewing subscription. New users are
+guided into the trial during onboarding (step 5 of `OnboardingView`); they can
+also start it from any AI-gated entry point that triggers `PaywallView`.
+
+This doc covers everything needed to keep that flow working end-to-end:
+local simulator testing, App Store Connect configuration, and the entitlement
+state machine it produces.
+
+---
+
+## 1. Product catalog
+
+| Product ID                          | Period | Intro offer        |
+| ----------------------------------- | ------ | ------------------ |
+| `com.solocompass.pro.monthly`       | P1M    | 1 month free       |
+| `com.solocompass.pro.yearly`        | P1Y    | 1 month free       |
+
+Both products belong to the **Solo Compass Pro** subscription group so a user
+can upgrade from monthly to yearly without losing access.
+
+The introductory offer is configured at the product level (not as a code
+offer) so eligibility is automatic for any Apple ID that has not previously
+redeemed it within the same subscription group.
+
+## 2. Local testing — `.storekit` config
+
+`apps/ios/SoloCompass/Resources/Configuration.storekit` is the source of truth
+for simulator + Xcode Previews. It mirrors the App Store Connect catalog and
+is wired into BOTH the `Run` and `Test` actions of the `SoloCompass` scheme
+via `apps/ios/project.yml`:
+
+```yaml
+schemes:
+  SoloCompass:
+    run:
+      storeKitConfiguration: SoloCompass/Resources/Configuration.storekit
+    test:
+      storeKitConfiguration: SoloCompass/Resources/Configuration.storekit
+```
+
+After editing the .storekit file, run `xcodegen` from `apps/ios/` so the
+generated `.xcodeproj` picks up the new config.
+
+### Trial period
+
+Both products specify `introductoryOffer.subscriptionPeriod: P1M`
+(ISO 8601 — 1 month). Change this if you ever shorten/extend the trial.
+
+### Resetting eligibility for repeated trials
+
+In the simulator: **Debug → StoreKit → Manage Transactions → Delete all**.
+This restores Introductory Offer eligibility so you can test the
+"first month free" pitch end-to-end repeatedly.
+
+## 3. App Store Connect configuration
+
+Each product in App Store Connect needs the introductory offer attached to
+the subscription itself (not as a promotional offer):
+
+1. App Store Connect → My Apps → Solo Compass → Monetization → **Subscriptions**
+2. Open the Solo Compass Pro group → tap the monthly subscription
+3. Under **Introductory Offers**, click **Set Up Introductory Offer**
+4. Configure:
+   - **Type**: Free
+   - **Duration**: 1 Month
+   - **Eligibility**: **New subscribers** (default — anyone who hasn't
+     previously redeemed any introductory offer in this subscription group)
+   - **Countries / Regions**: All
+5. Repeat for the yearly subscription
+
+After updating, the catalog can take up to 24 hours to propagate to the
+sandbox environment. Use Xcode → Product → Scheme → Edit Scheme → Run →
+Options → "StoreKit Configuration" to point at the local file in the
+meantime.
+
+## 4. Entitlement state machine
+
+`SubscriptionService.Entitlement` has four states. The transitions:
+
+```
+              ┌──────────────────────────────┐
+              ▼                              │
+   free ──(purchase intro)──→ proTrial ──(intro period ends, auto renews)──→ pro
+    ▲                          │                                              │
+    │                          │                                              │
+    │                  (trial cancelled / non-renew)                          │
+    │                          ▼                                              ▼
+    └──── (refund / revoke) ── proExpired ◀── (cancel + period ends) ─────────┘
+```
+
+- **`free`** — never paid, no active or expired subscription. Default state.
+- **`proTrial`** — inside the 1-month free trial. AI gates pass; UI shows
+  "X days remaining" + renewal date.
+- **`pro`** — active paid subscription. AI gates pass.
+- **`proExpired`** — was paying, currently lapsed (cancelled or payment
+  failed). AI gates fail. We don't downgrade silently to `free` so we can
+  show a "Welcome back" win-back paywall.
+
+The state is resolved by walking `Transaction.currentEntitlements` in
+`SubscriptionService.refreshEntitlement`. The result is mirrored to:
+
+1. **Keychain** (`account="entitlement"`) — survives app reinstall on same
+   device, lets the UI render the right state in <16ms at cold launch
+   before StoreKit returns.
+2. **Supabase `profiles.entitlement_tier`** — via the `subscription_events`
+   outbox enqueued by `_emitSubscriptionEventFields`. Edge functions
+   (chat-proxy, synthesize-experiences) gate AI calls on this column.
+
+## 5. UI entry points to Paywall
+
+| Surface                       | Trigger                                                    |
+| ----------------------------- | ---------------------------------------------------------- |
+| Onboarding step 5             | Shown to every new user; opt-out via "Maybe later"         |
+| MeSheet → EntitlementBanner   | Always visible; banner contents change by entitlement      |
+| MapViewModel AI gate          | Tapping Explore/voice/etc. while `entitlement.isActive==false` |
+| ExperienceDetailViewModel     | Tapping Per-place AI insight while ineligible              |
+| SettingsView                  | "Subscription" row                                         |
+
+All five paths feed into the same `PaywallView`, which auto-detects:
+- **Eligible for intro offer** → CTA = "Start 1-month free trial"
+- **Mid-trial** → banner shows X days remaining + manage subscription link
+- **Ineligible / already Pro** → CTA = "Subscribe" (no trial promise)
+
+This single-source-of-truth means future copy/legal tweaks happen in one
+file instead of N entry points.
+
+## 6. Apple compliance checklist
+
+App Store Reviewer #1 considerations the paywall already satisfies:
+
+- ✅ Trial price disclosed near the CTA (`paywall.fineprint.month` and
+  `onboarding.paywall.fineprint.format` interpolate the live displayPrice)
+- ✅ "Continue with Free" exit visible at all times
+- ✅ Restore Purchases link visible
+- ✅ Manage Subscription deep link to `apps.apple.com/account/subscriptions`
+- ✅ Family Sharing enabled on both products (`familyShareable: true`)
+- ✅ EULA reference in fine print
+- ✅ No nag on returning users who already declined (the
+  `hasSeenOnboardingPaywall` UserDefaults flag suppresses repeated
+  onboarding paywall presentations)
+
+## 7. Failure modes & recovery
+
+- **Catalog empty at first paywall tap** — `runPurchase()` retries
+  `loadProducts()` once before surfacing the `paywall.error.unavailable`
+  alert.
+- **Paid Apps Agreement unsigned** — products will silently 404. The
+  error alert above surfaces this; check App Store Connect → Agreements,
+  Tax, and Banking.
+- **Returning Apple ID — no intro offer** — `isEligibleForIntroOffer`
+  returns `false`; CTA falls back to the plain "Subscribe" copy; trial
+  badge on the product card disappears. Onboarding paywall fineprint
+  falls back to `onboarding.paywall.fineprint.fallback`.


### PR DESCRIPTION
## Summary

Redesigns the chat surface end-to-end to read as a calm doorway to a present companion — not a settings panel.

**Three movements:**

### R1 — Editorial assistant, accent user bubble
- Assistant reply sits **directly on the warm sheet** in `.serif` body (16pt / lineSpacing 6) — letter-style reading, not chat-density.
- User bubble keeps `CT.accent` solid as the sole color accent; tail removed, even 18pt rounded rect (Claude / GPT-5 / iMessage 2025 standard).
- `StreamingCursor` dropped — tokens fade in via opacity transition.
- Inter-turn spacing 10→18pt.

### R2 — Single-source thinking state
- `ChatInputBar`'s duplicate "Thinking…" label removed — it competed with the message-list `AgentStatusLine`.
- Input field gets a 1.4s angular-gradient `ThinkingBorderShimmer` while the agent works (GPT-5 composer cue).

### R3 — Animation throttling
- `ReasoningSummaryChip` settle spring staggers 0/80/160/240ms by hash so a tool chain unwinding many summaries doesn't fire N concurrent springs.

### Half-detent companion entry
The half-expanded empty state previously crammed the full hero + three full-width starter cards into the medium detent — read as a panel, not an entry. Now:
- **`SoloOrb`** — 3.2s breathing halo + core (the "someone is here" cue).
- **`HalfExpandedEmptyState`** — orb + serif invite + moment chip + 4 short pills (`附近 / 咖啡 / 落日 / 今晚`) + 56pt centered push-to-talk mic with pulse-when-listening.
- `ChatSheet` routes `detent == .medium` to the new layout; `.large` keeps the existing rich state.

## Visuals

**Half-detent (idle / light):**
- Breathing orb · serif "Ask me where to go" · 「午后柔和 · 适合走走」chip · 4 amber pills · push-to-talk mic + "Hold to talk".

**Half-detent (listening):**
- Mic morphs to waveform + sun-gold halo pulse; "Hold to talk" hides.

**Conversation (light + dark):**
- AI text breathes; user bubble carries the only color; AgentStatusLine is the single live thinking source.

PNG snapshots written to `/tmp/chat_redesign_*.png` and `/tmp/half_expanded_*.png` by the new tests below.

## Test plan

- [x] `xcodebuild build` — green
- [x] `ChatCardRenderVisualTest` 5/5 pass (existing snapshots unaffected)
- [x] `ChatRedesignVisualTest` 2/2 pass (new — light + dark conversation)
- [x] `HalfExpandedEmptyVisualTest` 3/3 pass (new — idle / listening / dark)
- [ ] On-device QA: open chat sheet, dwell at medium detent, confirm orb breathes & pills fire full prompts; long-press mic → recording state
- [ ] On-device QA: expand to large detent, confirm rich state still renders (place-anchored + global)
- [ ] zh-Hans + en strings render correctly (8 new keys per locale)

## Files

**New (5):** `SoloOrb.swift`, `HalfExpandedEmptyState.swift`, `ThinkingBorderShimmer.swift`, `ChatRedesignVisualTest.swift`, `HalfExpandedEmptyVisualTest.swift`

**Modified (8):** `MessageBubble.swift`, `MarkdownMessageText.swift`, `ChatInputBar.swift`, `ChatCardStack.swift`, `ChatSheet.swift`, `en.lproj/Localizable.strings`, `zh-Hans.lproj/Localizable.strings`, `project.yml` (xcodegen)