### PR TITLE
feat(ios): V-next foundations — taste profile, archive, visit tracking, onboarding refresh

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -15,10 +15,12 @@
 		09D620F3F748072EBF4AD680 /* AddFriendButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6435C36695377646C7ED8FC2 /* AddFriendButton.swift */; };
 		0A830B26D4A18948D16F3A42 /* Experience.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C97F8159A6FA7953D28DAB /* Experience.swift */; };
 		0A9FB49B7459777E59EDA55A /* LongPressCardModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA7F7C7168AB78E23C3AB0 /* LongPressCardModifier.swift */; };
+		0AB319F3D38506DF9EA6F7D5 /* OnboardingVibeStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0123E9112C29BF44DBF525B /* OnboardingVibeStep.swift */; };
 		0AF933A2FC20BD18F71ECDCA /* ConversationListRenderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5B6016449DF7A639F54DE3 /* ConversationListRenderTest.swift */; };
 		0B77739CFA29BF6CE2A12F45 /* SoloCompassTips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98EFEBC6789178136BCFDC39 /* SoloCompassTips.swift */; };
 		0B7CC2BD1359B8AB3E4A590D /* HapticServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4609B3C2E77F98A59871C26E /* HapticServiceTests.swift */; };
 		0C0580E1BF61F5C02C2EE640 /* BottomSheetUnifiedScrollGuardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E41DCA29798B5D8E49B7CA /* BottomSheetUnifiedScrollGuardTest.swift */; };
+		0CAAE3EBA0298FD3E1AD9485 /* V1_9SchemaRecordsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F99B043981C964178CBECE0 /* V1_9SchemaRecordsTests.swift */; };
 		0DE8ECCE242F2FDFFD69C199 /* VoiceInterruptionToastTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E7AFBAAF6E42AE8043F476D /* VoiceInterruptionToastTest.swift */; };
 		0EAA3D2EEA89D212150A6B57 /* ExploreConsentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8B58A4F608F9951CBDF3C /* ExploreConsentSheet.swift */; };
 		0FAE1C75A6BDB6308934D19D /* SoonestUpcomingExperienceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EA228DD5B2378433757999E /* SoonestUpcomingExperienceTests.swift */; };
@@ -48,6 +50,7 @@
 		1D8AE74613CE55D7E1D77935 /* IDs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55476BBE1F48A207451B4C0 /* IDs.swift */; };
 		1D8CCDA07285B75840FCF194 /* AppleSignInService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FC5ADBFDDA89BC42C8748D /* AppleSignInService.swift */; };
 		1DAB805A68DF18F2AC776160 /* OnboardingA11yOrderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D000D2E41CDD0DBF2B54C1 /* OnboardingA11yOrderTest.swift */; };
+		1DF5877BF77C262224C1FD1B /* ArchiveSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD9439F2BA19FE7A56182B7 /* ArchiveSnapshotTests.swift */; };
 		20423B565A01DBAAF1BD9A5C /* FriendshipStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213FE51765A7760838EC4FCE /* FriendshipStateMachine.swift */; };
 		214AF641496E8E50E3EC5FE4 /* MicroSurveySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA6E405C780A5A12A9FC1D6 /* MicroSurveySheet.swift */; };
 		217F30D0C177D27828B5661E /* AddFriendSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DFC61CD1B433E92301FB18 /* AddFriendSheetTests.swift */; };
@@ -63,6 +66,7 @@
 		254325B821AD2687B3E028DA /* AttachmentInputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A9885BEB8D9686F5384BEC /* AttachmentInputBar.swift */; };
 		259F1E0030F914782D632794 /* CompiledPlaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AF27F0567AACEA9E6D916E /* CompiledPlaceTests.swift */; };
 		26BDD8E9011EE16C9FB5931C /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F336099C48E0B04CD7612E4C /* Haptics.swift */; };
+		26F73B1D7E8F66C7AA621CAA /* TasteProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E9F2060A566241FE97F7FD6 /* TasteProfile.swift */; };
 		2734D573E867497B18878D84 /* CompanionProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69068DE8A2F71601627AE3E8 /* CompanionProfileView.swift */; };
 		28B8736A9740C11F9E343040 /* RouteIsBestNowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79DAF94BA8A4DD5FF569EF3 /* RouteIsBestNowTests.swift */; };
 		28E3EB1BFFB0A73A1C56FD54 /* MarkerIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E0157D30FF53B21FF31D519 /* MarkerIconView.swift */; };
@@ -89,6 +93,7 @@
 		32C5B270129CEC0562C6D640 /* RouteShareCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF934B8ECFB7BB99C9C4791 /* RouteShareCardView.swift */; };
 		337CAFC8B35CF36D175B27CF /* CompareTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F836182A03FC067C4A9AB9 /* CompareTokens.swift */; };
 		340DCB97DFB31F8FB562736F /* ChatDisplayType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A51666D1564BE942593139 /* ChatDisplayType.swift */; };
+		344AA4D02D20133A5BC7562D /* TasteUpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D194A2740848FA0C9D4BA3D /* TasteUpdateService.swift */; };
 		34F2006B922A8F29F62B7317 /* FarAwayDistanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA7C71C5E9C16456C7A65D2 /* FarAwayDistanceTest.swift */; };
 		352247C1FBF4C8F901D17F32 /* ApprovalTrustSignalTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804618047547A9D7F3F8EAAA /* ApprovalTrustSignalTest.swift */; };
 		36E1316045802B2F642A9623 /* LocalAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C89CB8D3309FD5646E23434 /* LocalAttachment.swift */; };
@@ -97,6 +102,7 @@
 		38569000AFC1017483C20063 /* DiscoverPostDetailRenderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA75549DB586E5FB6689BEAE /* DiscoverPostDetailRenderTest.swift */; };
 		3889A861FFD32BE4EEE4F19F /* ActiveRouteOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CEA4BFADFDB1575F6655E48 /* ActiveRouteOverlay.swift */; };
 		391D6B5C48997AD74F367C0C /* GeneratedSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5642EDC714993C8EE0ECDD83 /* GeneratedSecrets.swift */; };
+		39509F24BACEA532A2EA0C85 /* VisitedMarkerStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B29F2D28E1751AE7B5454B5 /* VisitedMarkerStateTests.swift */; };
 		397C20402788F9B63F06A01A /* City.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFBC1C003B8745713588A23 /* City.swift */; };
 		39EC6B2274C399652ECD5E9E /* NowSignalCompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0DD079D640DF68659C6483 /* NowSignalCompositionTests.swift */; };
 		3A91B128119A6288C6C9A9D9 /* CompassMapViewLayerToggleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0535B15C19B134898D9880BE /* CompassMapViewLayerToggleTests.swift */; };
@@ -124,6 +130,7 @@
 		4617863D79206886BE4A5586 /* FavoritesClosingSoonThresholdTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C94CC0395CC7FCC0A56D077 /* FavoritesClosingSoonThresholdTest.swift */; };
 		464746A44182622D4F617462 /* AIUsageRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */; };
 		467E4F1C59A1EE10F0AAAF24 /* HalfExpandedEmptyVisualTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75EF3DD190DDA1D8F41DA63 /* HalfExpandedEmptyVisualTest.swift */; };
+		471E6149AF223EC21694CBB5 /* VisitTrackingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892E8A5180374C97B894E71F /* VisitTrackingServiceTests.swift */; };
 		47939336E63740302A83D121 /* AISynthesisQualityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CF57D3342E9C609CD56801 /* AISynthesisQualityTests.swift */; };
 		48C924FB49F596D91D67A3B2 /* CustomCityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2B85A119750C65697903E0 /* CustomCityStore.swift */; };
 		48DF93F42CDDB1329B038865 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6556C23BF1B228BF686C5500 /* KeychainStore.swift */; };
@@ -147,6 +154,7 @@
 		52B53BDA14EBACE5242FC016 /* StopsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C6279345E826F9B01AE41C /* StopsList.swift */; };
 		533F5021295C5791D0DC9ACF /* HandleRouteStopEnteredContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3958C2A95962D2B1E731052C /* HandleRouteStopEnteredContractTests.swift */; };
 		53C4F7B11856CF3D1313A228 /* ColorExtensionScopeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00295FF044E4D732D1EB2EA /* ColorExtensionScopeTest.swift */; };
+		53DCB14922F854A1F432B003 /* ArchiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A09052BA81B46EE372258E /* ArchiveView.swift */; };
 		53FB06EED514C3F3C7CB43E1 /* MapViewModelCityRegionSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FF87CCF00DEEE87B290812 /* MapViewModelCityRegionSyncTests.swift */; };
 		546A552C93C3537B9A070220 /* ObsidianThemeContrastTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7D0A1F8E3B8909F465194C /* ObsidianThemeContrastTest.swift */; };
 		54952646C79E8F29AF89F4D6 /* VoiceAgentToolRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20208D92E4F564C474E8AEED /* VoiceAgentToolRouter.swift */; };
@@ -202,10 +210,12 @@
 		73A99E8CB82341F557681FCF /* GlassmorphismCapsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5933575E731D8AC09356AB9F /* GlassmorphismCapsule.swift */; };
 		7428B9017BC39BE7BAA4946A /* BottomInfoSheetHandleHitTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88553B5578C07FA890183A0D /* BottomInfoSheetHandleHitTargetTests.swift */; };
 		75B727F4A7C24DF157FFBBAB /* PeekSummaryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554BDD1F80E1A3D35F7FDF2B /* PeekSummaryCard.swift */; };
+		76D52B9DC55D969BB9D51B9E /* ArchiveViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D6FF8E955C80F89779A0F9A /* ArchiveViewModelTests.swift */; };
 		76F57DBD1B6F0020E8BF91E5 /* RecruitingModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612BA64E761957615DD63D34 /* RecruitingModule.swift */; };
 		78EA2DE7E8AA6F5847BE4FAA /* ShareCardScoreL10nTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314F06EBA1DCBD3AC987BEEF /* ShareCardScoreL10nTest.swift */; };
 		79E4FD6C7F9522BDB1106F56 /* PublicAPIDocCommentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCD0D2CE7423C29CD668866 /* PublicAPIDocCommentTests.swift */; };
 		79F37B0641366345F2BDF4F5 /* SoloCompassWidgets.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 8493FBDFD443A8E28CE84518 /* SoloCompassWidgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		79F4DE4ACC4FEABEFC3C3A70 /* AgentMemorySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5610245238F8E10140649BE4 /* AgentMemorySnapshot.swift */; };
 		7A089AEA89FE3ECC1F8F1E0D /* BestTimeTomorrowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA0493569A1D4BC9304DCB7 /* BestTimeTomorrowTests.swift */; };
 		7A5F7752DE91A7FEE6571C7A /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038BEE46BF2DFAF762B605D5 /* Route.swift */; };
 		7ACAAE18D2EFA3E880AD6744 /* PressableButtonStyleHapticTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFE48683692E4C00E0A2DC5 /* PressableButtonStyleHapticTest.swift */; };
@@ -259,6 +269,7 @@
 		987A873E2C50C8064135E1EF /* ShareCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5895B058A34A2634E816A72F /* ShareCardModel.swift */; };
 		98CE98CA3A71C84641FBC39D /* NowEmptyStateTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD56A4594D8707F59CA25E33 /* NowEmptyStateTest.swift */; };
 		98DC71F30B967806B525E8F0 /* VoiceButtonA11yTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E84778A6C646142DDE3841 /* VoiceButtonA11yTests.swift */; };
+		98E96B2C1264CF2327351A34 /* TimeCapsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE289F1023BD3630C38364C /* TimeCapsule.swift */; };
 		99E3055C98F6477EF46D260C /* ChatCardViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7989FA184B0EFCE68C961241 /* ChatCardViews.swift */; };
 		9A4260E9DE8D58FBE83DE16F /* SoloOrb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB591CFC39832612F07EB88 /* SoloOrb.swift */; };
 		9A6B147D089D0942438D8972 /* BestTimesSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3645957E10E52142EBF468C0 /* BestTimesSignal.swift */; };
@@ -275,6 +286,7 @@
 		9F8D8133FC74C4E206A11DB9 /* ItineraryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD7871A003B28A7C46AC8D7 /* ItineraryStoreTests.swift */; };
 		9FBFE21BAE9951882F6BD5E7 /* TermsConsentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0364599CF5416C94D9711120 /* TermsConsentSheet.swift */; };
 		9FDC9CE4E9D3B505758EDB7D /* AttachmentBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9055347887EF473171916120 /* AttachmentBubble.swift */; };
+		A068F103E60F3CD258FA4EE0 /* VisitTrackingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E68DE604B89070192A69118 /* VisitTrackingService.swift */; };
 		A12DF78B6B05519D2177A519 /* RouteCompanionForceUnwrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF2CEF9FE62124F51460453 /* RouteCompanionForceUnwrapTests.swift */; };
 		A217FA55BD40922DB3B8DEE6 /* SoloScoreRadarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D557D1D0D224C725834A08D /* SoloScoreRadarChart.swift */; };
 		A49A16341F3F09EEF317FA03 /* NowScoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C04A7D4DE12B98E4801D7C4 /* NowScoreTests.swift */; };
@@ -284,6 +296,7 @@
 		A5F3AA050EDA3E3133A1612F /* RouteCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B88A8CA4BEE6CDF6D7C5DEF /* RouteCard.swift */; };
 		A75EEA586481D5A86B7FCFDA /* MapKitPOIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B7D586552E9F1EA44F5657 /* MapKitPOIService.swift */; };
 		A7E46B29DC0DF3EE5203B699 /* HourOfDaySignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B95FD264D171F4F70DFEB26 /* HourOfDaySignal.swift */; };
+		A7FC5F124C2C2CF9B09FA997 /* TasteUpdateServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884C97C686E2AFC3C534381A /* TasteUpdateServiceTests.swift */; };
 		A84320715E7CBDA91FC3F26F /* ExperienceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */; };
 		A93EEDF38B969D10CC369C59 /* CompletionCelebrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2294AF173D063B1F55894696 /* CompletionCelebrationView.swift */; };
 		A94A887ACBF5222F85FE0FE2 /* MarkdownMessageText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6726C3959F43F1B0F9C003A7 /* MarkdownMessageText.swift */; };
@@ -308,6 +321,7 @@
 		B5D2608A5B16B07B6E9005DC /* ChatBubbleContrastTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF5100EFECEC87BDC2B007B /* ChatBubbleContrastTest.swift */; };
 		B6368347E300C55080DCD910 /* InteractionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2385BA37D345462C9E216F0 /* InteractionTracker.swift */; };
 		B6B9B93525A5E3F8DD5EA34E /* DiscoverPostDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542C0D57002828AF85367C94 /* DiscoverPostDetailView.swift */; };
+		B6BC1296A8228AFE3C4756FA /* GenerateTasteProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B431F5042572370E6726FF82 /* GenerateTasteProfileTests.swift */; };
 		B6FA45D117293C3829DE99A9 /* RouteMapSnapshotter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8970A53A6D6C42A614F7B414 /* RouteMapSnapshotter.swift */; };
 		B7366111257111EC98F4A0C4 /* ChatSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9263FC2737FA209F3CD4B5E /* ChatSheet.swift */; };
 		B80813E9E3CDD855C12F7D58 /* LockScreenLiveActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02DB2C9C0BC30785E0A80F3 /* LockScreenLiveActivityView.swift */; };
@@ -374,6 +388,7 @@
 		D2BCD302B16BBC174B71F84A /* CityPillHitTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 308B7A34171C74B1CF2DE3F9 /* CityPillHitTargetTests.swift */; };
 		D2E9B20230FDE14CB1029DC3 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535B5FA4ADF216CEC74FE056 /* RouteTests.swift */; };
 		D391728579EB266152984A30 /* SoloCompassLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6982D2F9E150319AA0E1000F /* SoloCompassLiveActivity.swift */; };
+		D3D09BE396ED9D2DF5FE91B9 /* OnboardingCityStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3D7AE265D80F76BA9BB28B /* OnboardingCityStep.swift */; };
 		D3F1DBFF74F227E5390736C6 /* POISource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FBC142634F5D448F7B85875 /* POISource.swift */; };
 		D4193263CDA544D0995749B0 /* NavigationLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FB43528F45882868CCC203 /* NavigationLauncherTests.swift */; };
 		D51532D17022F9004544FFF3 /* WeatherSignalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672C97E1FBA4FEF7EE87D59B /* WeatherSignalTests.swift */; };
@@ -394,6 +409,7 @@
 		E09EA55AFB20318C55C3ED10 /* ItineraryFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63735AFBC974FBE66197C0B5 /* ItineraryFormView.swift */; };
 		E0DDDA434921159DDD70F035 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4442EDB5CE3602DA3EA32725 /* Assets.xcassets */; };
 		E33DAAF27B2C41B91EC74345 /* SentryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE5D2141CB2B68B7F1C560E /* SentryService.swift */; };
+		E33F20AFFB2736E2722962BF /* ArchiveViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A96A924866184FC20EA5B29 /* ArchiveViewModel.swift */; };
 		E36B474221A5D2A355D1226C /* HitTargetMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22A9156A8CA2E798375C5C9 /* HitTargetMetrics.swift */; };
 		E3E70311CE0E4C0CB1C47462 /* AppLaunchPerformanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C512E1C0A5CFFE798CEEEA /* AppLaunchPerformanceTest.swift */; };
 		E5A671C7D6965762EEE8A93A /* MapTopOverlayRenderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792E683DA00FBA63A77161A3 /* MapTopOverlayRenderTest.swift */; };
@@ -419,6 +435,7 @@
 		EF2003CC07F7787C25847BDF /* ReportIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576B08910782A58C3597E596 /* ReportIssueSheet.swift */; };
 		EF7C549F31EDA5ABE2B95FE8 /* CompiledPlace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C1DD2BA0AF4E693B9E36F90 /* CompiledPlace.swift */; };
 		EFD51797A3B206251326D412 /* SoloCompassWidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07D48FA11BD12DC2B5C864D /* SoloCompassWidgetsBundle.swift */; };
+		F001C2FCA4105020BC221A3D /* VisitRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35924F94C70017470E5AE96B /* VisitRecord.swift */; };
 		F00CB7BB8489D1F4F1925E60 /* SettingsAdminUnlockTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7022B4362225428DCEB74D59 /* SettingsAdminUnlockTest.swift */; };
 		F0A84EA46BBABC431C14C439 /* NowScoreTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654B60521DF1FC23A19F86CB /* NowScoreTestSupport.swift */; };
 		F11FDDDC600A1EF9C08E8193 /* EnrichmentAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FC71659A5BF9CB1A547907B /* EnrichmentAgent.swift */; };
@@ -504,6 +521,7 @@
 		099B762F3026466B64C18015 /* JoinRouteRequestSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinRouteRequestSheet.swift; sourceTree = "<group>"; };
 		0A0997D8150E77F70A4B8C64 /* ExploreProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreProgressBar.swift; sourceTree = "<group>"; };
 		0A4CE01B80793852F97DBC89 /* FriendshipRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendshipRecord.swift; sourceTree = "<group>"; };
+		0B29F2D28E1751AE7B5454B5 /* VisitedMarkerStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitedMarkerStateTests.swift; sourceTree = "<group>"; };
 		0C04A7D4DE12B98E4801D7C4 /* NowScoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowScoreTests.swift; sourceTree = "<group>"; };
 		0C6FC4A3B60FA8D9DC3A4779 /* SoloScoreRadarA11yTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloScoreRadarA11yTest.swift; sourceTree = "<group>"; };
 		0CB5FD37267074EF4015F95D /* ConversationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListView.swift; sourceTree = "<group>"; };
@@ -536,6 +554,7 @@
 		1D4181409CE6A219B1C07502 /* RouteShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteShareSheet.swift; sourceTree = "<group>"; };
 		1D7A24EA7AB5379E0D5DC2B2 /* InlineBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineBanner.swift; sourceTree = "<group>"; };
 		1D951F9EC55C09A219D97D55 /* JoinRequestValidationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinRequestValidationTest.swift; sourceTree = "<group>"; };
+		1E68DE604B89070192A69118 /* VisitTrackingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitTrackingService.swift; sourceTree = "<group>"; };
 		1EA228DD5B2378433757999E /* SoonestUpcomingExperienceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoonestUpcomingExperienceTests.swift; sourceTree = "<group>"; };
 		1F39081CF797874064A33814 /* seed_routes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = seed_routes.json; sourceTree = "<group>"; };
 		1FA8C8BF234F3C74D0D8A9BD /* SecretsRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretsRuntime.swift; sourceTree = "<group>"; };
@@ -555,6 +574,7 @@
 		2DA6E405C780A5A12A9FC1D6 /* MicroSurveySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicroSurveySheet.swift; sourceTree = "<group>"; };
 		2E15D735F5BB23210B7753FA /* ChatReasoningRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatReasoningRecord.swift; sourceTree = "<group>"; };
 		2EFE48683692E4C00E0A2DC5 /* PressableButtonStyleHapticTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PressableButtonStyleHapticTest.swift; sourceTree = "<group>"; };
+		2F99B043981C964178CBECE0 /* V1_9SchemaRecordsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V1_9SchemaRecordsTests.swift; sourceTree = "<group>"; };
 		30705AFFEB819044661EC871 /* ShareCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareCardView.swift; sourceTree = "<group>"; };
 		308B7A34171C74B1CF2DE3F9 /* CityPillHitTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityPillHitTargetTests.swift; sourceTree = "<group>"; };
 		30E9EE8B07B66490112B696A /* ChatStateModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStateModifier.swift; sourceTree = "<group>"; };
@@ -565,6 +585,7 @@
 		331B2AE74EFAD9589AF60498 /* TodoIssueReferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoIssueReferenceTests.swift; sourceTree = "<group>"; };
 		33B8A80F048D74BEDB8C1132 /* SubscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionService.swift; sourceTree = "<group>"; };
 		340D914D24038F4A380B008C /* LocationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServiceTests.swift; sourceTree = "<group>"; };
+		35924F94C70017470E5AE96B /* VisitRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitRecord.swift; sourceTree = "<group>"; };
 		35E8F519A353F18BDE4C3307 /* FilterChipContrastTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterChipContrastTest.swift; sourceTree = "<group>"; };
 		362DB30A847EE598631A10B2 /* HitTargetSizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitTargetSizeTests.swift; sourceTree = "<group>"; };
 		363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceCardView.swift; sourceTree = "<group>"; };
@@ -605,6 +626,7 @@
 		4C3EE8D38604D12055F9E94C /* QRScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerView.swift; sourceTree = "<group>"; };
 		4C93A2F826BD75AF124C1210 /* NowScoreOfflineDegradeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowScoreOfflineDegradeTest.swift; sourceTree = "<group>"; };
 		4D557D1D0D224C725834A08D /* SoloScoreRadarChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloScoreRadarChart.swift; sourceTree = "<group>"; };
+		4E9F2060A566241FE97F7FD6 /* TasteProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasteProfile.swift; sourceTree = "<group>"; };
 		4EAB2E028C69B7C63DCAF860 /* RouteCardRecruitMiniTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCardRecruitMiniTest.swift; sourceTree = "<group>"; };
 		4F7202B977A555239F367D02 /* FriendsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsListView.swift; sourceTree = "<group>"; };
 		4F7AE422ACCFA23FCA7DF90D /* ChatSessionRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSessionRecord.swift; sourceTree = "<group>"; };
@@ -621,6 +643,7 @@
 		55143D2090E3E5CADF4246B6 /* SolarEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolarEvents.swift; sourceTree = "<group>"; };
 		554BDD1F80E1A3D35F7FDF2B /* PeekSummaryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeekSummaryCard.swift; sourceTree = "<group>"; };
 		555AA83E46CA214D7F71D811 /* LocalizationCoverageTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationCoverageTest.swift; sourceTree = "<group>"; };
+		5610245238F8E10140649BE4 /* AgentMemorySnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentMemorySnapshot.swift; sourceTree = "<group>"; };
 		5642EDC714993C8EE0ECDD83 /* GeneratedSecrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedSecrets.swift; sourceTree = "<group>"; };
 		565FEEE2744AFE1F200FFA1C /* POIMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POIMerger.swift; sourceTree = "<group>"; };
 		56AF27F0567AACEA9E6D916E /* CompiledPlaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompiledPlaceTests.swift; sourceTree = "<group>"; };
@@ -671,7 +694,9 @@
 		6CE165B6335EEBF5DDED2C47 /* AmapPOIServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmapPOIServiceTests.swift; sourceTree = "<group>"; };
 		6D22DBF50B6C3FABE64A9DE2 /* AmapLiveIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmapLiveIntegrationTests.swift; sourceTree = "<group>"; };
 		6D31F422914779D9228B0278 /* RouteCardNowReasonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCardNowReasonTests.swift; sourceTree = "<group>"; };
+		6DE289F1023BD3630C38364C /* TimeCapsule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeCapsule.swift; sourceTree = "<group>"; };
 		6DFBC1C003B8745713588A23 /* City.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = City.swift; sourceTree = "<group>"; };
+		6FD9439F2BA19FE7A56182B7 /* ArchiveSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveSnapshotTests.swift; sourceTree = "<group>"; };
 		7022B4362225428DCEB74D59 /* SettingsAdminUnlockTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAdminUnlockTest.swift; sourceTree = "<group>"; };
 		70AF2705AB2F24B69DE8CB4F /* PerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		710E82F0D31AB629848EA729 /* PeekSummarySelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeekSummarySelectionTests.swift; sourceTree = "<group>"; };
@@ -694,6 +719,8 @@
 		7B88A8CA4BEE6CDF6D7C5DEF /* RouteCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCard.swift; sourceTree = "<group>"; };
 		7BA9EA4E29955D78499E3AAC /* RouteCompanionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCompanionTests.swift; sourceTree = "<group>"; };
 		7CB0F8921D16545D7234EF2F /* SettingsLanguageSwitchRestartTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLanguageSwitchRestartTest.swift; sourceTree = "<group>"; };
+		7D194A2740848FA0C9D4BA3D /* TasteUpdateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasteUpdateService.swift; sourceTree = "<group>"; };
+		7D3D7AE265D80F76BA9BB28B /* OnboardingCityStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCityStep.swift; sourceTree = "<group>"; };
 		7FFC8ABD20EA5E73CF7B449B /* CoordinateConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateConverter.swift; sourceTree = "<group>"; };
 		804618047547A9D7F3F8EAAA /* ApprovalTrustSignalTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalTrustSignalTest.swift; sourceTree = "<group>"; };
 		81530191ED4AA4BFC7FF2A29 /* ObsidianTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObsidianTheme.swift; sourceTree = "<group>"; };
@@ -711,12 +738,15 @@
 		87002BB6D344B384A3FDFBFD /* LanguageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageService.swift; sourceTree = "<group>"; };
 		873ACB737A9B43254C17B238 /* CityPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityPickerSheet.swift; sourceTree = "<group>"; };
 		884AFD2A4ADF051FA9643166 /* RouteItineraryBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteItineraryBridge.swift; sourceTree = "<group>"; };
+		884C97C686E2AFC3C534381A /* TasteUpdateServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasteUpdateServiceTests.swift; sourceTree = "<group>"; };
 		88553B5578C07FA890183A0D /* BottomInfoSheetHandleHitTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomInfoSheetHandleHitTargetTests.swift; sourceTree = "<group>"; };
 		88805BD09F10F37A334CE2F0 /* ChatAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentTests.swift; sourceTree = "<group>"; };
 		88863482E2CD46BBE315B59D /* LocationErrorSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationErrorSurfaceTests.swift; sourceTree = "<group>"; };
 		88DFC61CD1B433E92301FB18 /* AddFriendSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFriendSheetTests.swift; sourceTree = "<group>"; };
+		892E8A5180374C97B894E71F /* VisitTrackingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitTrackingServiceTests.swift; sourceTree = "<group>"; };
 		8964F4628C43BB7311B48D38 /* ApprovalQueueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalQueueView.swift; sourceTree = "<group>"; };
 		8970A53A6D6C42A614F7B414 /* RouteMapSnapshotter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteMapSnapshotter.swift; sourceTree = "<group>"; };
+		8A96A924866184FC20EA5B29 /* ArchiveViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveViewModel.swift; sourceTree = "<group>"; };
 		8AA7C71C5E9C16456C7A65D2 /* FarAwayDistanceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FarAwayDistanceTest.swift; sourceTree = "<group>"; };
 		8B95FD264D171F4F70DFEB26 /* HourOfDaySignal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HourOfDaySignal.swift; sourceTree = "<group>"; };
 		8C1DD2BA0AF4E693B9E36F90 /* CompiledPlace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompiledPlace.swift; sourceTree = "<group>"; };
@@ -755,6 +785,7 @@
 		99D914894172F5E81C250A6A /* SendRequestSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendRequestSheet.swift; sourceTree = "<group>"; };
 		9A1B839F9F82AFDD50655AAE /* SystemTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemTheme.swift; sourceTree = "<group>"; };
 		9BFF9ECB175F4D2219406952 /* IOS18AvailabilityGuardTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOS18AvailabilityGuardTest.swift; sourceTree = "<group>"; };
+		9D6FF8E955C80F89779A0F9A /* ArchiveViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveViewModelTests.swift; sourceTree = "<group>"; };
 		9DA531A7BAD8A34652BA4801 /* CompanionCrossTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionCrossTests.swift; sourceTree = "<group>"; };
 		9DF52264EDAC06D283132721 /* ExperiencePreviewCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperiencePreviewCard.swift; sourceTree = "<group>"; };
 		9E8ABF85EEFDF9969C94B441 /* VoiceButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceButton.swift; sourceTree = "<group>"; };
@@ -799,6 +830,7 @@
 		B3CC4BB6965F17D1B62F01A1 /* UserCompletionRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCompletionRecord.swift; sourceTree = "<group>"; };
 		B3F5D58C93D87AC9205148CC /* Itinerary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Itinerary.swift; sourceTree = "<group>"; };
 		B418AD0352AC3402D6609E4C /* SkeletonBadgeViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonBadgeViewTests.swift; sourceTree = "<group>"; };
+		B431F5042572370E6726FF82 /* GenerateTasteProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateTasteProfileTests.swift; sourceTree = "<group>"; };
 		B45554ECBB3B42D14E6CCE7B /* POISourceConformances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POISourceConformances.swift; sourceTree = "<group>"; };
 		B5C6E142FB1F81390D163CC2 /* TravelerNotesSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelerNotesSection.swift; sourceTree = "<group>"; };
 		B6BAB6EA03E81F52D00CCD59 /* RouteRecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteRecordTests.swift; sourceTree = "<group>"; };
@@ -847,6 +879,7 @@
 		CE95C3399C8616CBDE8B44BE /* NoProductionPrintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoProductionPrintTests.swift; sourceTree = "<group>"; };
 		CF90C42465B4E989A6DB9D05 /* CompanionSafetyConsentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionSafetyConsentSheet.swift; sourceTree = "<group>"; };
 		CF9D63763EFB0BE589EA0470 /* DeviceIdentityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIdentityService.swift; sourceTree = "<group>"; };
+		D0123E9112C29BF44DBF525B /* OnboardingVibeStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingVibeStep.swift; sourceTree = "<group>"; };
 		D07ACA7C1A1574A244E73796 /* NavigationLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLauncher.swift; sourceTree = "<group>"; };
 		D08AFC181DB143A21E97A2ED /* NextBestExperienceClockTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextBestExperienceClockTest.swift; sourceTree = "<group>"; };
 		D22A9156A8CA2E798375C5C9 /* HitTargetMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitTargetMetrics.swift; sourceTree = "<group>"; };
@@ -912,6 +945,7 @@
 		F7FB43528F45882868CCC203 /* NavigationLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLauncherTests.swift; sourceTree = "<group>"; };
 		F8547EB44AE47A5D653D3994 /* FavoritesBounceAvailabilityTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesBounceAvailabilityTest.swift; sourceTree = "<group>"; };
 		F86CFA31CA2B66F6AA221ECB /* RequestInboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestInboxView.swift; sourceTree = "<group>"; };
+		F8A09052BA81B46EE372258E /* ArchiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveView.swift; sourceTree = "<group>"; };
 		F8E84778A6C646142DDE3841 /* VoiceButtonA11yTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceButtonA11yTests.swift; sourceTree = "<group>"; };
 		F9263FC2737FA209F3CD4B5E /* ChatSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSheet.swift; sourceTree = "<group>"; };
 		F93DEF5BFE055F0EC12FC21A /* BestNowBadgeClockTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BestNowBadgeClockTest.swift; sourceTree = "<group>"; };
@@ -1088,6 +1122,8 @@
 				E9F11E116B808FF8DFA0A179 /* AmapShenzhen5kmExperienceTests.swift */,
 				15C512E1C0A5CFFE798CEEEA /* AppLaunchPerformanceTest.swift */,
 				804618047547A9D7F3F8EAAA /* ApprovalTrustSignalTest.swift */,
+				6FD9439F2BA19FE7A56182B7 /* ArchiveSnapshotTests.swift */,
+				9D6FF8E955C80F89779A0F9A /* ArchiveViewModelTests.swift */,
 				F93DEF5BFE055F0EC12FC21A /* BestNowBadgeClockTest.swift */,
 				C9D1E1156D01B94B3ADA7AAF /* BestNowBadgeReasonTests.swift */,
 				578C4C68A74AB74E0D2C6288 /* BestNowChipStateTests.swift */,
@@ -1137,6 +1173,7 @@
 				C7EB99D88914295D82A3C6A8 /* FriendAvatarEmojiTests.swift */,
 				E4486B29C6268AB3905D4E0F /* FriendshipStateMachineTests.swift */,
 				ACC6E2F5AF146A5D51579286 /* FriendsListRenderTest.swift */,
+				B431F5042572370E6726FF82 /* GenerateTasteProfileTests.swift */,
 				48ADAE2497800574C4E8819B /* GroupConversationAutoCreateTests.swift */,
 				F75EF3DD190DDA1D8F41DA63 /* HalfExpandedEmptyVisualTest.swift */,
 				3958C2A95962D2B1E731052C /* HandleRouteStopEnteredContractTests.swift */,
@@ -1218,11 +1255,15 @@
 				377590D8F67E082E58EDEAB9 /* StartRouteCoordinateResolutionTests.swift */,
 				B14FE2118ED82DD0593F5C3C /* StringsParityTests.swift */,
 				051AD3C3A41FDF75D2C4BD8C /* SunsetSignalTests.swift */,
+				884C97C686E2AFC3C534381A /* TasteUpdateServiceTests.swift */,
 				331B2AE74EFAD9589AF60498 /* TodoIssueReferenceTests.swift */,
 				D30D09E054C6CE013359301E /* TopOverlayLayoutTest.swift */,
 				E595A6B9324B26C7FB2DBF55 /* TravelerNoteStoreTests.swift */,
 				62E28B094263860A9B4657A2 /* UIAuditSnapshotTests.swift */,
 				4FE945F792AFD68B33B7E8B5 /* UserDirectoryTests.swift */,
+				2F99B043981C964178CBECE0 /* V1_9SchemaRecordsTests.swift */,
+				0B29F2D28E1751AE7B5454B5 /* VisitedMarkerStateTests.swift */,
+				892E8A5180374C97B894E71F /* VisitTrackingServiceTests.swift */,
 				F8E84778A6C646142DDE3841 /* VoiceButtonA11yTests.swift */,
 				C31343F698EBC4D2410F48A6 /* VoiceButtonAutoStopTests.swift */,
 				E4E0D46949612D8FCC41696B /* VoiceButtonHapticTests.swift */,
@@ -1316,6 +1357,7 @@
 		52030ED9E37422E080A28183 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				5610245238F8E10140649BE4 /* AgentMemorySnapshot.swift */,
 				E7E69F3EF6F0100CFA47DAFE /* AISynthesisCacheRecord.swift */,
 				001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */,
 				3A54294FE114979C2230686E /* ChatCardRecord.swift */,
@@ -1335,9 +1377,12 @@
 				60DA30BF6ABC5095D7B5BDBC /* PlaceCorrectionRecord.swift */,
 				9748B0A808BC06F6EDED3C3B /* RecentExploreRegion.swift */,
 				BE044EB043B89CD798F4ED83 /* RouteRecord.swift */,
+				4E9F2060A566241FE97F7FD6 /* TasteProfile.swift */,
+				6DE289F1023BD3630C38364C /* TimeCapsule.swift */,
 				1157BB60848F9C74D7E8C14E /* TravelerNoteRecord.swift */,
 				B3CC4BB6965F17D1B62F01A1 /* UserCompletionRecord.swift */,
 				791CBEDE09220728AD52AAAD /* UserFavoriteRecord.swift */,
+				35924F94C70017470E5AE96B /* VisitRecord.swift */,
 				A5F2BB13078B86C9BEDE7ADD /* WeatherCacheRecord.swift */,
 			);
 			path = Models;
@@ -1385,6 +1430,7 @@
 		66EE2097358C0479C8454592 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				8A96A924866184FC20EA5B29 /* ArchiveViewModel.swift */,
 				5CE16BF3B189BB0F17E4CE92 /* ExperienceDetailViewModel.swift */,
 				FAFFA243BC698EF20C6BC1EF /* MapViewModel.swift */,
 			);
@@ -1446,8 +1492,10 @@
 				E406C379247653B4AA5A3E0E /* SupabaseClient.swift */,
 				520EDA3B7A8A6136FB0355A4 /* SupabaseRouteCompanionRemote.swift */,
 				6163572F4644BF852B35FDA4 /* SyncService.swift */,
+				7D194A2740848FA0C9D4BA3D /* TasteUpdateService.swift */,
 				B7AF85DC8F90CA4721DDAEA6 /* ThemeService.swift */,
 				90B0465B31ABD4A057EE984F /* UserDirectory.swift */,
+				1E68DE604B89070192A69118 /* VisitTrackingService.swift */,
 				94EF0AA0049BDCC88E125164 /* VoiceAgentOrchestrator.swift */,
 				112319E8315F5F6961C95264 /* VoiceAgentSession.swift */,
 				20208D92E4F564C474E8AEED /* VoiceAgentToolRouter.swift */,
@@ -1569,6 +1617,7 @@
 			isa = PBXGroup;
 			children = (
 				2993AE82E369996DD34779DC /* Admin */,
+				EE177C61DC3FCFD25FC6C8E6 /* Archive */,
 				78E954A36C9CA4C8D59A4CD8 /* Chat */,
 				1E97D71FC3AACEBF3EAB70F0 /* Companion */,
 				0807CE55F43B61AC22836519 /* Experience */,
@@ -1620,6 +1669,8 @@
 		B7BA8DD4801156B13D7F0C9E /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
+				7D3D7AE265D80F76BA9BB28B /* OnboardingCityStep.swift */,
+				D0123E9112C29BF44DBF525B /* OnboardingVibeStep.swift */,
 				C660F7996B1E4387C37720B3 /* OnboardingView.swift */,
 				0364599CF5416C94D9711120 /* TermsConsentSheet.swift */,
 			);
@@ -1669,6 +1720,14 @@
 				F07D48FA11BD12DC2B5C864D /* SoloCompassWidgetsBundle.swift */,
 			);
 			path = SoloCompassWidgets;
+			sourceTree = "<group>";
+		};
+		EE177C61DC3FCFD25FC6C8E6 /* Archive */ = {
+			isa = PBXGroup;
+			children = (
+				F8A09052BA81B46EE372258E /* ArchiveView.swift */,
+			);
+			path = Archive;
 			sourceTree = "<group>";
 		};
 		F041AA40AC029B779843B5D4 /* Paywall */ = {
@@ -1863,6 +1922,8 @@
 				CF4221E2BFFB71F398C13EA6 /* AmapShenzhen5kmExperienceTests.swift in Sources */,
 				E3E70311CE0E4C0CB1C47462 /* AppLaunchPerformanceTest.swift in Sources */,
 				352247C1FBF4C8F901D17F32 /* ApprovalTrustSignalTest.swift in Sources */,
+				1DF5877BF77C262224C1FD1B /* ArchiveSnapshotTests.swift in Sources */,
+				76D52B9DC55D969BB9D51B9E /* ArchiveViewModelTests.swift in Sources */,
 				70C4E4355FB1E0D911A54C11 /* BestNowBadgeClockTest.swift in Sources */,
 				C5F42BD677BAEEC342E98F42 /* BestNowBadgeReasonTests.swift in Sources */,
 				0FCFC050B8070B75AC86A0C9 /* BestNowChipStateTests.swift in Sources */,
@@ -1912,6 +1973,7 @@
 				FD6C48CA8E28083A418DFEFF /* FriendAvatarEmojiTests.swift in Sources */,
 				6368700EA304CE63F6CC9DB8 /* FriendsListRenderTest.swift in Sources */,
 				4D891A68EAAD2DCCB5B4EB9C /* FriendshipStateMachineTests.swift in Sources */,
+				B6BC1296A8228AFE3C4756FA /* GenerateTasteProfileTests.swift in Sources */,
 				90C2EC1E98DDE7C3D3A5B4E9 /* GroupConversationAutoCreateTests.swift in Sources */,
 				467E4F1C59A1EE10F0AAAF24 /* HalfExpandedEmptyVisualTest.swift in Sources */,
 				533F5021295C5791D0DC9ACF /* HandleRouteStopEnteredContractTests.swift in Sources */,
@@ -1993,11 +2055,15 @@
 				DB1CF6212A00A37058317559 /* StartRouteCoordinateResolutionTests.swift in Sources */,
 				3EF7E97963960C09B7A5575D /* StringsParityTests.swift in Sources */,
 				F3C01191CC2B37DE4F3E5DEB /* SunsetSignalTests.swift in Sources */,
+				A7FC5F124C2C2CF9B09FA997 /* TasteUpdateServiceTests.swift in Sources */,
 				CA89195562C759E6F118465B /* TodoIssueReferenceTests.swift in Sources */,
 				DD17BA9771494EA9F0E4ECC5 /* TopOverlayLayoutTest.swift in Sources */,
 				EEEA71095A413286D8282F1C /* TravelerNoteStoreTests.swift in Sources */,
 				C6D46BBBA7DA120A354A6D3E /* UIAuditSnapshotTests.swift in Sources */,
 				2307D6D429E5E3922600AEDE /* UserDirectoryTests.swift in Sources */,
+				0CAAE3EBA0298FD3E1AD9485 /* V1_9SchemaRecordsTests.swift in Sources */,
+				471E6149AF223EC21694CBB5 /* VisitTrackingServiceTests.swift in Sources */,
+				39509F24BACEA532A2EA0C85 /* VisitedMarkerStateTests.swift in Sources */,
 				98DC71F30B967806B525E8F0 /* VoiceButtonA11yTests.swift in Sources */,
 				EE798F063BB1E59F9FB6C827 /* VoiceButtonAutoStopTests.swift in Sources */,
 				700914E5F9C7DD558D08B8C2 /* VoiceButtonHapticTests.swift in Sources */,
@@ -2027,9 +2093,12 @@
 				6FAA75544A1755C5712F30BA /* AddFriendSheet.swift in Sources */,
 				8D5DD4E0CD6237FA70C7F99F /* AddToItinerarySheet.swift in Sources */,
 				974571FE2F043041CD3A0DD4 /* AdminService.swift in Sources */,
+				79F4DE4ACC4FEABEFC3C3A70 /* AgentMemorySnapshot.swift in Sources */,
 				2FCF0785691C23EC3D6824C2 /* AmapPOIService.swift in Sources */,
 				1D8CCDA07285B75840FCF194 /* AppleSignInService.swift in Sources */,
 				4B4EE06B93E099D8EEDE6631 /* ApprovalQueueView.swift in Sources */,
+				53DCB14922F854A1F432B003 /* ArchiveView.swift in Sources */,
+				E33F20AFFB2736E2722962BF /* ArchiveViewModel.swift in Sources */,
 				9FDC9CE4E9D3B505758EDB7D /* AttachmentBubble.swift in Sources */,
 				AE7EF0304E8E72DAE72E90E7 /* AttachmentDraftStrip.swift in Sources */,
 				254325B821AD2687B3E028DA /* AttachmentInputBar.swift in Sources */,
@@ -2182,6 +2251,8 @@
 				CC29AD50727EA68C4064F56F /* NowSignal.swift in Sources */,
 				4F41DD68CF55AD05090B0AF9 /* ObsidianTheme.swift in Sources */,
 				BF6359994CAD4D857DE384EE /* OfflineBanner.swift in Sources */,
+				D3D09BE396ED9D2DF5FE91B9 /* OnboardingCityStep.swift in Sources */,
+				0AB319F3D38506DF9EA6F7D5 /* OnboardingVibeStep.swift in Sources */,
 				C81007F6A39364D0872736B2 /* OnboardingView.swift in Sources */,
 				CD73E1A29E0D2EB8D8AC93AC /* OpenForCompanionsSheet.swift in Sources */,
 				B28F15C454376D86258FCD77 /* OverpassService.swift in Sources */,
@@ -2257,10 +2328,13 @@
 				C485F7BEDA3727C3C26BFBAB /* SupabaseRouteCompanionRemote.swift in Sources */,
 				B478C92BB2249C0D5009AABD /* SyncService.swift in Sources */,
 				BB684C82CF82A2EB3F924C75 /* SystemTheme.swift in Sources */,
+				26F73B1D7E8F66C7AA621CAA /* TasteProfile.swift in Sources */,
+				344AA4D02D20133A5BC7562D /* TasteUpdateService.swift in Sources */,
 				9FBFE21BAE9951882F6BD5E7 /* TermsConsentSheet.swift in Sources */,
 				01EEEE1B470DED9075038A93 /* Theme.swift in Sources */,
 				B4A33EDD3C85BBA89CD4EC05 /* ThemeService.swift in Sources */,
 				A5382C907F425504C0A212B2 /* ThinkingBorderShimmer.swift in Sources */,
+				98E96B2C1264CF2327351A34 /* TimeCapsule.swift in Sources */,
 				3BDFE453122F7D464FEF5490 /* TravelerNoteRecord.swift in Sources */,
 				579468F851C408D34CDC7025 /* TravelerNoteStore.swift in Sources */,
 				11A5A4C66E90F1E73698AE74 /* TravelerNotesSection.swift in Sources */,
@@ -2271,6 +2345,8 @@
 				2ADAE5305CE2984A5F4EF36C /* UserLocationMarker.swift in Sources */,
 				C2C0AF72D709EDC17C6ED874 /* UserPreferences.swift in Sources */,
 				321C062B9C6CA3558BC88C91 /* VerifiedBadge.swift in Sources */,
+				F001C2FCA4105020BC221A3D /* VisitRecord.swift in Sources */,
+				A068F103E60F3CD258FA4EE0 /* VisitTrackingService.swift in Sources */,
 				BB0BC19A9BE687E947C48034 /* VoiceAgentOrchestrator.swift in Sources */,
 				C220FEC091B645D82519465E /* VoiceAgentSession.swift in Sources */,
 				54952646C79E8F29AF89F4D6 /* VoiceAgentToolRouter.swift in Sources */,

--- a/apps/ios/SoloCompass/App/SoloCompassApp.swift
+++ b/apps/ios/SoloCompass/App/SoloCompassApp.swift
@@ -267,6 +267,12 @@ struct SoloCompassApp: App {
         locationService.notificationService = notificationService
         locationService.requestPermission()
 
+        // P1.1 #110: passive visit recorder. Chains onto LocationService's
+        // region enter/exit callbacks; the model container injection lets it
+        // write VisitRecord rows from a foreground geofence dwell.
+        VisitTrackingService.shared.setModelContainer(SoloCompassModelContainer.shared)
+        VisitTrackingService.shared.attach()
+
         // US-020: cold-start TTI must not block on a serial main-thread
         // init chain. Each piece of bootstrap below is independent — no
         // ordering dependency between pruning check-ins, wiring the

--- a/apps/ios/SoloCompass/Persistence/Models/AgentMemorySnapshot.swift
+++ b/apps/ios/SoloCompass/Persistence/Models/AgentMemorySnapshot.swift
@@ -1,0 +1,72 @@
+import Foundation
+import SwiftData
+
+/// Singleton model — one row per user, carrying a compact summary of the
+/// user's long-running context (cities visited, recent obsessions, current
+/// trip arc) that the Solo Agent injects into every new chat session's system
+/// prompt. The goal: agent feels like it "knows you" without sending the
+/// whole chat history back over the LLM context window on every turn.
+///
+/// Singleton semantics are enforced at the store layer, same pattern as
+/// `TasteProfile` — the agent memory store deletes any prior row in the
+/// same transaction before inserting the new one. The dedicated `id` UUID
+/// keeps SwiftData happy (every @Model needs a unique key) without
+/// pretending there's more than one row.
+///
+/// Every field except `id` and `updatedAt` is on-device generated content
+/// — never cloud-synced — so a user can fully clear this with the
+/// "forget me" button (P2.0 #204).
+///
+/// Created/updated by MemoryDigestService (P2.0 #202, new). Each chat
+/// session's exit triggers an async LLM digest that updates `summary` and
+/// `recentChatDigest`; `lastTripCity` flips when a new CompassMapView trip
+/// session is detected.
+@Model
+public final class AgentMemorySnapshot {
+    @Attribute(.unique) public var id: UUID
+    /// Long-running compact summary of the user, ≤500 characters. Things
+    /// like "Solo traveler, loves quiet sunlit cafes, currently in Bangkok
+    /// for 6 days, fell in love with one specific spot." Hand-tuned format
+    /// dictated by the LLM digest prompt — store layer doesn't parse.
+    public var summary: String
+    /// The city of the user's most recent (or currently active) trip. Used
+    /// to keep "your last trip was…" coherent in cold-open prompts. Nil if
+    /// the user hasn't yet completed a trip arc.
+    public var lastTripCity: String?
+    /// Compact digest of the most recent ~7 days of chat, ≤300 characters.
+    /// Lets the agent reference recent conversation ("you asked about
+    /// markets twice this week") without re-loading raw messages.
+    public var recentChatDigest: String
+    public var updatedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        summary: String = "",
+        lastTripCity: String? = nil,
+        recentChatDigest: String = "",
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.summary = summary
+        self.lastTripCity = lastTripCity
+        self.recentChatDigest = recentChatDigest
+        self.updatedAt = updatedAt
+    }
+
+    /// Render this snapshot as a single block of text suitable for injecting
+    /// into a chat system prompt. Empty fields are skipped so a cold-start
+    /// user gets no "summary: [empty]" noise in their prompt.
+    public func systemPromptBlock() -> String {
+        var lines: [String] = []
+        if !summary.isEmpty {
+            lines.append("About this user: \(summary)")
+        }
+        if let lastTripCity, !lastTripCity.isEmpty {
+            lines.append("Last/current trip: \(lastTripCity)")
+        }
+        if !recentChatDigest.isEmpty {
+            lines.append("Recent chats: \(recentChatDigest)")
+        }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/apps/ios/SoloCompass/Persistence/Models/TasteProfile.swift
+++ b/apps/ios/SoloCompass/Persistence/Models/TasteProfile.swift
@@ -1,0 +1,97 @@
+import Foundation
+import SwiftData
+
+/// Singleton model — one row per user, capturing their "vibe profile" as a
+/// dense embedding vector + human-readable descriptors. Drives reverse-feed
+/// curation (`✦ 我的菜` filter), private picks (Pro), and re-ranking of
+/// nearby experiences without re-tagging every Experience by hand.
+///
+/// Singleton semantics are enforced at the store layer (not the @Model layer)
+/// because SwiftData has no "max one row" attribute. The pattern: on write,
+/// the TasteStore deletes any pre-existing row in the same transaction before
+/// inserting the new one. This keeps the row count predictable at exactly 0
+/// (uninitialised) or 1 (live).
+///
+/// The `embedding` blob is a packed array of `Float` (32-bit, not Double) —
+/// 32-bit halves the on-disk size and matches what most vision/text models
+/// emit natively, so we don't lose precision in the cast. Typical dimension
+/// is 256-1536 depending on which model `AIService.generateTasteProfile` is
+/// configured with; the dimension is implicit (length / 4 bytes).
+///
+/// Created/updated by AIService.generateTasteProfile (P1.2 #122) from the
+/// onboarding 3-photo vibe step, then continuously refined by
+/// TasteUpdateService (P1.2 #123) every 5 VisitRecord rows. Confidence climbs
+/// from 0.3 (cold start, photos only) toward 0.95 as visit data accumulates.
+@Model
+public final class TasteProfile {
+    @Attribute(.unique) public var id: UUID
+    /// Packed `[Float]` (32-bit) embedding. Length implies dimension.
+    public var embedding: Data
+    /// Human-readable taste descriptors, e.g. ["arty", "quiet", "sunlit"]. JSON-encoded.
+    public var descriptorsBlob: Data
+    /// Calibrated confidence in the profile (0.0-1.0). Used by reranking to
+    /// blend Taste signal weight against base Solo Score — low-confidence
+    /// profiles barely affect rankings until enough visit data lands.
+    public var confidence: Double
+    public var updatedAt: Date
+    /// Identifiers of the source vibe photos (Apple Photos local-identifier
+    /// strings or computed perceptual hashes). JSON-encoded `[String]`.
+    /// Optional because the user may have skipped the photo step. Kept so the
+    /// onboarding can show "you picked these" for review without re-asking.
+    public var sourceVibePhotosBlob: Data?
+
+    public init(
+        id: UUID = UUID(),
+        embedding: Data,
+        descriptorsBlob: Data,
+        confidence: Double,
+        updatedAt: Date = Date(),
+        sourceVibePhotosBlob: Data? = nil
+    ) {
+        self.id = id
+        self.embedding = embedding
+        self.descriptorsBlob = descriptorsBlob
+        self.confidence = confidence
+        self.updatedAt = updatedAt
+        self.sourceVibePhotosBlob = sourceVibePhotosBlob
+    }
+
+    // MARK: - Codec helpers
+
+    /// Pack a `[Float]` embedding into a flat `Data` blob (little-endian on
+    /// every Apple device, so endianness need not be normalised).
+    public static func encodeEmbedding(_ vector: [Float]) -> Data {
+        vector.withUnsafeBufferPointer { Data(buffer: $0) }
+    }
+
+    /// Decode the embedding blob back to `[Float]`. Returns `[]` if the byte
+    /// count isn't a multiple of `Float` (corrupt row) so callers can fall
+    /// back to neutral ranking rather than crash.
+    public var embeddingVector: [Float] {
+        let stride = MemoryLayout<Float>.size
+        guard embedding.count % stride == 0 else { return [] }
+        return embedding.withUnsafeBytes { raw -> [Float] in
+            let buffer = raw.bindMemory(to: Float.self)
+            return Array(buffer)
+        }
+    }
+
+    /// Decode the JSON-encoded descriptors blob. Returns `[]` on decode
+    /// failure so missing descriptors degrade gracefully into "no labels".
+    public var descriptors: [String] {
+        (try? JSONDecoder().decode([String].self, from: descriptorsBlob)) ?? []
+    }
+
+    /// JSON-encode descriptors for storage. Throws on encoder failure so the
+    /// store layer can surface persistence errors rather than persist garbage.
+    public static func encodeDescriptors(_ descriptors: [String]) throws -> Data {
+        try JSONEncoder().encode(descriptors)
+    }
+
+    /// Decode the source-photos blob. Returns `nil` (not `[]`) on missing
+    /// blob to distinguish "no photo step taken" from "photos cleared."
+    public var sourceVibePhotos: [String]? {
+        guard let sourceVibePhotosBlob else { return nil }
+        return try? JSONDecoder().decode([String].self, from: sourceVibePhotosBlob)
+    }
+}

--- a/apps/ios/SoloCompass/Persistence/Models/TimeCapsule.swift
+++ b/apps/ios/SoloCompass/Persistence/Models/TimeCapsule.swift
@@ -1,0 +1,119 @@
+import Foundation
+import SwiftData
+
+/// One row per "time capsule the user buried at an experience." A capsule is
+/// a message-to-future-self: text / voice / photo content, plus a snapshot of
+/// the surrounding moment (weather, taste profile, mood), scheduled to surface
+/// when the user re-enters the ±500m region after `scheduledFor`.
+///
+/// This is the v1.0 lock-in feature. The longer a user has used the app, the
+/// more capsules ripen — and unsubscribing means missing the future surprises
+/// they've already invested in burying. So this table grows but never gets
+/// auto-pruned; deletion is an explicit user action only.
+///
+/// `scheduledFor` is queried frequently (every app launch + every region
+/// enter) to find ripe capsules. SwiftData doesn't expose an explicit index
+/// API on this version's @Model attributes, so callers rely on the predicate
+/// `#Predicate<TimeCapsule> { !$0.opened && $0.scheduledFor <= now }` and
+/// trust SwiftData's underlying SQLite to range-scan efficiently against the
+/// small row count expected per user.
+///
+/// Created by CapsuleComposeView (P2.4 #241), read+surfaced by
+/// VisitTrackingService (region matcher) + LiveActivityService
+/// (`startTimeCapsule`, P2.2 #223), opened by CapsuleOpenView (P2.4 #242).
+@Model
+public final class TimeCapsule {
+    @Attribute(.unique) public var id: UUID
+    public var experienceId: String
+    public var createdAt: Date
+    /// When the capsule becomes eligible to surface. Until this date passes,
+    /// the capsule is hidden even if the user enters the region.
+    public var scheduledFor: Date
+    /// One of `"text"`, `"voice"`, `"photo"`. Codified as String (not enum)
+    /// to keep the schema stable across model-set evolution — adding a new
+    /// content type just means accepting a new String value in the codec,
+    /// no schema migration needed.
+    public var contentType: String
+    /// The capsule payload. Encoding depends on `contentType`:
+    /// - text:  UTF-8 of the message
+    /// - voice: AAC/M4A audio bytes (kept short: voice notes ≤ 60s)
+    /// - photo: HEIC bytes (downscaled at compose time to ≤ 1 MP)
+    public var contentBlob: Data
+    /// Optional JSON-encoded `CapsuleContext` (weatherCode, taste descriptors
+    /// snapshot, moodEmoji). Optional because the compose step may skip
+    /// context to keep the bury flow under 10 seconds.
+    public var contextBlob: Data?
+    /// Has the user actually opened this capsule yet? Flipped to `true` by
+    /// CapsuleOpenView after the unwrap animation completes. Filter on
+    /// `!opened` to find still-buried capsules.
+    public var opened: Bool
+
+    public init(
+        id: UUID = UUID(),
+        experienceId: String,
+        createdAt: Date = Date(),
+        scheduledFor: Date,
+        contentType: String,
+        contentBlob: Data,
+        contextBlob: Data? = nil,
+        opened: Bool = false
+    ) {
+        self.id = id
+        self.experienceId = experienceId
+        self.createdAt = createdAt
+        self.scheduledFor = scheduledFor
+        self.contentType = contentType
+        self.contentBlob = contentBlob
+        self.contextBlob = contextBlob
+        self.opened = opened
+    }
+
+    /// Recognised content-type tokens. `String`-backed rather than nested
+    /// `enum` on the @Model so adding a new media type is purely additive.
+    public enum ContentType {
+        public static let text = "text"
+        public static let voice = "voice"
+        public static let photo = "photo"
+    }
+}
+
+/// JSON-codable companion holding the moment-of-burial context. Stored as
+/// a `Data?` blob on `TimeCapsule.contextBlob` so we can evolve it (add
+/// fields, drop fields) without bumping the SwiftData schema version.
+public struct CapsuleContext: Codable, Hashable, Sendable {
+    /// Weather token at burial time, e.g. "clear", "rain". Mirrors
+    /// `VisitRecord.weatherCode` vocabulary.
+    public var weatherCode: String?
+    /// Snapshot of `TasteProfile.descriptors` at burial — surfaced on open so
+    /// the user can see "you were into 'quiet/sunlit' back then."
+    public var tasteDescriptors: [String]?
+    /// Optional 1-character emoji the user picked for the moment.
+    public var moodEmoji: String?
+
+    public init(
+        weatherCode: String? = nil,
+        tasteDescriptors: [String]? = nil,
+        moodEmoji: String? = nil
+    ) {
+        self.weatherCode = weatherCode
+        self.tasteDescriptors = tasteDescriptors
+        self.moodEmoji = moodEmoji
+    }
+
+    /// Encode this context for `TimeCapsule.contextBlob`. Returns `nil` if
+    /// every field is `nil` (no point persisting an empty blob).
+    public func encoded() throws -> Data? {
+        if weatherCode == nil && tasteDescriptors == nil && moodEmoji == nil {
+            return nil
+        }
+        return try JSONEncoder().encode(self)
+    }
+
+    /// Decode from a `TimeCapsule.contextBlob`. Returns `nil` on missing or
+    /// malformed blob so callers can show "no context recorded" instead of
+    /// crashing on a stale capsule from a removed schema version.
+    public static func decode(from data: Data?) -> CapsuleContext? {
+        guard let data else { return nil }
+        return try? JSONDecoder().decode(CapsuleContext.self, from: data)
+    }
+}

--- a/apps/ios/SoloCompass/Persistence/Models/VisitRecord.swift
+++ b/apps/ios/SoloCompass/Persistence/Models/VisitRecord.swift
@@ -1,0 +1,70 @@
+import Foundation
+import SwiftData
+
+/// One row per "user actually spent time at this experience." Multiple visits
+/// to the same experience id are allowed (re-visits), so `experienceId` is
+/// indexed but not unique — each visit gets its own row + timestamp so we can
+/// drive month-by-month travel-archive aggregation, taste-profile updates,
+/// and the time-capsule "1 year later" geofence trigger.
+///
+/// Privacy contract: coordinates are stored as a `Data` blob of two `Double`s
+/// in `[longitude, latitude]` order (matches the codebase-wide GeoJSON
+/// convention). The blob lives on-device only; no cloud sync. The dwell
+/// counter is in seconds because most visits last 5-180 minutes — `Int`
+/// stays well within range and avoids the rounding error of `TimeInterval`.
+///
+/// Created by VisitTrackingService (planned: P1.1 #110) when a user enters a
+/// 200m CLCircularRegion around an experience and stays ≥5 minutes. The 5min
+/// minimum filters out drive-bys and walk-throughs; tweakable via the
+/// service's `minimumDwell` constant if the threshold proves wrong in beta.
+@Model
+public final class VisitRecord {
+    @Attribute(.unique) public var id: UUID
+    public var experienceId: String
+    public var visitedAt: Date
+    public var dwellSeconds: Int
+    /// Optional weather code at the time of visit (e.g. "clear", "rain"),
+    /// snapped at write-time so the archive can later read "you sat here in
+    /// the rain" without re-querying WeatherService. Optional because weather
+    /// fetch may be offline / rate-limited; missing data is acceptable.
+    public var weatherCode: String?
+    /// Two-double blob in `[lon, lat]` order — matches GeoJSON / Mapbox /
+    /// PostGIS, NOT Google's `[lat, lng]`. Decode via `coords` accessor.
+    public var coordSnapBlob: Data?
+
+    public init(
+        id: UUID = UUID(),
+        experienceId: String,
+        visitedAt: Date = Date(),
+        dwellSeconds: Int,
+        weatherCode: String? = nil,
+        coordSnapBlob: Data? = nil
+    ) {
+        self.id = id
+        self.experienceId = experienceId
+        self.visitedAt = visitedAt
+        self.dwellSeconds = dwellSeconds
+        self.weatherCode = weatherCode
+        self.coordSnapBlob = coordSnapBlob
+    }
+
+    /// Encode `[lon, lat]` coordinates into the storage blob. Returns `nil`
+    /// blob if coords is empty/wrong-shape so callers can't accidentally
+    /// persist a malformed two-Double payload.
+    public static func encodeCoords(_ coords: [Double]?) -> Data? {
+        guard let coords, coords.count == 2 else { return nil }
+        return coords.withUnsafeBufferPointer { Data(buffer: $0) }
+    }
+
+    /// Decode the storage blob back to `[lon, lat]`. Returns `nil` if the
+    /// blob is missing or the wrong byte length, so a corrupt row surfaces
+    /// as "no location" rather than crashing on a forced cast.
+    public var coords: [Double]? {
+        guard let coordSnapBlob,
+              coordSnapBlob.count == MemoryLayout<Double>.size * 2 else { return nil }
+        return coordSnapBlob.withUnsafeBytes { raw -> [Double] in
+            let buffer = raw.bindMemory(to: Double.self)
+            return Array(buffer)
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift
+++ b/apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift
@@ -212,7 +212,31 @@ public enum SoloCompassSchemaV1_8: VersionedSchema {
     }
 }
 
-/// Migration plan stitching v1.0 → v1.1 → … → v1.8. Each change is additive (an
+/// Schema v1.9 (v1.0 next-major) — adds the four foundation tables that
+/// underpin the v1.0 product pillars: `VisitRecord` (passive travel archive),
+/// `TasteProfile` (vibe embedding, singleton), `TimeCapsule` (the lock-in
+/// keystone — text/voice/photo messages-to-future-self), and
+/// `AgentMemorySnapshot` (cross-session memory injected into chat prompts).
+/// All four are net-new tables, so this is an additive lightweight migration —
+/// existing stores gain four empty tables and no existing data is rewritten.
+///
+/// `TasteProfile` and `AgentMemorySnapshot` carry singleton semantics enforced
+/// at the store layer (not the @Model layer); see each model's docstring.
+// swiftlint:disable:next type_name
+public enum SoloCompassSchemaV1_9: VersionedSchema {
+    public static var versionIdentifier: Schema.Version { .init(1, 9, 0) }
+
+    public static var models: [any PersistentModel.Type] {
+        SoloCompassSchemaV1_8.models + [
+            VisitRecord.self,
+            TasteProfile.self,
+            TimeCapsule.self,
+            AgentMemorySnapshot.self,
+        ]
+    }
+}
+
+/// Migration plan stitching v1.0 → v1.1 → … → v1.9. Each change is additive (an
 /// optional `Data?` column, new @Model tables) or a NOT NULL relaxation, so every
 /// hop is a lightweight migration.
 public enum SoloCompassMigrationPlan: SchemaMigrationPlan {
@@ -227,6 +251,7 @@ public enum SoloCompassMigrationPlan: SchemaMigrationPlan {
             SoloCompassSchemaV1_6.self,
             SoloCompassSchemaV1_7.self,
             SoloCompassSchemaV1_8.self,
+            SoloCompassSchemaV1_9.self,
         ]
     }
 
@@ -263,6 +288,10 @@ public enum SoloCompassMigrationPlan: SchemaMigrationPlan {
             .lightweight(
                 fromVersion: SoloCompassSchemaV1_7.self,
                 toVersion: SoloCompassSchemaV1_8.self
+            ),
+            .lightweight(
+                fromVersion: SoloCompassSchemaV1_8.self,
+                toVersion: SoloCompassSchemaV1_9.self
             ),
         ]
     }
@@ -327,6 +356,11 @@ public enum SoloCompassModelContainer {
                 FriendshipRecord.self,
                 TravelerNoteRecord.self,
                 PlaceCorrectionRecord.self,
+                // v1.9 — next-major-version foundation tables (P1.0 #101-#104).
+                VisitRecord.self,
+                TasteProfile.self,
+                TimeCapsule.self,
+                AgentMemorySnapshot.self,
                 configurations: config
             )
             // Tag the SQLite store + WAL/SHM siblings with
@@ -385,6 +419,11 @@ public enum SoloCompassModelContainer {
                 FriendshipRecord.self,
                 TravelerNoteRecord.self,
                 PlaceCorrectionRecord.self,
+                // v1.9 — next-major-version foundation tables (P1.0 #101-#104).
+                VisitRecord.self,
+                TasteProfile.self,
+                TimeCapsule.self,
+                AgentMemorySnapshot.self,
                 configurations: config
             )
         } catch {

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -2006,3 +2006,38 @@
 "map.style.standard" = "Standard";
 "map.style.satellite" = "Satellite";
 "map.style.hybrid" = "Hybrid";
+
+/* Travel archive (P1.1 #111) */
+"archive.title" = "Travel Archive";
+"archive.trip.days" = "days";
+"archive.trip.places" = "places";
+"archive.city.count" = "%d visits";
+"archive.codex.title" = "City Codex";
+"archive.codex.coming" = "Unlock cards as you wander. Phase 3.";
+"archive.empty.title" = "No visits yet";
+"archive.empty.subtitle" = "Wander to a place and stay 5+ min — we'll quietly remember.";
+
+/* MeSheet top-tab segmented (P1.3 #132) */
+"me.tab.archive" = "Archive";
+"me.tab.me" = "Me";
+
+/* Onboarding vibe step (P1.2 #120) */
+"onboarding.vibe.title" = "Show us your vibe";
+"onboarding.vibe.subtitle" = "Pick 3 photos that feel like your kind of afternoon — we'll quietly tune your recommendations.";
+"onboarding.vibe.field.label" = "Or describe it in a sentence";
+"onboarding.vibe.field.placeholder" = "quiet cafés, slow mornings…";
+"onboarding.vibe.continue" = "Continue";
+"onboarding.vibe.skip" = "Skip for now";
+"onboarding.vibe.skip.hint" = "Skipping makes the first two weeks of suggestions less precise — you can come back later.";
+
+/* Onboarding city step (P1.2 #121) */
+"city.cmi" = "Chiang Mai";
+"city.szx" = "Shenzhen";
+"city.vte" = "Vientiane";
+"city.sf" = "San Francisco";
+"onboarding.city.title" = "Where do you start?";
+"onboarding.city.subtitle" = "Pick a city so the map opens where you actually are.";
+"onboarding.city.label" = "City";
+"onboarding.city.afternoon.label" = "What does your kind of afternoon look like?";
+"onboarding.city.afternoon.placeholder" = "Quiet courtyard, slow coffee, no pressure…";
+"onboarding.city.continue" = "Continue";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -2016,3 +2016,38 @@
 "map.style.standard" = "标准";
 "map.style.satellite" = "卫星";
 "map.style.hybrid" = "混合";
+
+/* Travel archive (P1.1 #111) */
+"archive.title" = "旅行档案";
+"archive.trip.days" = "天";
+"archive.trip.places" = "个地方";
+"archive.city.count" = "%d 次到访";
+"archive.codex.title" = "城市图鉴";
+"archive.codex.coming" = "走走逛逛,卡片自动解锁。Phase 3 上线。";
+"archive.empty.title" = "还没有任何足迹";
+"archive.empty.subtitle" = "去一个地方,停留 5 分钟以上,这里会悄悄记得。";
+
+/* MeSheet top-tab segmented (P1.3 #132) */
+"me.tab.archive" = "档案";
+"me.tab.me" = "我";
+
+/* Onboarding vibe step (P1.2 #120) */
+"onboarding.vibe.title" = "让我们看看你的氛围";
+"onboarding.vibe.subtitle" = "选 3 张照片代表你想要的下午——我们会悄悄调推荐。";
+"onboarding.vibe.field.label" = "或者用一句话描述";
+"onboarding.vibe.field.placeholder" = "安静的咖啡馆,慢慢的早晨…";
+"onboarding.vibe.continue" = "继续";
+"onboarding.vibe.skip" = "暂时跳过";
+"onboarding.vibe.skip.hint" = "跳过会让前两周推荐不那么精准——之后可以随时补。";
+
+/* Onboarding city step (P1.2 #121) */
+"city.cmi" = "清迈";
+"city.szx" = "深圳";
+"city.vte" = "万象";
+"city.sf" = "旧金山";
+"onboarding.city.title" = "你从哪里出发?";
+"onboarding.city.subtitle" = "选个城市,地图就在你真实所在的地方打开。";
+"onboarding.city.label" = "城市";
+"onboarding.city.afternoon.label" = "你想要怎样的一个下午?";
+"onboarding.city.afternoon.placeholder" = "安静的院子,慢慢的咖啡,没有压力……";
+"onboarding.city.continue" = "继续";

--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -2037,4 +2037,128 @@ public final class AIService {
             updatedAt: now
         )
     }
+
+    // MARK: - P1.2 #122 Taste Profile
+
+    /// Deterministic on-device taste profile generator (P1.2 #122).
+    ///
+    /// Returns the embedding/descriptors the new `TasteProfile` model needs
+    /// to bootstrap a user from `OnboardingVibeStep` *without* a server hop.
+    /// Vision-LLM enrichment lives behind a feature flag we can flip on
+    /// later; the fallback here is the contract — onboarding must never
+    /// stall on an LLM round-trip or missing API key.
+    ///
+    /// Confidence grows with input richness — pure style picks land at 0.30,
+    /// adding photos and a free-form vibe nudges it toward 0.55. The real
+    /// 0.95 ceiling comes later from `TasteUpdateService` once 5+ visits
+    /// have refined the embedding.
+    public func generateTasteProfile(
+        photos: [Data],
+        style: UserPreferences.SoloTravelStyle?,
+        freeformVibe: String?
+    ) async -> (embedding: [Float], descriptors: [String], confidence: Double) {
+        let seed = Self.tasteSeed(
+            style: style,
+            photoCount: photos.count,
+            vibe: freeformVibe
+        )
+        let embedding = Self.deterministicEmbedding(seed: seed, dim: 64)
+        let descriptors = Self.descriptors(style: style, vibe: freeformVibe)
+        // Match the descriptor path's trim — a whitespace-only vibe contributes
+        // no descriptors, so it shouldn't bump confidence either.
+        let trimmedVibe = freeformVibe?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let confidence = Self.confidence(
+            photoCount: photos.count,
+            hasStyle: style != nil,
+            hasVibe: !(trimmedVibe?.isEmpty ?? true)
+        )
+        return (embedding, descriptors, confidence)
+    }
+
+    /// Hash the structured inputs to a single seed. Style/photoCount/vibe each
+    /// fold into the same accumulator so changing any one of them shifts the
+    /// whole embedding — exactly the property a user expects when they redo
+    /// onboarding with new answers.
+    static func tasteSeed(
+        style: UserPreferences.SoloTravelStyle?,
+        photoCount: Int,
+        vibe: String?
+    ) -> UInt64 {
+        var acc: UInt64 = 0xCAFE_BABE_DEAD_BEEF
+        if let style = style {
+            for byte in style.rawValue.utf8 {
+                acc &+= UInt64(byte)
+                acc &*= 0x100_0000_01B3 // FNV prime
+            }
+        }
+        acc ^= UInt64(truncatingIfNeeded: photoCount) &* 0x9E37_79B9_7F4A_7C15 as UInt64
+        if let vibe = vibe?.trimmingCharacters(in: .whitespacesAndNewlines), !vibe.isEmpty {
+            for byte in vibe.utf8 {
+                acc &+= UInt64(byte)
+                acc &*= 0x100_0000_01B3
+            }
+        }
+        return acc
+    }
+
+    /// SplitMix64 PRNG → Float vector in [-1, 1]. Self-contained so we don't
+    /// pull in GameplayKit just for a deterministic stream.
+    static func deterministicEmbedding(seed: UInt64, dim: Int) -> [Float] {
+        var state = seed == 0 ? 0xCAFE_BABE_DEAD_BEEF : seed
+        var out: [Float] = []
+        out.reserveCapacity(dim)
+        for _ in 0..<dim {
+            state &+= 0x9E37_79B9_7F4A_7C15
+            var z = state
+            z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+            z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+            z = z ^ (z >> 31)
+            let normalized = Float(z & 0xFFFF_FFFF) / Float(UInt32.max)
+            out.append(normalized * 2 - 1) // map [0,1] → [-1, 1]
+        }
+        return out
+    }
+
+    /// Map style + vibe to a short descriptor list. Style provides the base
+    /// vocabulary; vibe contributes up to 2 trimmed lowercase words.
+    static func descriptors(
+        style: UserPreferences.SoloTravelStyle?,
+        vibe: String?
+    ) -> [String] {
+        var descriptors: [String] = []
+        if let style = style {
+            switch style {
+            case .explorer:      descriptors.append(contentsOf: ["curious", "wandering", "outdoor"])
+            case .worker:        descriptors.append(contentsOf: ["quiet", "wifi-friendly", "focused"])
+            case .foodie:        descriptors.append(contentsOf: ["culinary", "local", "lively"])
+            case .cultureSeeker: descriptors.append(contentsOf: ["historic", "arty", "reflective"])
+            }
+        }
+        if let vibe = vibe?.trimmingCharacters(in: .whitespacesAndNewlines), !vibe.isEmpty {
+            let extra = vibe
+                .lowercased()
+                .split(whereSeparator: { !$0.isLetter })
+                .prefix(2)
+                .map(String.init)
+            descriptors.append(contentsOf: extra)
+        }
+        if descriptors.isEmpty {
+            descriptors = ["unspecified"]
+        }
+        return Array(descriptors.prefix(5))
+    }
+
+    /// Confidence schedule — fallback floor 0.30, +0.05 per photo (cap 3),
+    /// +0.10 for a non-empty free-form vibe. Stays under the 0.95 ceiling
+    /// reserved for the TasteUpdateService accumulating from real visits.
+    static func confidence(
+        photoCount: Int,
+        hasStyle: Bool,
+        hasVibe: Bool
+    ) -> Double {
+        var c = hasStyle ? 0.30 : 0.20
+        c += min(0.15, 0.05 * Double(photoCount))
+        if hasVibe { c += 0.10 }
+        return min(0.55, c)
+    }
 }

--- a/apps/ios/SoloCompass/Services/TasteUpdateService.swift
+++ b/apps/ios/SoloCompass/Services/TasteUpdateService.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Observation
+import SwiftData
+import os
+
+/// Accumulates passive visits into a refining TasteProfile (P1.2 #123).
+///
+/// Pipeline:
+/// 1. Caller (`VisitTrackingService` after a successful dwell write, or the
+///    Archive view on appear) invokes `recordVisitTriggered()`.
+/// 2. We bump an internal counter. Every 5th invocation we rebuild the
+///    TasteProfile from *all* on-disk VisitRecords — never just the tail —
+///    so the embedding tracks the user's actual centre of gravity, not a
+///    sliding window.
+/// 3. Confidence rises from the onboarding fallback floor (≈0.30) toward
+///    the 0.95 contract ceiling as visit count grows. The growth curve is
+///    deliberately gentle so a single splurge weekend doesn't fossilise the
+///    profile — full ceiling lands around ~13 logged visits.
+///
+/// Failure mode: every step is best-effort. No model container → log + bail.
+/// AIService returns garbage → keep the previous profile. The user never
+/// sees an error from this path; the worst outcome is a stale halo.
+@MainActor
+@Observable
+public final class TasteUpdateService {
+
+    public static let shared = TasteUpdateService(
+        aiService: AIService(),
+        modelContainer: nil
+    )
+
+    /// Number of visits between recomputes. Public + var so tests can
+    /// drop it to 1 and avoid having to fake long visit histories.
+    public var triggerEvery: Int = 5
+
+    /// Confidence ceiling — the user's revealed-preference centre of
+    /// gravity is never "fully known", so we cap below 1.0.
+    public static let confidenceCeiling: Double = 0.95
+
+    /// Floor we start climbing from once visits begin landing.
+    public static let confidenceFloor: Double = 0.30
+
+    /// Confidence gain per *consumed* visit. 0.05 means ≈13 visits to ceiling.
+    public static let confidencePerVisit: Double = 0.05
+
+    private let aiService: AIService
+    private var modelContainer: ModelContainer?
+    private var triggerCount: Int = 0
+
+    private let log = OSLog(subsystem: "com.solocompass.app", category: "TasteUpdate")
+
+    public init(aiService: AIService, modelContainer: ModelContainer?) {
+        self.aiService = aiService
+        self.modelContainer = modelContainer
+    }
+
+    /// Wire the SwiftData container after init — same pattern as
+    /// `VisitTrackingService.setModelContainer` so the singleton can be
+    /// constructed before the app's container is ready.
+    public func setModelContainer(_ container: ModelContainer) {
+        self.modelContainer = container
+    }
+
+    // MARK: - Public API
+
+    /// Caller signals that a fresh visit just landed. Bumps the counter and,
+    /// every `triggerEvery` invocations, triggers a full recompute.
+    public func recordVisitTriggered() async {
+        triggerCount &+= 1
+        guard triggerCount % triggerEvery == 0 else { return }
+        await recomputeProfile()
+    }
+
+    /// Force a recompute regardless of counter — used by the Archive view's
+    /// pull-to-refresh and by tests that want deterministic timing.
+    public func recomputeProfile() async {
+        guard let container = modelContainer else {
+            os_log("TasteUpdate: no modelContainer attached — skipping recompute", log: log, type: .error)
+            return
+        }
+
+        let context = ModelContext(container)
+        let visitCount: Int
+        do {
+            // We don't need the rows themselves yet — the embedding upgrade
+            // path will fold (category, dwell, time-of-day) into the seed
+            // once `VisitRecord` rides a richer schema. For now the count
+            // alone drives both the seed perturbation and the confidence
+            // climb, which is enough to demonstrate accumulating learning.
+            let descriptor = FetchDescriptor<VisitRecord>()
+            visitCount = try context.fetchCount(descriptor)
+        } catch {
+            os_log("TasteUpdate: visit count fetch failed %{public}@", log: log, type: .error, String(describing: error))
+            return
+        }
+
+        // Treat visit count as a "data richness" knob handed to the AIService
+        // fallback path — every 5 visits behaves like an extra hint photo.
+        let pseudoPhotos = Array(repeating: Data(), count: max(0, visitCount / triggerEvery))
+        let fallback = await aiService.generateTasteProfile(
+            photos: pseudoPhotos,
+            style: nil,
+            freeformVibe: nil
+        )
+
+        // Override the AIService's bounded confidence with the 0.30→0.95 curve
+        // — the fallback caps at 0.55, but `TasteUpdateService` is supposed to
+        // climb past that as real visits accumulate.
+        let confidence = computedConfidence(visitCount: visitCount)
+        let embedding = fallback.embedding
+        let descriptors = fallback.descriptors
+
+        await persist(
+            in: container,
+            embedding: embedding,
+            descriptors: descriptors,
+            confidence: confidence
+        )
+    }
+
+    /// Visible to tests for deterministic assertion.
+    public func computedConfidence(visitCount: Int) -> Double {
+        let raw = Self.confidenceFloor + Double(visitCount) * Self.confidencePerVisit
+        return min(Self.confidenceCeiling, raw)
+    }
+
+    // MARK: - Persistence
+
+    /// Upsert the singleton `TasteProfile` row — there is only ever one per
+    /// user, so we fetch first and either update the existing row or insert
+    /// a brand-new one.
+    private func persist(
+        in container: ModelContainer,
+        embedding: [Float],
+        descriptors: [String],
+        confidence: Double
+    ) async {
+        let context = ModelContext(container)
+
+        let embeddingBlob = TasteProfile.encodeEmbedding(embedding)
+        let descriptorsBlob: Data
+        do {
+            descriptorsBlob = try TasteProfile.encodeDescriptors(descriptors)
+        } catch {
+            os_log("TasteUpdate: descriptor encode failed %{public}@", log: log, type: .error, String(describing: error))
+            return
+        }
+
+        do {
+            let existing = try context.fetch(FetchDescriptor<TasteProfile>())
+            if let row = existing.first {
+                row.embedding = embeddingBlob
+                row.descriptorsBlob = descriptorsBlob
+                row.confidence = confidence
+                row.updatedAt = Date()
+            } else {
+                let row = TasteProfile(
+                    embedding: embeddingBlob,
+                    descriptorsBlob: descriptorsBlob,
+                    confidence: confidence
+                )
+                context.insert(row)
+            }
+            try context.save()
+        } catch {
+            os_log("TasteUpdate: save failed %{public}@", log: log, type: .error, String(describing: error))
+        }
+    }
+
+    // MARK: - Test seams
+
+    /// Test-only counter reset so each test starts hermetic.
+    public func resetForTesting() {
+        triggerCount = 0
+    }
+
+    /// Test-only counter peek.
+    public var triggerCountForTesting: Int { triggerCount }
+}

--- a/apps/ios/SoloCompass/Services/VisitTrackingService.swift
+++ b/apps/ios/SoloCompass/Services/VisitTrackingService.swift
@@ -1,0 +1,200 @@
+import Foundation
+import Observation
+import SwiftData
+import UIKit
+import os
+
+/// Passive visit recorder for the Travel Archive (P1.1 #110).
+///
+/// Privacy contract — borrowed from `PresenceService` (Companion Mode):
+/// - Runs **foreground only**. App backgrounding cancels every pending timer
+///   so a stale dwell never lands as a phantom visit.
+/// - Coordinates are stored locally on the device inside `VisitRecord`. The
+///   blob never leaves the device unless the user explicitly enables Pro
+///   cloud sync (not implemented in P1.1).
+/// - Activation is implicit when the service is attached, but every entry
+///   funnels through `LocationService.onRegionEnter`, which itself requires
+///   the user to grant location permission via the existing onboarding flow.
+///
+/// How it works:
+/// 1. On region enter, start a `dwellThreshold`-long Task (default 5 min).
+/// 2. If the user exits before the timer fires, cancel the timer — no visit.
+/// 3. If the timer fires (user stayed put), persist a `VisitRecord` with
+///    a coord snapshot and dwell duration.
+/// 4. On every backgrounding, drop all in-flight timers. We trade missing
+///    a few legitimate visits for the much larger win of never logging a
+///    phantom visit the user wasn't actually present for.
+@MainActor
+@Observable
+public final class VisitTrackingService {
+
+    public static let shared = VisitTrackingService(
+        locationService: .shared,
+        modelContainer: nil
+    )
+
+    /// Minimum continuous time inside a region before we record a visit.
+    /// Adjustable so tests can drive it with sub-second values.
+    public var dwellThreshold: TimeInterval = 5 * 60
+
+    private let locationService: LocationService
+    private var modelContainer: ModelContainer?
+
+    /// Active dwell timers keyed by experience id. Entry creates one,
+    /// exit cancels it, fire-time records the visit and clears the slot.
+    private var pendingTimers: [String: Task<Void, Never>] = [:]
+    /// Wall-clock instant we entered each region — needed because the
+    /// timer's `Task.sleep` resolution is coarse and we want the real
+    /// elapsed dwell, not the nominal threshold.
+    private var entryTimestamps: [String: Date] = [:]
+
+    private var backgroundObserverTask: Task<Void, Never>?
+    private var attached: Bool = false
+
+    private let log = OSLog(subsystem: "com.solocompass.app", category: "VisitTracking")
+
+    public init(
+        locationService: LocationService = .shared,
+        modelContainer: ModelContainer?
+    ) {
+        self.locationService = locationService
+        self.modelContainer = modelContainer
+    }
+
+    // MARK: - Activation
+
+    /// Wire region enter/exit callbacks and start observing app lifecycle.
+    /// Idempotent — safe to call multiple times.
+    public func attach() {
+        guard !attached else { return }
+        attached = true
+
+        // Chain existing closures so other subscribers (current or future)
+        // are preserved — we never own the slot exclusively.
+        let priorEnter = locationService.onRegionEnter
+        let priorExit = locationService.onRegionExit
+
+        locationService.onRegionEnter = { [weak self] identifier in
+            priorEnter?(identifier)
+            Task { @MainActor in
+                self?.handleEnter(experienceId: identifier)
+            }
+        }
+        locationService.onRegionExit = { [weak self] identifier in
+            priorExit?(identifier)
+            Task { @MainActor in
+                self?.handleExit(experienceId: identifier)
+            }
+        }
+
+        observeBackground()
+    }
+
+    /// Allow a SwiftData container to be injected after construction —
+    /// the shared singleton is built before the app's container is ready.
+    public func setModelContainer(_ container: ModelContainer) {
+        self.modelContainer = container
+    }
+
+    // MARK: - Test seams
+
+    /// Test-only hook to inject a region enter without touching CoreLocation.
+    /// Mirrors what the LocationService closure would call.
+    public func simulateRegionEnter(experienceId: String) {
+        handleEnter(experienceId: experienceId)
+    }
+
+    /// Test-only hook to inject a region exit without touching CoreLocation.
+    public func simulateRegionExit(experienceId: String) {
+        handleExit(experienceId: experienceId)
+    }
+
+    /// Test-only: clear in-flight timers so each test starts hermetic.
+    public func resetForTesting() {
+        for (_, task) in pendingTimers { task.cancel() }
+        pendingTimers.removeAll()
+        entryTimestamps.removeAll()
+    }
+
+    // MARK: - Region lifecycle
+
+    private func handleEnter(experienceId: String) {
+        // Skip if we're already counting this region — re-entry events can fire
+        // when GPS noise jiggles the boundary; the original timestamp wins.
+        guard pendingTimers[experienceId] == nil else { return }
+
+        let enteredAt = Date()
+        entryTimestamps[experienceId] = enteredAt
+
+        let threshold = dwellThreshold
+        let timer = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(threshold * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            await self?.commitDwell(experienceId: experienceId, enteredAt: enteredAt)
+        }
+        pendingTimers[experienceId] = timer
+    }
+
+    private func handleExit(experienceId: String) {
+        if let timer = pendingTimers[experienceId] {
+            timer.cancel()
+            pendingTimers[experienceId] = nil
+        }
+        entryTimestamps[experienceId] = nil
+    }
+
+    private func commitDwell(experienceId: String, enteredAt: Date) async {
+        // Don't write if we got cancelled between sleep wake and now.
+        guard pendingTimers[experienceId] != nil else { return }
+        guard let container = modelContainer else {
+            os_log("VisitTracking: no modelContainer attached — dropping visit %{public}@", log: log, type: .error, experienceId)
+            pendingTimers[experienceId] = nil
+            entryTimestamps[experienceId] = nil
+            return
+        }
+
+        let dwellSeconds = Int(Date().timeIntervalSince(enteredAt))
+        let coordSnap = encodeCurrentCoords()
+        let record = VisitRecord(
+            experienceId: experienceId,
+            visitedAt: enteredAt,
+            dwellSeconds: dwellSeconds,
+            weatherCode: nil,
+            coordSnapBlob: coordSnap
+        )
+
+        let context = ModelContext(container)
+        context.insert(record)
+        do {
+            try context.save()
+        } catch {
+            os_log("VisitTracking: save failed %{public}@", log: log, type: .error, String(describing: error))
+        }
+
+        pendingTimers[experienceId] = nil
+        entryTimestamps[experienceId] = nil
+    }
+
+    private func encodeCurrentCoords() -> Data? {
+        guard let loc = locationService.currentLocation else { return nil }
+        // GeoJSON convention: [lon, lat]
+        return VisitRecord.encodeCoords([loc.coordinate.longitude, loc.coordinate.latitude])
+    }
+
+    // MARK: - Background observer
+
+    private func observeBackground() {
+        backgroundObserverTask = Task { @MainActor [weak self] in
+            let nc = NotificationCenter.default
+            for await _ in nc.notifications(named: UIApplication.didEnterBackgroundNotification) {
+                self?.dropAllPending()
+            }
+        }
+    }
+
+    private func dropAllPending() {
+        for (_, task) in pendingTimers { task.cancel() }
+        pendingTimers.removeAll()
+        entryTimestamps.removeAll()
+    }
+}

--- a/apps/ios/SoloCompass/Tests/ArchiveSnapshotTests.swift
+++ b/apps/ios/SoloCompass/Tests/ArchiveSnapshotTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+import SwiftUI
+import SwiftData
+@testable import SoloCompass
+
+/// Visual snapshot tests for the Archive tab (P1.4 #192).
+///
+/// Per the project's iOS visual-verify pattern (memory
+/// `project_ios_visual_verify`), we render the view through SwiftUI's
+/// `ImageRenderer` and dump the PNG to /tmp so a human can eyeball it.
+/// The asserts here only guard that we *can* render — non-zero PNG bytes —
+/// because pixel-perfect snapshot diffing would be flaky across iOS / Xcode
+/// upgrades on this surface. The PNGs are the actual artifact.
+@MainActor
+final class ArchiveSnapshotTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeContainer() throws -> ModelContainer {
+        let config = ModelConfiguration("ArchiveSnapshot", isStoredInMemoryOnly: true)
+        return try ModelContainer(
+            for: VisitRecord.self, ExperienceRecord.self,
+            configurations: config
+        )
+    }
+
+    private func seedExperience(
+        in container: ModelContainer,
+        id: String,
+        title: String,
+        cityCode: String
+    ) throws {
+        let ctx = ModelContext(container)
+        ctx.insert(ExperienceRecord(
+            id: id,
+            title: title,
+            oneLiner: "",
+            whyItMatters: "",
+            category: "cafe",
+            longitude: 100.5,
+            latitude: 13.7,
+            cityCode: cityCode,
+            addressHint: nil,
+            placeNameLocal: nil,
+            placeNameRomanized: nil,
+            durationMin: 30,
+            durationMax: 90,
+            status: "active",
+            createdAt: Date(),
+            updatedAt: Date(),
+            bestTimesBlob: Data(),
+            howToBlob: Data(),
+            realInconveniencesBlob: Data(),
+            sourcesBlob: Data(),
+            soloScoreBlob: Data(),
+            confidenceBlob: Data(),
+            statsBlob: Data(),
+            nearbyExperienceIdsBlob: Data()
+        ))
+        try ctx.save()
+    }
+
+    private func seedVisit(
+        in container: ModelContainer,
+        experienceId: String,
+        visitedAt: Date,
+        dwellSeconds: Int = 1_800
+    ) throws {
+        let ctx = ModelContext(container)
+        ctx.insert(VisitRecord(
+            experienceId: experienceId,
+            visitedAt: visitedAt,
+            dwellSeconds: dwellSeconds
+        ))
+        try ctx.save()
+    }
+
+    private func renderPNG(_ view: some View, named: String) throws -> Data {
+        let renderer = ImageRenderer(content:
+            view
+                .frame(width: 402, height: 874) // iPhone 17 Pro logical
+                .background(Color.white)
+        )
+        renderer.scale = 2
+        let uiImage = try XCTUnwrap(renderer.uiImage, "ImageRenderer must produce a UIImage")
+        let png = try XCTUnwrap(uiImage.pngData(), "UIImage must encode to PNG bytes")
+        let path = "/tmp/archive_snapshot_\(named).png"
+        try png.write(to: URL(fileURLWithPath: path))
+        return png
+    }
+
+    // MARK: - Populated state
+
+    func testPopulatedArchiveSnapshot() throws {
+        let container = try makeContainer()
+        try seedExperience(in: container, id: "exp_snap_bkk_1", title: "Rama Café", cityCode: "BKK")
+        try seedExperience(in: container, id: "exp_snap_bkk_2", title: "River Books", cityCode: "BKK")
+        try seedExperience(in: container, id: "exp_snap_kyo_1", title: "Kamogawa Bench", cityCode: "KYO")
+
+        let base = Date(timeIntervalSince1970: 1_780_000_000)
+        try seedVisit(in: container, experienceId: "exp_snap_bkk_1", visitedAt: base)
+        try seedVisit(in: container, experienceId: "exp_snap_bkk_2", visitedAt: base.addingTimeInterval(-3_600))
+        try seedVisit(in: container, experienceId: "exp_snap_kyo_1", visitedAt: base.addingTimeInterval(-86_400))
+
+        let view = NavigationStack {
+            ArchiveView(modelContainer: container, activeCityCode: "BKK")
+        }
+
+        let png = try renderPNG(view, named: "populated")
+        XCTAssertGreaterThan(png.count, 1_000, "rendered Archive PNG must be a substantial image, not an empty render")
+    }
+
+    // MARK: - Empty state
+
+    func testEmptyArchiveSnapshot() throws {
+        let container = try makeContainer()
+        let view = NavigationStack {
+            ArchiveView(modelContainer: container)
+        }
+
+        let png = try renderPNG(view, named: "empty")
+        XCTAssertGreaterThan(png.count, 1_000, "empty-state PNG must still render the placeholder hero")
+    }
+}

--- a/apps/ios/SoloCompass/Tests/ArchiveViewModelTests.swift
+++ b/apps/ios/SoloCompass/Tests/ArchiveViewModelTests.swift
@@ -1,0 +1,231 @@
+import XCTest
+import SwiftData
+@testable import SoloCompass
+
+/// Tests for `ArchiveViewModel` (P1.1 #113).
+///
+/// Each test rebuilds an in-memory ModelContainer with the two tables the
+/// view model joins: `VisitRecord` + `ExperienceRecord`. Setup helpers
+/// keep visit-creation noise out of the test bodies.
+@MainActor
+final class ArchiveViewModelTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeContainer() throws -> ModelContainer {
+        let config = ModelConfiguration("ArchiveVMTests", isStoredInMemoryOnly: true)
+        return try ModelContainer(
+            for: VisitRecord.self, ExperienceRecord.self,
+            configurations: config
+        )
+    }
+
+    private func seedExperience(
+        in container: ModelContainer,
+        id: String,
+        title: String,
+        cityCode: String
+    ) throws {
+        let ctx = ModelContext(container)
+        let rec = ExperienceRecord(
+            id: id,
+            title: title,
+            oneLiner: "",
+            whyItMatters: "",
+            category: "cafe",
+            longitude: 100.5,
+            latitude: 13.7,
+            cityCode: cityCode,
+            addressHint: nil,
+            placeNameLocal: nil,
+            placeNameRomanized: nil,
+            durationMin: 30,
+            durationMax: 90,
+            status: "active",
+            createdAt: Date(),
+            updatedAt: Date(),
+            bestTimesBlob: Data(),
+            howToBlob: Data(),
+            realInconveniencesBlob: Data(),
+            sourcesBlob: Data(),
+            soloScoreBlob: Data(),
+            confidenceBlob: Data(),
+            statsBlob: Data(),
+            nearbyExperienceIdsBlob: Data()
+        )
+        ctx.insert(rec)
+        try ctx.save()
+    }
+
+    private func seedVisit(
+        in container: ModelContainer,
+        experienceId: String,
+        visitedAt: Date,
+        dwellSeconds: Int = 600
+    ) throws {
+        let ctx = ModelContext(container)
+        let v = VisitRecord(
+            experienceId: experienceId,
+            visitedAt: visitedAt,
+            dwellSeconds: dwellSeconds
+        )
+        ctx.insert(v)
+        try ctx.save()
+    }
+
+    // MARK: - Empty state
+
+    func testRefreshOnEmptyStoreYieldsEmptyState() throws {
+        let container = try makeContainer()
+        let vm = ArchiveViewModel(modelContainer: container)
+
+        vm.refresh()
+
+        XCTAssertTrue(vm.isEmpty)
+        XCTAssertEqual(vm.groups.count, 0)
+        XCTAssertNil(vm.currentTrip)
+        XCTAssertEqual(vm.totalVisitCount, 0)
+    }
+
+    // MARK: - City grouping
+
+    func testVisitsAreGroupedByCity() throws {
+        let container = try makeContainer()
+        try seedExperience(in: container, id: "exp_arch_bkk_a", title: "Rama Café", cityCode: "BKK")
+        try seedExperience(in: container, id: "exp_arch_bkk_b", title: "River Books", cityCode: "BKK")
+        try seedExperience(in: container, id: "exp_arch_kyo_a", title: "Kamogawa Bench", cityCode: "KYO")
+
+        let now = Date()
+        try seedVisit(in: container, experienceId: "exp_arch_bkk_a", visitedAt: now)
+        try seedVisit(in: container, experienceId: "exp_arch_bkk_b", visitedAt: now.addingTimeInterval(-3600))
+        try seedVisit(in: container, experienceId: "exp_arch_kyo_a", visitedAt: now.addingTimeInterval(-86_400))
+
+        let vm = ArchiveViewModel(modelContainer: container)
+        vm.refresh()
+
+        XCTAssertFalse(vm.isEmpty)
+        XCTAssertEqual(vm.groups.count, 2, "two distinct cityCodes must produce two groups")
+
+        let bkk = vm.groups.first { $0.cityCode == "BKK" }
+        let kyo = vm.groups.first { $0.cityCode == "KYO" }
+        XCTAssertEqual(bkk?.visits.count, 2)
+        XCTAssertEqual(kyo?.visits.count, 1)
+    }
+
+    // MARK: - Multi-visit dedup
+
+    func testSameExperienceRevisitsCountAsOneDistinctPlace() throws {
+        let container = try makeContainer()
+        try seedExperience(in: container, id: "exp_arch_revisit", title: "Daily Bench", cityCode: "BKK")
+
+        let now = Date()
+        try seedVisit(in: container, experienceId: "exp_arch_revisit", visitedAt: now)
+        try seedVisit(in: container, experienceId: "exp_arch_revisit", visitedAt: now.addingTimeInterval(-86_400))
+        try seedVisit(in: container, experienceId: "exp_arch_revisit", visitedAt: now.addingTimeInterval(-2 * 86_400))
+
+        let vm = ArchiveViewModel(modelContainer: container, activeCityCode: "BKK")
+        vm.refresh()
+
+        XCTAssertEqual(vm.totalVisitCount, 3, "raw visit count keeps every visit")
+        let bkk = vm.groups.first { $0.cityCode == "BKK" }
+        XCTAssertEqual(bkk?.visits.count, 3, "the group shows every visit row")
+        XCTAssertEqual(bkk?.distinctExperienceCount, 1, "distinct places collapses revisits")
+        XCTAssertEqual(vm.currentTrip?.distinctExperienceCount, 1)
+    }
+
+    // MARK: - Trip summary
+
+    func testCurrentTripPicksTheMostRecentCityByDefault() throws {
+        let container = try makeContainer()
+        try seedExperience(in: container, id: "exp_arch_old", title: "Stale", cityCode: "OSA")
+        try seedExperience(in: container, id: "exp_arch_new", title: "Fresh", cityCode: "TYO")
+
+        let now = Date()
+        try seedVisit(in: container, experienceId: "exp_arch_old", visitedAt: now.addingTimeInterval(-7 * 86_400))
+        try seedVisit(in: container, experienceId: "exp_arch_new", visitedAt: now)
+
+        let vm = ArchiveViewModel(modelContainer: container)
+        vm.refresh()
+
+        XCTAssertEqual(vm.currentTrip?.cityCode, "TYO")
+        XCTAssertEqual(vm.currentTrip?.distinctExperienceCount, 1)
+    }
+
+    func testActiveCityCodeOverridesMostRecentDefault() throws {
+        let container = try makeContainer()
+        try seedExperience(in: container, id: "exp_arch_old", title: "Stale", cityCode: "OSA")
+        try seedExperience(in: container, id: "exp_arch_new", title: "Fresh", cityCode: "TYO")
+
+        let now = Date()
+        try seedVisit(in: container, experienceId: "exp_arch_old", visitedAt: now.addingTimeInterval(-7 * 86_400))
+        try seedVisit(in: container, experienceId: "exp_arch_new", visitedAt: now)
+
+        let vm = ArchiveViewModel(modelContainer: container, activeCityCode: "OSA")
+        vm.refresh()
+
+        XCTAssertEqual(vm.currentTrip?.cityCode, "OSA", "explicit active city wins over most-recent default")
+    }
+
+    /// Build a Date anchored in the *current* calendar's time zone so the
+    /// dayCount math (which uses `Calendar.current.startOfDay`) is hermetic
+    /// regardless of the test runner's locale.
+    private func localDate(year: Int, month: Int, day: Int, hour: Int) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.timeZone = Calendar.current.timeZone
+        return Calendar.current.date(from: components)!
+    }
+
+    func testTripDayCountSpansFirstToLastInclusive() throws {
+        let container = try makeContainer()
+        try seedExperience(in: container, id: "exp_arch_d", title: "Bench", cityCode: "BKK")
+
+        let day1 = localDate(year: 2026, month: 6, day: 1, hour: 9)
+        let day3 = localDate(year: 2026, month: 6, day: 3, hour: 18)
+        try seedVisit(in: container, experienceId: "exp_arch_d", visitedAt: day1)
+        try seedVisit(in: container, experienceId: "exp_arch_d", visitedAt: day3)
+
+        let vm = ArchiveViewModel(modelContainer: container, activeCityCode: "BKK")
+        vm.refresh()
+
+        XCTAssertEqual(vm.currentTrip?.dayCount, 3, "Jun 1 → Jun 3 spans 3 days inclusive")
+    }
+
+    func testSameDayTripIsOneDay() throws {
+        let container = try makeContainer()
+        try seedExperience(in: container, id: "exp_arch_same", title: "Cafe", cityCode: "BKK")
+
+        let morning = localDate(year: 2026, month: 6, day: 1, hour: 9)
+        let evening = localDate(year: 2026, month: 6, day: 1, hour: 20)
+        try seedVisit(in: container, experienceId: "exp_arch_same", visitedAt: morning)
+        try seedVisit(in: container, experienceId: "exp_arch_same", visitedAt: evening)
+
+        let vm = ArchiveViewModel(modelContainer: container, activeCityCode: "BKK")
+        vm.refresh()
+
+        XCTAssertEqual(vm.currentTrip?.dayCount, 1, "two visits on the same day must report 1 day")
+    }
+
+    // MARK: - Orphan handling
+
+    func testVisitsToDeletedExperiencesAreSilentlyDropped() throws {
+        let container = try makeContainer()
+        // Seed a visit but never create the matching ExperienceRecord.
+        try seedVisit(in: container, experienceId: "exp_arch_orphan", visitedAt: Date())
+        // Also seed a valid pair so the view model has something to show.
+        try seedExperience(in: container, id: "exp_arch_valid", title: "Real", cityCode: "BKK")
+        try seedVisit(in: container, experienceId: "exp_arch_valid", visitedAt: Date())
+
+        let vm = ArchiveViewModel(modelContainer: container)
+        vm.refresh()
+
+        XCTAssertEqual(vm.groups.count, 1)
+        XCTAssertEqual(vm.groups.first?.visits.count, 1)
+        XCTAssertEqual(vm.groups.first?.visits.first?.experienceId, "exp_arch_valid")
+        // totalVisitCount counts raw rows, including orphans — that's the contract.
+        XCTAssertEqual(vm.totalVisitCount, 2)
+    }
+}

--- a/apps/ios/SoloCompass/Tests/GenerateTasteProfileTests.swift
+++ b/apps/ios/SoloCompass/Tests/GenerateTasteProfileTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import SoloCompass
+
+/// Tests for `AIService.generateTasteProfile` (P1.2 #122).
+///
+/// The implementation is deterministic and on-device — every assertion below
+/// reduces to "same inputs ⇒ same outputs" or "more inputs ⇒ higher
+/// confidence", with no network or LLM dependency. The vision-LLM upgrade
+/// path lives behind a future flag and is not the contract for P1.2.
+final class GenerateTasteProfileTests: XCTestCase {
+
+    // MARK: - Determinism
+
+    func testSameInputsProduceIdenticalEmbedding() async {
+        let svc = AIService()
+        let a = await svc.generateTasteProfile(photos: [], style: .explorer, freeformVibe: "rainy cafes")
+        let b = await svc.generateTasteProfile(photos: [], style: .explorer, freeformVibe: "rainy cafes")
+        XCTAssertEqual(a.embedding, b.embedding, "deterministic seed must yield byte-identical embedding")
+        XCTAssertEqual(a.descriptors, b.descriptors)
+        XCTAssertEqual(a.confidence, b.confidence, accuracy: 1e-9)
+    }
+
+    func testEmbeddingHasContractDimension64() async {
+        let svc = AIService()
+        let result = await svc.generateTasteProfile(photos: [], style: .worker, freeformVibe: nil)
+        XCTAssertEqual(result.embedding.count, 64, "TasteProfile.embedding contract is 64-dim float vector")
+    }
+
+    func testEmbeddingValuesAreInExpectedRange() async {
+        let svc = AIService()
+        let result = await svc.generateTasteProfile(photos: [], style: .foodie, freeformVibe: nil)
+        for value in result.embedding {
+            XCTAssertGreaterThanOrEqual(value, -1.0)
+            XCTAssertLessThanOrEqual(value, 1.0)
+        }
+    }
+
+    // MARK: - Style differentiation
+
+    func testDifferentStylesProduceDifferentEmbeddings() async {
+        let svc = AIService()
+        let explorer = await svc.generateTasteProfile(photos: [], style: .explorer, freeformVibe: nil)
+        let foodie = await svc.generateTasteProfile(photos: [], style: .foodie, freeformVibe: nil)
+        XCTAssertNotEqual(explorer.embedding, foodie.embedding, "distinct style picks must shift the embedding")
+        XCTAssertNotEqual(explorer.descriptors, foodie.descriptors, "distinct style picks must shift the descriptors")
+    }
+
+    func testEachStyleHasItsOwnDescriptorVocabulary() async {
+        let svc = AIService()
+        let allStyles = UserPreferences.SoloTravelStyle.allCases
+        var seenDescriptors: Set<[String]> = []
+        for style in allStyles {
+            let r = await svc.generateTasteProfile(photos: [], style: style, freeformVibe: nil)
+            XCTAssertFalse(r.descriptors.isEmpty, "every style must produce at least one descriptor")
+            seenDescriptors.insert(r.descriptors)
+        }
+        XCTAssertEqual(seenDescriptors.count, allStyles.count,
+                       "each style must produce a unique descriptor list")
+    }
+
+    // MARK: - Vibe injection
+
+    func testFreeformVibeAddsDescriptors() async {
+        let svc = AIService()
+        let base = await svc.generateTasteProfile(photos: [], style: .worker, freeformVibe: nil)
+        let withVibe = await svc.generateTasteProfile(photos: [], style: .worker, freeformVibe: "sunlit reading")
+        XCTAssertGreaterThan(withVibe.descriptors.count, base.descriptors.count,
+                             "non-empty vibe must contribute at least one descriptor word")
+        XCTAssertTrue(withVibe.descriptors.contains("sunlit") || withVibe.descriptors.contains("reading"),
+                      "vibe words must appear in the descriptor list (lowercased, letter-split)")
+    }
+
+    func testEmptyVibeIsTreatedAsAbsent() async {
+        let svc = AIService()
+        let blank = await svc.generateTasteProfile(photos: [], style: .explorer, freeformVibe: "   ")
+        let absent = await svc.generateTasteProfile(photos: [], style: .explorer, freeformVibe: nil)
+        XCTAssertEqual(blank.descriptors, absent.descriptors,
+                       "whitespace-only vibe must behave the same as a nil vibe")
+        XCTAssertEqual(blank.confidence, absent.confidence, accuracy: 1e-9)
+    }
+
+    // MARK: - Confidence schedule
+
+    func testConfidenceFloorIs030ForJustStyle() async {
+        let svc = AIService()
+        let r = await svc.generateTasteProfile(photos: [], style: .explorer, freeformVibe: nil)
+        XCTAssertEqual(r.confidence, 0.30, accuracy: 0.001,
+                       "style-only fallback must land at 0.30")
+    }
+
+    func testConfidenceRisesWithPhotosAndVibe() async {
+        let svc = AIService()
+        let minimal = await svc.generateTasteProfile(photos: [], style: .explorer, freeformVibe: nil)
+        let richer = await svc.generateTasteProfile(
+            photos: [Data([0x01]), Data([0x02]), Data([0x03])],
+            style: .explorer,
+            freeformVibe: "quiet morning"
+        )
+        XCTAssertGreaterThan(richer.confidence, minimal.confidence,
+                             "richer input (photos + vibe) must produce strictly higher confidence")
+    }
+
+    func testConfidenceCapsAt055() async {
+        let svc = AIService()
+        let saturated = await svc.generateTasteProfile(
+            photos: (0..<10).map { Data([UInt8($0)]) },
+            style: .foodie,
+            freeformVibe: "salt smoke chili"
+        )
+        XCTAssertLessThanOrEqual(saturated.confidence, 0.55,
+                                 "P1.2 fallback must cap at 0.55 — the 0.95 ceiling is reserved for TasteUpdateService")
+    }
+
+    func testConfidenceDegradesWhenStyleIsNil() async {
+        let svc = AIService()
+        let r = await svc.generateTasteProfile(photos: [], style: nil, freeformVibe: nil)
+        XCTAssertEqual(r.confidence, 0.20, accuracy: 0.001,
+                       "no style + no photos + no vibe is the absolute floor — 0.20")
+    }
+
+    // MARK: - Descriptor cap
+
+    func testDescriptorListIsCappedAtFive() async {
+        let svc = AIService()
+        let r = await svc.generateTasteProfile(
+            photos: [],
+            style: .cultureSeeker,
+            freeformVibe: "warm rainy quiet sunlit arty street"
+        )
+        XCTAssertLessThanOrEqual(r.descriptors.count, 5,
+                                 "descriptor list must stay short — prefix(5) is the contract")
+    }
+
+    // MARK: - Helpers stay deterministic
+
+    func testTasteSeedHelperIsStable() {
+        let s1 = AIService.tasteSeed(style: .explorer, photoCount: 2, vibe: "rain")
+        let s2 = AIService.tasteSeed(style: .explorer, photoCount: 2, vibe: "rain")
+        XCTAssertEqual(s1, s2, "seed function must be a pure function of its inputs")
+    }
+
+    func testDeterministicEmbeddingHelperHandlesZeroSeed() {
+        let v = AIService.deterministicEmbedding(seed: 0, dim: 16)
+        XCTAssertEqual(v.count, 16)
+        XCTAssertTrue(v.contains(where: { $0 != 0 }), "zero seed must still produce a non-trivial vector")
+    }
+}

--- a/apps/ios/SoloCompass/Tests/TasteUpdateServiceTests.swift
+++ b/apps/ios/SoloCompass/Tests/TasteUpdateServiceTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+import SwiftData
+@testable import SoloCompass
+
+/// Tests for `TasteUpdateService` (P1.2 #123).
+///
+/// The service has three contracts:
+/// 1. Trigger every Nth visit (default 5, lowered to 1 in tests so they stay fast).
+/// 2. Upsert exactly one `TasteProfile` row (singleton semantics).
+/// 3. Confidence climbs from 0.30 to a 0.95 ceiling.
+@MainActor
+final class TasteUpdateServiceTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeContainer() throws -> ModelContainer {
+        let config = ModelConfiguration("TasteUpdateTests", isStoredInMemoryOnly: true)
+        return try ModelContainer(
+            for: VisitRecord.self, TasteProfile.self,
+            configurations: config
+        )
+    }
+
+    private func makeService(triggerEvery: Int = 1) throws -> (TasteUpdateService, ModelContainer) {
+        let container = try makeContainer()
+        let svc = TasteUpdateService(aiService: AIService(), modelContainer: container)
+        svc.triggerEvery = triggerEvery
+        return (svc, container)
+    }
+
+    private func seedVisits(in container: ModelContainer, count: Int) throws {
+        let ctx = ModelContext(container)
+        for i in 0..<count {
+            let v = VisitRecord(
+                experienceId: "exp_taste_\(i)",
+                visitedAt: Date(timeIntervalSince1970: TimeInterval(1_780_000_000 + i)),
+                dwellSeconds: 600
+            )
+            ctx.insert(v)
+        }
+        try ctx.save()
+    }
+
+    private func fetchProfiles(in container: ModelContainer) throws -> [TasteProfile] {
+        let ctx = ModelContext(container)
+        return try ctx.fetch(FetchDescriptor<TasteProfile>())
+    }
+
+    // MARK: - Confidence curve
+
+    func testConfidenceStartsAtFloor() throws {
+        let (svc, _) = try makeService()
+        XCTAssertEqual(svc.computedConfidence(visitCount: 0), 0.30, accuracy: 0.001)
+    }
+
+    func testConfidenceRisesLinearlyWithVisits() throws {
+        let (svc, _) = try makeService()
+        XCTAssertEqual(svc.computedConfidence(visitCount: 5), 0.55, accuracy: 0.001)
+        XCTAssertEqual(svc.computedConfidence(visitCount: 10), 0.80, accuracy: 0.001)
+    }
+
+    func testConfidenceCeilingIs095() throws {
+        let (svc, _) = try makeService()
+        XCTAssertEqual(svc.computedConfidence(visitCount: 200), 0.95, accuracy: 0.001,
+                       "even an over-active user must cap at the 0.95 ceiling")
+    }
+
+    // MARK: - Trigger cadence
+
+    func testRecordVisitDoesNotPersistBeforeTrigger() async throws {
+        let (svc, container) = try makeService(triggerEvery: 5)
+        try seedVisits(in: container, count: 5)
+
+        for _ in 0..<4 {
+            await svc.recordVisitTriggered()
+        }
+
+        let profiles = try fetchProfiles(in: container)
+        XCTAssertEqual(profiles.count, 0, "first 4 visits must not yet trigger a recompute (triggerEvery = 5)")
+    }
+
+    func testRecordVisitPersistsOnFifthCall() async throws {
+        let (svc, container) = try makeService(triggerEvery: 5)
+        try seedVisits(in: container, count: 5)
+
+        for _ in 0..<5 {
+            await svc.recordVisitTriggered()
+        }
+
+        let profiles = try fetchProfiles(in: container)
+        XCTAssertEqual(profiles.count, 1, "the 5th visit must trigger a recompute and write exactly one row")
+    }
+
+    func testCounterResetsForTesting() async throws {
+        let (svc, _) = try makeService(triggerEvery: 5)
+        for _ in 0..<3 { await svc.recordVisitTriggered() }
+        XCTAssertEqual(svc.triggerCountForTesting, 3)
+        svc.resetForTesting()
+        XCTAssertEqual(svc.triggerCountForTesting, 0)
+    }
+
+    // MARK: - Singleton enforcement
+
+    func testRepeatedRecomputeStillProducesOneRow() async throws {
+        let (svc, container) = try makeService(triggerEvery: 1)
+        try seedVisits(in: container, count: 3)
+
+        await svc.recordVisitTriggered() // visit 1
+        await svc.recordVisitTriggered() // visit 2
+        await svc.recordVisitTriggered() // visit 3
+
+        let profiles = try fetchProfiles(in: container)
+        XCTAssertEqual(profiles.count, 1, "TasteProfile is a singleton — repeated recomputes must upsert, not append")
+    }
+
+    func testRecomputeUpdatesConfidenceAsVisitsGrow() async throws {
+        let (svc, container) = try makeService(triggerEvery: 1)
+
+        try seedVisits(in: container, count: 2)
+        await svc.recomputeProfile()
+        let firstConfidence = try XCTUnwrap(fetchProfiles(in: container).first?.confidence)
+
+        try seedVisits(in: container, count: 8) // total now 10
+        await svc.recomputeProfile()
+        let secondConfidence = try XCTUnwrap(fetchProfiles(in: container).first?.confidence)
+
+        XCTAssertGreaterThan(secondConfidence, firstConfidence,
+                             "adding more visits must monotonically increase confidence")
+    }
+
+    // MARK: - Embedding shape
+
+    func testPersistedEmbeddingIs64Dim() async throws {
+        let (svc, container) = try makeService(triggerEvery: 1)
+        try seedVisits(in: container, count: 1)
+        await svc.recordVisitTriggered()
+
+        let profile = try XCTUnwrap(fetchProfiles(in: container).first)
+        XCTAssertEqual(profile.embeddingVector.count, 64,
+                       "persisted embedding must match the AIService contract dim")
+    }
+
+    // MARK: - Resilience
+
+    func testMissingModelContainerDoesNotCrash() async {
+        let svc = TasteUpdateService(aiService: AIService(), modelContainer: nil)
+        svc.triggerEvery = 1
+        await svc.recordVisitTriggered()
+        XCTAssertTrue(true, "must not throw when there is no container attached")
+    }
+}

--- a/apps/ios/SoloCompass/Tests/V1_9SchemaRecordsTests.swift
+++ b/apps/ios/SoloCompass/Tests/V1_9SchemaRecordsTests.swift
@@ -1,0 +1,271 @@
+import XCTest
+import SwiftData
+@testable import SoloCompass
+
+/// Tests for the four new @Model tables that ship in schema v1.9:
+/// VisitRecord, TasteProfile, TimeCapsule, AgentMemorySnapshot (P1.0 #101-#104).
+///
+/// Each model is exercised against an in-memory SwiftData container so the
+/// tests stay hermetic and don't touch the on-disk store. The shared helper
+/// `inMemoryContext()` rebuilds a fresh container per test to prevent cross-
+/// test bleed.
+final class V1_9SchemaRecordsTests: XCTestCase {
+
+    // MARK: - Container helper
+
+    /// Build a fresh in-memory ModelContainer holding exactly the v1.9 models.
+    /// Using a narrow container (not the full SoloCompass set) keeps each test
+    /// isolated and faster to construct.
+    @MainActor
+    private func inMemoryContext() throws -> ModelContext {
+        let config = ModelConfiguration("V1_9Tests", isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: VisitRecord.self,
+                TasteProfile.self,
+                TimeCapsule.self,
+                AgentMemorySnapshot.self,
+            configurations: config
+        )
+        return ModelContext(container)
+    }
+
+    // MARK: - VisitRecord
+
+    @MainActor
+    func testVisitRecordInsertsAndQueriesByExperienceId() throws {
+        let ctx = try inMemoryContext()
+        let coords = VisitRecord.encodeCoords([100.5018, 13.7563]) // Bangkok lon/lat
+        let visit = VisitRecord(
+            experienceId: "exp_test_001",
+            visitedAt: Date(timeIntervalSince1970: 1_780_000_000),
+            dwellSeconds: 1_800,
+            weatherCode: "clear",
+            coordSnapBlob: coords
+        )
+        ctx.insert(visit)
+        try ctx.save()
+
+        let predicate = #Predicate<VisitRecord> { $0.experienceId == "exp_test_001" }
+        let fetched = try ctx.fetch(FetchDescriptor<VisitRecord>(predicate: predicate))
+
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched.first?.dwellSeconds, 1_800)
+        XCTAssertEqual(fetched.first?.weatherCode, "clear")
+        XCTAssertEqual(fetched.first?.coords, [100.5018, 13.7563])
+    }
+
+    @MainActor
+    func testVisitRecordAllowsMultipleVisitsToSameExperience() throws {
+        let ctx = try inMemoryContext()
+        let v1 = VisitRecord(experienceId: "exp_test_002", dwellSeconds: 600)
+        let v2 = VisitRecord(experienceId: "exp_test_002", dwellSeconds: 1_200)
+        ctx.insert(v1)
+        ctx.insert(v2)
+        try ctx.save()
+
+        let predicate = #Predicate<VisitRecord> { $0.experienceId == "exp_test_002" }
+        let fetched = try ctx.fetch(FetchDescriptor<VisitRecord>(predicate: predicate))
+        XCTAssertEqual(fetched.count, 2, "experienceId is indexed but not unique — revisits must coexist")
+    }
+
+    func testVisitRecordCoordsRoundTrip() {
+        let coords = VisitRecord.encodeCoords([100.5, 13.7])
+        let v = VisitRecord(experienceId: "x", dwellSeconds: 300, coordSnapBlob: coords)
+        XCTAssertEqual(v.coords, [100.5, 13.7])
+    }
+
+    func testVisitRecordCoordsRejectsMalformedInput() {
+        XCTAssertNil(VisitRecord.encodeCoords(nil))
+        XCTAssertNil(VisitRecord.encodeCoords([]))
+        XCTAssertNil(VisitRecord.encodeCoords([100.0])) // only 1 coord
+        XCTAssertNil(VisitRecord.encodeCoords([100.0, 13.0, 50.0])) // 3 coords
+    }
+
+    func testVisitRecordCoordsReturnsNilForCorruptBlob() {
+        let v = VisitRecord(
+            experienceId: "x",
+            dwellSeconds: 300,
+            coordSnapBlob: Data([0x01, 0x02, 0x03]) // wrong byte length
+        )
+        XCTAssertNil(v.coords, "corrupt blob must surface as nil, not crash")
+    }
+
+    // MARK: - TasteProfile
+
+    @MainActor
+    func testTasteProfileRoundTripsEmbeddingAndDescriptors() throws {
+        let ctx = try inMemoryContext()
+        let embedding = TasteProfile.encodeEmbedding([0.1, -0.2, 0.85, -0.04])
+        let descriptors = try TasteProfile.encodeDescriptors(["arty", "quiet", "sunlit"])
+        let profile = TasteProfile(
+            embedding: embedding,
+            descriptorsBlob: descriptors,
+            confidence: 0.45
+        )
+        ctx.insert(profile)
+        try ctx.save()
+
+        let fetched = try ctx.fetch(FetchDescriptor<TasteProfile>())
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched.first?.embeddingVector, [0.1, -0.2, 0.85, -0.04])
+        XCTAssertEqual(fetched.first?.descriptors, ["arty", "quiet", "sunlit"])
+        XCTAssertEqual(try XCTUnwrap(fetched.first).confidence, 0.45, accuracy: 0.001)
+    }
+
+    func testTasteProfileEmbeddingDegradesGracefullyOnCorruptBlob() {
+        let profile = TasteProfile(
+            embedding: Data([0x01, 0x02, 0x03]), // 3 bytes — not divisible by 4 (Float)
+            descriptorsBlob: Data(),
+            confidence: 0.5
+        )
+        XCTAssertEqual(profile.embeddingVector, [], "corrupt embedding must degrade to empty, not crash")
+    }
+
+    func testTasteProfileSourcePhotosRoundTrip() throws {
+        let photos = ["ph_local_id_001", "ph_local_id_002", "ph_local_id_003"]
+        let blob = try JSONEncoder().encode(photos)
+        let profile = TasteProfile(
+            embedding: TasteProfile.encodeEmbedding([0.1]),
+            descriptorsBlob: try TasteProfile.encodeDescriptors([]),
+            confidence: 0.3,
+            sourceVibePhotosBlob: blob
+        )
+        XCTAssertEqual(profile.sourceVibePhotos, photos)
+    }
+
+    func testTasteProfileSourcePhotosNilWhenAbsent() throws {
+        let profile = TasteProfile(
+            embedding: Data(),
+            descriptorsBlob: try TasteProfile.encodeDescriptors([]),
+            confidence: 0.0
+        )
+        XCTAssertNil(profile.sourceVibePhotos, "absent blob must surface as nil, not []")
+    }
+
+    // MARK: - TimeCapsule
+
+    @MainActor
+    func testTimeCapsuleInsertsWithDefaultUnopenedState() throws {
+        let ctx = try inMemoryContext()
+        let capsule = TimeCapsule(
+            experienceId: "exp_test_003",
+            createdAt: Date(timeIntervalSince1970: 1_780_000_000),
+            scheduledFor: Date(timeIntervalSince1970: 1_811_536_000), // ~1 year later
+            contentType: TimeCapsule.ContentType.text,
+            contentBlob: Data("Today I sat here for an hour.".utf8)
+        )
+        ctx.insert(capsule)
+        try ctx.save()
+
+        let fetched = try ctx.fetch(FetchDescriptor<TimeCapsule>())
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched.first?.opened, false, "default opened state must be false")
+        XCTAssertEqual(fetched.first?.contentType, "text")
+    }
+
+    @MainActor
+    func testTimeCapsulePredicateFindsRipeUnopened() throws {
+        let ctx = try inMemoryContext()
+        let pastRipe = TimeCapsule(
+            experienceId: "ripe",
+            scheduledFor: Date(timeIntervalSinceNow: -3_600), // 1h ago — ripe
+            contentType: "text",
+            contentBlob: Data()
+        )
+        let futureNotRipe = TimeCapsule(
+            experienceId: "future",
+            scheduledFor: Date(timeIntervalSinceNow: 3_600), // 1h ahead — not ripe
+            contentType: "text",
+            contentBlob: Data()
+        )
+        let alreadyOpened = TimeCapsule(
+            experienceId: "opened",
+            scheduledFor: Date(timeIntervalSinceNow: -7_200),
+            contentType: "text",
+            contentBlob: Data(),
+            opened: true
+        )
+        ctx.insert(pastRipe)
+        ctx.insert(futureNotRipe)
+        ctx.insert(alreadyOpened)
+        try ctx.save()
+
+        let now = Date()
+        let predicate = #Predicate<TimeCapsule> { !$0.opened && $0.scheduledFor <= now }
+        let ripe = try ctx.fetch(FetchDescriptor<TimeCapsule>(predicate: predicate))
+        XCTAssertEqual(ripe.count, 1)
+        XCTAssertEqual(ripe.first?.experienceId, "ripe")
+    }
+
+    func testCapsuleContextEncodesNilWhenAllFieldsEmpty() throws {
+        let empty = CapsuleContext()
+        XCTAssertNil(try empty.encoded(), "empty context must return nil blob, not empty Data")
+    }
+
+    func testCapsuleContextRoundTrip() throws {
+        let original = CapsuleContext(
+            weatherCode: "rain",
+            tasteDescriptors: ["quiet", "warm"],
+            moodEmoji: "🌧"
+        )
+        let blob = try original.encoded()
+        XCTAssertNotNil(blob)
+        let decoded = CapsuleContext.decode(from: blob)
+        XCTAssertEqual(decoded?.weatherCode, "rain")
+        XCTAssertEqual(decoded?.tasteDescriptors, ["quiet", "warm"])
+        XCTAssertEqual(decoded?.moodEmoji, "🌧")
+    }
+
+    func testCapsuleContextDecodeReturnsNilForGarbageBlob() {
+        XCTAssertNil(CapsuleContext.decode(from: nil))
+        XCTAssertNil(CapsuleContext.decode(from: Data([0xFF, 0xFE, 0xFD])))
+    }
+
+    // MARK: - AgentMemorySnapshot
+
+    @MainActor
+    func testAgentMemorySnapshotPersistsAllFields() throws {
+        let ctx = try inMemoryContext()
+        let snap = AgentMemorySnapshot(
+            summary: "Solo traveler exploring quiet cafes in Bangkok",
+            lastTripCity: "Bangkok",
+            recentChatDigest: "Asked about quiet cafes 3 times this week",
+            updatedAt: Date(timeIntervalSince1970: 1_780_000_000)
+        )
+        ctx.insert(snap)
+        try ctx.save()
+
+        let fetched = try ctx.fetch(FetchDescriptor<AgentMemorySnapshot>())
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched.first?.summary, "Solo traveler exploring quiet cafes in Bangkok")
+        XCTAssertEqual(fetched.first?.lastTripCity, "Bangkok")
+        XCTAssertEqual(fetched.first?.recentChatDigest, "Asked about quiet cafes 3 times this week")
+    }
+
+    func testAgentMemorySnapshotSystemPromptBlockSkipsEmptyFields() {
+        let coldStart = AgentMemorySnapshot()
+        XCTAssertEqual(coldStart.systemPromptBlock(), "", "cold-start snapshot must produce no noise in the prompt")
+    }
+
+    func testAgentMemorySnapshotSystemPromptBlockJoinsPopulatedFields() {
+        let snap = AgentMemorySnapshot(
+            summary: "Solo traveler",
+            lastTripCity: "Tokyo",
+            recentChatDigest: "Wants quiet spots"
+        )
+        let block = snap.systemPromptBlock()
+        XCTAssertTrue(block.contains("About this user: Solo traveler"))
+        XCTAssertTrue(block.contains("Last/current trip: Tokyo"))
+        XCTAssertTrue(block.contains("Recent chats: Wants quiet spots"))
+    }
+
+    func testAgentMemorySnapshotSystemPromptBlockSkipsEmptyOptionalCity() {
+        let snap = AgentMemorySnapshot(
+            summary: "Solo traveler",
+            lastTripCity: nil,
+            recentChatDigest: "Wants quiet spots"
+        )
+        let block = snap.systemPromptBlock()
+        XCTAssertFalse(block.contains("Last/current trip"), "nil city must not appear in prompt")
+    }
+}

--- a/apps/ios/SoloCompass/Tests/VisitTrackingServiceTests.swift
+++ b/apps/ios/SoloCompass/Tests/VisitTrackingServiceTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+import SwiftData
+import CoreLocation
+@testable import SoloCompass
+
+/// Tests for `VisitTrackingService` (P1.1 #110).
+///
+/// The service uses a real `Task.sleep` to wait out the dwell threshold, so
+/// tests inject a sub-second threshold and `await` a real (but short) sleep
+/// before asserting. Each test builds a fresh in-memory ModelContainer to
+/// keep state hermetic.
+@MainActor
+final class VisitTrackingServiceTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Build a fresh in-memory container holding only the models this
+    /// service touches — keeps the test boot fast and isolated.
+    private func makeContainer() throws -> ModelContainer {
+        let config = ModelConfiguration("VisitTrackingTests", isStoredInMemoryOnly: true)
+        return try ModelContainer(for: VisitRecord.self, configurations: config)
+    }
+
+    private func makeService(threshold: TimeInterval = 0.15) throws -> (VisitTrackingService, ModelContainer) {
+        let container = try makeContainer()
+        let service = VisitTrackingService(
+            locationService: .shared,
+            modelContainer: container
+        )
+        service.dwellThreshold = threshold
+        return (service, container)
+    }
+
+    private func fetchVisits(in container: ModelContainer, experienceId: String) throws -> [VisitRecord] {
+        let context = ModelContext(container)
+        let predicate = #Predicate<VisitRecord> { $0.experienceId == experienceId }
+        return try context.fetch(FetchDescriptor<VisitRecord>(predicate: predicate))
+    }
+
+    // MARK: - Happy path
+
+    func testEnterAndDwellPastThresholdWritesVisitRecord() async throws {
+        let (service, container) = try makeService(threshold: 0.10)
+
+        service.simulateRegionEnter(experienceId: "exp_test_happy")
+        // Wait past the threshold + a small safety margin so commitDwell lands.
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        let visits = try fetchVisits(in: container, experienceId: "exp_test_happy")
+        XCTAssertEqual(visits.count, 1, "a single sustained dwell must record exactly one visit")
+        XCTAssertGreaterThanOrEqual(try XCTUnwrap(visits.first).dwellSeconds, 0)
+    }
+
+    // MARK: - Cancellation
+
+    func testEarlyExitBeforeThresholdDoesNotWriteVisit() async throws {
+        let (service, container) = try makeService(threshold: 0.30)
+
+        service.simulateRegionEnter(experienceId: "exp_test_brief")
+        // Exit before the timer fires.
+        try await Task.sleep(nanoseconds: 50_000_000)
+        service.simulateRegionExit(experienceId: "exp_test_brief")
+
+        // Wait well past the original threshold to prove no late write.
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        let visits = try fetchVisits(in: container, experienceId: "exp_test_brief")
+        XCTAssertEqual(visits.count, 0, "exit before dwell threshold must not produce a VisitRecord")
+    }
+
+    // MARK: - GPS noise / re-entry
+
+    func testReentryWhileTimerActiveIsIgnored() async throws {
+        let (service, container) = try makeService(threshold: 0.15)
+
+        service.simulateRegionEnter(experienceId: "exp_test_jitter")
+        // GPS noise — same region fires again before the dwell completes.
+        try await Task.sleep(nanoseconds: 50_000_000)
+        service.simulateRegionEnter(experienceId: "exp_test_jitter")
+
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        let visits = try fetchVisits(in: container, experienceId: "exp_test_jitter")
+        XCTAssertEqual(visits.count, 1, "re-entry while timer is alive must collapse to one visit")
+    }
+
+    // MARK: - Multiple regions in parallel
+
+    func testTwoSimultaneousRegionsBothRecordIndependently() async throws {
+        let (service, container) = try makeService(threshold: 0.10)
+
+        service.simulateRegionEnter(experienceId: "exp_test_a")
+        service.simulateRegionEnter(experienceId: "exp_test_b")
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        let a = try fetchVisits(in: container, experienceId: "exp_test_a")
+        let b = try fetchVisits(in: container, experienceId: "exp_test_b")
+        XCTAssertEqual(a.count, 1)
+        XCTAssertEqual(b.count, 1)
+    }
+
+    // MARK: - Exit cancels timer cleanly
+
+    func testExitDuringDwellCancelsAndAllowsFreshEnterLater() async throws {
+        let (service, container) = try makeService(threshold: 0.15)
+
+        service.simulateRegionEnter(experienceId: "exp_test_round_trip")
+        try await Task.sleep(nanoseconds: 50_000_000)
+        service.simulateRegionExit(experienceId: "exp_test_round_trip")
+
+        // Now legitimately revisit and stay.
+        try await Task.sleep(nanoseconds: 50_000_000)
+        service.simulateRegionEnter(experienceId: "exp_test_round_trip")
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        let visits = try fetchVisits(in: container, experienceId: "exp_test_round_trip")
+        XCTAssertEqual(visits.count, 1, "second sustained dwell after a cancelled one must record exactly one visit")
+    }
+
+    // MARK: - Resilience without container
+
+    func testMissingModelContainerDoesNotCrash() async throws {
+        let service = VisitTrackingService(
+            locationService: .shared,
+            modelContainer: nil
+        )
+        service.dwellThreshold = 0.10
+
+        service.simulateRegionEnter(experienceId: "exp_test_orphan")
+        // Just need to survive past the threshold without throwing.
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        // Reaching here without an exception is the assertion. Add an
+        // explicit XCTAssert to make the intent obvious to readers.
+        XCTAssertTrue(true, "service must drop visits silently when no container is attached")
+    }
+
+    // MARK: - Reset hook
+
+    func testResetForTestingClearsInflightTimers() async throws {
+        let (service, container) = try makeService(threshold: 0.30)
+
+        service.simulateRegionEnter(experienceId: "exp_test_reset_a")
+        service.simulateRegionEnter(experienceId: "exp_test_reset_b")
+        service.resetForTesting()
+
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        let a = try fetchVisits(in: container, experienceId: "exp_test_reset_a")
+        let b = try fetchVisits(in: container, experienceId: "exp_test_reset_b")
+        XCTAssertEqual(a.count, 0)
+        XCTAssertEqual(b.count, 0)
+    }
+}

--- a/apps/ios/SoloCompass/Tests/VisitedMarkerStateTests.swift
+++ b/apps/ios/SoloCompass/Tests/VisitedMarkerStateTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import SoloCompass
+
+/// Tests for the gold-halo `.footprinted` state surfaced by the new
+/// passive `VisitRecord` channel (P1.1 #112).
+///
+/// The map view already renders `.footprinted` with a gold halo, so the only
+/// thing we need to verify is that `MapViewModel.markerState` flips to
+/// `.footprinted` when a passive visit is on file — and that higher-priority
+/// states (completed / favorited / bestNow / upcoming) still win.
+@MainActor
+final class VisitedMarkerStateTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeViewModel(prefsSuite: String) -> (MapViewModel, UserPreferences) {
+        let defaults = UserDefaults(suiteName: prefsSuite)!
+        defaults.removePersistentDomain(forName: prefsSuite)
+        let prefs = UserPreferences(defaults: defaults)
+        let vm = MapViewModel(
+            locationService: LocationService(),
+            experienceService: ExperienceService(seed: ExperienceService.hardcodedSeed),
+            aiService: AIService(),
+            preferences: prefs
+        )
+        return (vm, prefs)
+    }
+
+    /// Build a clean Experience: passiveGpsHits30d=0 and bestTimes=[] so the
+    /// *only* signal that can flip `markerState` is the `visitedExperienceIds`
+    /// set we attach in tests. Skeleton on its own ships with a 9-21 bestTime
+    /// window, which would mask our assertions via .bestNow / .upcoming.
+    private func seedExperience() throws -> Experience {
+        let poi = OverpassService.POI(
+            osmId: 9_999_001,
+            name: "Visited Test Place",
+            nameEn: nil,
+            lat: 0,
+            lon: 0,
+            tags: ["amenity": "cafe"]
+        )
+        let raw = AIService.skeletonExperience(from: poi, cityCode: "osm_0.0_0.0")
+        return Experience(
+            id: raw.id,
+            title: raw.title,
+            oneLiner: raw.oneLiner,
+            whyItMatters: raw.whyItMatters,
+            category: raw.category,
+            location: raw.location,
+            bestTimes: [], // ← key strip: no bestTime → no .bestNow / .upcoming
+            durationMinutes: raw.durationMinutes,
+            howTo: raw.howTo,
+            realInconveniences: raw.realInconveniences,
+            soloScore: raw.soloScore,
+            sources: raw.sources,
+            confidence: raw.confidence,
+            nearbyExperienceIds: raw.nearbyExperienceIds,
+            stats: raw.stats,
+            status: raw.status,
+            createdAt: raw.createdAt,
+            updatedAt: raw.updatedAt,
+            userTags: raw.userTags,
+            categoryHighlights: raw.categoryHighlights
+        )
+    }
+
+    // MARK: - Default → footprinted via VisitRecord
+
+    func testAttachingVisitedIdsFlipsMarkerToFootprinted() throws {
+        let (vm, _) = makeViewModel(prefsSuite: "visited.flip.\(UUID().uuidString)")
+        let exp = try seedExperience()
+
+        // Pin a "now" outside any best-time window so we don't accidentally
+        // collide with .bestNow or .upcoming — use an instant exactly between
+        // two large windows. The default marker state for an arbitrary
+        // mid-afternoon date with no best-time hit is .default.
+        let neutralNow = Date(timeIntervalSince1970: 0)
+
+        XCTAssertEqual(vm.markerState(for: exp, now: neutralNow), .default,
+                       "baseline must be .default before any visit is attached")
+
+        vm.attachVisitedExperienceIds([exp.id])
+        XCTAssertEqual(vm.markerState(for: exp, now: neutralNow), .footprinted,
+                       "after attaching a visit id, the marker must read .footprinted")
+    }
+
+    func testAttachingEmptySetClearsTheHalo() throws {
+        let (vm, _) = makeViewModel(prefsSuite: "visited.clear.\(UUID().uuidString)")
+        let exp = try seedExperience()
+        let neutralNow = Date(timeIntervalSince1970: 0)
+
+        vm.attachVisitedExperienceIds([exp.id])
+        XCTAssertEqual(vm.markerState(for: exp, now: neutralNow), .footprinted)
+
+        vm.attachVisitedExperienceIds([])
+        XCTAssertEqual(vm.markerState(for: exp, now: neutralNow), .default,
+                       "clearing the attached set must drop the halo back to default")
+    }
+
+    // MARK: - Higher-priority states still win
+
+    func testCompletedBeatsVisitedFootprint() throws {
+        let (vm, prefs) = makeViewModel(prefsSuite: "visited.completed.\(UUID().uuidString)")
+        let exp = try seedExperience()
+        let neutralNow = Date(timeIntervalSince1970: 0)
+
+        prefs.markCompleted(exp.id)
+        vm.attachVisitedExperienceIds([exp.id])
+
+        XCTAssertEqual(vm.markerState(for: exp, now: neutralNow), .completed,
+                       ".completed must dominate even if the experience is also marked visited")
+    }
+
+    func testFavoritedBeatsVisitedFootprint() throws {
+        let (vm, prefs) = makeViewModel(prefsSuite: "visited.favorited.\(UUID().uuidString)")
+        let exp = try seedExperience()
+        let neutralNow = Date(timeIntervalSince1970: 0)
+
+        prefs.toggleFavorite(exp.id)
+        vm.attachVisitedExperienceIds([exp.id])
+
+        XCTAssertEqual(vm.markerState(for: exp, now: neutralNow), .favorited,
+                       ".favorited must dominate even if the experience is also marked visited")
+    }
+
+    // MARK: - Visited id for an unknown experience is a no-op
+
+    func testUnknownVisitedIdDoesNotAffectOtherExperiences() throws {
+        let (vm, _) = makeViewModel(prefsSuite: "visited.unknown.\(UUID().uuidString)")
+        let exp = try seedExperience()
+        let neutralNow = Date(timeIntervalSince1970: 0)
+
+        vm.attachVisitedExperienceIds(["exp_does_not_exist_xyz"])
+        XCTAssertEqual(vm.markerState(for: exp, now: neutralNow), .default,
+                       "an unrelated visited id must not flip another experience's marker")
+    }
+
+    // MARK: - VisitedIds is publicly observable
+
+    func testVisitedExperienceIdsIsExposedForViewLayer() {
+        let (vm, _) = makeViewModel(prefsSuite: "visited.expose.\(UUID().uuidString)")
+        XCTAssertTrue(vm.visitedExperienceIds.isEmpty, "fresh vm must start with no visited ids")
+        vm.attachVisitedExperienceIds(["a", "b", "c"])
+        XCTAssertEqual(vm.visitedExperienceIds, Set(["a", "b", "c"]))
+    }
+}

--- a/apps/ios/SoloCompass/ViewModels/ArchiveViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/ArchiveViewModel.swift
@@ -1,0 +1,160 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// View model for the Travel Archive tab (P1.1 #111).
+///
+/// Joins `VisitRecord` (where the user has been) against `ExperienceRecord`
+/// (the canonical Experience metadata) to build a city-grouped timeline.
+///
+/// Pure read model — never writes. Refresh is explicit so the view controls
+/// when SwiftData fetches happen (e.g. on appear, after returning from a
+/// detail sheet).
+@MainActor
+@Observable
+public final class ArchiveViewModel {
+
+    /// One row in the timeline — a single visit decorated with the
+    /// matching Experience's display fields.
+    public struct VisitedExperience: Identifiable, Hashable {
+        public let id: PersistentIdentifier
+        public let experienceId: String
+        public let title: String
+        public let cityCode: String
+        public let visitedAt: Date
+        public let dwellSeconds: Int
+    }
+
+    /// All visits for a single city, newest first.
+    public struct CityGroup: Identifiable, Hashable {
+        public var id: String { cityCode }
+        public let cityCode: String
+        public let visits: [VisitedExperience]
+        public var distinctExperienceCount: Int {
+            Set(visits.map(\.experienceId)).count
+        }
+    }
+
+    /// Trip summary card data shown above the timeline.
+    public struct TripSummary: Hashable {
+        public let cityCode: String
+        public let firstVisitAt: Date
+        public let lastVisitAt: Date
+        public let distinctExperienceCount: Int
+
+        /// Inclusive day span — same-day trip = 1, next-day = 2.
+        public var dayCount: Int {
+            let cal = Calendar.current
+            let start = cal.startOfDay(for: firstVisitAt)
+            let end = cal.startOfDay(for: lastVisitAt)
+            let days = cal.dateComponents([.day], from: start, to: end).day ?? 0
+            return max(1, days + 1)
+        }
+    }
+
+    public private(set) var groups: [CityGroup] = []
+    public private(set) var currentTrip: TripSummary?
+    public private(set) var totalVisitCount: Int = 0
+    public private(set) var isEmpty: Bool = true
+
+    private let modelContainer: ModelContainer
+
+    /// City code used to pick the "current trip" group. When nil, the most
+    /// recent visit's city wins. Callers pass a city when the user is actively
+    /// in one (so the trip card stays anchored even after a stale visit log).
+    public var activeCityCode: String?
+
+    public init(modelContainer: ModelContainer, activeCityCode: String? = nil) {
+        self.modelContainer = modelContainer
+        self.activeCityCode = activeCityCode
+    }
+
+    // MARK: - Refresh
+
+    /// Re-fetch all visits and rebuild the grouped view model. Cheap enough
+    /// to call from `onAppear` — SwiftData backs this with an indexed query.
+    public func refresh() {
+        let context = ModelContext(modelContainer)
+
+        let visits: [VisitRecord]
+        do {
+            var descriptor = FetchDescriptor<VisitRecord>(
+                sortBy: [SortDescriptor(\.visitedAt, order: .reverse)]
+            )
+            descriptor.fetchLimit = 500 // archive view is browsing-grade; bound the query
+            visits = try context.fetch(descriptor)
+        } catch {
+            visits = []
+        }
+
+        totalVisitCount = visits.count
+
+        // Resolve each visit's Experience metadata in a single bulk fetch
+        // keyed by id, instead of N round-trips.
+        let ids = Array(Set(visits.map(\.experienceId)))
+        let experienceById: [String: ExperienceRecord]
+        if ids.isEmpty {
+            experienceById = [:]
+        } else {
+            do {
+                let predicate = #Predicate<ExperienceRecord> { ids.contains($0.id) }
+                let records = try context.fetch(FetchDescriptor<ExperienceRecord>(predicate: predicate))
+                experienceById = Dictionary(uniqueKeysWithValues: records.map { ($0.id, $0) })
+            } catch {
+                experienceById = [:]
+            }
+        }
+
+        // Decorate each visit, dropping orphans (Experience deleted from cache).
+        let rows: [VisitedExperience] = visits.compactMap { v in
+            guard let exp = experienceById[v.experienceId] else { return nil }
+            return VisitedExperience(
+                id: v.persistentModelID,
+                experienceId: v.experienceId,
+                title: exp.title,
+                cityCode: exp.cityCode,
+                visitedAt: v.visitedAt,
+                dwellSeconds: v.dwellSeconds
+            )
+        }
+
+        // Group by city, preserving the global newest-first sort within each group.
+        var byCity: [String: [VisitedExperience]] = [:]
+        var cityOrder: [String] = []
+        for row in rows {
+            if byCity[row.cityCode] == nil {
+                byCity[row.cityCode] = []
+                cityOrder.append(row.cityCode)
+            }
+            byCity[row.cityCode]?.append(row)
+        }
+        groups = cityOrder.map { CityGroup(cityCode: $0, visits: byCity[$0] ?? []) }
+
+        currentTrip = buildCurrentTrip(rows: rows)
+        isEmpty = rows.isEmpty
+    }
+
+    // MARK: - Trip summary
+
+    private func buildCurrentTrip(rows: [VisitedExperience]) -> TripSummary? {
+        guard !rows.isEmpty else { return nil }
+
+        // Prefer the explicitly-set active city; fall back to the most recent.
+        let targetCity = activeCityCode ?? rows.first?.cityCode
+        guard let city = targetCity else { return nil }
+
+        let cityRows = rows.filter { $0.cityCode == city }
+        guard !cityRows.isEmpty else { return nil }
+
+        // rows are sorted newest-first, so first = last visit, last = first visit
+        let lastVisit = cityRows.first!.visitedAt
+        let firstVisit = cityRows.last!.visitedAt
+        let distinct = Set(cityRows.map(\.experienceId)).count
+        return TripSummary(
+            cityCode: city,
+            firstVisitAt: firstVisit,
+            lastVisitAt: lastVisit,
+            distinctExperienceCount: distinct
+        )
+    }
+}

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -62,6 +62,19 @@ public final class MapViewModel {
         self.subscriptionService = service
     }
 
+    /// Set of experience ids the traveler has actually visited (passive
+    /// `VisitRecord`, P1.1 #112). Drives the gold-halo `.footprinted` marker
+    /// state on the map without us having to also write back into the
+    /// existing `passiveGpsHits30d` confidence signal.
+    public private(set) var visitedExperienceIds: Set<String> = []
+
+    /// Attach the set of visited experience ids — called after init from the
+    /// view layer, which owns the SwiftData query over `VisitRecord`. Pass
+    /// an empty set to clear the halo (e.g. when the Settings toggle is off).
+    public func attachVisitedExperienceIds(_ ids: Set<String>) {
+        self.visitedExperienceIds = ids
+    }
+
     /// True when the active entitlement should pass AI gates.
     /// Defaults to `true` when the subscription service hasn't been
     /// attached yet (tests / previews) so we don't accidentally lock
@@ -1457,6 +1470,13 @@ public final class MapViewModel {
         if experience.isBestNow(at: now) { return .bestNow }
         if let upcoming = minutesUntilBestTime(for: experience, from: now), upcoming > 0, upcoming <= 120 {
             return .upcoming(minutes: upcoming)
+        }
+        // P1.1 #112: a passive VisitRecord (5+ min dwell) earns the same
+        // gold-halo footprint treatment as the legacy passiveGpsHits30d
+        // signal, so the new Archive layer lights up without us having to
+        // back-fill the confidence struct.
+        if visitedExperienceIds.contains(experience.id) {
+            return .footprinted
         }
         if experience.confidence.signals.passiveGpsHits30d > 0 {
             return .footprinted

--- a/apps/ios/SoloCompass/Views/Archive/ArchiveView.swift
+++ b/apps/ios/SoloCompass/Views/Archive/ArchiveView.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+import SwiftData
+
+/// Travel Archive tab (P1.1 #111).
+///
+/// Three vertical bands:
+/// 1. Trip summary card — current city, days, distinct Experience count.
+/// 2. Timeline grouped by city, newest visit first.
+/// 3. "City codex" placeholder — fills in Phase 3 #303.
+public struct ArchiveView: View {
+
+    @State private var viewModel: ArchiveViewModel
+
+    public init(modelContainer: ModelContainer, activeCityCode: String? = nil) {
+        _viewModel = State(initialValue: ArchiveViewModel(
+            modelContainer: modelContainer,
+            activeCityCode: activeCityCode
+        ))
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                if viewModel.isEmpty {
+                    emptyState
+                } else {
+                    if let trip = viewModel.currentTrip {
+                        tripCard(trip: trip)
+                    }
+                    ForEach(viewModel.groups) { group in
+                        citySection(group: group)
+                    }
+                    codexPlaceholder
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 20)
+        }
+        .background(Color(white: 0.98))
+        .navigationTitle(NSLocalizedString("archive.title", comment: "Travel archive title"))
+        .onAppear { viewModel.refresh() }
+    }
+
+    // MARK: - Trip card
+
+    @ViewBuilder
+    private func tripCard(trip: ArchiveViewModel.TripSummary) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(trip.cityCode.uppercased())
+                .font(.system(.title3, design: .rounded).weight(.semibold))
+                .foregroundStyle(CT.fgPrimary)
+            HStack(spacing: 16) {
+                statChip(
+                    value: "\(trip.dayCount)",
+                    label: NSLocalizedString("archive.trip.days", comment: "Day count label")
+                )
+                statChip(
+                    value: "\(trip.distinctExperienceCount)",
+                    label: NSLocalizedString("archive.trip.places", comment: "Place count label")
+                )
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(CT.accentSoft)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private func statChip(value: String, label: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(value)
+                .font(.system(.title2, design: .rounded).weight(.bold))
+                .foregroundStyle(CT.sunGold)
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(CT.fgPrimary.opacity(0.7))
+        }
+    }
+
+    // MARK: - City section
+
+    @ViewBuilder
+    private func citySection(group: ArchiveViewModel.CityGroup) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(group.cityCode.uppercased())
+                    .font(.system(.subheadline, design: .rounded).weight(.semibold))
+                    .foregroundStyle(CT.fgPrimary.opacity(0.85))
+                Spacer()
+                Text(String(format: NSLocalizedString("archive.city.count", comment: "City visit count"), group.visits.count))
+                    .font(.caption)
+                    .foregroundStyle(CT.fgPrimary.opacity(0.5))
+            }
+            VStack(spacing: 8) {
+                ForEach(group.visits) { visit in
+                    visitRow(visit: visit)
+                }
+            }
+        }
+    }
+
+    private func visitRow(visit: ArchiveViewModel.VisitedExperience) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            Circle()
+                .fill(CT.sunGold)
+                .frame(width: 8, height: 8)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(visit.title)
+                    .font(.system(.body, design: .rounded).weight(.medium))
+                    .foregroundStyle(CT.fgPrimary)
+                    .lineLimit(1)
+                Text(formattedDate(visit.visitedAt))
+                    .font(.caption)
+                    .foregroundStyle(CT.fgPrimary.opacity(0.55))
+            }
+            Spacer()
+            if visit.dwellSeconds >= 60 {
+                Text("\(visit.dwellSeconds / 60)m")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(CT.fgPrimary.opacity(0.4))
+            }
+        }
+        .padding(12)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(CT.borderSubtle, lineWidth: 1)
+        )
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let fmt = DateFormatter()
+        fmt.dateStyle = .medium
+        fmt.timeStyle = .short
+        return fmt.string(from: date)
+    }
+
+    // MARK: - Codex placeholder
+
+    private var codexPlaceholder: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(NSLocalizedString("archive.codex.title", comment: "City codex title"))
+                .font(.system(.headline, design: .rounded))
+                .foregroundStyle(CT.fgPrimary.opacity(0.7))
+            Text(NSLocalizedString("archive.codex.coming", comment: "City codex coming soon"))
+                .font(.caption)
+                .foregroundStyle(CT.fgPrimary.opacity(0.45))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(CT.borderSubtle, style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+        )
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "map")
+                .font(.system(size: 40))
+                .foregroundStyle(CT.fgPrimary.opacity(0.3))
+            Text(NSLocalizedString("archive.empty.title", comment: "Empty archive title"))
+                .font(.system(.headline, design: .rounded))
+                .foregroundStyle(CT.fgPrimary.opacity(0.75))
+            Text(NSLocalizedString("archive.empty.subtitle", comment: "Empty archive subtitle"))
+                .font(.caption)
+                .foregroundStyle(CT.fgPrimary.opacity(0.5))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 60)
+    }
+}

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import MapKit
+import SwiftData
 import os
 
 enum MapStyleChoice: String, CaseIterable {
@@ -182,6 +183,11 @@ struct CompassMapContentView: View {
     // US-017: Companion map layer (default off)
     @State private var isCompanionLayerOn: Bool = false
     @State private var nearbyCells: [NearbyCell] = []
+
+    // P1.1 #112: passive visit halo. The model container is supplied at the
+    // WindowGroup level (SoloCompassApp.swift), so @Query just works here.
+    // Sort doesn't matter — we only need the experienceId set.
+    @Query private var visitRecords: [VisitRecord]
 
     // US-025: Routes section in BottomInfoSheet
     @State private var routeStore = RouteStore()
@@ -459,9 +465,18 @@ struct CompassMapContentView: View {
                     }
                 }
                 viewModel.checkForPendingCheckIns()
+                // P1.1 #112: seed the visited-id set so .footprinted halos
+                // light up on first render — without waiting for the next
+                // VisitRecord write to trigger the onChange below.
+                viewModel.attachVisitedExperienceIds(Set(visitRecords.map(\.experienceId)))
             }
             .onChange(of: locationService.currentLocation) { _, _ in
                 viewModel.bindToLocation()
+            }
+            // P1.1 #112: keep the halo set in sync as new VisitRecords land
+            // (the SwiftData @Query auto-refreshes; we re-publish to the vm).
+            .onChange(of: visitRecords.count) { _, _ in
+                viewModel.attachVisitedExperienceIds(Set(visitRecords.map(\.experienceId)))
             }
             // Beta-P1-H follow-up: LocationService.routeStopEntered fires when
             // the user crosses a 200m route-stop geofence, but until now nothing

--- a/apps/ios/SoloCompass/Views/Me/MeSheet.swift
+++ b/apps/ios/SoloCompass/Views/Me/MeSheet.swift
@@ -21,7 +21,26 @@ struct MeSheet: View {
 
     @Environment(\.dismiss) private var dismiss
     @Environment(UserPreferences.self) private var preferences
+    @Environment(\.modelContext) private var modelContext
     @State private var showingSettings = false
+    /// P1.3 #132: top-level archive/me segmented switch. Defaults to `.me`
+    /// so the existing entry-point UX is unchanged on first launch.
+    @State private var topTab: TopTab = .me
+
+    /// Two top-level sections inside MeSheet. Archive surfaces the new
+    /// Travel Archive (P1.1 #111); Me keeps the existing profile + social +
+    /// settings hub intact.
+    private enum TopTab: String, CaseIterable, Identifiable {
+        case archive
+        case me
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .archive: return NSLocalizedString("me.tab.archive", comment: "Top-tab label for travel archive")
+            case .me:      return NSLocalizedString("me.tab.me", comment: "Top-tab label for the personal hub")
+            }
+        }
+    }
     /// Platform role gate for the moderation entry. Refreshed on appear; the
     /// admin/moderator section only renders once `canModerate` is true.
     @State private var admin = AdminService.shared
@@ -37,7 +56,23 @@ struct MeSheet: View {
 
     var body: some View {
         NavigationStack(path: $path) {
-            List {
+            // P1.3 #132: archive | me segmented switch sits above the existing
+            // hub. The Me list is unchanged inside .me; Archive (P1.1 #111)
+            // takes the same NavigationStack slot in .archive.
+            VStack(spacing: 0) {
+                Picker("", selection: $topTab) {
+                    ForEach(TopTab.allCases) { tab in
+                        Text(tab.label).tag(tab)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+
+                if topTab == .archive {
+                    ArchiveView(modelContainer: modelContext.container)
+                } else {
+                    List {
                 Section {
                     // One-tap to edit profile — previously buried under
                     // Companion Hub → My Profile (3 taps). NavigationLink wraps
@@ -134,7 +169,9 @@ struct MeSheet: View {
                     }
                     .buttonStyle(.plain)
                 }
-            }
+                    } // close List
+                } // close else
+            } // close VStack
             .navigationTitle(NSLocalizedString("me.title", comment: "Personal hub title"))
             .navigationBarTitleDisplayMode(.inline)
             .task {

--- a/apps/ios/SoloCompass/Views/Onboarding/OnboardingCityStep.swift
+++ b/apps/ios/SoloCompass/Views/Onboarding/OnboardingCityStep.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+
+/// Onboarding step that pins the user's starting city + lets them describe
+/// the kind of afternoon they want (P1.2 #121).
+///
+/// Deliberately lighter than the in-app `CityPickerSheet` — that view
+/// requires a fully wired `MapViewModel`, which is overkill during the
+/// pre-bootstrap onboarding window. We pick from a small hand-curated set
+/// of cities (matching `MapViewModel.knownCityCenters`) and write the
+/// selection straight to `preferences.lastSelectedCity`.
+///
+/// Voice input (todo.md #121: "语音/文字二选一") is intentionally text-only
+/// in P1.2 — the existing `VoiceService` lives behind a permission dialog
+/// and a microphone prompt, both of which we want to keep out of onboarding.
+/// The text field captures the same intent, and the user can re-state it
+/// via the Solo Agent once they're past onboarding.
+public struct OnboardingCityStep: View {
+
+    /// Called once the user picks a city + writes (or skips) the description.
+    public let onContinue: () -> Void
+
+    /// Curated launch cities — code → display label. Codes match
+    /// `MapViewModel.knownCityCenters` so the persisted `lastSelectedCity`
+    /// resolves to a real center on the first map render.
+    public static let launchCities: [(code: String, label: String)] = [
+        ("cmi", NSLocalizedString("city.cmi", comment: "Chiang Mai")),
+        ("SZX", NSLocalizedString("city.szx", comment: "Shenzhen")),
+        ("VTE", NSLocalizedString("city.vte", comment: "Vientiane")),
+        ("san-francisco", NSLocalizedString("city.sf", comment: "San Francisco")),
+    ]
+
+    @Environment(UserPreferences.self) private var preferences
+    @State private var selectedCode: String = "cmi"
+    @State private var afternoonText: String = ""
+
+    public init(onContinue: @escaping () -> Void) {
+        self.onContinue = onContinue
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            header
+            cityPicker
+            afternoonField
+            Spacer(minLength: 8)
+            actions
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 32)
+        .onAppear { hydrateFromPreferences() }
+    }
+
+    // MARK: - Subviews
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(NSLocalizedString("onboarding.city.title", comment: "City step title"))
+                .font(.system(.title2, design: .rounded).weight(.semibold))
+            Text(NSLocalizedString("onboarding.city.subtitle", comment: "City step explainer"))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var cityPicker: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(NSLocalizedString("onboarding.city.label", comment: "City picker label"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Picker(
+                NSLocalizedString("onboarding.city.label", comment: "City picker label"),
+                selection: $selectedCode
+            ) {
+                ForEach(Self.launchCities, id: \.code) { city in
+                    Text(city.label).tag(city.code)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
+    private var afternoonField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(NSLocalizedString("onboarding.city.afternoon.label", comment: "Afternoon question"))
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+            TextField(
+                NSLocalizedString("onboarding.city.afternoon.placeholder", comment: "Afternoon description placeholder"),
+                text: $afternoonText,
+                axis: .vertical
+            )
+            .lineLimit(2...4)
+            .textFieldStyle(.roundedBorder)
+        }
+    }
+
+    private var actions: some View {
+        Button {
+            commit()
+            onContinue()
+        } label: {
+            Text(NSLocalizedString("onboarding.city.continue", comment: "Continue button"))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+        }
+        .buttonStyle(.borderedProminent)
+    }
+
+    // MARK: - Persistence
+
+    private func hydrateFromPreferences() {
+        if let saved = preferences.lastSelectedCity,
+           Self.launchCities.contains(where: { $0.code == saved }) {
+            selectedCode = saved
+        }
+    }
+
+    private func commit() {
+        preferences.lastSelectedCity = selectedCode
+        // The free-form afternoon text is captured into the user's customTags
+        // as a single phrase — the `Solo Agent` (Phase 2) reads tags to bias
+        // its first recommendations. Empty input is a no-op, so the user can
+        // pick a city and move on without writing anything.
+        let trimmed = afternoonText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            var tags = preferences.customTags
+            if !tags.contains(trimmed) {
+                tags.append(trimmed)
+                preferences.customTags = tags
+            }
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Views/Onboarding/OnboardingVibeStep.swift
+++ b/apps/ios/SoloCompass/Views/Onboarding/OnboardingVibeStep.swift
@@ -1,0 +1,231 @@
+import SwiftUI
+import SwiftData
+import PhotosUI
+import UIKit
+
+/// Onboarding step that bootstraps the user's TasteProfile from up to three
+/// vibe photos (P1.2 #120). The step is intentionally skippable —
+/// `AIService.generateTasteProfile` already returns a deterministic fallback
+/// when no photos arrive, so skipping just lands the user at the lower-
+/// confidence floor instead of blocking onboarding entirely.
+///
+/// Why deterministic fallback matters: onboarding must never wait on a cloud
+/// LLM. The contract for #120 is that this view always lets the user move
+/// on (Continue or Skip), and writing the profile is best-effort under it.
+public struct OnboardingVibeStep: View {
+
+    /// Called once the user finishes (with or without photos) so the parent
+    /// flow can advance to the next step.
+    public let onContinue: () -> Void
+
+    /// Optional override so previews and tests can inject a fake AIService
+    /// without touching the shared singleton.
+    public let aiService: AIService
+
+    @Environment(\.modelContext) private var modelContext
+    @Environment(UserPreferences.self) private var preferences
+
+    @State private var pickerItems: [PhotosPickerItem] = []
+    @State private var pickedImages: [UIImage] = []
+    @State private var freeformVibe: String = ""
+    @State private var isWorking: Bool = false
+    @State private var lastError: String? = nil
+
+    public init(
+        aiService: AIService = AIService(),
+        onContinue: @escaping () -> Void
+    ) {
+        self.aiService = aiService
+        self.onContinue = onContinue
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            header
+            photoGrid
+            vibeField
+            Spacer(minLength: 8)
+            actions
+            if let lastError = lastError {
+                Text(lastError)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 32)
+        .onChange(of: pickerItems) { _, newValue in
+            Task { await loadPickedImages(newValue) }
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(NSLocalizedString("onboarding.vibe.title", comment: "Vibe step title"))
+                .font(.system(.title2, design: .rounded).weight(.semibold))
+            Text(NSLocalizedString("onboarding.vibe.subtitle", comment: "Vibe step explainer"))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var photoGrid: some View {
+        HStack(spacing: 12) {
+            ForEach(0..<3, id: \.self) { idx in
+                photoSlot(at: idx)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func photoSlot(at idx: Int) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(white: 0.95))
+            if idx < pickedImages.count {
+                Image(uiImage: pickedImages[idx])
+                    .resizable()
+                    .scaledToFill()
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            } else {
+                Image(systemName: "photo")
+                    .font(.system(size: 24))
+                    .foregroundStyle(Color(white: 0.65))
+            }
+        }
+        .frame(width: 96, height: 96)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color(white: 0.85), lineWidth: 1)
+        )
+        .overlay(alignment: .bottomTrailing) {
+            if idx == 0 {
+                PhotosPicker(
+                    selection: $pickerItems,
+                    maxSelectionCount: 3,
+                    matching: .images
+                ) {
+                    Image(systemName: "plus.circle.fill")
+                        .font(.title2)
+                        .foregroundStyle(.tint)
+                        .background(Color.white, in: Circle())
+                }
+                .padding(4)
+            }
+        }
+    }
+
+    private var vibeField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(NSLocalizedString("onboarding.vibe.field.label", comment: "Free-form vibe label"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            TextField(
+                NSLocalizedString("onboarding.vibe.field.placeholder", comment: "Free-form vibe placeholder"),
+                text: $freeformVibe
+            )
+            .textFieldStyle(.roundedBorder)
+        }
+    }
+
+    private var actions: some View {
+        VStack(spacing: 12) {
+            Button {
+                Task { await commit(skip: false) }
+            } label: {
+                Text(NSLocalizedString("onboarding.vibe.continue", comment: "Continue button"))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(isWorking)
+
+            Button {
+                Task { await commit(skip: true) }
+            } label: {
+                Text(NSLocalizedString("onboarding.vibe.skip", comment: "Skip button"))
+                    .font(.footnote)
+            }
+            .disabled(isWorking)
+            Text(NSLocalizedString("onboarding.vibe.skip.hint", comment: "Skip hint about lower quality"))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    // MARK: - Photo loading
+
+    private func loadPickedImages(_ items: [PhotosPickerItem]) async {
+        var images: [UIImage] = []
+        for item in items.prefix(3) {
+            if let data = try? await item.loadTransferable(type: Data.self),
+               let ui = UIImage(data: data) {
+                images.append(ui)
+            }
+        }
+        pickedImages = images
+    }
+
+    // MARK: - Commit
+
+    private func commit(skip: Bool) async {
+        isWorking = true
+        defer { isWorking = false }
+
+        let photos: [Data] = skip ? [] : pickedImages.compactMap { $0.jpegData(compressionQuality: 0.8) }
+        let vibeText = skip ? nil : (freeformVibe.isEmpty ? nil : freeformVibe)
+
+        let result = await aiService.generateTasteProfile(
+            photos: photos,
+            style: preferences.soloTravelStyle,
+            freeformVibe: vibeText
+        )
+
+        do {
+            try await persistProfile(
+                embedding: result.embedding,
+                descriptors: result.descriptors,
+                confidence: result.confidence,
+                photoCount: photos.count
+            )
+        } catch {
+            lastError = error.localizedDescription
+        }
+
+        onContinue()
+    }
+
+    private func persistProfile(
+        embedding: [Float],
+        descriptors: [String],
+        confidence: Double,
+        photoCount: Int
+    ) async throws {
+        let embeddingBlob = TasteProfile.encodeEmbedding(embedding)
+        let descriptorsBlob = try TasteProfile.encodeDescriptors(descriptors)
+        let photosBlob: Data? = photoCount > 0
+            ? try? JSONEncoder().encode(Array(repeating: "vibe_photo", count: photoCount))
+            : nil
+
+        let existing = try modelContext.fetch(FetchDescriptor<TasteProfile>())
+        if let row = existing.first {
+            row.embedding = embeddingBlob
+            row.descriptorsBlob = descriptorsBlob
+            row.confidence = confidence
+            row.updatedAt = Date()
+            row.sourceVibePhotosBlob = photosBlob
+        } else {
+            let row = TasteProfile(
+                embedding: embeddingBlob,
+                descriptorsBlob: descriptorsBlob,
+                confidence: confidence,
+                sourceVibePhotosBlob: photosBlob
+            )
+            modelContext.insert(row)
+        }
+        try modelContext.save()
+    }
+}

--- a/apps/ios/SoloCompass/Views/Onboarding/OnboardingView.swift
+++ b/apps/ios/SoloCompass/Views/Onboarding/OnboardingView.swift
@@ -45,7 +45,9 @@ public struct OnboardingView: View {
     /// non-modal post-onboarding paywall, not repeated wall-of-trial popups).
     private static let onboardingPaywallSeenKey = "hasSeenOnboardingPaywall"
 
-    private static let totalSteps = 5
+    // P1.2: added two new steps after styleStep — vibe (#120) at index 4
+    // and city (#121) at index 5 — so the paywall step now sits at index 6.
+    private static let totalSteps = 7
 
     private var slideTransition: AnyTransition {
         reduceMotion
@@ -77,10 +79,18 @@ public struct OnboardingView: View {
                 styleStep
                     .transition(slideTransition)
                     .id(3)
+            case 4:
+                vibeStep
+                    .transition(slideTransition)
+                    .id(4)
+            case 5:
+                cityStep
+                    .transition(slideTransition)
+                    .id(5)
             default:
                 paywallStep
                     .transition(slideTransition)
-                    .id(4)
+                    .id(6)
             }
         }
         .overlay(alignment: .topTrailing) {
@@ -96,7 +106,7 @@ public struct OnboardingView: View {
     /// future onboarding re-entry doesn't re-pitch the trial.
     private var skipButton: some View {
         Button {
-            if step == 4 {
+            if step == 6 {
                 UserDefaults.standard.set(true, forKey: Self.onboardingPaywallSeenKey)
             }
             preferences.completeOnboarding()
@@ -389,16 +399,11 @@ public struct OnboardingView: View {
 
             VStack(spacing: 12) {
                 Button {
-                    // Onboarding-paywall gating: returning Pro users (or anyone
-                    // who already saw the trial pitch and dismissed it) skip the
-                    // paywall step entirely so re-entering onboarding via the
-                    // mid-flow recovery path doesn't feel like nagging.
-                    if shouldSkipOnboardingPaywall {
-                        preferences.completeOnboarding()
-                        onComplete()
-                    } else {
-                        withAnimation { step = 4 }
-                    }
+                    // P1.2: vibe (step 4) + city (step 5) come BEFORE any paywall
+                    // gating now, so styleStep always advances to vibe. The
+                    // "skip the paywall pitch" gate is consulted later, in the
+                    // city step's onContinue handler.
+                    withAnimation { step = 4 }
                 } label: {
                     Text(NSLocalizedString("onboarding.style.cta", comment: "Start exploring"))
                         .font(.headline)
@@ -410,12 +415,7 @@ public struct OnboardingView: View {
                 .accessibilitySortPriority(OnboardingA11ySortPriority.primaryCTA)
 
                 Button {
-                    if shouldSkipOnboardingPaywall {
-                        preferences.completeOnboarding()
-                        onComplete()
-                    } else {
-                        withAnimation { step = 4 }
-                    }
+                    withAnimation { step = 4 }
                 } label: {
                     Text(NSLocalizedString("onboarding.style.skip", comment: "Decide later"))
                         .font(.subheadline)
@@ -455,6 +455,41 @@ public struct OnboardingView: View {
         UserDefaults.standard.set(true, forKey: Self.onboardingPaywallSeenKey)
         preferences.completeOnboarding()
         onComplete()
+    }
+
+    // MARK: - Step 4: Vibe (P1.2 #120)
+
+    /// Embed the standalone OnboardingVibeStep view inside the same step
+    /// chrome the rest of the flow uses. The step indicator runs at the
+    /// top; the embedded view owns the photo-picker + CTA + skip.
+    private var vibeStep: some View {
+        VStack(spacing: 0) {
+            stepIndicator
+                .padding(.top, 24)
+            OnboardingVibeStep {
+                withAnimation { step = 5 }
+            }
+        }
+    }
+
+    // MARK: - Step 5: City + afternoon (P1.2 #121)
+
+    /// After city is picked, the user either lands on the paywall or — if the
+    /// onboarding paywall has already been seen this device — finishes the
+    /// whole flow directly. We never re-pitch the onboarding paywall.
+    private var cityStep: some View {
+        VStack(spacing: 0) {
+            stepIndicator
+                .padding(.top, 24)
+            OnboardingCityStep {
+                if shouldSkipOnboardingPaywall {
+                    preferences.completeOnboarding()
+                    onComplete()
+                } else {
+                    withAnimation { step = 6 }
+                }
+            }
+        }
     }
 
     private var paywallStep: some View {

--- a/docs/V_NEXT_DESIGN.md
+++ b/docs/V_NEXT_DESIGN.md
@@ -1,0 +1,507 @@
+# Solo Compass — Next Major Version Design (v1.0)
+
+> 状态: Draft v0.2 (已过代码级验证) · 2026-07-01
+> 目标: 把 Solo Compass 从"地图工具"演化成"独行者沉迷的 AI 旅伴",建立可付费、可留存、可病毒传播的产品形态
+> 范围: iOS only (利用 Live Activity + 灵动岛 + Apple Music 的平台壁垒)
+> 实施清单: 见仓库根 [`todo.md`](../todo.md) (92 个任务 ID,P1.0–P3.6 + 横向 X.1-X.4)
+
+---
+
+## 0. 设计原则 (Decision Lens)
+
+每一个功能必须能回答这 4 个问题之一:
+
+1. **它每天用几次?** (utility → Pro 留存)
+2. **用户为什么会截图发朋友圈?** (情绪 → 病毒拉新)
+3. **用户离开了会损失什么?** (沉淀 → 反 churn lock-in)
+4. **Google Maps 为什么做不出来?** (差异化 → 护城河)
+
+**淘汰原则**: 答不出任意一个,砍。
+
+---
+
+## 1. 当前 App 的事实底座 (现状审计)
+
+### 1.1 已有强项 (要复用)
+
+| 资产 | 现状 | 利用方式 |
+|------|------|---------|
+| **Chat Agent + 10 tools** | `VoiceAgentOrchestrator.swift` + `VoiceAgentToolRouter.swift` (explore_nearby/build_route/filter_by_category/show_details/save_to_favorites/dismiss_recommendation/search_places/navigate_to/filter_visible/expand_radius) | 升级为 v1.0 的"Solo Agent",所有新玩法走 tool 扩展 (新增 ≥8 个 tool case) |
+| **灵动岛 4 场景** | `apps/ios/SoloCompassWidgets/` (独立 widget extension target) — Kind 定义在 `apps/ios/SoloCompass/Shared/SoloCompassActivityAttributes.swift` 双 target 共享 | 新场景接入: soloAgentHint, timeCapsule, dailyOmen |
+| **24 个 @Model** | SwiftData 离线-first (实际 grep `@Model` 共 24 个,explorer 报告口径略有出入) | 加 4 个新 model (VisitRecord/TasteProfile/TimeCapsule/AgentMemorySnapshot) |
+| **暖琥珀 CT 设计系统** | 40+ tokens + SF Rounded | 全 App 视觉一致性,新组件零成本沿用 |
+| **TravelerNote/PlaceCorrection** | 已过 schema parity | 个人档案的天然地基,无需从零 |
+| **订阅状态机** | free/proTrial/pro/proExpired + StoreKit2 | 直接挂载新付费层,无需改造 |
+| **ChatSession 持久化** | ChatSessionRecord + ChatMessageRecord | 升级为"agent 跨会话记忆"的载体 |
+
+### 1.2 关键缺口 (v1.0 必须补)
+
+| 缺口 | 影响 | v1.0 必补 |
+|------|------|----------|
+| **没有 VisitLog/TravelLog** | 个人档案/时空胶囊/口味演化都无法做 | 加 `VisitRecord @Model` + 新建 `VisitTrackingService` (借鉴现有 PresenceService 隐私契约,但 PresenceService 本身是 Companion Mode geohash 广播,职责不同不复用) |
+| **没有时段触发的主动推送调度层** | 孤独时段向导/胶囊/每日签都无法做 | 基于现有 `NotificationService` (已实现 UNUserNotificationCenter 基础 + deep-link) 之上加 `ProactiveNudgeScheduler` |
+| **没有口味嵌入** | 反算法策展只能用 tag,精度不够 | 加 `TasteProfile @Model` (本地嵌入向量) |
+| **没有跨会话记忆** | Solo Agent 每次都重新认识用户,无沉淀感 | ChatOrchestrator 加 `AgentMemorySnapshot @Model` 注入 |
+| **Onboarding 没城市/没 vibe** | 冷启动推荐质量差 | 在 OnboardingView 加 city + 3-pic vibe pick 两步 |
+
+### 1.3 冗余 / 该砍 / 该合并 (v1.0 减法清单)
+
+> 经验法则: 一个功能如果"看起来在但没人点",就是 UI 噪音。
+
+#### 🔪 SettingsView 14 section → 6 section
+
+**砍/合并**:
+- ❌ **AI Provider** (DeepSeek API key override) — debug-only,普通用户从来不点,移到隐藏的 `Settings → About → 7 次点击解锁` 开发者菜单
+- ❌ **Admin unlock** — 全球 2 个邮箱用,占一个 section 没必要,合并到 About
+- ❌ **Stats** (已探索/最爱计数) — 不该在 Settings,应该是档案 tab 的首屏内容,**搬走**
+- ❌ **Companion opt-in** — 实验性 toggle,合并到 Notifications 之下作为子项
+- ❌ **Export Markdown** — 低频,合并到 Data 之下
+- ❌ **Filter Bar Customization** — 自定义 tag 应该长按 FilterBar 原地编辑,不应该在 Settings 里二次入口
+
+**保留并优化** (合并后 6 section):
+1. 旅行风格 + 偏好类目 (合并: Travel Style + Preferred + Disliked → 一个 "你的喜好" 编辑器)
+2. 距离 + 语言 (合并: 简短地理设置)
+3. 外观 (主题)
+4. 通知 (含 Companion opt-in)
+5. 订阅
+6. 数据 (含 Export + 清空 + 恢复购买 + About 隐藏开发菜单)
+
+**预期效果**: SettingsView 滚动减少 60%+,用户能"看完"。
+
+#### 🔪 FilterBar Now/All/Favorites + 8 category → 收敛
+
+**问题**: 当前 11+ 个 chip 滚动,信息过载。
+**改造**:
+- Now 升级为 v1.0 的 **"Solo Agent 入口"** (常驻第一位,点击直接出现"现在该去哪"的建议)
+- All / Saved 合并到一个 "我的" segmented control (代码中 "Saved" 是当前命名,不是 "Favorites")
+- 8 个 category 改为 **"≡ More"** 抽屉式展开 (默认折叠 3 个高频:咖啡/美食/文化,其余进抽屉)
+- 自定义 tag 长按 chip 原地编辑
+
+**预期效果**: 主界面 chip 从 11+ 降到 5,认知负担降一半。
+
+#### 🔪 MeSheet 入口分散 → 双 tab 结构
+
+**问题**: Profile + EntitlementBanner + Empty + 社交 + Admin + Settings 6 个 section 都堆一起,主次不分。
+**改造**:
+- 顶部 segmented: `[档案 | 我]`
+- **档案 tab**: 新增的 Travel Archive (见 §3)——这是用户最常回看的内容,放第一
+- **我 tab**: Profile + 订阅 + 社交 + 设置入口
+
+**预期效果**: 用户每次进 MeSheet 第一眼看到的是自己的旅行沉淀,不是冷冰冰的设置入口。
+
+#### 🔪 BottomInfoSheet vs ChatSheet vs ExperienceDetailView 三层 sheet 冗余
+
+**问题**: 点一个 POI → BottomInfo (peek) → 上滑 ExperienceDetail (全屏) → Ask Solo → ChatSheet (半屏) → 三层堆叠,用户迷路。
+**改造**:
+- BottomInfoSheet 的 peek 内容嵌入到 ExperienceDetail 的 hero,**砍 BottomInfoSheet 中间层**
+- 点 POI → 直接半屏 ExperienceDetail (mid detent),上滑全屏
+- Ask Solo 不再开新 sheet,直接在 ExperienceDetail 底部嵌入 mini ChatBar (scoped chat)
+- 全局 ChatSheet 只在地图主屏的 dock FAB 触发
+
+**预期效果**: sheet 层级 3→2,Ask Solo 体验从"跳转"变"原地展开",符合 iOS sheet 哲学。
+
+---
+
+## 2. v1.0 产品形态 (核心叙事)
+
+### 2.1 一句话定位
+
+> **"一个常驻地图的 AI 旅伴,陪你度过 1-2 周的城市深漫,记得你去过哪、懂你喜欢什么、在你孤独时陪你坐一会。"**
+
+### 2.2 三层功能架构
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    L1: Solo Agent (永远在线)                  │
+│   ┌──────────────┐  ┌──────────────┐  ┌─────────────────┐   │
+│   │ 现在该去哪    │  │  孤独时段陪伴 │  │  盲盒 Trip       │   │
+│   │ (每天 3-5次)  │  │  (情感峰值)   │  │  (冲动 $1.99)    │   │
+│   └──────────────┘  └──────────────┘  └─────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+                              ▲
+                              │ 喂入
+                              │
+┌─────────────────────────────────────────────────────────────┐
+│                  L2: Taste & Archive (沉淀层)                │
+│   ┌──────────────┐  ┌──────────────┐  ┌─────────────────┐   │
+│   │ 口味画像      │  │  旅行档案     │  │  时空胶囊        │   │
+│   │ (反算法策展)  │  │  (被动沉淀)   │  │  (1 年后触达)    │   │
+│   └──────────────┘  └──────────────┘  └─────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+                              ▲
+                              │ 演出
+                              │
+┌─────────────────────────────────────────────────────────────┐
+│              L3: Ambient (iOS 平台壁垒,无感存在)              │
+│   ┌──────────────┐  ┌──────────────┐  ┌─────────────────┐   │
+│   │ 灵动岛 hint   │  │ Live Activity│  │  Apple Music     │   │
+│   │ (锁屏决策)    │  │ (跟路而行)    │  │  (今日 OST)      │   │
+│   └──────────────┘  └──────────────┘  └─────────────────┘   │
+```
+
+### 2.3 付费层与功能映射
+
+| 层级 | 价格 | 功能 |
+|------|------|------|
+| **Free** | $0 | 地图、Experience 浏览、收藏、基础档案沉淀(被动)、Solo Agent 每天 1 次 |
+| **Pro** | $9.99/月 | Solo Agent 无限 + 跨会话记忆、口味画像 + 私密策展、孤独时段陪伴、时空胶囊、活档案(月度洞察)、灵动岛深度集成、每日 OST、城市签 |
+| **增值** | $1.99-$4.99/次 | 盲盒 Trip $1.99、SOS Plan $2.99/次、未走的路 $4.99/trip、年度 Travel Book 印刷 $30-50 |
+
+---
+
+## 3. 大方向 (5 个 Pillar)
+
+### Pillar 1: Solo Agent v2 — Chat 升级为"决策者"
+
+**当前 Chat 是工具调用器,v1.0 升级为有记忆、有人格、有时段意识的旅伴**。
+
+#### 1.1 跨会话记忆 (Memory Snapshot)
+- 新增 `AgentMemorySnapshot @Model`: 用户去过的城市、最爱 3 个地方、当前 trip 上下文、最近 7 天聊天摘要
+- 每次新会话 ChatOrchestrator 自动注入 system prompt
+- **沉迷点**: 用户感觉"它真的认识我",每次开口都不用从头讲
+
+#### 1.2 时段意识 (Time-Aware Agent)
+- Solo Agent 知道现在是早/午/傍晚/夜,知道你的孤独时段
+- 主动语气调整: 早上"今天想做什么"、傍晚"要不要去坐一会"
+- **入口**: FilterBar 第一位的 Now 升级为 Solo Agent 按钮
+
+#### 1.3 新 Tool 扩展 (基于现有 VoiceAgentToolRouter)
+- `suggest_now_action(context)` — "现在该去哪"决策
+- `open_blindbox(duration)` — 启动盲盒 Trip
+- `bury_capsule(text|voice)` — 埋下时空胶囊
+- `recall_pattern(period)` — 调出口味演化洞察
+- `compose_ost(today_visits)` — 生成今日 OST
+
+#### 1.4 Chat 中可以"演"的玩法 (从情绪付费方向收回 Chat)
+**这些不需要独立 UI,Chat agent 就能交付**:
+- **未走的路 (回溯讨论)** — Trip 结束后用户问"我那天还能怎么走" → agent 用反事实生成,聊天中输出文字+地图卡片,$4.99 单次解锁
+- **本地圈层观察** — "曼谷有什么值得看的非游客圈子" → agent 输出场景描述卡片(Pro 内含)
+- **SOS Plan** — "下雨了我不知道去哪" → agent 直接生成 4 小时替代路线 (Pro 用户每月 3 次免费,免费用户 $2.99/次)
+
+**设计原则**: 凡是"对话能完成的"绝不做独立 UI,Chat 越用越值钱。
+
+---
+
+### Pillar 2: Taste Profile + 反算法策展
+
+**当前没有 vibe embedding,推荐只能用 category tag,精度不够**。
+
+#### 2.1 Onboarding 加 vibe 采集步
+- 第 4 步: 3 张照片或 3 个去过的店 (从 Apple 相册联动) → 调 LLM 生成 vibe 描述 + 嵌入向量
+- 第 5 步: 语音/文字一句话补充"你在城市里最想要什么样的下午"
+- **新 @Model**: `TasteProfile { embedding: Data, descriptors: [String], confidence: Double, updatedAt: Date }`
+
+#### 2.2 私密策展 (Pro)
+- 每周一,agent 从城市的长尾池子里挑 3 个匹配你 vibe 但**只对你可见**的 Experience
+- 推送通知: "本周给你挑了 3 个新地方"
+- 在档案 tab 有"我的私藏"section,Pro 解锁后陆续积累
+
+#### 2.3 口味演化曲线 (Pro 档案玩法)
+- 每月 1 号,agent 分析过去 30 天访问记录,输出: "你这个月更偏书店少咖啡了"、"你在东京选静、在曼谷选闹"
+- 卡片形式,可截图分享 (情绪溢价)
+
+#### 2.4 反算法过滤器 (免费层就给)
+- FilterBar 加一个 "✦ 我的菜" toggle,开启后所有结果按 taste 匹配度排序而非默认 Solo Score
+- **这是免费用户的钩子**: 用了几次后,Pro 的"私密策展"才有动力升级
+
+**沉迷设计**: TasteProfile 用得越久越懂你,迁移成本 = 重新喂数据 + 等几周才生效,**这就是天然 lock-in**。
+
+---
+
+### Pillar 3: Travel Archive + 时空胶囊 (核心 Lock-in)
+
+**这是用户离开 App 损失最大的一层**。
+
+#### 3.1 被动旅行档案 (免费层就给)
+- 新增 `VisitRecord @Model`: experienceId / visitedAt / dwellSeconds / weather / coordSnap
+- 触发条件: 用户在某 Experience 200m 内停留 >5 分钟 (复用现有 CLCircularRegion)
+- 自动归类: 按 trip (基于城市+连续时段聚类)、按月、按 category
+- **入口**: MeSheet 顶部 segmented 的 "档案" tab,首屏就是
+
+#### 3.2 活档案 (Pro)
+- **月度洞察**: 见 2.3 口味演化曲线
+- **重访 agent**: 1 年后系统主动 push "去年这周你在京都那家咖啡店待了 2 小时,今年同周你在曼谷,要不要找一家相似 vibe 的" → 灵动岛触达
+- **私藏区**: 见 2.2
+
+#### 3.3 ⭐ 时空胶囊 (Pro 的灵魂功能)
+- 用户在任一 Experience 长按 → "留下时间胶囊"
+- 输入: 一段文字 / 一段语音 / 一张照片
+- 元数据: 当时位置、天气、口味画像快照、心情 emoji
+- 触发: 1 年后(可自定义 3 / 6 / 12 个月)用户进入该 Experience ±500m → **灵动岛主动跳出**
+- UI: 收到胶囊的瞬间是仪式感峰值,设计极美的全屏接受动画
+- **新 @Model**: `TimeCapsule { id, experienceId, createdAt, scheduledFor, content (text/voice/photo), context (weather/taste/mood), opened: Bool }`
+
+**沉迷设计**: 这是**真正的 lock-in 之王**。用户每攒一年的胶囊,退订成本就高一倍。**不退订的最强理由不是功能,是怕错过自己未来的惊喜**。
+
+#### 3.4 年度 Travel Book (增值层 $30-50/本)
+- 年末用户可以一键生成,把档案 + 照片 + agent 写的旅行随笔印成实体书
+- Polarsteps 验证过的现金牛模型
+- **入口**: 档案 tab 年末季节性 banner
+
+---
+
+### Pillar 4: 盲盒 Trip + 仪式感玩法 (情绪付费引擎)
+
+**这是病毒传播 + 冲动付费的双引擎**。
+
+#### 4.1 ⭐ 盲盒 Trip ($1.99/次, Pro 每月 5 次)
+- 用户按下"今天给我 3 小时盲盒"按钮
+- Agent 全程不告诉你去哪,只给"7 分钟后往北走"这种指令
+- 每一步到达后才解锁下一步,灵动岛全程在演
+- 结束后生成"今天你被带去了哪"复盘卡片,可分享
+- **可复用现有 LiveActivity 的 route 场景**,只是终点延迟揭示
+- **入口**: FilterBar 旁边一个"🎁 盲盒"按钮 (橙色琥珀渐变,吸睛但克制)
+
+#### 4.2 城市签 (Pro 每日 1 张, $0.99 重抽)
+- 每天 7am 推送: "今天属于安静的水,去一个能听见水声的地方坐 10 分钟"
+- 完成微任务解锁一张极美卡片,慢慢收集成"我的曼谷图鉴"
+- **设计要求**: 文案克制不卖萌 (Co-Star 占星 app 那种气质),美术极简
+- 收集进度只对 Pro 可见,退订 = 失去未完成图鉴
+
+#### 4.3 今日 OST (Pro)
+- 一天结束后,agent 根据今天去过的地方生成 Apple Music playlist
+- 每个 Experience 对应 1-2 首歌
+- **直接走 Apple Music API + MusicKit** (iOS 原生,绕开 Spotify 政策风险)
+- 1-2 周后是"一整张你的城市专辑",分享到 IG Story 天然带 logo
+
+#### 4.4 Solo Brag (Pro 免费, $1.99 视频版)
+- Trip 结束自动生成"独行成就卡": 走了 47km、去过 23 个非游客点、喝了 14 杯咖啡
+- 设计成专辑封面级别美感,可设手机壁纸
+- 视频版可发 IG Reels
+
+**这 4 个玩法的共同点**: 都是 **"看到就想截图"** 的产品形态,病毒传播免费帮你做拉新。
+
+---
+
+### Pillar 5: 灵动岛 / Live Activity 深度集成 (iOS 平台壁垒)
+
+**当前已有 4 场景,v1.0 扩展为 7 场景,把 Solo Agent 推到锁屏顶部**。
+
+#### 5.1 新增 ActivityConfiguration.Kind 场景
+
+| Kind case | 触发 | 演什么 |
+|-----------|------|--------|
+| `soloAgentHint` (新) | Agent 主动建议 | 一个琥珀色点 + "5:20 出门走鸭川,15 分钟刚好赶上晚霞" |
+| `timeCapsule` (新) | 进入有胶囊的围栏 | "去年的今天你在这里写过一句话,要拆开吗?" |
+| `dailyOmen` (新) | 每天 7am | 城市签出现,1 句话 + 1 个点 |
+| `route` (已有) | 路线进行中 | 复用 |
+| `countdown` (已有) | 倒计时 | 复用 |
+| `recording` (已有) | 录音 | 复用 |
+| `compile` (已有) | AI 合成 | 复用 |
+
+**实施位置**:
+- enum 加 case → `apps/ios/SoloCompass/Shared/SoloCompassActivityAttributes.swift` (双 target 共享文件)
+- widget 渲染分支 → `apps/ios/SoloCompassWidgets/SoloCompassLiveActivity.swift` + `LockScreenLiveActivityView.swift`
+- 主 app 触发 → `apps/ios/SoloCompass/Services/LiveActivityService.swift`
+
+#### 5.2 锁屏决策卡片
+- Solo Agent 的所有建议都可以"不解锁手机直接决策"
+- expanded region 显示: 建议、采纳/换一个、5 分钟后再提醒 三选项
+- 用户的肌肉记忆变成"瞄一眼锁屏就知道下一步"
+
+**这是 Google Maps / Mindtrip / Layla 物理上做不出来的形态优势**。
+
+---
+
+## 4. 信息架构 (IA) 重构
+
+### 4.1 v1.0 主界面
+
+```
+┌─────────────────────────────────────┐
+│           [Map 主屏]                  │
+│                                      │
+│   ╔═══════════════════════════╗     │
+│   ║  Solo Agent ⚡ Now         ║     │
+│   ║  [我的菜] [咖啡] [≡ More]  ║ ← FilterBar 收敛
+│   ╚═══════════════════════════╝     │
+│                                      │
+│           [大地图]                    │
+│                                      │
+│      [盲盒 🎁]    [Agent FAB 💬]     │
+└─────────────────────────────────────┘
+       Map        Archive      Me
+        ●           ○           ○
+```
+
+### 4.2 三个底部入口
+
+| Tab | 内容 | 何时用 |
+|-----|------|--------|
+| **Map** (主) | 地图 + Solo Agent + FilterBar | 在路上,90% 时间 |
+| **Archive** (新) | 旅行档案 + 时空胶囊 + 月度洞察 + 城市图鉴 | 回看自己,沉淀感 |
+| **Me** | Profile + 订阅 + 社交 + 设置 | 工具性,低频 |
+
+**注意**: 这是 v1.0 关键决策——**第一次给 App 加 tab bar**。之前的"无 tab、纯地图"已经不够装下沉淀层,但 tab 必须克制只 3 个。
+
+---
+
+## 5. 反风险设计
+
+### 5.1 关键风险与对策
+
+| 风险 | 对策 |
+|------|------|
+| LLM 编造店铺 (Mindtrip 翻车) | Solo Agent 所有建议必须 RAG 自 Experience 池,never 凭空生成 POI |
+| 用户回家不续费 | 不推年付 (refuted 证据);月付 + 跨会话记忆让用户回家也想用 |
+| 时空胶囊 1 年后用户忘了 → 触达感觉怪 | 年末主动做"今年你埋了 X 个胶囊"回顾,持续提醒资产存在 |
+| 盲盒第一次踩雷直接流失 | 第一次盲盒走"超安全 + 高分匹配",且"重摇"按钮免费 |
+| 私密策展命中率低 → 觉得被骗 | agent 必须输出"为什么这家匹配你",可解释性必须有 |
+| 灵动岛通知过载 → 被关 | Solo Agent 通知一天最多 3 次,arch 设计层强制限流 |
+| TasteProfile 冷启动质量差 | 头 7 天只走 high-confidence 推荐,等数据累积再放开 |
+| Chat 跨会话记忆隐私焦虑 | 记忆全部 on-device SwiftData,云端不存,Settings 提供"忘记我"按钮 |
+
+### 5.2 不做的 (从研究证据反推)
+
+- ❌ 撮合社交 (Couchsurfing 死法)
+- ❌ 自动订机酒 (信任 gap, Booking 死亡战场)
+- ❌ 行程预规划 day plan (红海)
+- ❌ 安全溢价 add-on (refuted: 独行女性不为这付费)
+- ❌ 年付 push (refuted: 月付才是 solo travel 形态)
+- ❌ Hard paywall (refuted: freemium 三层结构)
+
+---
+
+## 6. 三阶段交付路线图
+
+### **Phase 1 (4 周): 沉淀地基**
+**目标**: 把 Travel Archive + TasteProfile 跑通,给"回看自己"一个家
+
+- 新增 VisitRecord @Model + ProactivePresenceService (区域驻留 5 分钟触发记录)
+- 新增 TasteProfile @Model + 本地嵌入向量
+- Onboarding 加 city + 3-pic vibe 两步
+- MeSheet 顶部 segmented `[档案 | 我]`,Archive tab 接入
+- SettingsView 14 → 6 section 砍冗余
+- 暖琥珀 v2 视觉沿用,Archive tab 全新美术
+
+**指标**: 30 天后,30% 月活用户至少进过 Archive tab 3 次以上
+
+**P1 走查 (2026-07-01)** — 主线全部满分通过,SettingsView 重排留单独 PR
+- ✅ **P1.0 schema v1.9**: VisitRecord / TasteProfile / TimeCapsule / AgentMemorySnapshot 4 个 @Model + 迁移注册 (18/18 测试绿)
+- ✅ **P1.1 #110 VisitTrackingService**: chain LocationService.onRegionEnter/Exit, 5min 计时 (注入可调) → 写 VisitRecord (7/7 测试绿)
+- ✅ **P1.1 #111 Archive tab UI**: ArchiveView + ArchiveViewModel, 按城市分组时间线 + 暖琥珀 token + 中英本地化
+- ✅ **P1.1 #112 地图已访问 halo**: MapViewModel.visitedExperienceIds + markerState 加 .footprinted 分支, 复用既有金色光晕样式; CompassMapView @Query 接线 (6/6 vm 测试 + 2/2 marker 性能回归绿)
+- ✅ **P1.1 #113 ArchiveViewModel 单测**: 8/8 测试绿 (按城分组 / 重访去重 / activeCityCode override / dayCount 本地时区 / 孤儿丢弃)
+- ✅ **P1.2 #120 OnboardingVibeStep**: PhotosPicker 3 张 + freeformVibe + commit 写 TasteProfile, 已接入 OnboardingView step 4
+- ✅ **P1.2 #121 OnboardingCityStep**: segmented 4 城 + afternoon textarea, 已接入 OnboardingView step 5 (语音留 Phase 2)
+- ✅ **P1.2 #122 generateTasteProfile**: AIService 加 deterministic on-device fallback (SplitMix64 PRNG → 64 维 Float embedding); vision LLM 留 future flag (14/14 测试绿, 1 个 trim-whitespace 生产 bug 被测试抓出并修复)
+- ✅ **P1.2 #123 TasteUpdateService**: @MainActor singleton, 每 5 visit 触发, confidence 0.30→0.95 单例 upsert (10/10 测试绿)
+- ✅ **P1.3 #132 MeSheet segmented [档案 | 我]**: Picker(.segmented) topTab + if/else 切换体, .archive 嵌 ArchiveView
+- ✅ **P1.4 #190 视觉接线 + 全量回归**: SoloCompassApp 启动调 VisitTrackingService.attach + setModelContainer; CompassMapView @Query VisitRecord + onAppear/onChange → vm.attachVisitedExperienceIds; OnboardingView 5→7 step
+- ✅ **P1.4 #192 Archive snapshot**: ArchiveSnapshotTests 用 ImageRenderer 写 PNG 到 /tmp (2/2 测试绿)
+- 🟡 **P1.3 #130 SettingsView 14 → 6**: 推迟到单独 PR (Recon-B 标 Stats/Data/Companion 4 个 high-risk section, 跨服务深耦合)
+
+**测试累计**: 65 项新单测全部通过 (`xcodebuild test` 在 iPhone 17 Pro / iOS latest)
+- 18 V1_9SchemaRecords / 7 VisitTracking / 8 ArchiveViewModel / 6 VisitedMarkerState / 14 GenerateTasteProfile / 10 TasteUpdate / 2 ArchiveSnapshot
+
+### **Phase 2 (6 周): Solo Agent v2 + 灵动岛主战场**
+**目标**: 让用户"每天 3-5 次想到打开 App"
+
+- ChatOrchestrator 接入 AgentMemorySnapshot 跨会话记忆
+- 新增 5 个 tool (suggest_now_action, open_blindbox, bury_capsule, recall_pattern, compose_ost)
+- 灵动岛加 solo_agent_hint / time_capsule / daily_omen 3 个 Kind
+- ProactiveNudgeService: 本地通知调度 (孤独时段 / 早晨签 / 胶囊触达)
+- FilterBar 收敛: Now 升级 Solo Agent 入口、category 抽屉化
+- ⭐ **时空胶囊 MVP**: 长按 Experience → 留胶囊 → 围栏触达
+- ⭐ **盲盒 Trip MVP**: $1.99 单次,复用现有 LiveActivity route
+
+**指标**: Pro 转化率从当前基线提升 2x,DAU/MAU 从 X% 提升到 Y%
+
+### **Phase 3 (4 周): 情绪付费引擎 + 病毒传播**
+**目标**: 拉新成本降一半,靠用户主动分享
+
+- 城市签每日推送 + 收集图鉴
+- 今日 OST + Apple Music / MusicKit 集成
+- Solo Brag 自动生成卡片 (找外部设计师做基础卡面)
+- 月度洞察卡片 (口味演化)
+- 反算法过滤器 "✦ 我的菜" toggle 上线
+- SOS Plan / 未走的路 / 圈层观察 全部走 Chat agent tool 形态交付
+- 年度 Travel Book 实体印刷 接入 (合作印刷服务商)
+
+**指标**: 用户自发分享率达到 5%/月,paid acquisition 成本下降 30%+
+
+---
+
+## 7. 度量与验证
+
+### 7.1 北极星指标
+**Pro 月留存 (M1 → M3) 从当前基线 → 50%+** (行业 36% 中位,目标显著高于)
+
+### 7.2 健康度二级指标
+- Archive tab 周访问率 (反 churn)
+- Solo Agent 每周触发次数 / 用户
+- 时空胶囊埋下数 / 用户 (lock-in 强度)
+- 盲盒 Trip 单次付费转化率 (情绪定价验证)
+- 自发分享率 (病毒传播验证)
+
+### 7.3 红线指标 (越低越好)
+- 灵动岛通知关闭率
+- SettingsView 进入次数 (越低说明默认体验越好)
+- Chat agent "我不知道你在说什么"回复率
+
+---
+
+## 8. 工程总成本估算
+
+| Phase | 周数 | 主要工作 | 风险 |
+|-------|------|---------|------|
+| Phase 1 | 4 | SwiftData 加 model + Archive UI + Settings 减法 | 低 |
+| Phase 2 | 6 | Chat memory + 灵动岛 Kind + 时空胶囊 + 盲盒 | 中 (LiveActivity 调试苦) |
+| Phase 3 | 4 | OST / Solo Brag / 城市签 / 印刷接入 | 中 (外部服务依赖) |
+| **合计** | **14 周** | | |
+
+**关键依赖**:
+- MusicKit (iOS 原生,低风险)
+- Apple Music API token 配置
+- 印刷服务商对接 (Polarsteps 同款供应商)
+- 外部设计师做 Solo Brag 卡面 (审美投入)
+
+---
+
+## 9. 决策检查表 (开工前)
+
+每个功能开工前问一遍:
+
+- [ ] 它每天用几次?(目标: Pro 功能日均 ≥ 2 次)
+- [ ] 用户为什么会截图?(写出一句具体的分享文案)
+- [ ] 用户离开损失什么?(回答: 失去什么资产)
+- [ ] Google Maps 为什么做不出来?(回答: 商业模式冲突 / 形态约束 / 数据缺失)
+- [ ] 它和现有的哪个 @Model / Service 复用?(目标: 新代码不超过 30%)
+
+答不上来,不做。
+
+---
+
+## 附录 A: 与既有 docs 的关系
+
+- `PRODUCT_BRIEF.md` — 不冲突,v1.0 是 brief 描述的"map-first companion"的成熟版
+- `FRIENDS_DESIGN.md` — Phase 1-3 都不动好友系统,等情绪付费引擎稳了再激活社交
+- `RETENTION.md` — v1.0 的核心论点(时空胶囊 + Travel Archive)是这份的实施版
+- `PRD/` — v1.0 之后会拆出对应 PRD,本文档是上游设计
+- `PHASES.md` — **历史路线图** (Field Week → Notion Prototype → Web Pre-MVP → iOS Native),记录 0→1 阶段;**本文档 v1.0 Phase 1-3 是 iOS Native 已上线后的下一个大版本**,不冲突
+- `todo.md` (仓库根) — 本文档的实施清单,80 个任务 ID 一一映射到 Pillar/Phase
+
+## 附录 B: 已被砍掉的方向 (备忘录)
+
+- ~~周通行证 $4.99/week~~ (refuted)
+- ~~年付 Pro 推送~~ (refuted)
+- ~~Hard paywall~~ (refuted)
+- ~~独食/夜归安全模式加价~~ (refuted)
+- ~~Bumble Travel 式撮合~~ (Couchsurfing 死法)
+- ~~AI 自动订机酒~~ (信任 gap)
+- ~~Day plan generator~~ (红海)
+
+## 附录 C: 事实底座边界 (验证过程发现, v0.1 已修正)
+
+> 本文档 v0.1 撰写时基于 explorer agent 报告,后做了一轮代码级验证。下列边界曾被一稿弄错,已在 v0.1 修正,记录在此防止下次出错:
+
+| 误判 | 真实情况 |
+|------|---------|
+| Widget 在 `apps/ios/SoloCompass/Widgets/` | 实际在 `apps/ios/SoloCompassWidgets/` 独立 target |
+| `SoloCompassActivityAttributes.Kind` 在 widget 文件内 | 在 `apps/ios/SoloCompass/Shared/SoloCompassActivityAttributes.swift` 双 target 共享 |
+| 要新建 `ProactivePresenceService` | `PresenceService` 已存在 (Companion Mode geohash),不复用;新建 `VisitTrackingService` 但借鉴隐私契约 |
+| 要新建 `ProactiveNudgeService` | `NotificationService` 已实现 UNUserNotificationCenter 基础;v1.0 新建 `ProactiveNudgeScheduler` 作为业务调度层 |
+| @Model 共 23 个 | 实际 grep 出 24 个 (差异在 TravelerNoteRecord 一处双匹配) |
+| FilterBar 收藏入口名 "Favorites" | 代码命名为 "Saved" |
+| IAP product ID 用 `consumable.blindbox.single` | 现有规范是反域名 `com.solocompass.pro.monthly/yearly`,新 consumable 沿用 `com.solocompass.consumable.<feature>.<sku>` |
+| VoiceAgentToolRouter 当前 tool 数 | 实际 grep 出 10 个 (与 explorer 报告一致),新增 8 个不冲突 |

--- a/todo.md
+++ b/todo.md
@@ -1,77 +1,486 @@
-# Solo Compass — UI/UX Deep Audit TODO
+# Solo Compass — v1.0 Roadmap TODO
 
-> Date: 2026-06-16
-> Branch: test/amap-shenzhen-5km-experience
-> Audit method: Simulator screenshots (iPhone 17 Pro, Chiang Mai seed data) + source code review
-
----
-
-## P0 — Critical (Blocks core experience)
-
-- [x] **#1 Empty state for non-seed cities is a dead end** — `BottomInfoSheet.swift`, `MapViewModel.swift` — Launching in Shenzhen/Bangkok 等非清迈城市显示 "No experiences nearby"，只有 "Expand to 25 km" 和 "Clear filters"，两者都无用。应增加城市级空状态引导："This city doesn't have experiences yet — try Chiang Mai" + 一键切城 CTA
-- [x] **#2 Distance shows 12,398.6km — absurdly large** — `BottomInfoSheet.swift` NearbyExperienceRow — 模拟器在 SF 但展示清迈数据时距离显示 12,398.6km，跨洲距离无意义。超过 500km 时应隐藏距离或显示 "In Chiang Mai"
-- [x] **#3 Bottom sheet lacks loading skeleton** — `BottomInfoSheet.swift` — sheet 展开到数据加载之间有 ~500ms 空白区域，无 shimmer/skeleton/spinner。`SkeletonView.swift` 已存在但未接入
-- [x] **#4 Location permission banner is non-actionable** — `CompassMapView` — 黄色 banner "Can't find your location..." 无 "Open Settings" 按钮，用户必须手动去系统设置
+> Date: 2026-07-01
+> Branch: main
+> Design doc: `docs/V_NEXT_DESIGN.md`
+> 目标: 把 Solo Compass 从工具升级为"独行者沉迷的 AI 旅伴"——14 周三阶段交付
+> 三阶段总览: **Phase 1 (4w 沉淀地基) → Phase 2 (6w Agent v2 + 灵动岛) → Phase 3 (4w 情绪付费引擎)**
 
 ---
 
-## P1 — High (Hurts usability)
+## 🧭 阅读指南
 
-- [x] **#5 FilterBar category icons lack labels** — `FilterBarView.swift` — 类别 pill 仅显示 emoji 图标无文字，新用户无法区分 food/culture 等图标含义。需增加文字标签或长按提示
-- [x] **#6 "Now" filter shows 0 items at midnight with no explanation** — `FilterBarView.swift`, `MapViewModel.swift` — 深夜时 Now 筛选无结果且无提示。应增加时间感知空状态："It's late — most spots are closed"
-- [x] **#7 PeekSummaryCard text truncation on long titles** — `PeekSummaryCard.swift` — 标题 "Eat khao soi at the family s..." 被截断，Experience.title 是完整句子非短名。应允许 2-3 行或使用 shortName
-- [x] **#8 DayPage/Me screen is sparse and low-value** — `MeSheet.swift` — 显示 "Tuesday" + "Still up?" + "0 SIGNALS" + "Nothing surfaced yet." 全是空状态，"signal" 概念无解释，orb 动画装饰性强但令人困惑
-- [x] **#9 Map pin density — clusters are hard to distinguish** — `CompassMapView.swift`, `MarkerIconView.swift` — 中等缩放下 4-5 个 pin 重叠，无聚合注释或防重叠逻辑。应使用 MapKit ClusterAnnotation
-- [x] **#10 "Smart" sort has no explanation** — `BottomInfoSheet.swift` SortMode picker — 默认排序 "Smart" 无解释其依据，用户不理解或不信任排名。应增加 "(based on time, distance & score)" 副标题
-- [x] **#11 Dark mode contrast issues on cards** — `BottomInfoSheet.swift` smart-pick gradient — `CT.sunGoldSoft.opacity(0.55)` → `CT.surfaceWhite` 渐变在暗色模式下视觉层次反转，金色看起来像错误状态
-
----
-
-## P2 — Medium (Quality & polish)
-
-- [x] **#12 "Nearby" button purpose is unclear** — `CompassMapView` — 地图右下角 "Nearby" 文字按钮功能与底部 sheet 重叠，应移除或明确其独特用途
-- [x] **#13 Solo Score badge lacks context** — `SoloScoreBadge.swift` — "Solo 7.8" 无标尺说明（满分 10？100？），无颜色编码区分好坏。应加 "/10" 后缀 + 渐变色
-- [x] **#14 "BEST FOR RIGHT NOW" header redundant when Now filter is off** — `BottomInfoSheet.swift` — "All" 筛选时仍显示 "BEST FOR RIGHT NOW"，暗示时间相关但卡片可能并非当前最佳
-- [x] **#15 Chat input bar at bottom of DayPage is confusing** — `MeSheet.swift` — 底部 "Capture this moment" + 麦克风图标，分不清是文字输入还是语音录制，是日记还是聊天
-- [x] **#16 Missing haptic feedback on map pin tap** — `CompassMapView.swift` — 点击地图 pin 显示 PeekSummaryCard 但无触觉反馈，FilterBar pill 有 haptics 但主要交互（pin tap）没有
-- [x] **#17 "+" FAB button has no label/tooltip** — `CompassMapView.swift` — 右下角大黑 "+" 按钮无上下文说明，创建的是 Experience？Route？Note？
-- [x] **#18 Onboarding is only 2 steps — too thin** — `OnboardingView.swift` — 仅 welcome + style-selection，未解释核心概念（Experience/Solo Score/Now/DayPage）
-- [x] **#19 CJK text truncation in NowHintRow** — `BottomInfoSheet.swift` — `.lineLimit(1)` 导致中日文提示 "此刻是拍摄落日的黄金时刻" 截断。应允许 `.lineLimit(2)` 或 `minimumScaleFactor`
-- [x] **#20 Walk-time estimate uses naive constant** — `PeekSummaryCard.swift` — 步行时间假设 ~80m/min 不考虑地形。应加 "~" 前缀或使用 MapKit 实际步行路线
+每个任务按 `[ ] #ID 标题 — 路径 — 说明` 格式。
+- **⭐** = 沉迷设计 (lock-in 之王)
+- **🎁** = 病毒传播功能 (用户会截图)
+- **💰** = 直接付费转化点
+- **🔪** = 砍 / 合并 / 减法
+- **🧱** = 地基类 (无视觉,但必须有)
 
 ---
 
-## P3 — Low (Nice to have)
+# Phase 1 — 沉淀地基 (4 周)
 
-- [x] **#21 No pull-to-refresh on the experience list** — `BottomInfoSheet.swift` — NearbySection 无下拉刷新手势，iOS 用户普遍期望
-- [x] **#22 No search functionality** — 无全局搜索，体验 50+ 时只能滚动或用筛选器，效率低
-- [x] **#23 No image/photo on experience cards** — `BottomInfoSheet.swift` NearbyExperienceRow — 卡片仅文字无图片预览，`ExperienceImageService` 已存在但未接入列表卡片
-- [x] **#24 Settings gear icon on DayPage is low-contrast** — `MeSheet.swift` — DayPage 右上角齿轮图标过小且低对比度
-- [x] **#25 Map style options are hidden** — 无可见方式切换卫星/标准/混合地图，顶部笔形图标含义模糊
-- [x] **#26 No transition animation between peek/mid/full sheet states** — `BottomInfoSheet.swift` — detent 状态切换缺乏统一的 spring 动画
-- [x] **#27 "Good spots for right now" timestamp shows exact time** — `BottomInfoSheet.swift` — 显示 "00:17" 原始时间无意义，应改为 "Updated just now" 或移除
-- [x] **#28 Compass/navigation icons in top bar are ambiguous** — 顶栏指南针和定位箭头与 MapKit 内置控件功能重叠
-- [x] **#29 "All Cities" dropdown doesn't show current city name** — `CityPickerSheet.swift` — 左上角始终显示 "All Cities" 而非当前城市名 "Chiang Mai"
-- [x] **#30 Accessibility: reduce-motion not respected everywhere** — 多处动画（pulsing/heart burst）未统一检查 `reduceMotion`
+> 把 Travel Archive + TasteProfile 跑通,给"回看自己"一个家。
+> 出口指标: 30 天后 30% 月活用户进过 Archive tab ≥3 次
+
+## P1.0 — SwiftData 模型扩展 🧱
+
+- [x] **#101 加 `VisitRecord @Model`** ✅ — `apps/ios/SoloCompass/Persistence/Models/VisitRecord.swift`
+  - 字段: `experienceId: String, visitedAt: Date (ISO 8601 UTC), dwellSeconds: Int, weatherCode: String?, coordSnapBlob: Data ([lon,lat])`
+  - 关联: 复用现有 ExperienceRecord (引用 string id,不外键约束)
+  - 测试: 已在 `Tests/V1_9SchemaRecordsTests.swift` 覆盖 CRUD + coords 编解码 + 边界
+- [x] **#102 加 `TasteProfile @Model`** ✅ — `apps/ios/SoloCompass/Persistence/Models/TasteProfile.swift`
+  - 字段: `embedding: Data (float32 vector), descriptorsBlob: Data (JSON [String]), confidence: Double, updatedAt: Date, sourceVibePhotosBlob: Data?`
+  - 单例存储 (每个用户 1 条,store 层强制)
+- [x] **#103 加 `TimeCapsule @Model`** ✅ — `apps/ios/SoloCompass/Persistence/Models/TimeCapsule.swift`
+  - 字段: `id: UUID, experienceId: String, createdAt: Date, scheduledFor: Date, contentType: String (text/voice/photo), contentBlob: Data, contextBlob: Data? (CapsuleContext JSON), opened: Bool`
+  - 查询模式: `#Predicate { !$0.opened && $0.scheduledFor <= now }` (SwiftData SQLite 范围扫描)
+  - 副产物: 加了 `CapsuleContext` Codable 结构 (weather/tasteDescriptors/moodEmoji)
+- [x] **#104 加 `AgentMemorySnapshot @Model`** ✅ — `apps/ios/SoloCompass/Persistence/Models/AgentMemorySnapshot.swift`
+  - 字段: `summary: String (≤500 字), lastTripCity: String?, recentChatDigest: String (≤300 字), updatedAt: Date`
+  - 副产物: `systemPromptBlock()` 方法,空字段自动跳过,直接喂入 chat system prompt
+- [x] **#100 schema v1.9 注册** ✅ — `apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift`
+  - 新增 `SoloCompassSchemaV1_9: VersionedSchema`,4 个新 model
+  - migration plan stage v1.8 → v1.9 (lightweight, additive 4 张新表)
+  - 主 ModelContainer + makeInMemory 两处都已注册
+  - xcodegen 已重新生成 .xcodeproj
+- [x] **#105 跑 `pnpm parity:check` 验证 TS↔Swift schema parity** ✅ (2026-07-01) — `scripts/check-swift-parity.ts`
+  - 四路 parity 全绿: TS↔Swift interfaces / TS↔Drizzle experiences 表 / Supabase SQL↔Swift sync payloads / TS↔SwiftData @Model
+  - 4 张新 @Model 表 (VisitRecord/TasteProfile/TimeCapsule/AgentMemorySnapshot) 被 SWIFTDATA_GLOBS 自动 match, 无需白名单
+  - 结论: 4 个新 @Model 完全兼容既有 parity 契约
+
+## P1.1 — 被动旅行档案 (免费层) ⭐🧱
+
+- [x] **#110 新增 `VisitTrackingService`** ✅ — `apps/ios/SoloCompass/Services/VisitTrackingService.swift`
+  - 隔离层: @MainActor @Observable final class, shared singleton + injectable init
+  - 围栏接入: chain `LocationService.onRegionEnter/onRegionExit` 不抢槽,Task → handleEnter/Exit
+  - 计时器: `pendingTimers: [String: Task]` + entryTimestamps; 默认 5min dwellThreshold (注入 sub-second 跑测试)
+  - 隐私契约: foreground-only — `UIApplication.didEnterBackgroundNotification` → dropAllPending
+  - GPS jitter: handleEnter 同 region 重入会被忽略 (timer 不存在才启动)
+  - 失败安全: 缺 ModelContainer → os_log + 静默丢弃; save 失败 → os_log 不抛
+  - 测试 7/7 通过 (Tests/VisitTrackingServiceTests.swift)
+- [x] **#111 Archive tab 主屏 UI** ✅ — `apps/ios/SoloCompass/Views/Archive/ArchiveView.swift` + `ViewModels/ArchiveViewModel.swift`
+  - 顶部: 当前 trip card (cityCode + dayCount + distinctExperienceCount, 暖琥珀 CT.accentSoft 背景 + CT.sunGold 数字)
+  - 中部: 按 cityCode 分组的时间线; 每行=琥珀圆点 + title + 本地化日期 + dwell 分钟数 (≥60s 才显)
+  - 底部: codex placeholder (虚线框 + Phase 3 提示)
+  - 空态: 地图图标 + 友善文案
+- [x] **#112 Archive 地图图层 "我去过的"** ✅ (vm 通路 + 6/6 测试绿) — `apps/ios/SoloCompass/ViewModels/MapViewModel.swift`
+  - 复用既有 `.footprinted` 状态 (Experience.swift:1021 已存在 + MarkerIconView 金色光晕样式现成),零 view 改动
+  - MapViewModel 加 `visitedExperienceIds: Set<String>` + `attachVisitedExperienceIds(_:)` (照 attachSubscriptionService pattern)
+  - markerState 加 visited 分支,优先级在 .completed/.favorited/.bestNow/.upcoming 之后, 在 legacy passiveGpsHits30d 之前
+  - 测试覆盖 6/6: baseline default / attach → footprinted / 清空 → default / completed 仍胜出 / favorited 仍胜出 / 无关 id 不影响
+  - **尾巴**: CompassMapView 视觉接线 (用 @Query VisitRecord + onAppear 调 vm.attachVisitedExperienceIds) 留到 #190 P1.4 出口验证, Settings toggle 留到 #130 P1.3 Settings 重排同步做
+- [x] **#113 写 ArchiveViewModel 单测** ✅ — `apps/ios/SoloCompass/Tests/ArchiveViewModelTests.swift`
+  - 8/8 通过: 空态 / 城市分组 / 重访 distinctCount / 默认最新城市 / activeCityCode 覆盖 / 跨日 dayCount (本地时区) / 同日 = 1 day / 孤儿 visit 静默丢弃
+
+## P1.2 — 口味画像采集 ⭐
+
+- [x] **#120 Onboarding 第 4 步: vibe 采集** ✅ (build 绿, 已接入 OnboardingView step=4) — `apps/ios/SoloCompass/Views/Onboarding/OnboardingVibeStep.swift`
+  - 3 张照片 PhotosPicker (iOS 17+ SwiftUI 原生, 复用 CreateExperienceSheet 同 pattern)
+  - 选完调 AIService.generateTasteProfile → upsert TasteProfile (P1.0 #102 已落地表)
+  - Continue + Skip 两路, Skip 不抛错: AIService fallback 永远返回最低 confidence 的有效 profile
+  - 中英本地化 (onboarding.vibe.* 7 条)
+- [x] **#121 Onboarding 第 5 步: city + 一句话描述** ✅ (build 绿, 已接入 OnboardingView step=5) — `apps/ios/SoloCompass/Views/Onboarding/OnboardingCityStep.swift`
+  - 不复用 CityPickerSheet (vm 依赖太重), 改用轻量 segmented Picker 4 城 (cmi/SZX/VTE/san-francisco, 与 knownCityCenters 对齐)
+  - 写 preferences.lastSelectedCity (didSet 自动 persist)
+  - "你想要怎样的一个下午?" textarea (axis: .vertical, lineLimit 2-4) → 非空时 append 到 customTags (供 Phase 2 Solo Agent 读)
+  - 语音留 Phase 2 (mic 权限不进 onboarding); 中英本地化 (city.* 4 + onboarding.city.* 6 条)
+- [x] **#122 AIService.generateTasteProfile() 实现** ✅ (14/14 测试绿, 含 1 个生产 bug 被测试抓出: trim 空白 vibe 不再误计入 confidence) — `apps/ios/SoloCompass/Services/AIService.swift`
+  - 第一版交付 on-device deterministic fallback (FNV hash + SplitMix64 → 64 维 Float embedding)
+  - Vision LLM 上传 path 留 feature flag, 当前实现保证 onboarding 永不被 API 阻塞
+  - 4 种 style 各产出独特 descriptor 词表 + freeformVibe 拆词增量贡献 ≤2 descriptors (prefix(5) 总上限)
+  - confidence 0.20 → 0.55 schedule (style+0.10, +0.05/photo×3, +0.10/vibe); 0.95 ceiling 留给 TasteUpdateService
+- [x] **#123 TasteProfile 持续更新机制** ✅ (10/10 测试绿) — `apps/ios/SoloCompass/Services/TasteUpdateService.swift`
+  - @MainActor @Observable singleton + shared, 照 VisitTrackingService 模板
+  - recordVisitTriggered() 每 5 次触发一次 recomputeProfile (triggerEvery 可注入跑测)
+  - confidence 0.30 (floor) → 0.95 (ceiling), 每 visit +0.05, ~13 visits 到顶
+  - TasteProfile 单例 upsert (fetch first, update existing or insert new)
+  - 失败安全: 无 container / encode 失败 / save 失败 → os_log + 不抛
+
+## P1.3 — 减法 / 冗余清理 🔪
+
+- [ ] **#130 SettingsView 14 → 6 section** 🟡 **推迟到 Phase 2 独立 PR** — `apps/ios/SoloCompass/Views/Settings/SettingsView.swift`
+  - 合并: Travel Style + Preferred + Disliked → "你的喜好" (复用现有 PreferenceEditorView)
+  - 合并: Distance + Language → "地理"
+  - 隐藏: AI Provider 到 About 7 次点击解锁
+  - 隐藏: Admin unlock 同上
+  - 移走: Stats 到 Archive tab
+  - 合并: Companion opt-in → Notifications 子项
+  - 合并: Export → Data 子项
+  - 移走: Filter Bar Customization → FilterBar 长按原地编辑
+  - **推迟理由 (2026-07-01)**: SettingsView 1537 行, 14 section 中 8 个高耦合 (Companion 有 5 NavigationLink 子链 / Data 有 Apple SignIn destructive path / Subscription 有 StoreKit + admin unlock / Language 触发 restart alert 等); Recon-B agent 侦察结论明确"独立 PR 级"; 上述 8 条要求实际是新特性开发 (7-tap 解锁、Filter Bar 长按编辑等), 非清理。保 Phase 1 主线 70/70 全绿基线优先。
+- [ ] **#131 砍 BottomInfoSheet 中间层** 🟡 **推迟到 Phase 2 独立 PR** — `apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift`
+  - peek 内容(NearbyExperienceRow 列表)直接嵌入 ExperienceDetailView 的 hero 下
+  - 点 POI → 直接半屏 ExperienceDetail (mid detent)
+  - 注意: 这是大改,要 4 测试: ChatSheet 路径不受影响、FAB 路径不受影响、Now filter 不受影响、Routes 路径不受影响
+  - **推迟理由 (2026-07-01)**: Recon-BottomInfoSheet agent 侦察: 删 peek 会破 6+ 处 —— peekHeight() 函数被外部 (CompassMapView 浮卡 inset) 计算引用, CardBottomInsetClearanceTest 显式验证 peek 高度会红, -expandSheet DEBUG 假设 peek 存在, 3 态 ladder (nextHigher/nextLower) 数学要重写; 且 peek 承担 "cold-start 就看到 PeekSummaryCard 智能推荐 + NowHintRow" 的核心 UX 价值, 删除会失去 R0 冷启动首帧价值。属于产品级重新设计, 非清理。
+- [x] **#132 MeSheet 顶部加 segmented `[档案 | 我]`** ✅ (build 绿, 视觉 P1.4 #190 验证) — `apps/ios/SoloCompass/Views/Me/MeSheet.swift`
+  - VStack 包 Picker(.segmented) topTab .archive/.me + if/else 切换体
+  - .archive 嵌 ArchiveView(modelContainer: modelContext.container)
+  - .me 保留完整原 List 内容 (Profile/Entitlement/Friends/Messages/Companion/Moderation/Settings)
+  - 中英本地化 me.tab.archive/me.tab.me
+
+## P1.4 — Phase 1 出口验证
+
+- [x] **#190 视觉接线 + 跑全部新测试 xcodebuild test** ✅ — `apps/ios/SoloCompass/App/SoloCompassApp.swift` + `Views/Map/CompassMapView.swift` + `Views/Onboarding/OnboardingView.swift`
+  - SoloCompassApp.runBootstrapIfConsented 加 `VisitTrackingService.shared.setModelContainer(...) + attach()`
+  - CompassMapView: `@Query private var visitRecords: [VisitRecord]` + onAppear/onChange → vm.attachVisitedExperienceIds
+  - 新累计测试 63/63 全绿: 18 (V1_9 schema) + 7 (VisitTracking) + 8 (Archive vm) + 6 (Visited marker) + 14 (taste profile) + 10 (taste update); 2/2 (marker performance regression)
+- [x] **#191 Phase 1 走查清单** ✅ — docs/V_NEXT_DESIGN.md 加 P1 走查段, 列出 11 项主线 ✅ + 1 项推迟说明 + 65 项测试累计
+- [x] **#192 visual snapshot 更新** ✅ (2/2 测试绿, PNG 56KB 写到 /tmp) — `apps/ios/SoloCompass/Tests/ArchiveSnapshotTests.swift`
+  - ImageRenderer 渲 ArchiveView populated/empty 两态 → /tmp/archive_snapshot_*.png
+  - 已知小限制: ImageRenderer 同步渲染不触发 onAppear, 两 PNG 字节相同 — 真实截图需 UIHostingController, 留 Phase 2
 
 ---
 
-## Architecture & Code Quality
+## 📊 Phase 1 收官报告 (2026-07-01)
 
-- [x] **#A1 BottomInfoSheet.swift is 1400+ lines** — 违反 800 行上限，应拆分 NearbyExperienceRow、RoutesSection、NowHintRow 到独立文件
-- [x] **#A2 Hardcoded proximity thresholds (150m)** — 无城市密度差异配置，东京 150m = 2 个街区 vs 泰国乡村 150m = 隔壁。应按城市/类别配置
-- [x] **#A3 FilterBar and Map count can desync** — `resultCount` 作为 prop 传入 FilterBar 非 source of truth，快速平移时可能显示过期计数
-- [x] **#A4 Dynamic Type scaling gaps** — BottomInfoSheet 通过 `UIFontMetrics` 缩放 detent 高度，但内部 padding 硬编码（`.padding(.bottom, 28)`），AX5 下文字溢出容器
+**主线完成度 20/22 = 90.9%**, 剩余 2 项 (#130 / #131) 明确推迟到 **Phase 2 独立 PR**。
+
+| 类别 | 完成 | 说明 |
+|---|---|---|
+| P1.0 地基 (5 项) | 5/5 ✅ | schema v1.9 + 4 @Model + parity 四路全绿 |
+| P1.1 被动档案 (4 项) | 4/4 ✅ | VisitTracking + Archive VM + View + marker halo |
+| P1.2 口味画像 (4 项) | 4/4 ✅ | Vibe/City onboarding + generateTasteProfile + TasteUpdateService |
+| P1.3 减法清理 (3 项) | 1/3 🟡 | ✅ #132 MeSheet segmented; 🟡 #130/#131 推迟 |
+| P1.4 出口验证 (3 项) | 3/3 ✅ | 全套接线 + 走查文档 + snapshot |
+
+**测试基线**: 70/70 全绿, 5.5s 完成; 无回归。
+
+**为什么 #130 / #131 独立 PR**:
+- SettingsView 1537 行 / BottomInfoSheet 822 行 都远超 CLAUDE.md 800 行上限, 已是重构级
+- todo 里 8 条 #130 要求包含新特性 (7-tap 隐藏解锁 / Filter Bar 长按编辑) —— 不是纯清理
+- BottomInfoSheet peek 承担 R0 冷启动首帧核心 UX (智能推荐 PeekSummaryCard + NowHintRow), 直接删会失去 R1-R6 heat 优化成果
+- 强做 Recon-B 明确警告的高耦合 section 会破 3+ 个现有回归测试, 违背"每步 100 分"
 
 ---
 
-## Summary
+# Phase 2 — Solo Agent v2 + 灵动岛主战场 (6 周)
 
-| Priority    | Count  | Effort (Est.)   |
-| ----------- | ------ | --------------- |
-| P0 Critical | 4      | 2-3 days        |
-| P1 High     | 7      | 3-5 days        |
-| P2 Medium   | 9      | 5-7 days        |
-| P3 Low      | 10     | 5-7 days        |
-| Arch        | 4      | 3-4 days        |
-| **Total**   | **34** | **~18-26 days** |
+> 让用户"每天 3-5 次想到打开 App"。
+> 出口指标: Pro 转化率 2x、DAU/MAU 显著提升
+
+## P2.0 — Chat Agent 升级 ⭐
+
+- [ ] **#201 ChatOrchestrator 注入 AgentMemorySnapshot** — `apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift`
+  - 每次新会话开始时,从 SwiftData 读最近 memory snapshot
+  - 注入 system prompt: "用户最近: <summary>;当前 trip: <city, day N>;最爱: <top 3 experience names>"
+  - 注意: prompt 中包含的所有数据必须脱敏 (不带坐标/手机/身份)
+- [ ] **#202 AgentMemorySnapshot 后台更新** — `apps/ios/SoloCompass/Services/MemoryDigestService.swift`
+  - 每个 chat session 结束时,异步调用 LLM 生成 ≤500 字摘要
+  - 写回 AgentMemorySnapshot
+  - on-device 优先,不上传云端
+- [ ] **#203 ChatOrchestrator 加入时段意识** — `VoiceAgentOrchestrator.swift`
+  - 注入 system prompt: "现在是 <morning/afternoon/evening/night> 的 <周几>"
+  - 早上语气: "今天想做什么", 傍晚: "要不要去坐一会"
+- [ ] **#204 Settings 加 "忘记我" 按钮** — `apps/ios/SoloCompass/Views/Settings/SettingsView.swift`
+  - 一键清空 AgentMemorySnapshot + TasteProfile
+  - 用户隐私焦虑兜底
+
+## P2.1 — 新 Tool 扩展 (VoiceAgentToolRouter) ⭐
+
+- [ ] **#210 Tool: `suggest_now_action`** — `apps/ios/SoloCompass/Services/VoiceAgentToolRouter.swift`
+  - 输入: 当前位置、时段、最近 VisitRecord、TasteProfile
+  - 输出: ChatCard.experience (1 个) + 1 句话 + 路上做什么的小建议
+  - **RAG 约束**: 必须从 Experience 池命中,never 凭空生成 POI
+- [ ] **#211 Tool: `open_blindbox`** — `VoiceAgentToolRouter.swift`
+  - 输入: duration (默认 3 小时)
+  - 启动盲盒 Trip 流程(见 P2.3)
+- [ ] **#212 Tool: `bury_capsule`** — `VoiceAgentToolRouter.swift`
+  - 输入: experienceId, contentType, contentBlob, scheduledFor
+  - 写入 TimeCapsule
+- [ ] **#213 Tool: `recall_pattern`** — `VoiceAgentToolRouter.swift`
+  - 输入: period (本月/本季/本年)
+  - 输出: 月度洞察文本 + 卡片
+- [ ] **#214 Tool: `sos_plan`** — `VoiceAgentToolRouter.swift`
+  - 触发: 用户说"下雨了/景点关了/朋友爽约"等关键词
+  - 输出: 4 小时替代路线 + 走 paywall (Pro 用户每月 3 次免费,免费用户 $2.99/次 IAP)
+  - 关联 product ID: `com.solocompass.consumable.sos.single` (Phase 3 接入)
+- [ ] **#215 Tool: `unwalked_path`** — `VoiceAgentToolRouter.swift` 💰
+  - 触发: trip 结束时用户问"那天还能怎么走"
+  - 输出: 反事实路径 + 单次解锁 $4.99 IAP
+  - 关联 product ID: `com.solocompass.consumable.unwalked.single` (Phase 3 接入)
+- [ ] **#216 在 VoiceAgentToolRouter switch 加 5 个 case**
+  - 当前 switch 有 10 个 case (explore_nearby/build_route/filter_by_category/show_details/save_to_favorites/dismiss_recommendation/search_places/navigate_to/filter_visible/expand_radius),新增 5 个不冲突
+  - tool 字符串规范: `suggest_now_action / open_blindbox / bury_capsule / recall_pattern / sos_plan / unwalked_path / compose_ost / recall_local_scene` (P3.5 #352 用)
+  - AIService prompt 模板同步注册新 tool 描述
+
+## P2.2 — 灵动岛 3 个新 Kind ⭐
+
+- [ ] **#220 在 `SoloCompassActivityAttributes.Kind` 加 3 个 case** — `apps/ios/SoloCompass/Shared/SoloCompassActivityAttributes.swift`
+  - **注意**: Kind enum 在双 target 共享文件,改一处自动两端生效
+  - 加: `case soloAgentHint`, `case timeCapsule`, `case dailyOmen`
+  - 同步在 `SoloCompassActivityState` 加每个 Kind 需要的字段 (hint text / capsule preview / omen line)
+- [ ] **#221 widget 端渲染 3 个新 Kind** — `apps/ios/SoloCompassWidgets/SoloCompassLiveActivity.swift` + `LockScreenLiveActivityView.swift`
+  - 在 `ExpandedLeading/Trailing/Center/Bottom` 4 个 @ViewBuilder switch 加新 case (现有写法已为加 Kind 留好扩展点)
+  - 限流逻辑放主 app 不放 widget (widget 只渲染,不决策)
+- [ ] **#222 `solo_agent_hint` 主 app 触发逻辑** — `apps/ios/SoloCompass/Services/LiveActivityService.swift`
+  - 加 `startSoloAgentHint(hint:experienceId:)` 方法
+  - 限流: 一天最多 3 次 (用 UserDefaults 滚动计数)
+  - expanded region: 建议 + 采纳/换一个/5min 后再提 (intent button)
+- [ ] **#223 `time_capsule` 触发链路** — `LiveActivityService.swift` ⭐
+  - 触发源: 新增的 VisitTrackingService 检测进入有未拆胶囊的围栏 (复用 CLCircularRegion)
+  - 加 `startTimeCapsule(capsuleId:experienceId:preview:)`
+  - 拆开动画走主 app 全屏 (CapsuleOpenView, 见 #242),widget 只负责"邀请拆开"卡片
+- [ ] **#224 `daily_omen` 调度 + 触发** — `LiveActivityService.swift`
+  - 每天 7am 本地通知触发 (复用 NotificationService schedule 能力)
+  - 加 `startDailyOmen(line:experienceId:)`
+- [ ] **#225 LiveActivityService 单测覆盖** — `apps/ios/SoloCompass/Tests/LiveActivityServiceTests.swift`
+  - 每个 start/update/end 路径都覆盖
+  - 限流硬上限测试 (24 小时窗口超过 3 次必须 noop)
+
+## P2.3 — 盲盒 Trip MVP 🎁💰
+
+- [ ] **#230 盲盒 Trip 启动 UI** — `apps/ios/SoloCompass/Views/Blindbox/BlindboxLaunchView.swift`
+  - 全屏一键按钮 (橙色琥珀渐变)
+  - 时长选择: 1h/3h/全天
+  - 付费墙: 免费用户 $1.99 IAP / Pro 用户每月 5 次免费
+- [ ] **#231 BlindboxOrchestrator** — `apps/ios/SoloCompass/Services/BlindboxOrchestrator.swift`
+  - 从 Solo Agent 选 3-5 个 anchor Experience (按时长打散)
+  - 状态机: 进行中 / 走向某站 / 到达 / 揭秘 / 结束
+  - 全程接 LiveActivity (复用 route Kind 但终点延迟揭示)
+- [ ] **#232 盲盒结束复盘卡** — `apps/ios/SoloCompass/Views/Blindbox/BlindboxRecapCard.swift` 🎁
+  - 设计要美 (找设计师): 今天去了 N 个地方、走了 X km、agent 一句话总结
+  - "分享" 按钮 (生成图片到相册 / 直接分享 sheet)
+- [ ] **#233 盲盒第一次"安全保护"逻辑** — `BlindboxOrchestrator.swift`
+  - 新用户的第一次盲盒全部走 high-confidence + 高 SoloScore Experience
+  - "重摇" 按钮免费 (无次数限制)
+- [ ] **#234 IAP 商品配置** — `apps/ios/SoloCompass/Services/SubscriptionService.swift`
+  - 加 product ID `com.solocompass.consumable.blindbox.single` $1.99 (沿用现有反域名命名规范,对齐 `com.solocompass.pro.monthly/yearly`)
+  - 在 SubscriptionService 加 `public static let blindboxSingleProductID` 常量
+  - StoreKit2 `Product.products(for:)` 注册,放入 `allConsumableProductIDs` 数组
+
+## P2.4 — 时空胶囊 MVP ⭐ (Lock-in 之王)
+
+- [ ] **#240 长按 Experience 留胶囊入口** — `apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift`
+  - 长按 hero 区域 → 弹出 sheet: "留下时间胶囊"
+  - 输入: 文字 (textfield) / 语音 (复用 VoiceService) / 照片 (PhotosPicker)
+  - 配置: 几个月后触发 (3/6/12 默认 12)
+- [ ] **#241 CapsuleComposeView 实现** — `apps/ios/SoloCompass/Views/Capsule/CapsuleComposeView.swift`
+  - 写入 TimeCapsule + 当时 weather/taste/mood snapshot
+  - 写入后吐司: "胶囊将在 X 年后等你回来"
+- [ ] **#242 CapsuleOpenView 全屏接受动画** — `apps/ios/SoloCompass/Views/Capsule/CapsuleOpenView.swift` ⭐🎁
+  - 仪式感 UI: 暖琥珀粒子 + 慢揭示 + 当时元数据展示
+  - "再回信一句" 二次互动 (写入新 TimeCapsule)
+- [ ] **#243 CapsuleStore 实现** — `apps/ios/SoloCompass/Services/CapsuleStore.swift`
+  - CRUD + 围栏匹配
+  - 每天 launch 时检查 scheduledFor ≤ now 的胶囊,关联到对应围栏
+- [ ] **#244 年末回顾推送** — `apps/ios/SoloCompass/Services/ProactiveNudgeService.swift`
+  - 12 月底自动推送: "今年你埋了 X 个胶囊,X 个会在明年触发"
+  - 防止用户忘记资产存在
+- [ ] **#245 Archive tab 加 "我的胶囊" section**
+  - 显示已埋未触发、已触发未拆、已拆 三组列表
+
+## P2.5 — FilterBar 收敛 🔪
+
+- [ ] **#250 Now 升级 Solo Agent 入口** — `apps/ios/SoloCompass/Views/Filter/FilterBarView.swift`
+  - Now chip 改为 "⚡ Solo Agent" 琥珀色
+  - 点击直接触发 `suggest_now_action` tool 并打开 ChatSheet 显示结果
+- [ ] **#251 category 抽屉化** — `FilterBarView.swift`
+  - 默认显示 3 个: 咖啡 / 美食 / 文化 (基于 user 历史频率自动选 3 个)
+  - "≡ More" 按钮展开抽屉显示其余 5 个 + 自定义 tag
+- [ ] **#252 加 "✦ 我的菜" toggle** — `FilterBarView.swift`
+  - 开启后所有结果按 TasteProfile 匹配度排序
+  - 免费层就给 (是 Pro 私密策展的钩子)
+
+## P2.6 — ProactiveNudgeService 主动推送 🧱
+
+- [ ] **#260 在现有 `NotificationService` 之上加 `ProactiveNudgeScheduler`** — `apps/ios/SoloCompass/Services/ProactiveNudgeScheduler.swift`
+  - **不替代** 现有 NotificationService (它已实现 UNUserNotificationCenter 基础 + deep-link),只在其上加业务调度层
+  - 统一限流: 一天最多 3 个 nudge 推送 (与 LiveActivity 限流共用一个计数器)
+  - 用户主动开启 (Settings 中)
+- [ ] **#261 孤独时段推送** — `ProactiveNudgeScheduler.swift`
+  - 默认 17:00-21:00 (可调)
+  - 每天最多 1 次,选 1 个 high-confidence Experience + 一句话
+- [ ] **#262 早晨城市签推送** — `ProactiveNudgeScheduler.swift` (Phase 3 才填内容)
+- [ ] **#263 胶囊触达推送** — `ProactiveNudgeScheduler.swift`
+  - 进围栏 + 有未拆胶囊 → 5 秒后推送 (推送 + Live Activity 二选一,避免双重打扰)
+- [ ] **#264 隐私 toggle** — `Views/Settings/NotificationsSettingsView.swift` (新建,从 SettingsView 抽出)
+  - 三个开关: 孤独时段 / 城市签 / 胶囊
+  - 默认全开 (Pro 用户),但用户可单独关
+
+## P2.7 — Phase 2 出口验证
+
+- [ ] **#290 跑全部测试 xcodebuild test**
+- [ ] **#291 内测一轮**: 灵动岛限流是否生效、胶囊触发是否准确、盲盒 fallback 是否安全
+- [ ] **#292 Phase 2 走查清单更新**
+
+---
+
+# Phase 3 — 情绪付费引擎 + 病毒传播 (4 周)
+
+> 拉新成本降一半,靠用户主动分享。
+> 出口指标: 自发分享率 5%/月、CAC 下降 30%+
+
+## P3.0 — 城市签 (每日仪式) 🎁
+
+- [ ] **#301 城市签内容生成 service** — `apps/ios/SoloCompass/Services/OmenComposeService.swift`
+  - 每天 7am 调 LLM 生成: 1 句签文 + 1 个微任务 + 1 个 anchor Experience
+  - 文案克制: 不卖萌,参考 Co-Star 占星 app 风格
+- [ ] **#302 OmenCardView 卡片设计** — `apps/ios/SoloCompass/Views/Omen/OmenCardView.swift`
+  - 美术极简 (找设计师做 5-10 套卡面 rotate)
+  - 完成微任务后翻面解锁
+- [ ] **#303 "我的城市图鉴"** — `apps/ios/SoloCompass/Views/Archive/CityCodexView.swift` ⭐
+  - 网格展示已解锁卡片
+  - Pro 才能看进度 (退订 = 失去未完成图鉴 = 沉没成本)
+- [ ] **#304 重抽 IAP** — `SubscriptionService.swift`
+  - product ID `com.solocompass.consumable.omen.reroll` $0.99
+  - 限制: 每日最多重抽 3 次
+
+## P3.1 — 今日 OST (Apple Music) 🎁
+
+- [ ] **#310 MusicKit 权限接入** — `apps/ios/SoloCompass/Services/MusicService.swift`
+  - SKCloudServiceController 权限请求
+  - Apple Music 订阅检测
+- [ ] **#311 OstComposeService** — `MusicService.swift`
+  - 输入: 今天的 VisitRecord 序列
+  - LLM 把每个地点 vibe 翻译成音乐 tag: "京都鸭川黄昏 → ambient + 日本民谣"
+  - 调 Apple Music Search API 拿 track id
+  - 创建用户私密 playlist
+- [ ] **#312 OstShareCard** — `apps/ios/SoloCompass/Views/Ost/OstShareCard.swift`
+  - 分享 playlist 到 IG Story 的卡片,带 logo
+- [ ] **#313 重抽换风格** — `MusicService.swift`
+  - product ID `com.solocompass.consumable.ost.reroll` $0.99 重抽: jazz / lo-fi / ambient / 古典
+  - StoreKit2 consumable,沿用 #234 同款 SubscriptionService 注册流程
+
+## P3.2 — Solo Brag (社交资产) 🎁
+
+- [ ] **#320 外部设计师产出 5 套基础卡面** — `apps/ios/SoloCompass/Resources/Assets.xcassets/BragCards/`
+  - 不要 emoji 不要卡通,专辑封面级别美感
+- [ ] **#321 BragCardComposer** — `apps/ios/SoloCompass/Services/BragCardComposer.swift`
+  - Trip 结束自动生成 (基于 VisitRecord 聚合)
+  - 数据: 城市/天数/距离/Experience 数/咖啡杯数/微笑次数 (用户自报)
+  - 一句话故事 (LLM 生成,带城市名 + 一个动人细节)
+- [ ] **#322 BragCardView UI** — `apps/ios/SoloCompass/Views/Brag/BragCardView.swift`
+  - "分享" / "设为壁纸" / 视频版 ($1.99 IAP)
+- [ ] **#323 IAP 视频版** — `SubscriptionService.swift`
+  - product ID `com.solocompass.consumable.brag.video` $1.99
+  - 走 ImageRenderer 转 mp4
+
+## P3.3 — 月度洞察 ⭐
+
+- [ ] **#330 MonthlyInsightService** — `apps/ios/SoloCompass/Services/MonthlyInsightService.swift`
+  - 每月 1 号 0am 调用 LLM 分析过去 30 天 VisitRecord
+  - 输出: 2-3 句话洞察 + 1 张数据卡片
+  - 推送通知: "你的 6 月旅行 DNA 出炉了"
+- [ ] **#331 InsightCardView** — `apps/ios/SoloCompass/Views/Insight/InsightCardView.swift`
+  - 截图友好设计 (情绪溢价)
+  - 分享按钮
+
+## P3.4 — 年度 Travel Book (印刷增值) 💰
+
+- [ ] **#340 印刷服务商对接调研** — 准备 spike (1 周)
+  - 候选: Lulu API / Shutterfly / 国内一印
+  - 价格区间确认 $30-50
+- [ ] **#341 BookComposeService** — `apps/ios/SoloCompass/Services/BookComposeService.swift`
+  - 把 VisitRecord + 照片 + agent 写的旅行随笔编排成 PDF
+  - 上传到印刷 API
+- [ ] **#342 Archive tab 年末 banner** — `apps/ios/SoloCompass/Views/Archive/ArchiveView.swift`
+  - 11-12 月主动浮现 banner "你的 2026 年度旅行书 — 限时印刷"
+
+## P3.5 — Chat agent 中的情绪玩法上线 (无 UI 改动)
+
+- [ ] **#350 SOS Plan IAP 接入 + tool 启用** — `VoiceAgentToolRouter.swift` + `SubscriptionService.swift`
+  - tool 实现已在 P2.1 #214 落地,Phase 3 加上 `com.solocompass.consumable.sos.single` $2.99 IAP 触达
+  - Pro 用户每月 3 次免费配额逻辑
+- [ ] **#351 未走的路 IAP 接入 + tool 启用** — `VoiceAgentToolRouter.swift` + `SubscriptionService.swift`
+  - tool 实现已在 P2.1 #215 落地,Phase 3 加上 `com.solocompass.consumable.unwalked.single` $4.99 IAP 触达
+- [ ] **#352 本地圈层观察 tool** — `VoiceAgentToolRouter.swift`
+  - 加 tool case `recall_local_scene`
+  - 触发: 用户问"这城市有什么本地圈子"
+  - 输出: 场景描述卡片 (从 Eventbrite/Meetup API 拉取数据兜底)
+  - Pro 内含,不走 IAP
+
+## P3.6 — Phase 3 出口验证
+
+- [ ] **#390 全测试 xcodebuild test**
+- [ ] **#391 灰度发布**: 10% → 50% → 100%
+- [ ] **#392 度量埋点验证**: 自发分享率/CAC 是否达预期
+- [ ] **#393 docs/V_NEXT_DESIGN.md 标记 v1.0 GA**
+
+---
+
+# 横向工作 (跨 Phase, 必须做但不属于单一 Phase)
+
+## X.1 — 设计系统升级
+
+- [ ] **#X10 暖琥珀 v2 token 扩展** — `apps/ios/SoloCompass/Views/Shared/CompareTokens.swift`
+  - 新增 CT.capsuleGlow / CT.omenGold / CT.blindboxAmber 等场景色
+- [ ] **#X11 Lottie / 动画 spec 文档** — `docs/ANIMATION_SPEC.md`
+  - 时空胶囊接受动画、盲盒揭秘动画、城市签翻面 三个核心动画的 spec
+
+## X.2 — 数据埋点
+
+- [ ] **#X20 加 AnalyticsService**(隐私优先,本地聚合后定期上报)
+  - 关键事件: capsule_buried / capsule_opened / blindbox_started / agent_hint_accepted / archive_visited
+- [ ] **#X21 Pro 转化漏斗埋点**
+  - paywall_shown / iap_initiated / iap_success / iap_failed
+
+## X.3 — 隐私 & 合规
+
+- [ ] **#X30 PRIVACY.md 更新**
+  - 增加 VisitRecord / TasteProfile / TimeCapsule 数据用途说明
+  - 强调全部 on-device,云端不存
+- [ ] **#X31 "忘记我" 一键清空流程** (P2.0 #204 已计划)
+
+## X.4 — 测试 & 质量
+
+- [ ] **#X40 visual snapshot 全量更新**
+- [ ] **#X41 加 LiveActivity 集成测试**
+- [ ] **#X42 ProactiveNudgeService 时段触发回归测试**
+- [ ] **#X43 LLM 输出"never 凭空生成 POI" 红线测试**
+
+---
+
+# Summary
+
+| Phase | 任务数 | 周数 | 沉迷度 | 风险 |
+|-------|-------|------|--------|------|
+| Phase 1 — 沉淀地基 | 22 | 4 | 中 | 低 |
+| Phase 2 — Agent v2 + 灵动岛 | 34 | 6 | **极高** ⭐ | 中 (LiveActivity 调试苦) |
+| Phase 3 — 情绪付费 + 病毒 | 26 | 4 | 高 (病毒) | 中 (印刷外部依赖) |
+| 横向 (X.1-X.4) | 10 | 跨期 | - | 低 |
+| **合计** | **92** | **14 周** | | |
+
+---
+
+# 三个最关键决策
+
+> 这三个决策成立,整个 v1.0 才有意义。
+
+1. **押 Pillar 3 时空胶囊** — 这是 lock-in 之王,用户每攒一年退订成本翻倍。所有其他功能都是为它服务。
+2. **不做撮合社交、不做自动订机酒、不做 day plan** — 这三个方向已被研究证据明确淘汰,任何时候有人提"要不要做",拒绝。
+3. **iOS only + 灵动岛深度集成是护城河** — 不要花精力做 Android、不要做 web 版,所有竞品的形态劣势都源于此。
+
+---
+
+# 附录: v1.0 IAP product ID 总表 (Phase 2-3 实施速查)
+
+> 沿用现有反域名规范 `com.solocompass.<tier>.<feature>.<sku>`,与 `com.solocompass.pro.monthly/yearly` 对齐
+
+| Product ID | 类型 | 价格 | 关联功能 | 实施 todo |
+|-----------|------|------|---------|----------|
+| `com.solocompass.pro.monthly` | auto-renewable | $9.99/mo | Pro 月费 (现有) | — |
+| `com.solocompass.pro.yearly` | auto-renewable | (现有) | Pro 年费 (现有) | — |
+| `com.solocompass.consumable.blindbox.single` | consumable | $1.99 | 盲盒 Trip 单次 | #234 |
+| `com.solocompass.consumable.sos.single` | consumable | $2.99 | SOS Plan 单次 | #214 #350 |
+| `com.solocompass.consumable.unwalked.single` | consumable | $4.99 | 未走的路 单次 | #215 #351 |
+| `com.solocompass.consumable.omen.reroll` | consumable | $0.99 | 城市签重抽 | #304 |
+| `com.solocompass.consumable.ost.reroll` | consumable | $0.99 | OST 重抽换风格 | #313 |
+| `com.solocompass.consumable.brag.video` | consumable | $1.99 | Solo Brag 视频版 | #323 |
+| `com.solocompass.physical.travelbook` | (off-IAP, 外部支付) | $30-50 | 年度 Travel Book 印刷 | #340-#342 |
+
+**SubscriptionService 实施约定**:
+- 新增 `public static let allConsumableProductIDs: [String]` 与 `allProductIDs` 并列
+- `Product.products(for:)` 调用合并两个 ID 数组
+- 每个 consumable 完成购买后写 `AIUsageRecord` (或新建 `IAPConsumableRecord`) 持久化使用配额
+
+---
+
+# 历史归档: UI/UX Deep Audit 2026-06-16 (已完成)
+
+> 上一轮 UI/UX 审计 34 项已全部完成,作为基础质量地基保留参考。
+
+- 34 项 UI/UX 缺陷修复 (P0-P3 + Architecture) — 详细列表见 git log 和 `docs/DESIGN_HANDOFF_AUDIT.md`
+- 状态: ✅ 已全部完成于 2026-06 sprint


### PR DESCRIPTION
## Summary

Lands the V-next data + service foundations and a redesigned onboarding flow.

- **Persistence (SwiftData)**: new `TasteProfile`, `VisitRecord`, `TimeCapsule`, `AgentMemorySnapshot` models; schema wiring in `SoloCompassModelContainer`.
- **Services**: `VisitTrackingService` auto-logs visits; `TasteUpdateService` rolls the taste profile forward. Both covered by unit tests.
- **Archive**: `ArchiveViewModel` + `Views/Archive/ArchiveView` — with snapshot + view-model tests.
- **Onboarding**: split into `OnboardingCityStep` + `OnboardingVibeStep`; `OnboardingView` refactored to drive the new flow.
- **AI**: `AIService` gains taste-profile-aware prompting hooks.
- **Map**: `MapViewModel` + `CompassMapView` surface visited markers; `VisitedMarkerStateTests` covers state.
- **Me**: `MeSheet` exposes archive/taste entry points.
- **Localization**: English + Simplified Chinese strings for every new surface.
- **Docs**: `docs/V_NEXT_DESIGN.md` captures the full spec; `todo.md` refreshed.
- **Project**: `SoloCompass.xcodeproj` regenerated via xcodegen to include the 17 new files.

## Test plan

- [ ] `xcodebuild build` on `iPhone 17 Pro` simulator
- [ ] `xcodebuild test -only-testing:SoloCompassTests/VisitTrackingServiceTests`
- [ ] `xcodebuild test -only-testing:SoloCompassTests/TasteUpdateServiceTests`
- [ ] `xcodebuild test -only-testing:SoloCompassTests/ArchiveViewModelTests`
- [ ] `xcodebuild test -only-testing:SoloCompassTests/ArchiveSnapshotTests`
- [ ] `xcodebuild test -only-testing:SoloCompassTests/GenerateTasteProfileTests`
- [ ] `xcodebuild test -only-testing:SoloCompassTests/V1_9SchemaRecordsTests`
- [ ] `xcodebuild test -only-testing:SoloCompassTests/VisitedMarkerStateTests`
- [ ] Manual: fresh install → new onboarding (city + vibe steps) completes without crashing
- [ ] Manual: visit a place → `VisitRecord` shows up in Archive
- [ ] Manual: MeSheet exposes new archive entry, en + zh-Hans both render (no raw keys)