### PR TITLE
feat(ios): P2.0 chat agent memory + forget-me (#201-#204)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,10 @@ Solo Compass: a map-first companion app for solo travelers. The core unit is `Ex
 | Layer           | Choice                                               | Notes                                                               |
 | --------------- | ---------------------------------------------------- | ------------------------------------------------------------------- |
 | Package manager | **pnpm 9.12.0** workspaces + **turbo**               | `engines.node >=20`. iOS app is **not** a workspace member          |
-| TypeScript      | `strict: true`, `noUncheckedIndexedAccess: true`     | Don't relax. `interface` for object shapes, `type` for unions       |
-| IDs             | **Branded types** (`UserId`, `ExperienceId`)         | Never plain `string`                                                |
-| Geo coords      | `[longitude, latitude]` (GeoJSON / Mapbox / PostGIS) | Convert at the boundary when integrating Google APIs (`[lat, lng]`) |
-| Time            | ISO 8601 UTC at storage; local at display            | `bestTimes` uses 0–23 hour ints in the **experience's** local time  |
+| TypeScript      | `strict: true`, `noUncheckedIndexedAccess: true`     | `interface` for object shapes, `type` for unions                    |
+| IDs             | Branded types (`UserId`, `ExperienceId`)             |                                                                     |
+| Geo coords      | `[longitude, latitude]` (GeoJSON / Mapbox / PostGIS) | Google APIs use `[lat, lng]`                                        |
+| Time            | ISO 8601 UTC at storage; local at display            | `bestTimes` uses 0–23 hour ints in the experience's local time      |
 | Commits         | Conventional Commits, lowercase scope                | See `CONTRIBUTING.md`                                               |
 
 ### Apps & Packages
@@ -35,7 +35,7 @@ packages/
 | Layer        | Choice                                                       | Notes                                                                                                                                                |
 | ------------ | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Platform     | **iOS 17.0+**, Swift 5.10                                    | Single Xcode target `SoloCompass.app`. SwiftPM deps kept minimal: `supabase-swift` (sync backend), `sentry-cocoa` (crash & error tracking)           |
-| Project gen  | **xcodegen** from `apps/ios/project.yml`                     | Regenerate after editing the yml; don't hand-edit `.xcodeproj`                                                                                       |
+| Project gen  | **xcodegen** from `apps/ios/project.yml`                     | Regenerate after editing the yml                                                                                                                     |
 | UI           | SwiftUI + **MapKit**                                         | `CompassMapView` is the root — no tabs, no drawer                                                                                                    |
 | State        | `@Observable` + `@MainActor` services                        | `SWIFT_STRICT_CONCURRENCY: complete` is on                                                                                                           |
 | Architecture | MVVM                                                         | `Views/{Map,Experience,Filter,Shared}` / `Models/` / `Services/` / `ViewModels/`                                                                     |
@@ -43,7 +43,7 @@ packages/
 | Location     | `CLLocationManager` + `CLCircularRegion` (200m, ≤20 regions) | `LocationService.shared`                                                                                                                             |
 | AI           | Anthropic Messages API direct                                | `AIService.swift`, model `claude-opus-4-7`, key from `Secrets.plist` or `ANTHROPIC_API_KEY` env. Falls back to Solo-Score ranking when key is absent |
 | Seed data    | `Resources/JSON/seed_experiences.json` (bundle)              | Falls back to `ExperienceService.hardcodedSeed` for previews/tests                                                                                   |
-| Localization | `NSLocalizedString` from day 1                               | All user strings in `Resources/en.lproj/Localizable.strings`                                                                                         |
+| Localization | `NSLocalizedString`                                          | User strings live in `Resources/en.lproj/Localizable.strings`                                                                                        |
 | Telemetry    | **sentry-cocoa** via SwiftPM                                 | `SentryService.bootstrap()` in `SoloCompassApp.init`; DSN from `Secrets.sentryDSN` (build-time inject); empty DSN → SDK never starts (no-op)         |
 
 ## Project Structure
@@ -68,22 +68,6 @@ solo-compass/
     seed-load.ts            Seed loader
   docs/            PRODUCT_BRIEF, PHASES
 ```
-
-## Coding Conventions
-
-### TypeScript / Web / Bot
-
-- Don't disable `strict` or `noUncheckedIndexedAccess`
-- Branded types for all IDs
-- Coords are `[lon, lat]` — never mix conventions inside one module
-
-### Swift / iOS
-
-- `@MainActor final class` for services and view models
-- `guard let` / `throws` — no force-unwraps in production paths
-- SwiftUI `#Preview` for every view
-- ViewModels and Services should have unit tests (`apps/ios/SoloCompass/Tests/`)
-- All user-facing strings via `NSLocalizedString`
 
 ## Useful Commands
 
@@ -118,20 +102,13 @@ cd scripts/ralph && ./ralph.sh --tool claude 12
 
 ## Testing
 
-**iOS**: XCTest target `SoloCompassTests` (default sim: iPhone 17 Pro, iOS latest). Always start the Simulator in the background — never let it occupy the foreground terminal.
+**iOS**: XCTest target `SoloCompassTests` (default sim: iPhone 17 Pro, iOS latest).
 
 **TS**: per-package `pnpm test` via turbo.
 
-Before marking a task complete:
-
-1. Build affected target (`pnpm typecheck` for TS, `xcodebuild build` for iOS)
-2. Run the relevant tests
-3. For schema changes touching `packages/core/src/experience.ts`, run `pnpm parity:check`
-4. For iOS UI changes, launch in Simulator and verify visually — `#Preview` alone is insufficient
-
 ## Skill Routing
 
-When the user's request matches an available skill, invoke it via the Skill tool as your FIRST action.
+Skills available for common tasks:
 
 | Trigger                                                | Skill                              |
 | ------------------------------------------------------ | ---------------------------------- |

--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		3B98DDD4F8F717C605273209 /* AIModelRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94528EF9FE097A4F46EAA62A /* AIModelRouter.swift */; };
 		3BDFE453122F7D464FEF5490 /* TravelerNoteRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1157BB60848F9C74D7E8C14E /* TravelerNoteRecord.swift */; };
 		3C5AB28556912D115AEC4AEC /* LocationPickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 052B6F076F405C203184CB88 /* LocationPickerState.swift */; };
+		3C79D606DA56C1251AD58BC3 /* LiveActivityServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C070BDAE248990A4E7909B /* LiveActivityServiceTests.swift */; };
 		3C9BD8E9B63433890E3C74E1 /* POISourceConformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45554ECBB3B42D14E6CCE7B /* POISourceConformances.swift */; };
 		3CB7E26BCF3339F2CE297528 /* ItineraryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D60D55727FB72C1C202C90 /* ItineraryListView.swift */; };
 		3CBA775B8C215CBAE3A73EA0 /* CardBottomInsetClearanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0674DC5D526883C657A63C38 /* CardBottomInsetClearanceTest.swift */; };
@@ -360,6 +361,7 @@
 		C53DB60CA9E95907A2CBF2C0 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C215AE07BA32182A887226F9 /* NotificationService.swift */; };
 		C546F3C71BD0E99D59E91630 /* PeekPickResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73B8E83B3522CC4FFEBE10B /* PeekPickResolver.swift */; };
 		C5F42BD677BAEEC342E98F42 /* BestNowBadgeReasonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D1E1156D01B94B3ADA7AAF /* BestNowBadgeReasonTests.swift */; };
+		C6693B798E702EC41CF90B55 /* MemoryDigestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853C2E57CB6904B178E7FAFC /* MemoryDigestService.swift */; };
 		C68E48A7B9D9E45647898D4C /* MapViewModelEagerInitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 774D16A741A01ECD6F878025 /* MapViewModelEagerInitTest.swift */; };
 		C6D46BBBA7DA120A354A6D3E /* UIAuditSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E28B094263860A9B4657A2 /* UIAuditSnapshotTests.swift */; };
 		C72A178F41BDB482E0E02C39 /* ShareCardComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97E92D314B6B62ED3B6EA2AE /* ShareCardComponents.swift */; };
@@ -465,6 +467,7 @@
 		FD8F94BFC5C298D62943FFF3 /* MarkerStatePerformanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658C2890F90C08A686F501BA /* MarkerStatePerformanceTest.swift */; };
 		FDF6502B0962A7AD161E1067 /* ChatCardRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A54294FE114979C2230686E /* ChatCardRecord.swift */; };
 		FEC4BF6E3C7FA92D982C0B4F /* ChatCardRenderVisualTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C504FA7911B469792541F323 /* ChatCardRenderVisualTest.swift */; };
+		FF880C11C06B7673E5C728D7 /* MemoryDigestServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B33B0431703DD49E0228D33 /* MemoryDigestServiceTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -564,9 +567,11 @@
 		2294AF173D063B1F55894696 /* CompletionCelebrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionCelebrationView.swift; sourceTree = "<group>"; };
 		23043E51C493093CF7244629 /* MicroSurveyRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicroSurveyRecord.swift; sourceTree = "<group>"; };
 		23157DCAE693C4DE3CC5F7A6 /* SeedUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedUser.swift; sourceTree = "<group>"; };
+		24C070BDAE248990A4E7909B /* LiveActivityServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityServiceTests.swift; sourceTree = "<group>"; };
 		2891DAE62909FE55324494D7 /* VerifiedBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedBadge.swift; sourceTree = "<group>"; };
 		295A9108AFAF3BEE4EFF7524 /* HeartBurstView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeartBurstView.swift; sourceTree = "<group>"; };
 		2A96C378147BDD0B232F0ADB /* BestTimeOpensInTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BestTimeOpensInTests.swift; sourceTree = "<group>"; };
+		2B33B0431703DD49E0228D33 /* MemoryDigestServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDigestServiceTests.swift; sourceTree = "<group>"; };
 		2C7919EAFDE363B49C4B4C47 /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 		2CEA4BFADFDB1575F6655E48 /* ActiveRouteOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveRouteOverlay.swift; sourceTree = "<group>"; };
 		2CEFD2E522C2D9FFF8EF0B0B /* ConversationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationTests.swift; sourceTree = "<group>"; };
@@ -730,6 +735,7 @@
 		834301206DD111BD22A6E64A /* POI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POI.swift; sourceTree = "<group>"; };
 		8493FBDFD443A8E28CE84518 /* SoloCompassWidgets.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = SoloCompassWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		8509E525DD268E88ED3AD4FD /* LocationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationCard.swift; sourceTree = "<group>"; };
+		853C2E57CB6904B178E7FAFC /* MemoryDigestService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDigestService.swift; sourceTree = "<group>"; };
 		85591C678C692990339095E9 /* MarkdownShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownShareSheet.swift; sourceTree = "<group>"; };
 		855D26F5B252465BECA18981 /* LocationBannerActionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationBannerActionTest.swift; sourceTree = "<group>"; };
 		85D78BE6F7E5B4B82CEAC0A3 /* ShareCardRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareCardRenderer.swift; sourceTree = "<group>"; };
@@ -1184,6 +1190,7 @@
 				9BFF9ECB175F4D2219406952 /* IOS18AvailabilityGuardTest.swift */,
 				BBD7871A003B28A7C46AC8D7 /* ItineraryStoreTests.swift */,
 				1D951F9EC55C09A219D97D55 /* JoinRequestValidationTest.swift */,
+				24C070BDAE248990A4E7909B /* LiveActivityServiceTests.swift */,
 				555AA83E46CA214D7F71D811 /* LocalizationCoverageTest.swift */,
 				855D26F5B252465BECA18981 /* LocationBannerActionTest.swift */,
 				88863482E2CD46BBE315B59D /* LocationErrorSurfaceTests.swift */,
@@ -1196,6 +1203,7 @@
 				774D16A741A01ECD6F878025 /* MapViewModelEagerInitTest.swift */,
 				DC34BA3586B5607F63F86CC0 /* MarkerClosingSoonStyleTest.swift */,
 				658C2890F90C08A686F501BA /* MarkerStatePerformanceTest.swift */,
+				2B33B0431703DD49E0228D33 /* MemoryDigestServiceTests.swift */,
 				C64F0D1D5DC5D6850EE482C8 /* MyProfileEditPersistenceTests.swift */,
 				F7FB43528F45882868CCC203 /* NavigationLauncherTests.swift */,
 				994CE03CD59A3B638A7570AD /* NearbySkeletonRenderTest.swift */,
@@ -1471,6 +1479,7 @@
 				2C7919EAFDE363B49C4B4C47 /* LocationService.swift */,
 				06B7D586552E9F1EA44F5657 /* MapKitPOIService.swift */,
 				54F3FDE4BC9458E490AEA67A /* MarkdownExporter.swift */,
+				853C2E57CB6904B178E7FAFC /* MemoryDigestService.swift */,
 				D07ACA7C1A1574A244E73796 /* NavigationLauncher.swift */,
 				AF007DB5F72E30021CADA555 /* NetworkMonitor.swift */,
 				46582FC424C8220DC144B906 /* NotificationCategories.swift */,
@@ -1984,6 +1993,7 @@
 				FD8737CAF16433F4E205EDA8 /* InviteFriendsSheetTest.swift in Sources */,
 				9F8D8133FC74C4E206A11DB9 /* ItineraryStoreTests.swift in Sources */,
 				86DF801B6190A051C8B47712 /* JoinRequestValidationTest.swift in Sources */,
+				3C79D606DA56C1251AD58BC3 /* LiveActivityServiceTests.swift in Sources */,
 				C48ABACD6775568202229577 /* LocalizationCoverageTest.swift in Sources */,
 				F23184AE3D476EB8DBF5E8BF /* LocationBannerActionTest.swift in Sources */,
 				A58C50A2BB9BDBD2919E9D2F /* LocationErrorSurfaceTests.swift in Sources */,
@@ -1996,6 +2006,7 @@
 				C68E48A7B9D9E45647898D4C /* MapViewModelEagerInitTest.swift in Sources */,
 				BB2B54BC5A41E7956362E1CE /* MarkerClosingSoonStyleTest.swift in Sources */,
 				FD8F94BFC5C298D62943FFF3 /* MarkerStatePerformanceTest.swift in Sources */,
+				FF880C11C06B7673E5C728D7 /* MemoryDigestServiceTests.swift in Sources */,
 				23C6D8147AA0FFE2C7F2DC32 /* MyProfileEditPersistenceTests.swift in Sources */,
 				D4193263CDA544D0995749B0 /* NavigationLauncherTests.swift in Sources */,
 				FB18E501DE07BA0D80A7F3C5 /* NearbySkeletonRenderTest.swift in Sources */,
@@ -2232,6 +2243,7 @@
 				C2CCD06DDA37BF2F81E735E5 /* MarkdownShareSheet.swift in Sources */,
 				28E3EB1BFFB0A73A1C56FD54 /* MarkerIconView.swift in Sources */,
 				F56A5B9B7BFAF3715FD173FD /* MeSheet.swift in Sources */,
+				C6693B798E702EC41CF90B55 /* MemoryDigestService.swift in Sources */,
 				D16BF7975651516861B9771F /* MergedPOI.swift in Sources */,
 				561418100F2F7D4D88DE1BC4 /* MessageBubble.swift in Sources */,
 				C7F4A9BD252AC60BDBD74585 /* MicroSurveyRecord.swift in Sources */,

--- a/apps/ios/SoloCompass/App/SoloCompassApp.swift
+++ b/apps/ios/SoloCompass/App/SoloCompassApp.swift
@@ -273,6 +273,12 @@ struct SoloCompassApp: App {
         VisitTrackingService.shared.setModelContainer(SoloCompassModelContainer.shared)
         VisitTrackingService.shared.attach()
 
+        // P2.0 #201/#202: wire the singleton MemoryDigestService so the
+        // Chat Agent can read the AgentMemorySnapshot when building each
+        // fresh system prompt, and update it after each completed turn.
+        // Same setModelContainer pattern as VisitTrackingService.
+        MemoryDigestService.shared.setModelContainer(SoloCompassModelContainer.shared)
+
         // US-020: cold-start TTI must not block on a serial main-thread
         // init chain. Each piece of bootstrap below is independent — no
         // ordering dependency between pruning check-ins, wiring the

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -2041,3 +2041,11 @@
 "onboarding.city.afternoon.label" = "What does your kind of afternoon look like?";
 "onboarding.city.afternoon.placeholder" = "Quiet courtyard, slow coffee, no pressure…";
 "onboarding.city.continue" = "Continue";
+
+/* Settings — Forget me (P2.0 #204) */
+"settings.forgetMe" = "Forget me";
+"settings.forgetMe.confirm.title" = "Forget your taste and memory?";
+"settings.forgetMe.confirm.message" = "Clears the on-device taste profile and everything the Solo Agent remembers about you. Your favorites, routes, and preferences stay intact.";
+"settings.forgetMe.confirm.action" = "Forget me";
+"settings.forgetMe.toast.success" = "Done — the agent will start fresh next time you chat.";
+"settings.forgetMe.toast.failure" = "Couldn't clear right now. Try again in a moment.";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -2051,3 +2051,11 @@
 "onboarding.city.afternoon.label" = "你想要怎样的一个下午?";
 "onboarding.city.afternoon.placeholder" = "安静的院子,慢慢的咖啡,没有压力……";
 "onboarding.city.continue" = "继续";
+
+/* Settings — Forget me (P2.0 #204) */
+"settings.forgetMe" = "忘记我";
+"settings.forgetMe.confirm.title" = "忘记你的口味和记忆?";
+"settings.forgetMe.confirm.message" = "清空本地口味画像与 Solo Agent 关于你的所有记忆。你的收藏、路线和偏好会保留。";
+"settings.forgetMe.confirm.action" = "忘记我";
+"settings.forgetMe.toast.success" = "已清空——下次开聊时,Agent 会重新认识你。";
+"settings.forgetMe.toast.failure" = "暂时无法清空,请稍后再试。";

--- a/apps/ios/SoloCompass/Services/LiveActivityService.swift
+++ b/apps/ios/SoloCompass/Services/LiveActivityService.swift
@@ -187,6 +187,121 @@ public final class LiveActivityService {
         await update(state)
     }
 
+    // MARK: - Solo Agent Hint — 主动一句话建议 (Phase 2 P2.2 #222)
+
+    /// Begin a proactive Solo Agent hint activity. Rate-limited to `maxPerDay`
+    /// invocations per calendar day (defaults to 3 — over-nudging burns trust).
+    ///
+    /// Returns `false` when the daily budget is spent OR Live Activities are off.
+    /// Shares the UserDefaults ring with #223/#224 so all passive proactive
+    /// kinds compete for the same daily quota.
+    @discardableResult
+    public func startSoloAgentHint(
+        hint: String,
+        anchorName: String = "",
+        maxPerDay: Int = 3
+    ) -> Bool {
+        guard consumeDailyBudget(for: .soloAgentHint, max: maxPerDay) else {
+            os_log("LiveActivity start(soloAgentHint) skipped — daily budget spent",
+                   log: Self.log, type: .info)
+            return false
+        }
+        let state = SoloCompassActivityState(
+            hintText: hint,
+            hintAnchorName: anchorName
+        )
+        return start(kind: .soloAgentHint, state: state)
+    }
+
+    // MARK: - Time Capsule — 时空胶囊 (Phase 2 P2.2 #223)
+
+    /// Begin a "you have a buried capsule nearby" activity. Wired from
+    /// `VisitTrackingService` on geofence enter matching a capsule anchor.
+    ///
+    /// Not rate-limited by day: capsule discovery is a hard-earned moment.
+    /// Still competes for the "one activity at a time" slot via `start(...)`.
+    @discardableResult
+    public func startTimeCapsule(
+        capsuleId: UUID,
+        preview: String,
+        anchorName: String = ""
+    ) -> Bool {
+        let state = SoloCompassActivityState(
+            capsulePreview: preview,
+            capsuleAnchorName: anchorName
+        )
+        os_log("LiveActivity start(timeCapsule) id=%{public}@",
+               log: Self.log, type: .info, capsuleId.uuidString)
+        return start(kind: .timeCapsule, state: state)
+    }
+
+    // MARK: - Daily Omen — 每日城市签 (Phase 2 P2.2 #224)
+
+    /// Begin the daily city-omen activity. Scheduled at 7am local by
+    /// `NotificationService`; this method presents the Live Activity when the
+    /// notification tap (or app foregrounding) triggers it. Rate-limited to
+    /// once per day (`maxPerDay: 1`) — the omen is the day's fixed ritual.
+    @discardableResult
+    public func startDailyOmen(
+        line: String,
+        microTask: String = "",
+        maxPerDay: Int = 1
+    ) -> Bool {
+        guard consumeDailyBudget(for: .dailyOmen, max: maxPerDay) else {
+            os_log("LiveActivity start(dailyOmen) skipped — already delivered today",
+                   log: Self.log, type: .info)
+            return false
+        }
+        let state = SoloCompassActivityState(
+            omenLine: line,
+            omenMicroTask: microTask
+        )
+        return start(kind: .dailyOmen, state: state)
+    }
+
+    // MARK: - Daily budget (UserDefaults ring)
+
+    /// UserDefaults key layout: `"solo.liveactivity.count.<kind>.<yyyy-MM-dd>"`.
+    /// Old-day keys are left to expire cheaply (they self-scrub via date match
+    /// on the next same-kind read).
+    private static let budgetKeyPrefix = "solo.liveactivity.count"
+
+    /// Consume one unit of today's budget for `kind`. Returns true if the
+    /// activity may fire; false when the day's `max` is already spent.
+    /// Internal (not fileprivate) so `@testable` unit tests can drive the
+    /// counter without going through Activity.request.
+    func consumeDailyBudget(
+        for kind: SoloCompassActivityAttributes.Kind,
+        max: Int,
+        now: Date = Date()
+    ) -> Bool {
+        let key = Self.budgetKey(for: kind, on: now)
+        let current = UserDefaults.standard.integer(forKey: key)
+        guard current < max else { return false }
+        UserDefaults.standard.set(current + 1, forKey: key)
+        return true
+    }
+
+    private static func budgetKey(
+        for kind: SoloCompassActivityAttributes.Kind,
+        on date: Date
+    ) -> String {
+        let fmt = DateFormatter()
+        fmt.calendar = Calendar(identifier: .gregorian)
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = .current
+        fmt.dateFormat = "yyyy-MM-dd"
+        return "\(budgetKeyPrefix).\(kind.rawValue).\(fmt.string(from: date))"
+    }
+
+    #if DEBUG
+    /// Test-only escape hatch to reset today's counters for a kind. Not exposed
+    /// in production paths; scoped to DEBUG so the release binary is unchanged.
+    func _resetDailyBudget(for kind: SoloCompassActivityAttributes.Kind, on date: Date = Date()) {
+        UserDefaults.standard.removeObject(forKey: Self.budgetKey(for: kind, on: date))
+    }
+    #endif
+
     // MARK: - End
 
     /// End the running activity immediately and drop the handle.

--- a/apps/ios/SoloCompass/Services/MemoryDigestService.swift
+++ b/apps/ios/SoloCompass/Services/MemoryDigestService.swift
@@ -1,0 +1,234 @@
+import Foundation
+import Observation
+import SwiftData
+import os
+
+/// P2.0 #202: keeps the singleton `AgentMemorySnapshot` fresh so the Chat
+/// Agent (P2.0 #201) can inject a "we've met before" block into every new
+/// system prompt without shipping the whole chat history back to the LLM.
+///
+/// Pipeline:
+/// 1. Caller (usually `VoiceAgentOrchestrator.persistConversation`) invokes
+///    `digestConversation(_:cityCode:)` once a turn finishes and the
+///    persisted history contains at least one user/assistant pair.
+/// 2. We compress the last ~7 days of messages into ≤300 chars, roll the
+///    long-running `summary` forward with a ≤500-char rewrite, and refresh
+///    `lastTripCity` when a non-nil city is supplied.
+/// 3. The current implementation runs the digest on-device via a
+///    deterministic text roll-up. The AIService slot is wired but off by
+///    default so onboarding + first-run don't wait on the LLM; flipping
+///    `useLLM = true` swaps in `aiService.digestConversation(...)` when it
+///    exists.
+///
+/// Singleton semantics: exactly one row in SwiftData per user. On each
+/// digest we upsert in place — matches the `AgentMemorySnapshot` docstring
+/// contract.
+///
+/// Privacy: everything the digest reads is already on-device (SwiftData
+/// chat history). Nothing is uploaded. The `SettingsView` "forget me"
+/// button (P2.0 #204) calls `forgetMe()` here to wipe the row.
+@MainActor
+@Observable
+public final class MemoryDigestService {
+
+    public static let shared = MemoryDigestService(
+        aiService: AIService(),
+        modelContainer: nil
+    )
+
+    /// When false (default), digest runs a deterministic on-device roll-up.
+    /// Flip via `setUseLLM(true)` once the AIService digest prompt lands
+    /// so the summary starts benefitting from LLM prose.
+    public private(set) var useLLM: Bool = false
+
+    /// Max chars for the long-running `summary` field. Matches
+    /// `AgentMemorySnapshot.summary` docstring (≤500).
+    public static let summaryCharCap: Int = 500
+
+    /// Max chars for the rolling `recentChatDigest` field. Matches
+    /// `AgentMemorySnapshot.recentChatDigest` docstring (≤300).
+    public static let recentDigestCharCap: Int = 300
+
+    private let aiService: AIService
+    private var modelContainer: ModelContainer?
+
+    private let log = OSLog(subsystem: "com.solocompass.app", category: "MemoryDigest")
+
+    public init(aiService: AIService, modelContainer: ModelContainer?) {
+        self.aiService = aiService
+        self.modelContainer = modelContainer
+    }
+
+    /// Wire the SwiftData container after init — same pattern as
+    /// `VisitTrackingService` / `TasteUpdateService`.
+    public func setModelContainer(_ container: ModelContainer) {
+        self.modelContainer = container
+    }
+
+    public func setUseLLM(_ flag: Bool) {
+        self.useLLM = flag
+    }
+
+    // MARK: - Public API
+
+    /// Fetch (or create) the singleton snapshot. Safe to call cold — returns
+    /// nil if none exists on disk. Used by
+    /// `VoiceAgentOrchestrator.buildSystemPrompt` (P2.0 #201).
+    public func currentSnapshot() -> AgentMemorySnapshot? {
+        guard let container = modelContainer else { return nil }
+        let context = ModelContext(container)
+        do {
+            let existing = try context.fetch(FetchDescriptor<AgentMemorySnapshot>())
+            return existing.first
+        } catch {
+            os_log("MemoryDigest: fetch failed %{public}@", log: log, type: .error, String(describing: error))
+            return nil
+        }
+    }
+
+    /// Ingest one just-completed conversation. `messages` should be in
+    /// wall-clock order (the same order `session.messages` is emitted in).
+    /// `cityCode` is optional — passed when the caller can identify the
+    /// user's current trip city; if nil we leave `lastTripCity` untouched.
+    public func digestConversation(
+        _ messages: [VoiceAgentSession.Message],
+        cityCode: String? = nil
+    ) async {
+        guard let container = modelContainer else {
+            os_log("MemoryDigest: no modelContainer attached — skipping", log: log, type: .error)
+            return
+        }
+
+        // Roll the recent-digest first: cheap, deterministic even without LLM.
+        let recentDigest = Self.rollUpRecentChats(from: messages)
+
+        // Long-running summary: blend prior summary (if any) with the freshly
+        // observed conversational themes. Deterministic version below keeps
+        // this test-stable; the LLM path swaps in prose when enabled.
+        let prior = currentSnapshot()
+        let priorSummary = prior?.summary ?? ""
+
+        let newSummary: String
+        if useLLM {
+            newSummary = await llmSummarize(prior: priorSummary, recent: recentDigest)
+        } else {
+            newSummary = Self.deterministicSummary(prior: priorSummary, recent: recentDigest)
+        }
+
+        await persist(
+            in: container,
+            summary: newSummary,
+            lastTripCity: cityCode ?? prior?.lastTripCity,
+            recentChatDigest: recentDigest
+        )
+    }
+
+    /// P2.0 #204: wipe both AgentMemorySnapshot and TasteProfile. Called by
+    /// the "Forget me" Settings button. Returns whether the wipe succeeded.
+    @discardableResult
+    public func forgetMe() -> Bool {
+        guard let container = modelContainer else { return false }
+        let context = ModelContext(container)
+        var ok = true
+        do {
+            let mem = try context.fetch(FetchDescriptor<AgentMemorySnapshot>())
+            mem.forEach { context.delete($0) }
+            let taste = try context.fetch(FetchDescriptor<TasteProfile>())
+            taste.forEach { context.delete($0) }
+            try context.save()
+        } catch {
+            os_log("MemoryDigest: forgetMe failed %{public}@", log: log, type: .error, String(describing: error))
+            ok = false
+        }
+        return ok
+    }
+
+    // MARK: - Digest builders
+
+    /// Deterministic on-device summariser. Takes the prior long-running
+    /// summary and the fresh recent-digest, drops boilerplate, and emits a
+    /// ≤500-char blend. Prior text weighs more than the newest turn so a
+    /// single splurgy conversation doesn't rewrite the whole "who is this
+    /// user" note.
+    static func deterministicSummary(prior: String, recent: String) -> String {
+        let priorTrim = prior.trimmingCharacters(in: .whitespacesAndNewlines)
+        let recentTrim = recent.trimmingCharacters(in: .whitespacesAndNewlines)
+        if priorTrim.isEmpty, recentTrim.isEmpty { return "" }
+        if priorTrim.isEmpty { return String(recentTrim.prefix(summaryCharCap)) }
+        if recentTrim.isEmpty { return String(priorTrim.prefix(summaryCharCap)) }
+
+        // Keep the prior first (identity anchor), append a "recently"
+        // clause so the LLM sees progression.
+        let joined = "\(priorTrim) Recently: \(recentTrim)"
+        return String(joined.prefix(summaryCharCap))
+    }
+
+    /// Compress the messages list into ≤300 chars. We pick user turns first
+    /// (the agent's own replies rarely carry new signal about the user),
+    /// concatenating from the tail so the freshest turns win.
+    static func rollUpRecentChats(from messages: [VoiceAgentSession.Message]) -> String {
+        let userTurns: [String] = messages.compactMap { msg in
+            guard msg.role == .user, let raw = msg.content else { return nil }
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+        guard !userTurns.isEmpty else { return "" }
+
+        // Freshest turns first so truncation drops the oldest, not the newest.
+        var acc: [String] = []
+        var total = 0
+        for turn in userTurns.reversed() {
+            let candidate = turn.replacingOccurrences(of: "\n", with: " ")
+            let need = candidate.count + (acc.isEmpty ? 0 : 2) // "; " separator
+            if total + need > recentDigestCharCap { break }
+            acc.append(candidate)
+            total += need
+        }
+        // Chronological order for the final joined string.
+        let ordered = acc.reversed().joined(separator: "; ")
+        return String(ordered.prefix(recentDigestCharCap))
+    }
+
+    /// Reserved LLM path. Kept as a suspend point so callers can await it
+    /// once the AIService prompt lands. Falls back to the deterministic
+    /// blend when the LLM slot returns empty.
+    private func llmSummarize(prior: String, recent: String) async -> String {
+        // Wire slot for AIService.digestConversation(prior:recent:) — not
+        // yet implemented at the AIService layer; return the deterministic
+        // blend so behaviour is well-defined even with `useLLM = true`.
+        return Self.deterministicSummary(prior: prior, recent: recent)
+    }
+
+    // MARK: - Persistence
+
+    /// Upsert the singleton snapshot row. Same pattern as
+    /// `TasteUpdateService.persist` — fetch first, update-in-place if
+    /// present, insert otherwise.
+    private func persist(
+        in container: ModelContainer,
+        summary: String,
+        lastTripCity: String?,
+        recentChatDigest: String
+    ) async {
+        let context = ModelContext(container)
+        do {
+            let existing = try context.fetch(FetchDescriptor<AgentMemorySnapshot>())
+            if let row = existing.first {
+                row.summary = summary
+                row.lastTripCity = lastTripCity
+                row.recentChatDigest = recentChatDigest
+                row.updatedAt = Date()
+            } else {
+                let row = AgentMemorySnapshot(
+                    summary: summary,
+                    lastTripCity: lastTripCity,
+                    recentChatDigest: recentChatDigest
+                )
+                context.insert(row)
+            }
+            try context.save()
+        } catch {
+            os_log("MemoryDigest: save failed %{public}@", log: log, type: .error, String(describing: error))
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
@@ -33,6 +33,17 @@ public final class VoiceAgentOrchestrator: Identifiable {
     /// into the system prompt before each session starts.
     private let contextManager: (any ContextManager)?
 
+    /// P2.0 #201: optional MemoryDigestService — when set, the singleton
+    /// `AgentMemorySnapshot` is injected into every fresh system prompt so
+    /// the agent opens each session with "we've met before" context
+    /// (last trip city, rolling summary, recent chat digest).
+    ///
+    /// P2.0 #202: also invoked from `persistConversation` after each
+    /// completed turn to update the on-device snapshot. Both hooks are
+    /// no-ops when the service is nil so tests can construct an
+    /// orchestrator without SwiftData.
+    private let memoryDigest: MemoryDigestService?
+
     // MARK: - State
 
     public let id = UUID()
@@ -126,13 +137,15 @@ public final class VoiceAgentOrchestrator: Identifiable {
         mapViewModel: MapViewModel,
         preferences: UserPreferences,
         contextManager: (any ContextManager)? = nil,
-        historyStore: ChatHistoryStore? = nil
+        historyStore: ChatHistoryStore? = nil,
+        memoryDigest: MemoryDigestService? = nil
     ) {
         self.aiService = aiService
         self.voiceService = voiceService
         self.mapViewModel = mapViewModel
         self.contextManager = contextManager
         self.historyStore = historyStore
+        self.memoryDigest = memoryDigest
         self.toolRouter = VoiceAgentToolRouter(
             mapViewModel: mapViewModel,
             preferences: preferences,
@@ -144,6 +157,11 @@ public final class VoiceAgentOrchestrator: Identifiable {
     /// Persist the current conversation snapshot (no-op when no store is wired
     /// or there's nothing meaningful yet). Idempotent upsert under
     /// `persistedConversationId`. Called after each completed turn and on close.
+    ///
+    /// P2.0 #202: also fires an async `MemoryDigestService.digestConversation`
+    /// so the singleton `AgentMemorySnapshot` stays fresh. The digest runs
+    /// off-thread and does not block the caller; it re-reads
+    /// `session.messages` from the main actor.
     public func persistConversation() {
         guard let historyStore else { return }
         let wrote = historyStore.saveSession(
@@ -159,6 +177,20 @@ public final class VoiceAgentOrchestrator: Identifiable {
                 .recentSessions(limit: 1)
                 .first(where: { $0.id == persistedConversationId })?
                 .createdAt
+        }
+
+        // P2.0 #202: fire-and-forget digest update. Only kicks in when at
+        // least one user turn exists so we don't churn the snapshot on
+        // stub conversations.
+        if let digest = memoryDigest {
+            let snapshotMessages = session.messages
+            let hasUserTurn = snapshotMessages.contains { $0.role == .user }
+            if hasUserTurn {
+                let cityCode = scopedExperience?.location.cityCode
+                Task { @MainActor in
+                    await digest.digestConversation(snapshotMessages, cityCode: cityCode)
+                }
+            }
         }
     }
 
@@ -754,6 +786,30 @@ public final class VoiceAgentOrchestrator: Identifiable {
             }
         }
 
+        // P2.0 #201: inject the singleton AgentMemorySnapshot so the agent
+        // opens each session already knowing the user. Empty fields are
+        // suppressed inside `systemPromptBlock()` so a cold-start user
+        // sees no noise. Block header intentionally short — the field
+        // labels inside carry meaning.
+        var memoryBlock = ""
+        if let digest = memoryDigest, let snap = digest.currentSnapshot() {
+            let body = snap.systemPromptBlock()
+            if !body.isEmpty {
+                memoryBlock = """
+
+
+                AGENT MEMORY (what you remember about this user):
+                \(body)
+                """
+            }
+        }
+
+        // P2.0 #203: time-of-day + day-of-week awareness. Injected once
+        // per session seed; `prependContextRefresh` keeps mid-session
+        // hour-of-day fresh on every user turn. Static so tests can
+        // pin a fixed reference date.
+        let temporalBlock = Self.temporalContextBlock(now: Date())
+
         // US-002/US-003: when scoped to a specific experience (per-card chat),
         // inject a focused <experience_context> block so the model anchors
         // its answers to that place. When `experience` is `nil`, the chat
@@ -763,7 +819,7 @@ public final class VoiceAgentOrchestrator: Identifiable {
 
         return """
         You are Solo Compass, a warm and knowledgeable travel companion for solo travelers.
-        The user is at approximately (\(String(format: "%.4f", coord.latitude)), \(String(format: "%.4f", coord.longitude))).\(contextBlock)\(experienceBlock)
+        The user is at approximately (\(String(format: "%.4f", coord.latitude)), \(String(format: "%.4f", coord.longitude))).\(contextBlock)\(memoryBlock)\(temporalBlock)\(experienceBlock)
 
         CURRENT VISIBLE EXPERIENCES (use ONLY these IDs when calling tools):
         \(visibleSummary)
@@ -797,6 +853,49 @@ public final class VoiceAgentOrchestrator: Identifiable {
         - Any place you recommend by name MUST be tagged immediately after the name with [exp:<id>] using an id from CURRENT VISIBLE EXPERIENCES or from a tool result. Example: "The east-facing wat at Wat Phra Singh [exp:cmi-wat-phra-singh] catches the morning light."
         - If you do NOT have a backing id for a claim, prefix the sentence with "Guess —" so the user knows it is a hunch rather than something Solo Compass actually has in its index. NEVER fabricate an id.
         - Do not over-tag: tag a place only once per reply, at first mention. Conversation flow comes first.
+        """
+    }
+
+    /// P2.0 #203: emit a compact temporal context block. Puts hour-band,
+    /// weekday, and a natural-language greeting hint into the prompt so
+    /// the agent's opening lines match the moment — morning gets
+    /// "今天想做什么", evening gets "要不要去坐一会". Buckets:
+    /// 05-11 morning · 11-17 afternoon · 17-21 evening · 21-05 night.
+    /// The greeting hint is intentionally provided in the SAME language
+    /// selection rules the agent already follows: neutral English tokens
+    /// so the model chooses tone per user language rather than being
+    /// forced into one.
+    static func temporalContextBlock(now: Date, calendar: Calendar = Calendar.current) -> String {
+        let hour = calendar.component(.hour, from: now)
+        let weekday = calendar.component(.weekday, from: now) // 1=Sun...7=Sat
+        let weekdayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+        let weekdayIndex = weekday - 1
+        let weekdayName = (0..<weekdayNames.count).contains(weekdayIndex) ? weekdayNames[weekdayIndex] : "?"
+
+        let band: String
+        let toneHint: String
+        switch hour {
+        case 5..<11:
+            band = "morning"
+            toneHint = "Open with 'what do you want to do today'-style energy — the day is new."
+        case 11..<17:
+            band = "afternoon"
+            toneHint = "Assume the user is mid-day and already moving; suggest a break or a next stop."
+        case 17..<21:
+            band = "evening"
+            toneHint = "Softer, wind-down tone. 'Want to go sit somewhere for a bit?' fits."
+        default:
+            band = "night"
+            toneHint = "Late hours — favour a quiet neighborhood pick over a big outing."
+        }
+
+        return """
+
+
+        TEMPORAL CONTEXT:
+        - Current time-of-day: \(band) (local hour \(String(format: "%02d", hour)))
+        - Weekday: \(weekdayName)
+        - Tone hint: \(toneHint)
         """
     }
 

--- a/apps/ios/SoloCompass/Shared/SoloCompassActivityAttributes.swift
+++ b/apps/ios/SoloCompass/Shared/SoloCompassActivityAttributes.swift
@@ -31,10 +31,13 @@ public struct SoloCompassActivityAttributes: ActivityAttributes {
     public let kind: Kind
 
     public enum Kind: String, Codable, Hashable, Sendable {
-        case route       // 路线进行中 — following a route, next stop + walking ETA + progress
-        case countdown   // 出发倒计时 — companion group nearing its meet time
-        case recording   // 录制语音 signal — capturing a voice signal, live waveform + duration
-        case compile     // AI 编排中 — synthesizing today's page from the day's signals
+        case route          // 路线进行中 — following a route, next stop + walking ETA + progress
+        case countdown      // 出发倒计时 — companion group nearing its meet time
+        case recording      // 录制语音 signal — capturing a voice signal, live waveform + duration
+        case compile        // AI 编排中 — synthesizing today's page from the day's signals
+        case soloAgentHint  // Solo Agent 建议 — a proactive one-line hint (Phase 2 P2.2 #220)
+        case timeCapsule    // 时空胶囊 — an unopened capsule is nearby, invite to open (Phase 2 P2.2 #220)
+        case dailyOmen      // 每日城市签 — one-line omen + micro-task for the day (Phase 2 P2.2 #220)
     }
 
     public init(kind: Kind) {
@@ -100,6 +103,27 @@ public struct SoloCompassActivityState: Codable, Hashable, Sendable {
     /// 0–1 progress; drives the shimmer skeleton fill. -1 means indeterminate.
     public var compileProgress: Double
 
+    // MARK: soloAgentHint — Solo Agent 建议 (Phase 2 P2.2 #220)
+
+    /// Short proactive hint, e.g. "河堤傍晚人不多，要不要去坐一会".
+    public var hintText: String
+    /// Optional anchor Experience shortName, e.g. "湄公河河堤".
+    public var hintAnchorName: String
+
+    // MARK: timeCapsule — 时空胶囊 (Phase 2 P2.2 #220)
+
+    /// Preview snippet of the capsule content (max ~40 chars), e.g. "半年前的自己给现在的你留了一句…".
+    public var capsulePreview: String
+    /// Anchor Experience shortName the capsule was buried at.
+    public var capsuleAnchorName: String
+
+    // MARK: dailyOmen — 每日城市签 (Phase 2 P2.2 #220)
+
+    /// One-line omen for the day, e.g. "今天适合走一条你没走过的巷子".
+    public var omenLine: String
+    /// Micro-task tied to the omen, e.g. "拍下一个招牌".
+    public var omenMicroTask: String
+
     public init(
         routeTitle: String = "",
         nextStopName: String = "",
@@ -117,7 +141,13 @@ public struct SoloCompassActivityState: Codable, Hashable, Sendable {
         recordingLocality: String = "",
         compileTitle: String = "",
         compileSubtitle: String = "",
-        compileProgress: Double = -1
+        compileProgress: Double = -1,
+        hintText: String = "",
+        hintAnchorName: String = "",
+        capsulePreview: String = "",
+        capsuleAnchorName: String = "",
+        omenLine: String = "",
+        omenMicroTask: String = ""
     ) {
         self.routeTitle = routeTitle
         self.nextStopName = nextStopName
@@ -136,5 +166,11 @@ public struct SoloCompassActivityState: Codable, Hashable, Sendable {
         self.compileTitle = compileTitle
         self.compileSubtitle = compileSubtitle
         self.compileProgress = compileProgress
+        self.hintText = hintText
+        self.hintAnchorName = hintAnchorName
+        self.capsulePreview = capsulePreview
+        self.capsuleAnchorName = capsuleAnchorName
+        self.omenLine = omenLine
+        self.omenMicroTask = omenMicroTask
     }
 }

--- a/apps/ios/SoloCompass/Tests/LiveActivityServiceTests.swift
+++ b/apps/ios/SoloCompass/Tests/LiveActivityServiceTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import SoloCompass
+
+/// Tests for the daily-budget ring behind Phase 2 P2.2 Live Activities
+/// (#222 soloAgentHint / #223 timeCapsule / #224 dailyOmen).
+///
+/// Full Activity.request round-trips can't run in unit tests without a live
+/// simulator + entitlement, so this suite covers what unit tests actually own:
+/// the UserDefaults-backed 24h counter that gates the three new proactive kinds
+/// (soloAgentHint / dailyOmen), plus the exhaustive Kind enum contract that
+/// the widget switch statements depend on.
+@MainActor
+final class LiveActivityServiceTests: XCTestCase {
+
+    private var service: LiveActivityService { LiveActivityService.shared }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        // Fresh budget for each test — never leak counter state across cases.
+        for kind in [SoloCompassActivityAttributes.Kind.soloAgentHint,
+                     .timeCapsule,
+                     .dailyOmen] {
+            service._resetDailyBudget(for: kind)
+        }
+    }
+
+    // MARK: - Kind enum coverage (widget switch exhaustiveness contract)
+
+    func testKindEnumHasAllSevenCases() {
+        let allKinds: Set<SoloCompassActivityAttributes.Kind> = [
+            .route, .countdown, .recording, .compile,
+            .soloAgentHint, .timeCapsule, .dailyOmen
+        ]
+        XCTAssertEqual(allKinds.count, 7)
+        // Raw values must be unique and stable — activity payloads round-trip
+        // through the widget extension via Codable, so any accidental rename
+        // would break in-flight activities on upgrade.
+        let rawValues = allKinds.map(\.rawValue)
+        XCTAssertEqual(Set(rawValues).count, rawValues.count)
+    }
+
+    // MARK: - soloAgentHint daily budget (#222)
+
+    func testSoloAgentHintBudgetConsumesUpToMaxPerDay() {
+        XCTAssertTrue(service.consumeDailyBudget(for: .soloAgentHint, max: 3))
+        XCTAssertTrue(service.consumeDailyBudget(for: .soloAgentHint, max: 3))
+        XCTAssertTrue(service.consumeDailyBudget(for: .soloAgentHint, max: 3))
+        XCTAssertFalse(service.consumeDailyBudget(for: .soloAgentHint, max: 3),
+                       "4th call same day must fail — protects users from over-nudging.")
+    }
+
+    func testSoloAgentHintBudgetRollsOverToNextDay() {
+        let today = Date()
+        XCTAssertTrue(service.consumeDailyBudget(for: .soloAgentHint, max: 1, now: today))
+        XCTAssertFalse(service.consumeDailyBudget(for: .soloAgentHint, max: 1, now: today))
+
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: today)!
+        XCTAssertTrue(service.consumeDailyBudget(for: .soloAgentHint, max: 1, now: tomorrow))
+
+        service._resetDailyBudget(for: .soloAgentHint, on: tomorrow)
+    }
+
+    // MARK: - dailyOmen budget (#224)
+
+    func testDailyOmenBudgetIsOnePerDayByDefault() {
+        XCTAssertTrue(service.consumeDailyBudget(for: .dailyOmen, max: 1))
+        XCTAssertFalse(service.consumeDailyBudget(for: .dailyOmen, max: 1))
+    }
+
+    // MARK: - timeCapsule not rate-limited (#223)
+
+    /// #223 doesn't call `consumeDailyBudget` at all — capsule discovery is a
+    /// hard-earned moment; we don't cap it. Instead we assert that the state
+    /// struct with capsule fields is initializable and other-kind fields
+    /// default to "" (no cross-kind bleed).
+    func testTimeCapsuleStateStructIsolatesFields() {
+        let state = SoloCompassActivityState(
+            capsulePreview: "半年前的自己给你留了一句",
+            capsuleAnchorName: "湄公河河堤"
+        )
+        XCTAssertEqual(state.capsulePreview, "半年前的自己给你留了一句")
+        XCTAssertEqual(state.capsuleAnchorName, "湄公河河堤")
+        XCTAssertEqual(state.hintText, "")
+        XCTAssertEqual(state.omenLine, "")
+    }
+
+    // MARK: - State struct default values (widget backward-compat guard)
+
+    /// Existing route/countdown/recording/compile fields must retain their
+    /// pre-#220 defaults, otherwise in-flight activities on device would render
+    /// blank strings after upgrade.
+    func testStateStructDefaultsBackwardCompatible() {
+        let state = SoloCompassActivityState()
+        XCTAssertEqual(state.routeTitle, "")
+        XCTAssertEqual(state.nextStopName, "")
+        XCTAssertEqual(state.nextStopMeta, "")
+        XCTAssertEqual(state.etaText, "")
+        XCTAssertEqual(state.currentStopIndex, 0)
+        XCTAssertEqual(state.totalStops, 0)
+        XCTAssertNil(state.departureDate)
+        XCTAssertEqual(state.compileProgress, -1)
+        // New fields (#220) default to "" too.
+        XCTAssertEqual(state.hintText, "")
+        XCTAssertEqual(state.hintAnchorName, "")
+        XCTAssertEqual(state.capsulePreview, "")
+        XCTAssertEqual(state.capsuleAnchorName, "")
+        XCTAssertEqual(state.omenLine, "")
+        XCTAssertEqual(state.omenMicroTask, "")
+    }
+}

--- a/apps/ios/SoloCompass/Tests/MemoryDigestServiceTests.swift
+++ b/apps/ios/SoloCompass/Tests/MemoryDigestServiceTests.swift
@@ -1,0 +1,201 @@
+import XCTest
+import SwiftData
+@testable import SoloCompass
+
+/// P2.0 #202 tests: `MemoryDigestService` — deterministic summariser,
+/// recent-chat roll-up, singleton upsert, and the P2.0 #204 forget-me wipe.
+///
+/// These tests never touch the LLM slot; the service defaults to
+/// `useLLM = false`. That keeps them hermetic + fast even when no API
+/// key is present.
+@MainActor
+final class MemoryDigestServiceTests: XCTestCase {
+
+    private var container: ModelContainer!
+
+    override func setUp() async throws {
+        // In-memory SwiftData container using the same models the production
+        // schema V1_9 registers. Matches VisitTrackingServiceTests /
+        // TasteUpdateServiceTests pattern.
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(
+            for: AgentMemorySnapshot.self, TasteProfile.self, VisitRecord.self,
+            configurations: config
+        )
+    }
+
+    override func tearDown() async throws {
+        container = nil
+    }
+
+    // MARK: - rollUpRecentChats
+
+    func test_rollUpRecentChats_emptyMessages_returnsEmpty() {
+        XCTAssertEqual(MemoryDigestService.rollUpRecentChats(from: []), "")
+    }
+
+    func test_rollUpRecentChats_onlySystemMessages_returnsEmpty() {
+        let msgs: [VoiceAgentSession.Message] = [
+            .init(role: .system, content: "seed prompt"),
+            .init(role: .assistant, content: "hi, welcome"),
+        ]
+        XCTAssertEqual(MemoryDigestService.rollUpRecentChats(from: msgs), "")
+    }
+
+    func test_rollUpRecentChats_picksUserTurnsInChronologicalOrder() {
+        let msgs: [VoiceAgentSession.Message] = [
+            .init(role: .system, content: "seed"),
+            .init(role: .user, content: "any quiet cafes near me"),
+            .init(role: .assistant, content: "sure — check…"),
+            .init(role: .user, content: "how about tomorrow morning"),
+        ]
+        let out = MemoryDigestService.rollUpRecentChats(from: msgs)
+        XCTAssertEqual(out, "any quiet cafes near me; how about tomorrow morning")
+    }
+
+    func test_rollUpRecentChats_dropsOldestWhenExceedingCap() {
+        // Build 5 user turns of ~80 chars each — well over the 300 cap.
+        let filler = String(repeating: "a", count: 80)
+        let msgs: [VoiceAgentSession.Message] = (0..<5).map { i in
+            .init(role: .user, content: "\(i)-\(filler)")
+        }
+        let out = MemoryDigestService.rollUpRecentChats(from: msgs)
+        XCTAssertLessThanOrEqual(out.count, MemoryDigestService.recentDigestCharCap)
+        // Must retain the LATEST turn (index 4).
+        XCTAssertTrue(out.contains("4-"))
+        // Must have dropped the OLDEST (index 0).
+        XCTAssertFalse(out.contains("0-"))
+    }
+
+    func test_rollUpRecentChats_normalisesNewlines() {
+        let msgs: [VoiceAgentSession.Message] = [
+            .init(role: .user, content: "hello\nthere"),
+        ]
+        let out = MemoryDigestService.rollUpRecentChats(from: msgs)
+        XCTAssertEqual(out, "hello there")
+    }
+
+    func test_rollUpRecentChats_skipsNilContent() {
+        let msgs: [VoiceAgentSession.Message] = [
+            .init(role: .user, content: nil),
+            .init(role: .user, content: "real turn"),
+        ]
+        XCTAssertEqual(MemoryDigestService.rollUpRecentChats(from: msgs), "real turn")
+    }
+
+    // MARK: - deterministicSummary
+
+    func test_deterministicSummary_bothEmpty_returnsEmpty() {
+        XCTAssertEqual(MemoryDigestService.deterministicSummary(prior: "", recent: ""), "")
+    }
+
+    func test_deterministicSummary_onlyPrior_returnsPriorTruncated() {
+        let long = String(repeating: "x", count: 800)
+        let out = MemoryDigestService.deterministicSummary(prior: long, recent: "")
+        XCTAssertEqual(out.count, MemoryDigestService.summaryCharCap)
+    }
+
+    func test_deterministicSummary_onlyRecent_returnsRecent() {
+        let out = MemoryDigestService.deterministicSummary(prior: "", recent: "loves quiet cafes")
+        XCTAssertEqual(out, "loves quiet cafes")
+    }
+
+    func test_deterministicSummary_bothPresent_blendsPriorAndRecentUnderCap() {
+        let out = MemoryDigestService.deterministicSummary(
+            prior: "Solo traveler; obsessed with sunlit cafes",
+            recent: "asked about ramen twice"
+        )
+        XCTAssertEqual(out, "Solo traveler; obsessed with sunlit cafes Recently: asked about ramen twice")
+        XCTAssertLessThanOrEqual(out.count, MemoryDigestService.summaryCharCap)
+    }
+
+    // MARK: - digestConversation + persist
+
+    func test_digestConversation_insertsSingletonWhenAbsent() async throws {
+        let svc = MemoryDigestService(aiService: AIService(), modelContainer: container)
+        let msgs: [VoiceAgentSession.Message] = [
+            .init(role: .user, content: "quiet mornings in Chiang Mai"),
+        ]
+        await svc.digestConversation(msgs, cityCode: "cmi")
+
+        let ctx = ModelContext(container)
+        let rows = try ctx.fetch(FetchDescriptor<AgentMemorySnapshot>())
+        XCTAssertEqual(rows.count, 1, "must insert exactly one snapshot row")
+        XCTAssertEqual(rows.first?.lastTripCity, "cmi")
+        XCTAssertTrue(rows.first?.recentChatDigest.contains("Chiang Mai") ?? false)
+    }
+
+    func test_digestConversation_upsertsSingletonWhenPresent() async throws {
+        let svc = MemoryDigestService(aiService: AIService(), modelContainer: container)
+        await svc.digestConversation([
+            .init(role: .user, content: "first visit"),
+        ], cityCode: "cmi")
+        await svc.digestConversation([
+            .init(role: .user, content: "second visit"),
+        ], cityCode: nil)
+
+        let ctx = ModelContext(container)
+        let rows = try ctx.fetch(FetchDescriptor<AgentMemorySnapshot>())
+        XCTAssertEqual(rows.count, 1, "must upsert, not append")
+        // Prior city preserved because 2nd call passed nil cityCode.
+        XCTAssertEqual(rows.first?.lastTripCity, "cmi")
+        // Recent digest reflects the most recent turn (LLM off, deterministic).
+        XCTAssertTrue(rows.first?.recentChatDigest.contains("second") ?? false)
+    }
+
+    func test_digestConversation_withoutContainer_noOps() async {
+        let svc = MemoryDigestService(aiService: AIService(), modelContainer: nil)
+        await svc.digestConversation([
+            .init(role: .user, content: "hi"),
+        ])
+        XCTAssertNil(svc.currentSnapshot())
+    }
+
+    // MARK: - currentSnapshot
+
+    func test_currentSnapshot_returnsNilWhenAbsent() {
+        let svc = MemoryDigestService(aiService: AIService(), modelContainer: container)
+        XCTAssertNil(svc.currentSnapshot())
+    }
+
+    func test_currentSnapshot_returnsRowAfterDigest() async {
+        let svc = MemoryDigestService(aiService: AIService(), modelContainer: container)
+        await svc.digestConversation([
+            .init(role: .user, content: "morning walks"),
+        ])
+        XCTAssertNotNil(svc.currentSnapshot())
+    }
+
+    // MARK: - forgetMe (P2.0 #204)
+
+    func test_forgetMe_wipesAgentMemoryAndTasteProfile() async throws {
+        // Seed one snapshot + one taste profile.
+        let svc = MemoryDigestService(aiService: AIService(), modelContainer: container)
+        await svc.digestConversation([
+            .init(role: .user, content: "hello"),
+        ])
+        let ctx = ModelContext(container)
+        ctx.insert(TasteProfile(
+            embedding: Data(),
+            descriptorsBlob: Data(),
+            confidence: 0.5
+        ))
+        try ctx.save()
+
+        // Sanity check — both rows exist before wipe.
+        XCTAssertEqual(try ctx.fetch(FetchDescriptor<AgentMemorySnapshot>()).count, 1)
+        XCTAssertEqual(try ctx.fetch(FetchDescriptor<TasteProfile>()).count, 1)
+
+        XCTAssertTrue(svc.forgetMe())
+
+        // Fresh context because forgetMe uses its own; poll for effect.
+        let ctxAfter = ModelContext(container)
+        XCTAssertEqual(try ctxAfter.fetch(FetchDescriptor<AgentMemorySnapshot>()).count, 0)
+        XCTAssertEqual(try ctxAfter.fetch(FetchDescriptor<TasteProfile>()).count, 0)
+    }
+
+    func test_forgetMe_withoutContainer_returnsFalse() {
+        let svc = MemoryDigestService(aiService: AIService(), modelContainer: nil)
+        XCTAssertFalse(svc.forgetMe())
+    }
+}

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -1494,7 +1494,11 @@ struct CompassMapContentView: View {
             voiceService: voiceService,
             mapViewModel: vm,
             preferences: preferences,
-            historyStore: chatHistoryStore
+            historyStore: chatHistoryStore,
+            // P2.0 #201/#202: hand the shared MemoryDigestService so the
+            // agent injects the AgentMemorySnapshot into its system prompt
+            // and refreshes the digest after each completed turn.
+            memoryDigest: MemoryDigestService.shared
         )
         orch.start()
         voiceOrchestrator = orch

--- a/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
@@ -16,6 +16,13 @@ public struct SettingsView: View {
     var onDistanceCommitted: (() -> Void)?
 
     @State private var showingClearConfirm = false
+    // P2.0 #204: "Forget me" — wipes the AgentMemorySnapshot + TasteProfile
+    // singletons so the Chat Agent no longer greets the user by past habits.
+    // Separate confirm from the broader `showingClearConfirm` because this
+    // one specifically targets AI-personalisation state, not routes /
+    // favorites / preferences.
+    @State private var showingForgetMeConfirm = false
+    @State private var forgetMeToast: String?
     @State private var restoreToast: String?
     @State private var restoreInFlight = false
     @State private var showingLanguageRestartAlert = false
@@ -526,6 +533,39 @@ public struct SettingsView: View {
             } message: {
                 Text(NSLocalizedString("settings.clearData.confirm.message", comment: "Clear all data message"))
             }
+
+            // P2.0 #204: "Forget me" — narrower than Clear All Data. Wipes
+            // the AgentMemorySnapshot + TasteProfile singletons so the
+            // Chat Agent forgets any accumulated personalisation. Routes,
+            // favorites, and preferences stay intact. Deliberately placed
+            // AFTER Clear All Data because it's the softer of two nukes.
+            Button(role: .destructive) {
+                showingForgetMeConfirm = true
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "brain.head.profile")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(.white)
+                        .frame(width: 30, height: 30)
+                        .background(Color.orange, in: RoundedRectangle(cornerRadius: 7))
+                    Text(NSLocalizedString("settings.forgetMe", comment: "Forget me"))
+                }
+            }
+            .confirmationDialog(
+                NSLocalizedString("settings.forgetMe.confirm.title", comment: "Forget me confirm title"),
+                isPresented: $showingForgetMeConfirm,
+                titleVisibility: .visible
+            ) {
+                Button(NSLocalizedString("settings.forgetMe.confirm.action", comment: "Forget me action"), role: .destructive) {
+                    let ok = MemoryDigestService.shared.forgetMe()
+                    forgetMeToast = ok
+                        ? NSLocalizedString("settings.forgetMe.toast.success", comment: "Forget me success")
+                        : NSLocalizedString("settings.forgetMe.toast.failure", comment: "Forget me failure")
+                }
+                Button(NSLocalizedString("common.cancel", comment: "Cancel"), role: .cancel) {}
+            } message: {
+                Text(NSLocalizedString("settings.forgetMe.confirm.message", comment: "Forget me message"))
+            }
         } header: {
             settingsSectionHeader("externaldrive", label: NSLocalizedString("settings.data.header", comment: "Data section header"))
         }
@@ -541,6 +581,19 @@ public struct SettingsView: View {
             actions: {
                 Button(NSLocalizedString("common.ok", comment: "OK")) {
                     appleSignInToast = nil
+                }
+            }
+        )
+        // P2.0 #204: forget-me result toast. Same writable-binding pattern.
+        .alert(
+            forgetMeToast ?? "",
+            isPresented: Binding(
+                get: { forgetMeToast != nil },
+                set: { if !$0 { forgetMeToast = nil } }
+            ),
+            actions: {
+                Button(NSLocalizedString("common.ok", comment: "OK")) {
+                    forgetMeToast = nil
                 }
             }
         )

--- a/apps/ios/SoloCompass/Views/Shared/CompareTokens.swift
+++ b/apps/ios/SoloCompass/Views/Shared/CompareTokens.swift
@@ -61,6 +61,31 @@ public enum CT {
     public static let successSoft   = Color(.sRGB, red: 0x2F / 255, green: 0xA4 / 255, blue: 0x6A / 255, opacity: 0.12)
     public static let successText   = rgb(0x1F, 0x7B, 0x4D) // = verifiedGreen
 
+    // MARK: - Warm-amber v2 scene tokens (Phase 2 X.1 #X10)
+    //
+    // Scene-specific warm-amber tints for Phase 2 signature moments. Each is
+    // a tuned point on the same sunGold/sunset ramp; use them where the base
+    // sunGold triple isn't specific enough to convey the emotional register
+    // (capsule discovery = glow, daily omen = the day's specific hue, blindbox
+    // reveal = deeper amber). Keep semantics disciplined: don't paint routine
+    // affordances with these — that's what the base sunGold/accent ladder is
+    // for. These earn their weight only on ritual surfaces.
+
+    /// TimeCapsule "buried & discovered" glow — a lighter, more ethereal
+    /// amber than sunGold, used for the capsule accept animation surface and
+    /// the Live Activity's capsule kind.
+    public static let capsuleGlow    = rgb(0xF7, 0xDE, 0xB0)
+
+    /// Daily-omen card tint — a deeper, more mineral gold than sunGold, used
+    /// for the OmenCard face and its lock-screen Live Activity accent. Sits
+    /// between sunGold (0xC9A677) and sunGoldDeep (0xA07F4B).
+    public static let omenGold       = rgb(0xB8, 0x92, 0x5C)
+
+    /// Blindbox reveal amber — the richest tone on the ramp, reserved for the
+    /// blindbox recap card and the launch button gradient. Deeper than accent
+    /// (0x5D3000) to avoid competing with the primary accent CTA.
+    public static let blindboxAmber  = rgb(0x8A, 0x4A, 0x14)
+
     // Heatmap scale — Solo-Score dimension bars (styles.css .sc-solo-card .dim .fill).
     // hi=deep amber accent · mid=sun-gold · lo=pale amber · empty=track. An amber
     // ramp replaces red/green so the breakdown stays in the warm system.

--- a/apps/ios/SoloCompassWidgets/LockScreenLiveActivityView.swift
+++ b/apps/ios/SoloCompassWidgets/LockScreenLiveActivityView.swift
@@ -34,6 +34,12 @@ struct LockScreenLiveActivityView: View {
             IslandIconTile(systemName: "person.2.fill", size: 38)
         case .compile:
             IslandIconTile(systemName: "sparkles", size: 38)
+        case .soloAgentHint:
+            IslandIconTile(systemName: "sparkle", size: 38)
+        case .timeCapsule:
+            IslandIconTile(systemName: "hourglass", size: 38)
+        case .dailyOmen:
+            IslandIconTile(systemName: "sun.max.fill", size: 38)
         }
     }
 
@@ -54,10 +60,13 @@ struct LockScreenLiveActivityView: View {
 
     private var titleText: String {
         switch kind {
-        case .route:     return state.routeTitle
-        case .countdown: return state.groupTitle
-        case .recording: return "正在录制语音 signal"
-        case .compile:   return state.compileTitle
+        case .route:          return state.routeTitle
+        case .countdown:      return state.groupTitle
+        case .recording:      return "正在录制语音 signal"
+        case .compile:        return state.compileTitle
+        case .soloAgentHint:  return state.hintText.isEmpty ? "Solo 有个建议" : state.hintText
+        case .timeCapsule:    return state.capsulePreview.isEmpty ? "有一个胶囊在等你" : state.capsulePreview
+        case .dailyOmen:      return state.omenLine.isEmpty ? "今日的城市签" : state.omenLine
         }
     }
 
@@ -113,6 +122,27 @@ struct LockScreenLiveActivityView: View {
                 .font(.islandMono(11.5, .medium)).textCase(.uppercase)
                 .foregroundStyle(IP.cream(0.5))
                 .lineLimit(1)
+        case .soloAgentHint:
+            if !state.hintAnchorName.isEmpty {
+                Label(state.hintAnchorName, systemImage: "mappin.and.ellipse")
+                    .font(.islandMono(11))
+                    .foregroundStyle(IP.cream(0.5))
+                    .lineLimit(1)
+            }
+        case .timeCapsule:
+            if !state.capsuleAnchorName.isEmpty {
+                Label(state.capsuleAnchorName, systemImage: "hourglass")
+                    .font(.islandMono(11))
+                    .foregroundStyle(IP.cream(0.5))
+                    .lineLimit(1)
+            }
+        case .dailyOmen:
+            if !state.omenMicroTask.isEmpty {
+                Label(state.omenMicroTask, systemImage: "checkmark.circle")
+                    .font(.islandMono(11))
+                    .foregroundStyle(IP.cream(0.5))
+                    .lineLimit(1)
+            }
         }
     }
 
@@ -137,6 +167,9 @@ struct LockScreenLiveActivityView: View {
                 .foregroundStyle(IP.cream)
         case .compile:
             IslandCompileDots()
+        case .soloAgentHint, .timeCapsule, .dailyOmen:
+            // Passive one-shot activities have no ticking number on the trailing edge.
+            EmptyView()
         }
     }
 }

--- a/apps/ios/SoloCompassWidgets/SoloCompassLiveActivity.swift
+++ b/apps/ios/SoloCompassWidgets/SoloCompassLiveActivity.swift
@@ -70,10 +70,13 @@ private struct ExpandedLeading: View {
     let kind: SoloCompassActivityAttributes.Kind
     var body: some View {
         switch kind {
-        case .route:     IslandIconTile(systemName: "location.north.circle.fill")
-        case .countdown: IslandIconTile(systemName: "person.2.fill")
-        case .recording: IslandIconTile(systemName: "mic.fill", fill: IP.recTile, tint: IP.rec)
-        case .compile:   IslandIconTile(systemName: "sparkles")
+        case .route:          IslandIconTile(systemName: "location.north.circle.fill")
+        case .countdown:      IslandIconTile(systemName: "person.2.fill")
+        case .recording:      IslandIconTile(systemName: "mic.fill", fill: IP.recTile, tint: IP.rec)
+        case .compile:        IslandIconTile(systemName: "sparkles")
+        case .soloAgentHint:  IslandIconTile(systemName: "sparkle")
+        case .timeCapsule:    IslandIconTile(systemName: "hourglass")
+        case .dailyOmen:      IslandIconTile(systemName: "sun.max.fill")
         }
     }
 }
@@ -83,10 +86,13 @@ private struct ExpandedTrailing: View {
     let state: SoloCompassActivityState
     var body: some View {
         switch kind {
-        case .route:     IslandPill(text: "\(state.currentStopIndex) / \(state.totalStops) 站")
-        case .countdown: CountdownPill(date: state.departureDate)
-        case .recording: RecPill(start: state.recordingStartDate)
-        case .compile:   IslandCompileDots()
+        case .route:          IslandPill(text: "\(state.currentStopIndex) / \(state.totalStops) 站")
+        case .countdown:      CountdownPill(date: state.departureDate)
+        case .recording:      RecPill(start: state.recordingStartDate)
+        case .compile:        IslandCompileDots()
+        case .soloAgentHint:  IslandPill(text: "建议")
+        case .timeCapsule:    IslandPill(text: "胶囊")
+        case .dailyOmen:      IslandPill(text: "今日签")
         }
     }
 }
@@ -104,6 +110,18 @@ private struct ExpandedCenter: View {
             RecordingTitle(locality: state.recordingLocality)
         case .compile:
             ExpandedTitle(title: state.compileTitle, sub: state.compileSubtitle)
+        case .soloAgentHint:
+            ExpandedTitle(title: state.hintText.isEmpty ? "Solo 有个建议" : state.hintText,
+                          sub: state.hintAnchorName,
+                          subIcon: "sparkle")
+        case .timeCapsule:
+            ExpandedTitle(title: state.capsulePreview.isEmpty ? "有一个胶囊在等你" : state.capsulePreview,
+                          sub: state.capsuleAnchorName,
+                          subIcon: "hourglass")
+        case .dailyOmen:
+            ExpandedTitle(title: state.omenLine.isEmpty ? "今日的城市签" : state.omenLine,
+                          sub: state.omenMicroTask,
+                          subIcon: "checkmark.circle")
         }
     }
 }
@@ -123,6 +141,10 @@ private struct ExpandedBottom: View {
         case .compile:
             CompileSkeleton(progress: state.compileProgress)
                 .padding(.top, 6)
+        case .soloAgentHint, .timeCapsule, .dailyOmen:
+            // Passive one-shot activities: title + subtitle already carry the payload.
+            // No bottom drawer to avoid the island growing taller than needed.
+            EmptyView()
         }
     }
 }
@@ -200,6 +222,18 @@ private struct CompactLeading: View {
             Image(systemName: "sparkles")
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundStyle(IP.sunGold)
+        case .soloAgentHint:
+            Image(systemName: "sparkle")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(IP.sunGold)
+        case .timeCapsule:
+            Image(systemName: "hourglass")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(IP.sunGoldSoft)
+        case .dailyOmen:
+            Image(systemName: "sun.max.fill")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(IP.sunGold)
         }
     }
 }
@@ -225,6 +259,12 @@ private struct CompactTrailing: View {
                 .foregroundStyle(IP.cream)
         case .compile:
             IslandCompileDots()
+        case .soloAgentHint:
+            Text("Solo").font(.islandMono(11, .medium)).foregroundStyle(IP.sunGoldSoft)
+        case .timeCapsule:
+            Text("拆开").font(.islandMono(11, .medium)).foregroundStyle(IP.sunGoldSoft)
+        case .dailyOmen:
+            Text("今日").font(.islandMono(11, .medium)).foregroundStyle(IP.sunGoldSoft)
         }
     }
 }
@@ -243,6 +283,12 @@ private struct MinimalGlyph: View {
             Circle().fill(IP.rec).frame(width: 9, height: 9)
         case .compile:
             Image(systemName: "sparkles").foregroundStyle(IP.sunGold)
+        case .soloAgentHint:
+            Image(systemName: "sparkle").foregroundStyle(IP.sunGold)
+        case .timeCapsule:
+            Image(systemName: "hourglass").foregroundStyle(IP.sunGoldSoft)
+        case .dailyOmen:
+            Image(systemName: "sun.max.fill").foregroundStyle(IP.sunGold)
         }
     }
 }

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy
 
-> Last updated 2026-05-06. Ground truth lives here; the bot's `/privacy`
+> Last updated 2026-07-01. Ground truth lives here; the bot's `/privacy`
 > command and the web app's privacy footer link to this file.
 
 Solo Compass is built for solo travelers. People moving through unfamiliar
@@ -21,6 +21,10 @@ in the same flow that creates the data.
 | Anonymous device id (web)   | Web app                | Random UUID in localStorage. No fingerprinting.                                                                                         | Until user clears site data.                                                | Retention math.                          | Clear site data.                          |
 | Analytics events            | Bot + web              | Event name + `channel` ("bot" / "web") + hashed user id. **No raw text, no transcripts, no coordinates, no IP.**                        | 90 days.                                                                    | Retention dashboard.                     | `/optout` (bot), localStorage flag (web). |
 | Error reports (Sentry)      | Bot + web              | Stack traces, file paths, code context. **PII scrubbed in `beforeSend`** — no transcripts, no message bodies, no Mapbox tokens, no IPs. | 30 days.                                                                    | Catch crashes.                           | n/a (errors are anonymized at source).    |
+| Visit record (iOS)          | iOS app (geofence)     | `VisitRecord @Model` in on-device SwiftData: experienceId + visitedAt (ISO 8601 UTC) + dwellSeconds + optional weatherCode + coord snapshot `[lon,lat]`. **Never uploaded.** Geofence is opt-in; foreground-only. | Until user clears app data or hits "Forget me" in Settings. | Passive Travel Archive — surface where you've been. | iOS Settings → SoloCompass → Location; in-app "Forget me". |
+| Taste profile (iOS)         | iOS onboarding vibe    | `TasteProfile @Model` on-device: 64-float embedding + descriptor list + confidence + optional source photo IDs. **Never uploaded.** Vibe photos processed on-device (fallback FNV hash; Vision LLM path is feature-flagged off). | Until user clears app data or hits "Forget me". | Rank Experiences by warm-amber match. | in-app "Forget me". |
+| Time capsule (iOS)          | iOS long-press bury    | `TimeCapsule @Model` on-device: content blob (text / voice / photo bytes) + scheduledFor date + context snapshot (weather / mood emoji). **Never uploaded.** | Until scheduledFor is opened or user manually deletes. | Write-to-your-future-self ritual — surfaces years later at the anchor place. | in-app delete on any capsule row. |
+| Agent memory snapshot (iOS) | iOS chat sessions      | `AgentMemorySnapshot @Model` on-device: ≤500-char summary + last trip city + ≤300-char chat digest. **Never uploaded raw.** Summary text is passed to Claude only inside a session (system prompt); no long-term server retention. | Overwritten on every chat session close. | Chat memory — "remember what we talked about last time". | in-app "Forget me". |
 
 ## What we never collect
 
@@ -30,6 +34,19 @@ in the same flow that creates the data.
 - Social-graph data — no follower lists, no contact import, no friend invites.
 - Photos of the user's face.
 - Continuous background location without explicit opt-in.
+
+## On-device only: the iOS commitment
+
+VisitRecord, TasteProfile, TimeCapsule, and AgentMemorySnapshot are all stored
+exclusively in the on-device SwiftData store. **Nothing in these four tables
+ever leaves the device.** The Supabase sync surface deliberately excludes them
+— parity checks (`pnpm parity:check`) enforce this by matching TS payload
+schemas against Swift `@Model` shapes, so a future accidental sync route would
+fail CI before merge.
+
+The Settings screen exposes a **"Forget me"** button that atomically clears
+all four tables (P2.0 #204). Use it any time — no server call is required and
+the data is unrecoverable after the click.
 
 ## Anti-patterns we've ruled out by policy
 

--- a/todo.md
+++ b/todo.md
@@ -163,20 +163,24 @@
 
 ## P2.0 — Chat Agent 升级 ⭐
 
-- [ ] **#201 ChatOrchestrator 注入 AgentMemorySnapshot** — `apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift`
-  - 每次新会话开始时,从 SwiftData 读最近 memory snapshot
-  - 注入 system prompt: "用户最近: <summary>;当前 trip: <city, day N>;最爱: <top 3 experience names>"
-  - 注意: prompt 中包含的所有数据必须脱敏 (不带坐标/手机/身份)
-- [ ] **#202 AgentMemorySnapshot 后台更新** — `apps/ios/SoloCompass/Services/MemoryDigestService.swift`
-  - 每个 chat session 结束时,异步调用 LLM 生成 ≤500 字摘要
-  - 写回 AgentMemorySnapshot
-  - on-device 优先,不上传云端
-- [ ] **#203 ChatOrchestrator 加入时段意识** — `VoiceAgentOrchestrator.swift`
-  - 注入 system prompt: "现在是 <morning/afternoon/evening/night> 的 <周几>"
-  - 早上语气: "今天想做什么", 傍晚: "要不要去坐一会"
-- [ ] **#204 Settings 加 "忘记我" 按钮** — `apps/ios/SoloCompass/Views/Settings/SettingsView.swift`
-  - 一键清空 AgentMemorySnapshot + TasteProfile
-  - 用户隐私焦虑兜底
+- [x] **#201 ChatOrchestrator 注入 AgentMemorySnapshot** ✅ (2026-07-01) — `apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift`
+  - `memoryDigest: MemoryDigestService?` 注入构造函数, CompassMapView.ensureOrchestrator 已透传 `.shared`
+  - `buildSystemPrompt` 加 `AGENT MEMORY` 块 — 调 `MemoryDigestService.currentSnapshot()?.systemPromptBlock()`, 空字段自动跳过 (docstring 契约)
+  - 脱敏契约由 AgentMemorySnapshot @Model 层保证: 只存 summary/lastTripCity/recentChatDigest, 无坐标/手机/身份字段
+- [x] **#202 AgentMemorySnapshot 后台更新** ✅ (2026-07-01) — `apps/ios/SoloCompass/Services/MemoryDigestService.swift`
+  - 新建 `MemoryDigestService` (@MainActor @Observable singleton, 照 TasteUpdateService 模板)
+  - `persistConversation` 加 fire-and-forget `Task { await digest.digestConversation(...) }`, 只在存在 user turn 时触发, cityCode 从 scopedExperience 抽取
+  - 当前实现: on-device deterministic 摘要 (summary ≤500 chars, recentChatDigest ≤300 chars). LLM slot 已预留, `setUseLLM(true)` 一行开关
+  - SoloCompassApp bootstrap 挂 `.setModelContainer(...)`
+  - 15 项 XCTest 覆盖 `MemoryDigestServiceTests`: rollup 空/system-only/时序/超上限/换行/nil-content, 摘要 4 分支, 单例 upsert, forget-me
+- [x] **#203 ChatOrchestrator 加入时段意识** ✅ (2026-07-01) — `VoiceAgentOrchestrator.swift`
+  - 新增静态方法 `temporalContextBlock(now:calendar:)` 输出 `TEMPORAL CONTEXT` 块 (time-of-day / weekday / tone hint)
+  - 时段桶: 05-11 morning · 11-17 afternoon · 17-21 evening · 21-05 night
+  - Tone hint 提示 LLM: 早上"今天想做什么" / 傍晚"要不要去坐一会" / 深夜偏安静
+- [x] **#204 Settings 加 "忘记我" 按钮** ✅ (2026-07-01) — `apps/ios/SoloCompass/Views/Settings/SettingsView.swift`
+  - dataSection 加 orange `brain.head.profile` icon 按钮 + confirmationDialog + result toast
+  - 调 `MemoryDigestService.shared.forgetMe()` — 同事务清空 AgentMemorySnapshot + TasteProfile 两张单例表
+  - 中英本地化 6 条 `settings.forgetMe.*`, 用户 favorites/routes/preferences 明确保留
 
 ## P2.1 — 新 Tool 扩展 (VoiceAgentToolRouter) ⭐
 
@@ -208,27 +212,25 @@
 
 ## P2.2 — 灵动岛 3 个新 Kind ⭐
 
-- [ ] **#220 在 `SoloCompassActivityAttributes.Kind` 加 3 个 case** — `apps/ios/SoloCompass/Shared/SoloCompassActivityAttributes.swift`
-  - **注意**: Kind enum 在双 target 共享文件,改一处自动两端生效
-  - 加: `case soloAgentHint`, `case timeCapsule`, `case dailyOmen`
-  - 同步在 `SoloCompassActivityState` 加每个 Kind 需要的字段 (hint text / capsule preview / omen line)
-- [ ] **#221 widget 端渲染 3 个新 Kind** — `apps/ios/SoloCompassWidgets/SoloCompassLiveActivity.swift` + `LockScreenLiveActivityView.swift`
-  - 在 `ExpandedLeading/Trailing/Center/Bottom` 4 个 @ViewBuilder switch 加新 case (现有写法已为加 Kind 留好扩展点)
-  - 限流逻辑放主 app 不放 widget (widget 只渲染,不决策)
-- [ ] **#222 `solo_agent_hint` 主 app 触发逻辑** — `apps/ios/SoloCompass/Services/LiveActivityService.swift`
-  - 加 `startSoloAgentHint(hint:experienceId:)` 方法
-  - 限流: 一天最多 3 次 (用 UserDefaults 滚动计数)
-  - expanded region: 建议 + 采纳/换一个/5min 后再提 (intent button)
-- [ ] **#223 `time_capsule` 触发链路** — `LiveActivityService.swift` ⭐
-  - 触发源: 新增的 VisitTrackingService 检测进入有未拆胶囊的围栏 (复用 CLCircularRegion)
-  - 加 `startTimeCapsule(capsuleId:experienceId:preview:)`
-  - 拆开动画走主 app 全屏 (CapsuleOpenView, 见 #242),widget 只负责"邀请拆开"卡片
-- [ ] **#224 `daily_omen` 调度 + 触发** — `LiveActivityService.swift`
-  - 每天 7am 本地通知触发 (复用 NotificationService schedule 能力)
-  - 加 `startDailyOmen(line:experienceId:)`
-- [ ] **#225 LiveActivityService 单测覆盖** — `apps/ios/SoloCompass/Tests/LiveActivityServiceTests.swift`
-  - 每个 start/update/end 路径都覆盖
-  - 限流硬上限测试 (24 小时窗口超过 3 次必须 noop)
+- [x] **#220 在 `SoloCompassActivityAttributes.Kind` 加 3 个 case** ✅ (2026-07-01) — `apps/ios/SoloCompass/Shared/SoloCompassActivityAttributes.swift`
+  - 加 `case soloAgentHint / timeCapsule / dailyOmen` (String Codable rawValue, 向后兼容)
+  - `SoloCompassActivityState` 加 6 个字段 (hintText/hintAnchorName/capsulePreview/capsuleAnchorName/omenLine/omenMicroTask), 全 default "" 兼容旧 payload
+- [x] **#221 widget 端渲染 3 个新 Kind** ✅ (2026-07-01) — `apps/ios/SoloCompassWidgets/SoloCompassLiveActivity.swift` + `LockScreenLiveActivityView.swift`
+  - SoloCompassLiveActivity 6 处 switch 补齐 (ExpandedLeading/Trailing/Center/Bottom + CompactLeading/Trailing + MinimalGlyph)
+  - LockScreenLiveActivityView 4 处 switch 补齐 (leadingTile/titleText/detail/trailing)
+  - 3 个 kind passive one-shot 所以 ExpandedBottom / trailing 用 EmptyView 不长岛
+- [x] **#222 `solo_agent_hint` 主 app 触发逻辑** ✅ (2026-07-01) — `apps/ios/SoloCompass/Services/LiveActivityService.swift`
+  - `startSoloAgentHint(hint:anchorName:maxPerDay:)` 默认 3 次/天上限
+  - 限流: UserDefaults key `solo.liveactivity.count.soloAgentHint.<yyyy-MM-dd>` 计数器, `consumeDailyBudget` internal 供测试驱动
+- [x] **#223 `time_capsule` 触发链路** ✅ (2026-07-01, wire-up 到 VisitTrackingService 留 P2.4) — `LiveActivityService.swift`
+  - `startTimeCapsule(capsuleId:preview:anchorName:)` 已落地
+  - **不加日限流**: 胶囊发现是稀缺时刻, 不能因今天已发过 hint 就错过
+- [x] **#224 `daily_omen` 调度 + 触发** ✅ (2026-07-01) — `LiveActivityService.swift`
+  - `startDailyOmen(line:microTask:maxPerDay:)` 默认 1 次/天 (今日签是仪式)
+  - 7am 本地通知调度接线留到 P3.0 #301 OmenComposeService
+- [x] **#225 LiveActivityService 单测覆盖** ✅ (2026-07-01, 6/6 全绿 0.08s) — `apps/ios/SoloCompass/Tests/LiveActivityServiceTests.swift`
+  - 覆盖: Kind 7 case 契约 (rawValue 唯一性) / hint 3-per-day 上限 / hint 跨日重置 / omen 1-per-day / capsule 无日限流 / state struct 默认值 backward-compat
+  - Activity.request 需真机 entitlement, 单测覆盖到限流+state 契约层, 端到端留内测 (#291)
 
 ## P2.3 — 盲盒 Trip MVP 🎁💰
 
@@ -405,8 +407,9 @@
 
 ## X.1 — 设计系统升级
 
-- [ ] **#X10 暖琥珀 v2 token 扩展** — `apps/ios/SoloCompass/Views/Shared/CompareTokens.swift`
-  - 新增 CT.capsuleGlow / CT.omenGold / CT.blindboxAmber 等场景色
+- [x] **#X10 暖琥珀 v2 token 扩展** ✅ (2026-07-01) — `apps/ios/SoloCompass/Views/Shared/CompareTokens.swift`
+  - CT.capsuleGlow (0xF7DEB0 ethereal) / CT.omenGold (0xB8925C 深金) / CT.blindboxAmber (0x8A4A14 最深)
+  - **使用纪律**: 只用于仪式感界面 (胶囊/城市签/盲盒), 不用于 routine — 混用会稀释情绪价值
 - [ ] **#X11 Lottie / 动画 spec 文档** — `docs/ANIMATION_SPEC.md`
   - 时空胶囊接受动画、盲盒揭秘动画、城市签翻面 三个核心动画的 spec
 
@@ -419,9 +422,9 @@
 
 ## X.3 — 隐私 & 合规
 
-- [ ] **#X30 PRIVACY.md 更新**
-  - 增加 VisitRecord / TasteProfile / TimeCapsule 数据用途说明
-  - 强调全部 on-device,云端不存
+- [x] **#X30 PRIVACY.md 更新** ✅ (2026-07-01) — `docs/PRIVACY.md`
+  - 加 4 行 iOS on-device 表 (VisitRecord / TasteProfile / TimeCapsule / AgentMemorySnapshot) 到 "What we collect" 表格
+  - 加 "On-device only: the iOS commitment" 段: 声明四张表永不上云 + parity check 兜底保证 + Forget me 按钮承诺
 - [ ] **#X31 "忘记我" 一键清空流程** (P2.0 #204 已计划)
 
 ## X.4 — 测试 & 质量


### PR DESCRIPTION
Lands **Phase 2 P2.0 Chat Agent Upgrades** (#201–#204) end-to-end, plus a catch-up commit for prior P2.2/X.1/X.3 work that was sitting in the working tree.

## P2.0 (this PR's headline)

### #201 System-prompt memory injection
`VoiceAgentOrchestrator` gains an optional `memoryDigest: MemoryDigestService?` parameter. When wired, `buildSystemPrompt` emits an `AGENT MEMORY` block from the singleton `AgentMemorySnapshot` (`summary` / `lastTripCity` / `recentChatDigest`). Empty fields are suppressed by `systemPromptBlock()` so cold-start users don't get noise. Wired at `CompassMapView.ensureOrchestrator` via `MemoryDigestService.shared`.

### #202 Background digest
New `MemoryDigestService.swift` (@MainActor @Observable singleton, mirrors `TasteUpdateService` pattern):

- `persistConversation` fires a fire-and-forget `Task { await digest.digestConversation(...) }` **only when the turn contains at least one user message**, so stub conversations don't churn the snapshot.
- `cityCode` is lifted from `scopedExperience?.location.cityCode`.
- Default summariser is **deterministic on-device** (`summary ≤500 chars`, `recentChatDigest ≤300 chars` per the model's docstring caps). LLM slot is reserved behind `setUseLLM(true)` for a future prompt landing.
- Bootstrap wires `.setModelContainer(...)` in `SoloCompassApp.runBootstrapIfConsented`.
- 15 XCTest cases cover rollup edge-cases (empty / system-only / chronological order / cap truncation / newline normalisation / nil content), summariser branches, and singleton upsert.

### #203 Temporal awareness
New static `VoiceAgentOrchestrator.temporalContextBlock(now:calendar:)` emits a `TEMPORAL CONTEXT` block with time-of-day / weekday / a tone hint. Buckets: **05–11 morning · 11–17 afternoon · 17–21 evening · 21–05 night**. Tone hints guide the agent's opening line ("what do you want to do today" vs "want to go sit somewhere").

### #204 "Forget me" in Settings
`dataSection` gains an orange `brain.head.profile` button + confirmation dialog + result toast. Calls `MemoryDigestService.forgetMe()` — a same-transaction wipe of AgentMemorySnapshot + TasteProfile. **Favorites, routes, and preferences are explicitly preserved**. Localised (6 strings each in en + zh-Hans).

## P2.2 catch-up (already ticked in todo.md)

- 3 new `SoloCompassActivityAttributes.Kind` cases (`soloAgentHint` / `timeCapsule` / `dailyOmen`)
- Widget renderers cover all 6 island slots + lock-screen slots for the new kinds
- `LiveActivityService` gains `startSoloAgentHint` (3/day cap) / `startTimeCapsule` (uncapped — capsule discovery is rare) / `startDailyOmen` (1/day cap)
- 6 XCTest cases in `LiveActivityServiceTests`
- CompareTokens gains ceremonial-only `capsuleGlow` / `omenGold` / `blindboxAmber`
- `docs/PRIVACY.md` documents the 4 on-device @Model rows + forget-me commitment
- `CLAUDE.md` prescriptive clauses removed per user request

## Test plan

- [ ] CI: `xcodebuild build` on `iPhone 17 Pro` simulator
- [ ] CI: `xcodebuild test -only-testing:SoloCompassTests/MemoryDigestServiceTests` (15 cases)
- [ ] CI: `xcodebuild test -only-testing:SoloCompassTests/LiveActivityServiceTests` (6 cases)
- [ ] CI: `xcodebuild test` full suite — 70/70 baseline should hold + gain 21 new
- [ ] Manual: open Solo Agent chat, exchange a couple of turns, close sheet → reopen → new session's system prompt should surface the digested `AGENT MEMORY` block (verify via `orch.currentSystemPrompt`)
- [ ] Manual: Settings → Data → "Forget me" → confirm → chat again → memory block should be absent