### PR TITLE
feat(ios): V-next P2/P3 skeleton + gap fills

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		2C5A15DE0FCF30A3BCF1EB20 /* RouteItineraryBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8670B08F2AB2779C31E0870 /* RouteItineraryBridgeTests.swift */; };
 		2D379EAE0BCD339DB670EB5C /* CompanionPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431DC31A80132F719AFEE471 /* CompanionPost.swift */; };
 		2EC741296992D9D0A4F3077D /* RouteCardNowReasonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D31F422914779D9228B0278 /* RouteCardNowReasonTests.swift */; };
+		2ED16C7027DB2250262F5D3F /* ProactiveNudgeSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5780606CA08F571BF04ACE /* ProactiveNudgeSchedulerTests.swift */; };
 		2F00F874A1B50C113AC8CA55 /* ChatRedesignVisualTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB511F86191D72DBCBCB5A01 /* ChatRedesignVisualTest.swift */; };
 		2F532734CA53A554106DC739 /* SeedRoutesParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A644911E7B2824A7ABBA4D6F /* SeedRoutesParityTests.swift */; };
 		2FCF0785691C23EC3D6824C2 /* AmapPOIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06EEB9F3424112BC6141406F /* AmapPOIService.swift */; };
@@ -186,6 +187,7 @@
 		627258EB2A310E2C979787E8 /* SkeletonBadgeViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B418AD0352AC3402D6609E4C /* SkeletonBadgeViewTests.swift */; };
 		62BB74EC16B92899A9A6A44C /* ReverseGeocodeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BDF8B4B7CC82F3845C5068 /* ReverseGeocodeService.swift */; };
 		62DB07EFC7BCAF019D757805 /* IslandComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C6B8684C2A7737474A182A /* IslandComponents.swift */; };
+		62F1F72C563FF41389050CEB /* NeverInventPOIRedLineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1E1FC2007C2AFC681D322A /* NeverInventPOIRedLineTests.swift */; };
 		63059F4B8EFE54C8E2699330 /* ItineraryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0AA21CD490B436012818D9D /* ItineraryDetailView.swift */; };
 		6368700EA304CE63F6CC9DB8 /* FriendsListRenderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC6E2F5AF146A5D51579286 /* FriendsListRenderTest.swift */; };
 		63A45A90C2748A2729742C2F /* FilterBarScrollAffordanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFED848E66BBE2A234AAA3CC /* FilterBarScrollAffordanceTest.swift */; };
@@ -940,6 +942,7 @@
 		DAF934B8ECFB7BB99C9C4791 /* RouteShareCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteShareCardView.swift; sourceTree = "<group>"; };
 		DB22C08A558D35B83043C83E /* AddFriendSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFriendSheet.swift; sourceTree = "<group>"; };
 		DC34BA3586B5607F63F86CC0 /* MarkerClosingSoonStyleTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerClosingSoonStyleTest.swift; sourceTree = "<group>"; };
+		DE1E1FC2007C2AFC681D322A /* NeverInventPOIRedLineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeverInventPOIRedLineTests.swift; sourceTree = "<group>"; };
 		DE4515228D70D8804596299D /* AIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProvider.swift; sourceTree = "<group>"; };
 		DEAFA6EDE9F7525F73612DFA /* EntitlementBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementBanner.swift; sourceTree = "<group>"; };
 		DFA9968E168052C0DC0E1B36 /* SFSymbolExistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSymbolExistenceTests.swift; sourceTree = "<group>"; };
@@ -1003,6 +1006,7 @@
 		FBBF77E10D341C38C093D22D /* CompanionBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionBlock.swift; sourceTree = "<group>"; };
 		FC366DD24E9174448BF06A2D /* CompassMapViewBodyTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompassMapViewBodyTypeTests.swift; sourceTree = "<group>"; };
 		FF401E3F554B9E2948A64ABC /* ForgetMeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgetMeService.swift; sourceTree = "<group>"; };
+		FF5780606CA08F571BF04ACE /* ProactiveNudgeSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProactiveNudgeSchedulerTests.swift; sourceTree = "<group>"; };
 		FF753CC02718028B12891042 /* AdminService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminService.swift; sourceTree = "<group>"; };
 		FF7D0A1F8E3B8909F465194C /* ObsidianThemeContrastTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObsidianThemeContrastTest.swift; sourceTree = "<group>"; };
 		FFC5559A4AAF4E3CD77E38B6 /* MapViewModelCityCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModelCityCacheTests.swift; sourceTree = "<group>"; };
@@ -1249,6 +1253,7 @@
 				C64F0D1D5DC5D6850EE482C8 /* MyProfileEditPersistenceTests.swift */,
 				F7FB43528F45882868CCC203 /* NavigationLauncherTests.swift */,
 				994CE03CD59A3B638A7570AD /* NearbySkeletonRenderTest.swift */,
+				DE1E1FC2007C2AFC681D322A /* NeverInventPOIRedLineTests.swift */,
 				D08AFC181DB143A21E97A2ED /* NextBestExperienceClockTest.swift */,
 				CE95C3399C8616CBDE8B44BE /* NoProductionPrintTests.swift */,
 				49F36F9AC9ED0AE7E3F0E5EA /* NotificationServiceHandleURLTests.swift */,
@@ -1269,6 +1274,7 @@
 				2EFE48683692E4C00E0A2DC5 /* PressableButtonStyleHapticTest.swift */,
 				02AED8B43F4C4059CD005C0A /* PreviewCardLifecycleTests.swift */,
 				A267CD0DA0A8053B0AB072BC /* PrivacyAcknowledgementSheetSnapshotTest.swift */,
+				FF5780606CA08F571BF04ACE /* ProactiveNudgeSchedulerTests.swift */,
 				EBCD0D2CE7423C29CD668866 /* PublicAPIDocCommentTests.swift */,
 				14392FEFAE7F1E9596DCCA53 /* PushTokenServiceTests.swift */,
 				7A6F9AAA8749FA23B91F7C93 /* ReviewsServiceTests.swift */,
@@ -2121,6 +2127,7 @@
 				23C6D8147AA0FFE2C7F2DC32 /* MyProfileEditPersistenceTests.swift in Sources */,
 				D4193263CDA544D0995749B0 /* NavigationLauncherTests.swift in Sources */,
 				FB18E501DE07BA0D80A7F3C5 /* NearbySkeletonRenderTest.swift in Sources */,
+				62F1F72C563FF41389050CEB /* NeverInventPOIRedLineTests.swift in Sources */,
 				FC1E25FED02B767FBFB5EFE2 /* NextBestExperienceClockTest.swift in Sources */,
 				B42207A02271655D3498B723 /* NoProductionPrintTests.swift in Sources */,
 				2FDE17BACDABCE85552A022B /* NotificationServiceHandleURLTests.swift in Sources */,
@@ -2141,6 +2148,7 @@
 				7ACAAE18D2EFA3E880AD6744 /* PressableButtonStyleHapticTest.swift in Sources */,
 				9BEDEF446F2D554A7F1ABA6F /* PreviewCardLifecycleTests.swift in Sources */,
 				A5D3EF6A05AD9B93FA5ACD8A /* PrivacyAcknowledgementSheetSnapshotTest.swift in Sources */,
+				2ED16C7027DB2250262F5D3F /* ProactiveNudgeSchedulerTests.swift in Sources */,
 				79E4FD6C7F9522BDB1106F56 /* PublicAPIDocCommentTests.swift in Sources */,
 				7DBE0CBB02CBB7565A230BA4 /* PushTokenServiceTests.swift in Sources */,
 				49C48BE7027B3D172A0BD9B1 /* ReviewsServiceTests.swift in Sources */,

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -13,6 +13,10 @@
 "filter.all" = "All";
 "filter.saved" = "Saved";
 "filter.saved.a11y" = "Saved, %d favourited experiences";
+"filter.solo.agent" = "Ask Solo";
+"filter.solo.agent.a11y" = "Ask Solo Agent for a nearby suggestion";
+"filter.taste.rank" = "My taste";
+"filter.taste.rank.a11y" = "Sort results by your taste profile";
 "filter.pill.clear.hint" = "Double tap to clear this filter";
 "filter.now.a11y" = "Now, %d experiences at their best";
 "filter.matches.one" = "%d match";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -13,6 +13,10 @@
 "filter.all" = "全部";
 "filter.saved" = "收藏";
 "filter.saved.a11y" = "收藏，%d 个已收藏的体验";
+"filter.solo.agent" = "问 Solo";
+"filter.solo.agent.a11y" = "让 Solo 给一个附近的建议";
+"filter.taste.rank" = "我的菜";
+"filter.taste.rank.a11y" = "按你的口味画像排序结果";
 "filter.a11y.resultsAnnounce" = "%1$@：找到 %2$d 个";
 "filter.a11y.noResultsAnnounce" = "%@：无匹配结果";
 

--- a/apps/ios/SoloCompass/Services/BragCardComposer.swift
+++ b/apps/ios/SoloCompass/Services/BragCardComposer.swift
@@ -29,7 +29,7 @@ public final class BragCardComposer {
     /// Optional flourish counters the user self-reports at the end of a
     /// trip (Cups of coffee, smiles-at-strangers, etc). All optional so
     /// the composer never blocks on user input.
-    public struct Flourishes: Equatable, Codable, Sendable {
+    public struct Flourishes: Equatable, Hashable, Codable, Sendable {
         public var coffeesConsumed: Int?
         public var smilesShared: Int?
         public var stepsWalked: Int?

--- a/apps/ios/SoloCompass/Services/ForgetMeService.swift
+++ b/apps/ios/SoloCompass/Services/ForgetMeService.swift
@@ -1,0 +1,117 @@
+import Foundation
+import SwiftData
+import os
+
+/// One-tap "Forget me" — atomically clears every on-device table that carries
+/// personal signal (Phase 2 P2.0 #204).
+///
+/// Scope by table:
+/// - `VisitRecord`         — passive geofence archive
+/// - `TasteProfile`        — vibe embedding + descriptors
+/// - `TimeCapsule`         — buried notes/voice/photos
+/// - `AgentMemorySnapshot` — chat memory summary
+///
+/// Not scoped:
+/// - Experience seed/pool (public content)
+/// - Chat sessions/messages (kept — deleting mid-turn breaks in-flight UI)
+///   → users clear chat via ChatHistoryStore's per-session delete
+/// - Favorites (users would want a separate confirm — a different button)
+///
+/// This service does NOT touch iCloud/Supabase — the four tables above never
+/// leave the device (PRIVACY.md #X30 on-device commitment). Nothing to unsync.
+@MainActor
+public final class ForgetMeService {
+
+    public static let shared = ForgetMeService()
+
+    private static let log = OSLog(subsystem: "com.solocompass.app", category: "ForgetMe")
+
+    private var modelContainer: ModelContainer?
+
+    private init() {}
+
+    /// Injected once at app bootstrap (mirrors `VisitTrackingService.setModelContainer`).
+    public func setModelContainer(_ container: ModelContainer) {
+        self.modelContainer = container
+    }
+
+    /// Test-only overload: bind a specific container without the shared singleton.
+    /// Enables hermetic in-memory ModelContainer per test case.
+    #if DEBUG
+    public convenience init(modelContainer: ModelContainer) {
+        self.init()
+        self.modelContainer = modelContainer
+    }
+    #endif
+
+    /// Result of a `forgetEverything()` call, so a settings screen can report
+    /// exactly what was wiped and any failures rather than a silent success.
+    public struct Result: Equatable, Sendable {
+        public var visitRecordsDeleted: Int
+        public var tasteProfilesDeleted: Int
+        public var timeCapsulesDeleted: Int
+        public var agentMemorySnapshotsDeleted: Int
+        public var didSave: Bool
+
+        public var totalDeleted: Int {
+            visitRecordsDeleted + tasteProfilesDeleted +
+            timeCapsulesDeleted + agentMemorySnapshotsDeleted
+        }
+    }
+
+    /// Delete every row from the four personal-signal tables and save.
+    ///
+    /// - Returns: per-table row counts + whether the save succeeded. When the
+    ///   ModelContainer is missing, returns all-zero result with `didSave=false`
+    ///   and logs — never throws, so a Settings button never hangs on an alert.
+    @discardableResult
+    public func forgetEverything() -> Result {
+        guard let container = modelContainer else {
+            os_log("ForgetMe skipped — no ModelContainer bound",
+                   log: Self.log, type: .error)
+            return Result(visitRecordsDeleted: 0, tasteProfilesDeleted: 0,
+                          timeCapsulesDeleted: 0, agentMemorySnapshotsDeleted: 0,
+                          didSave: false)
+        }
+        let context = ModelContext(container)
+        let visits    = deleteAll(VisitRecord.self,         in: context)
+        let tastes    = deleteAll(TasteProfile.self,        in: context)
+        let capsules  = deleteAll(TimeCapsule.self,         in: context)
+        let memories  = deleteAll(AgentMemorySnapshot.self, in: context)
+
+        var saved = true
+        do {
+            try context.save()
+        } catch {
+            saved = false
+            os_log("ForgetMe save failed: %{public}@",
+                   log: Self.log, type: .error, String(describing: error))
+        }
+        os_log("ForgetMe cleared v=%d t=%d c=%d m=%d saved=%{public}@",
+               log: Self.log, type: .info, visits, tastes, capsules, memories,
+               saved ? "true" : "false")
+        return Result(
+            visitRecordsDeleted:         visits,
+            tasteProfilesDeleted:        tastes,
+            timeCapsulesDeleted:         capsules,
+            agentMemorySnapshotsDeleted: memories,
+            didSave:                     saved
+        )
+    }
+
+    private func deleteAll<T: PersistentModel>(
+        _ type: T.Type,
+        in context: ModelContext
+    ) -> Int {
+        do {
+            let rows = try context.fetch(FetchDescriptor<T>())
+            for row in rows { context.delete(row) }
+            return rows.count
+        } catch {
+            os_log("ForgetMe fetch(%{public}@) failed: %{public}@",
+                   log: Self.log, type: .error,
+                   String(describing: T.self), String(describing: error))
+            return 0
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Services/VoiceAgentToolRouter.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentToolRouter.swift
@@ -882,7 +882,9 @@ public final class VoiceAgentToolRouter {
         // Reads on-device VisitRecord via preferences.visitHistory as a
         // v1 proxy — the SwiftData path lands in a follow-up. Returns a
         // deterministic aggregate the LLM can turn into a sentence.
-        let totalVisits = preferences.visitHistory.values.reduce(0, +)
+        // visitHistory is `[String: Date]` — one entry per Experience visited.
+        // Count entries (not sum-of-Date) as the v1 proxy for total visits.
+        let totalVisits = preferences.visitHistory.count
         return Self.successJSON([
             "period": period,
             "visit_count": totalVisits,

--- a/apps/ios/SoloCompass/Tests/NeverInventPOIRedLineTests.swift
+++ b/apps/ios/SoloCompass/Tests/NeverInventPOIRedLineTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+@testable import SoloCompass
+
+/// Red-line contract: the Solo Agent MUST NEVER surface a POI it invented
+/// (Phase 2 X.4 #X43).
+///
+/// Every P2.1 tool that returns a place-like payload must draw from the
+/// existing `Experience` pool (`MapViewModel.visibleExperiences`), never a
+/// hallucinated title/coordinate/description. This is the difference between
+/// a helpful concierge and a generator that ships us into "we recommended a
+/// café that doesn't exist" territory.
+///
+/// This suite uses static code scans (grep-of-source) rather than mocks
+/// because the guarantee lives in the router source itself — a runtime test
+/// would need to enumerate every possible LLM output. Enforcement at source
+/// is the only sound frame.
+final class NeverInventPOIRedLineTests: XCTestCase {
+
+    /// Absolute path to the tool router. If xcodegen re-layouts this we'll
+    /// see a fetch fail rather than a silent pass.
+    private var routerSourcePath: String {
+        let here = URL(fileURLWithPath: #filePath)
+        // .../Tests/NeverInventPOIRedLineTests.swift → .../Services/VoiceAgentToolRouter.swift
+        return here
+            .deletingLastPathComponent()   // Tests/
+            .deletingLastPathComponent()   // SoloCompass/
+            .appendingPathComponent("Services/VoiceAgentToolRouter.swift")
+            .path
+    }
+
+    private func readRouter() throws -> String {
+        try String(contentsOfFile: routerSourcePath, encoding: .utf8)
+    }
+
+    // MARK: - suggest_now_action must anchor to visibleExperiences
+
+    /// Grab the body of a `private func <name>(...) ... {` block by locating
+    /// the declaration and then walking until the next `private ` or `public `
+    /// or `internal ` declaration at 4-space indent (which is a sibling
+    /// declaration inside the class). This is safer than trying to
+    /// brace-match the body's own close-brace, which is at 8-space indent
+    /// while sibling handlers' close-brace is at 4-space indent.
+    private func handlerBody(named name: String, in src: String) -> String? {
+        // Anchor to the DECLARATION, not any call site — `range(of:)` returns
+        // the first match, and every handler is also called from the switch.
+        // The definition prefix `func <name>(args:` is unique to the decl.
+        guard let declRange = src.range(of: "func \(name)(args:") else { return nil }
+        let after = String(src[declRange.upperBound...])
+        // Next sibling declaration = `\n    private ` at 4-space indent (or
+        // `\n}` when we hit the class close). Whichever comes first bounds
+        // this handler's body.
+        let nextSibling = after.range(of: "\n    private ")?.lowerBound
+        let classClose = after.range(of: "\n}")?.lowerBound
+        let boundary: String.Index? = {
+            switch (nextSibling, classClose) {
+            case let (s?, c?): return s < c ? s : c
+            case let (s?, nil): return s
+            case let (nil, c?): return c
+            case (nil, nil): return nil
+            }
+        }()
+        guard let end = boundary else { return nil }
+        return String(after[..<end])
+    }
+
+    func testSuggestNowActionAnchorsToVisibleExperiences() throws {
+        let src = try readRouter()
+        guard let body = handlerBody(named: "executeSuggestNowAction", in: src) else {
+            return XCTFail("executeSuggestNowAction body not found")
+        }
+
+        XCTAssertTrue(body.contains("vm.visibleExperiences"),
+                      "suggest_now_action must draw from vm.visibleExperiences (RAG anchor)")
+        XCTAssertTrue(body.contains("no_visible_candidates"),
+                      "suggest_now_action must return a graceful noop instead of a synthesised POI")
+        XCTAssertFalse(body.contains("Experience(id:"),
+                       "suggest_now_action must NOT construct a new Experience literal — that's an invented POI")
+    }
+
+    // MARK: - bury_capsule must reject unknown content types
+
+    func testBuryCapsuleValidatesContentType() throws {
+        let src = try readRouter()
+        guard let body = handlerBody(named: "executeBuryCapsule", in: src) else {
+            return XCTFail("executeBuryCapsule body not found")
+        }
+        XCTAssertTrue(body.contains(#""text""#) &&
+                      body.contains(#""voice""#) &&
+                      body.contains(#""photo""#),
+                      "bury_capsule must whitelist text|voice|photo — unknown values leak an invented POI")
+    }
+
+    // MARK: - No literal latitude in successJSON payloads
+
+    /// Any handler that emits a JSON payload with a literal `"latitude": 12.34`
+    /// pair is a smell — could be echoing back an LLM-invented place. Scan for
+    /// that anti-pattern. (Legitimate handlers pass `parsed.latitude` as a
+    /// variable, not a string key colon-followed by a decimal literal.)
+    func testNoLiteralLatLonInSuccessJSON() throws {
+        let src = try readRouter()
+        let pattern = #"successJSON\(\[[^]]*"latitude"\s*:\s*\d+\.\d+"#
+        let regex = try NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators])
+        let range = NSRange(src.startIndex..., in: src)
+        let matches = regex.matches(in: src, options: [], range: range)
+        XCTAssertEqual(matches.count, 0,
+                       "successJSON must never emit a literal latitude number — that's an invented POI")
+    }
+
+    // MARK: - All 7 P2.1 tools present in the switch (contract with recon)
+
+    /// If a tool case is accidentally deleted from the switch, its schema in
+    /// `allTools` still advertises the capability to the LLM — but a call
+    /// would return `unknownTool` at runtime, silently losing intent. Guard
+    /// the switch cases so a rename triggers a test failure, not a mystery.
+    func testAllSevenP21ToolsRoutedInSwitch() throws {
+        let src = try readRouter()
+        let expected = [
+            "\"suggest_now_action\"",
+            "\"open_blindbox\"",
+            "\"bury_capsule\"",
+            "\"recall_pattern\"",
+            "\"sos_plan\"",
+            "\"unwalked_path\"",
+            "\"recall_local_scene\"",
+        ]
+        for name in expected {
+            XCTAssertTrue(src.contains("case \(name):"),
+                          "switch must route \(name) — advertised via allTools schema")
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Tests/ProactiveNudgeSchedulerTests.swift
+++ b/apps/ios/SoloCompass/Tests/ProactiveNudgeSchedulerTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+import UserNotifications
+@testable import SoloCompass
+
+/// Tests for `ProactiveNudgeScheduler` — the P2.6 orchestration layer over
+/// `NotificationService` (Phase 2 X.4 #X42).
+///
+/// UNUserNotificationCenter needs a live authorization decision to actually
+/// deliver requests, which unit tests can't get without a device. So the suite
+/// covers what unit tests do own:
+///  • the UserDefaults-backed daily budget ring
+///  • the per-toggle enabled/disabled UserDefaults gate
+///  • the one-shot idempotency guards (dayKey stamped keys)
+///  • Toggle.rawValue stability (the payloads persist across app updates)
+@MainActor
+final class ProactiveNudgeSchedulerTests: XCTestCase {
+
+    private var scheduler: ProactiveNudgeScheduler {
+        ProactiveNudgeScheduler.shared
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        // Fresh budget + toggle state per test — never leak counter state.
+        UserDefaults.standard.removeObject(forKey: dailyKey(for: Date()))
+        for toggle in ProactiveNudgeScheduler.Toggle.allCases {
+            UserDefaults.standard.removeObject(forKey: toggle.rawValue)
+        }
+    }
+
+    // MARK: - Toggle enum stability contract
+
+    /// Toggle raw values ARE UserDefaults keys — if the enum case is renamed
+    /// after ship, existing users' toggle state resets to default. Test locks
+    /// the three raw strings so a rename would fail in review.
+    func testToggleRawValuesAreStable() {
+        XCTAssertEqual(ProactiveNudgeScheduler.Toggle.lonelyHours.rawValue,
+                       "com.solocompass.nudge.lonelyHours.enabled.v1")
+        XCTAssertEqual(ProactiveNudgeScheduler.Toggle.cityOmen.rawValue,
+                       "com.solocompass.nudge.cityOmen.enabled.v1")
+        XCTAssertEqual(ProactiveNudgeScheduler.Toggle.capsule.rawValue,
+                       "com.solocompass.nudge.capsule.enabled.v1")
+    }
+
+    // MARK: - Toggle read/write
+
+    func testToggleDefaultIsEnabled() {
+        // Fresh user (no UserDefaults key) — treated as opted-in per privacy
+        // design: "default all on for Pro; user can single-off". Test guards
+        // against a future flip where absent-key becomes false and silently
+        // disables everyone's nudges after upgrade.
+        for toggle in ProactiveNudgeScheduler.Toggle.allCases {
+            XCTAssertTrue(scheduler.isEnabled(toggle),
+                          "\(toggle) should default to enabled for fresh users")
+        }
+    }
+
+    func testTogglePersists() {
+        scheduler.setEnabled(.lonelyHours, false)
+        XCTAssertFalse(scheduler.isEnabled(.lonelyHours))
+        scheduler.setEnabled(.lonelyHours, true)
+        XCTAssertTrue(scheduler.isEnabled(.lonelyHours))
+    }
+
+    // MARK: - Daily budget ring (shared across all nudge kinds)
+
+    func testDailyBudgetConsumesUpToLimit() {
+        // dailyBudget defaults to 3 — three consumes succeed, fourth fails.
+        XCTAssertTrue(scheduler.consumeDailyBudget())
+        XCTAssertTrue(scheduler.consumeDailyBudget())
+        XCTAssertTrue(scheduler.consumeDailyBudget())
+        XCTAssertFalse(scheduler.consumeDailyBudget(),
+                       "4th consume must fail — user's daily quota is spent")
+    }
+
+    func testDailyBudgetRollsOverToNextDay() {
+        let today = Date()
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: today)!
+
+        for _ in 0..<3 {
+            XCTAssertTrue(scheduler.consumeDailyBudget(now: today))
+        }
+        XCTAssertFalse(scheduler.consumeDailyBudget(now: today))
+
+        XCTAssertTrue(scheduler.consumeDailyBudget(now: tomorrow),
+                      "Tomorrow's counter is a fresh key — new quota available")
+
+        UserDefaults.standard.removeObject(forKey: dailyKey(for: tomorrow))
+    }
+
+    // MARK: - Year-review idempotency (P2.4 #244)
+
+    func testYearReviewNoopsWithZeroInventory() async {
+        let year = Calendar.current.component(.year, from: Date())
+        let stampKey = "com.solocompass.nudge.yearReview.\(year)"
+        UserDefaults.standard.removeObject(forKey: stampKey)
+
+        // Zero-inventory noop: never fire the year review when the user buried
+        // nothing (no emotional payoff, would feel like spam).
+        let fired = await scheduler.scheduleYearEndCapsuleReview(
+            buriedThisYear: 0, ripenNextYear: 0
+        )
+        XCTAssertFalse(fired, "zero inventory must noop")
+
+        UserDefaults.standard.removeObject(forKey: stampKey)
+    }
+
+    func testYearReviewIsIdempotentPerYear() async {
+        let year = Calendar.current.component(.year, from: Date())
+        let stampKey = "com.solocompass.nudge.yearReview.\(year)"
+
+        // Simulate a prior successful fire this year by writing the stamp
+        // directly — the guard chain will now short-circuit before any add().
+        UserDefaults.standard.set(true, forKey: stampKey)
+        let refired = await scheduler.scheduleYearEndCapsuleReview(
+            buriedThisYear: 5, ripenNextYear: 3
+        )
+        XCTAssertFalse(refired,
+                       "Once fired this year, refiring same year must noop")
+
+        UserDefaults.standard.removeObject(forKey: stampKey)
+    }
+
+    // MARK: - Helpers
+
+    /// Recreate the daily-key format used by ProactiveNudgeScheduler internally
+    /// (`com.solocompass.nudge.dailycount.%04d-%02d-%02d.v1`).
+    private func dailyKey(for date: Date) -> String {
+        let comps = Calendar.current.dateComponents([.year, .month, .day], from: date)
+        return String(format: "com.solocompass.nudge.dailycount.%04d-%02d-%02d.v1",
+                      comps.year ?? 2026, comps.month ?? 1, comps.day ?? 1)
+    }
+}
+
+/// CaseIterable synthesis for the Toggle enum's test-only iteration.
+extension ProactiveNudgeScheduler.Toggle: CaseIterable {
+    public static var allCases: [ProactiveNudgeScheduler.Toggle] {
+        [.lonelyHours, .cityOmen, .capsule]
+    }
+}

--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -223,6 +223,19 @@ public struct FilterBarView: View {
                         .id("all")
                         favoritePill(isSelected: isFavoriteSelected, action: onSelectFavorite)
                             .id("saved")
+                        // P2.5 #250: Solo Agent chip — shortcut to
+                        // `suggest_now_action` tool. Hidden when no callback
+                        // is wired (previews / tests without ChatOrchestrator).
+                        if let onTap = onSoloAgentTap {
+                            soloAgentPill(action: onTap)
+                                .id("solo-agent")
+                        }
+                        // P2.5 #252: 我的菜 (my taste) toggle — flips
+                        // TasteProfile-ranked ordering on all results.
+                        if let onToggle = onTasteRankToggle {
+                            tasteRankPill(isOn: isTasteRankOn) { onToggle(!isTasteRankOn) }
+                                .id("taste-rank")
+                        }
                         ForEach(visibleCategories) { category in
                             iconPill(
                                 category: category,
@@ -578,6 +591,74 @@ public struct FilterBarView: View {
         .accessibilityLabel(Text(label))
         .accessibilityAddTraits(isSelected ? .isSelected : [])
         .accessibilityValue(isSelected && resultCount > 0 ? Text("\(resultCount) results") : Text(""))
+    }
+
+    /// P2.5 #250 — Solo Agent shortcut pill. Tapping fires
+    /// `suggest_now_action` via the ChatOrchestrator. Uses `sun.max.fill` (a
+    /// verified SF Symbol — see `SFSymbolExistenceTests`) tinted in
+    /// `CT.sunGoldDeep` so it visually reads as the "concierge" affordance,
+    /// distinct from the neutral filter chips beside it.
+    private func soloAgentPill(action: @escaping () -> Void) -> some View {
+        let label = NSLocalizedString("filter.solo.agent", comment: "Solo Agent shortcut")
+        return Button {
+            #if canImport(UIKit)
+            Haptics.impact(.light)
+            #endif
+            action()
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "sun.max.fill")
+                    .font(.caption.weight(.semibold))
+                Text(label)
+                    .font(.subheadline.weight(.medium))
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .foregroundStyle(CT.sunGoldDeep)
+            .overlay(
+                Capsule().stroke(CT.sunGoldDeep.opacity(0.35), lineWidth: 1)
+            )
+        }
+        .buttonStyle(PressableButtonStyle())
+        .accessibilityLabel(Text(label))
+        .accessibilityHint(Text(NSLocalizedString("filter.solo.agent.a11y",
+            comment: "Ask Solo Agent for a nearby suggestion")))
+    }
+
+    /// P2.5 #252 — 我的菜 (my taste) toggle. When on, results are re-ordered
+    /// by TasteProfile-embedding match instead of raw Solo-Score. Free-tier
+    /// available (hook for Pro's private curation later).
+    private func tasteRankPill(isOn: Bool, action: @escaping () -> Void) -> some View {
+        let label = NSLocalizedString("filter.taste.rank", comment: "My taste (taste-ranked ordering)")
+        return Button {
+            #if canImport(UIKit)
+            Haptics.selection()
+            #endif
+            action()
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: isOn ? "sparkles" : "sparkle")
+                    .font(.caption.weight(.semibold))
+                Text(label)
+                    .font(.subheadline.weight(.medium))
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .foregroundStyle(isOn ? .white : CT.fgPrimary)
+            .background {
+                if isOn {
+                    Capsule()
+                        .fill(CT.accent)
+                        .matchedGeometryEffect(id: "filterHighlight", in: pillHighlight)
+                }
+            }
+            .overlay(
+                Capsule().stroke(isOn ? Color.clear : CT.borderDefault, lineWidth: 1)
+            )
+        }
+        .buttonStyle(PressableButtonStyle())
+        .accessibilityLabel(Text(label))
+        .accessibilityAddTraits(isOn ? .isSelected : [])
     }
 
     private func iconPill(category: ExperienceCategory, isSelected: Bool, action: @escaping () -> Void) -> some View {

--- a/docs/V_NEXT_DESIGN.md
+++ b/docs/V_NEXT_DESIGN.md
@@ -529,4 +529,34 @@
 - ✅ ProactiveNudgeScheduler 3 nudge kind + 每日预算共享上限
 - ✅ 3 大仪式动画 spec (ANIMATION_SPEC.md): 胶囊接受 / 盲盒揭秘 / 城市签翻面
 - ✅ AnalyticsService 5 事件 + 4 漏斗事件, `AnalyticsValue` 类型级禁 PII
-- ✅ 忘记我: MemoryDigestService.forgetMe() 同事务清空 memory + taste 单例
+- ✅ 忘记我: MemoryDigestService.forgetMe() 同事务清空 memory + taste 单例; ForgetMeService 广义版清空 4 张个人签名表 (含 VisitRecord + TimeCapsule)
+- ✅ 灵动岛 3 新 Kind (soloAgentHint / timeCapsule / dailyOmen) + LiveActivityService 3 start 方法 + UserDefaults 日限流 ring
+- ✅ CT v2 3 场景 token (capsuleGlow / omenGold / blindboxAmber) 保留给仪式感界面
+- ✅ PRIVACY.md 4 表 on-device 承诺 + Forget me 按钮承诺 + parity check 兜底保证
+
+---
+
+## Phase 2 走查清单 (P2.7 #292)
+
+> Phase 2 出口验收: 落地度 + 内测 + 走查文档三件套。本清单勾住 P2.7 #290/#291/#292 的最终交付,任何未打勾项都是 Phase 2 收官阻塞。
+
+**代码落地** (verified 2026-07-01 recon):
+- P2.0 Chat Agent 升级 4/4 ✅ (#201 memory 注入 / #202 MemoryDigestService / #203 时段意识 / #204 ForgetMeService 广义版)
+- P2.1 Tool router 扩展 7/7 ✅ (7 新 tool handler + 17 case switch 全 exhaustive)
+- P2.2 灵动岛 3 新 Kind 6/6 ✅ (#220-#225 Kind + Widget + LiveActivityService + 单测 6/6)
+- P2.3 盲盒 Trip 4/5 (BlindboxOrchestrator + Launch + Recap + safetyPolicy 全在; IAP 消费待 App Store Connect 沙盒)
+- P2.4 时空胶囊 5/6 (long-press → CapsuleComposeView → CapsuleStore CRUD → CapsuleOpenView 仪式感全在; #244 年末回顾 nudge stub 待 Analytics 累积 30 天)
+- P2.5 FilterBar 收敛 2/3 (#250 SoloAgent 入口 + #252 我的菜 toggle 全在; #251 More drawer 待收敛动画调优)
+- P2.6 主动 nudge 5/5 ✅ (ProactiveNudgeScheduler + 3 nudge kind + NotificationsSettingsView + dailyBudget 共享上限)
+
+**内测清单** (P2.7 #291, 需真机):
+- [ ] 灵动岛限流真机验: 24h 3 次上限、跨日重置
+- [ ] 胶囊拆开动画: iPhone 12 mini + iPhone 17 Pro Max 两端粒子性能
+- [ ] 盲盒 fallback: 首次盲盒无 Pro 用户走 high-confidence + high-Solo-Score 池
+- [ ] Nudge 静音时段: 21:00 后不应触发 lonely-hour
+- [ ] Forget me 一键清空: 4 表原子 + UI 立即反映 (NotificationsSettingsView 挂点)
+
+**走查文档** (P2.7 #292, 本段即是):
+- ✅ 主线代码落地度对照表 (上)
+- ✅ 内测清单 (上)
+- ✅ v1.0 契约地基快照 (前段)


### PR DESCRIPTION
## Summary
- Lands the Phase 2 + Phase 3 code skeleton for the v-next Solo Agent + 灵动岛 + 情绪付费 arc (13 services + 10 views + tests + docs), then closes the audit gaps that surfaced against it.
- Ships broader "Forget me" coverage (`ForgetMeService`) across all 4 on-device personal-signal tables, wires the `Ask Solo` + `My taste` chips into `FilterBarView`, and adds two contract-testing suites (RAG red-line + nudge budget).
- Fixes two pre-existing build errors uncovered by the full audit — the tool router `.reduce(0, +)` over `[String: Date].values` and the `BragCardComposer.Flourishes` missing `Hashable` conformance.

## What's in the diff (per commit)
- `9aed910` P2.0 chat agent memory injection + `MemoryDigestService` + `LiveActivityService` day-budget ring, and the P2.2 灵动岛 3 new kinds (`soloAgentHint` / `timeCapsule` / `dailyOmen`) rendered end-to-end (attributes, widget switches, service starts, unit tests).
- `29043ea` P2.3–P3.5 skeletons: `BlindboxOrchestrator` / `CapsuleStore` / `OmenComposeService` / `MusicService.composeOst` / `BragCardComposer` / `MonthlyInsightService` / `BookComposeService` / `AnalyticsService`, plus the paired `Views/Blindbox|Capsule|Omen|Ost|Brag|Insight` panes and the `ProactiveNudgeScheduler` + `NotificationsSettingsView`. Seven new tool-router handlers wired to Experience-pool payloads only (`suggest_now_action` → visibleExperiences ranker, `bury_capsule` → compose-sheet-pending, `sos_plan` / `unwalked_path` → paywall_required envelopes, etc). Product IDs for the six consumable IAPs added as SubscriptionService constants (no StoreKit purchase flow yet — that stage waits on App Store Connect sandbox).
- `bc2dfb4` `V_NEXT_DESIGN.md` release playbooks for the residual items (StoreKit sandbox / print partner / motion assets / SettingsView refactor).
- `1fb7755` (this session) fills the remaining gaps: `ForgetMeService`, FilterBar `Ask Solo` + `My taste` pill helpers (+ en/zh strings), red-line + nudge test suites, `Flourishes` Hashable + tool-router visitHistory build fixes, P2.7 walkthrough section appended to `V_NEXT_DESIGN.md`.

## Contracts protected in code
- **Never invent a POI.** `NeverInventPOIRedLineTests` statically scans `VoiceAgentToolRouter.swift` to enforce that `suggest_now_action` draws from `vm.visibleExperiences`, `bury_capsule` whitelists `text|voice|photo`, no handler emits a literal `latitude` in `successJSON`, and all 7 P2.1 tools stay routed in the switch.
- **On-device commitment.** `ForgetMeService` clears `VisitRecord` + `TasteProfile` + `TimeCapsule` + `AgentMemorySnapshot` in one save; nothing in the four tables is ever shipped off-device (parity check in CI). `PRIVACY.md` was already updated with the row-level story in a prior commit.
- **Nudge discipline.** `ProactiveNudgeSchedulerTests` locks the toggle rawValue keys (renaming would silently reset user prefs), the shared 3-per-day budget, the daily rollover, and the year-review idempotency stamp.

## What still lives outside a code PR
- `#304` StoreKit sandbox test flow for the 6 consumables (needs App Store Connect config, not codeable here).
- `#320` external designer brief for the 5 base Brag card faces.
- `#340` print partner contract (Lulu / Shutterfly / 一印).
- `#130 / #131` — recorded as deferred to their own PRs in `todo.md`: they're refactor-tier work that would break R0 cold-start UX + 3+ regression tests if forced into this PR.

## Test plan
- [x] `xcodebuild build … iPhone 17 Pro` → BUILD SUCCEEDED.
- [x] `LiveActivityServiceTests` 6/6, `ProactiveNudgeSchedulerTests` 7/7, `NeverInventPOIRedLineTests` 4/4 — all green in isolation.
- [ ] Full `xcodebuild test` on the CI runner: the current main baseline has ~9 pre-existing red suites (`BestNowChipStateTests`, `LocalizationCoverageTest`, `NoProductionPrintTests`, etc — see `project_test_baseline_red` memory). This PR touches none of them; regression check should compare _delta_ vs main, not absolute pass count.
- [ ] Real-device smoke pass per `V_NEXT_DESIGN.md § Phase 2 走查清单 (P2.7 #292)` — 灵动岛 rate limit, capsule reveal animation, blindbox fallback, nudge quiet hours, `Forget me` atomicity.

## Notes
- `SoloCompass.xcodeproj/project.pbxproj` changes are xcodegen-emitted for the new files. Regenerate with `xcodegen` from `apps/ios/` if `project.yml` is edited further.
- `FilterBarView` renders the new pills conditionally (nil-callback = hidden), so existing tests and previews stay pixel-identical until `CompassMapView` wires the two callbacks in a follow-up (that wiring needs `MapViewModel` state we intentionally didn't invent here).