### PR TITLE
feat(ios): add developer options panel unlocked via tester email

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -2083,3 +2083,58 @@
 "solo.agent.bubble.dismiss" = "Dismiss";
 "solo.agent.bubble.diagnostics.cta" = "Ask Solo how to fix it →";
 "solo.agent.bubble.diagnostics.subtitle.multi" = "%d more to talk through — tap and I'll explain.";
+
+/* MARK: - Developer Options (tester-email unlock only) */
+"dev.header" = "Developer";
+"dev.footer" = "Tools for testers and developers. Changes here only affect this device.";
+"dev.title" = "Developer Options";
+"dev.entry.subtitle" = "APIs, feature flags, and debug tools";
+
+"dev.status.header" = "Status";
+"dev.status.footer" = "Read-only diagnostics for the current build.";
+"dev.status.build" = "Build";
+"dev.status.version" = "Version";
+"dev.status.entitlement" = "Entitlement";
+"dev.status.aiModel" = "AI model";
+"dev.status.backendSync" = "Backend sync";
+
+"dev.value.on" = "On";
+"dev.value.off" = "Off";
+"dev.value.default" = "Default";
+
+"dev.api.header" = "API Configuration";
+"dev.api.footer" = "Override a built-in key to point the app at your own account. Leave blank to use the bundled default. Applies immediately — no rebuild.";
+"dev.api.notSet" = "Not set";
+"dev.api.foursquare" = "Foursquare key";
+"dev.api.openWeather" = "OpenWeather key";
+"dev.api.amap" = "Amap key";
+"dev.api.placeholder" = "Paste key to override default";
+"dev.api.clear" = "Clear override";
+
+"dev.flags.header" = "Feature Flags";
+"dev.flags.footer" = "Flip experimental features on or off. \"Default\" restores the shipped value.";
+"dev.flag.backendSync.title" = "Backend sync";
+"dev.flag.backendSync.subtitle" = "Supabase auth, sync, and Edge Functions.";
+"dev.flag.routeAIThroughEdge.title" = "Route AI through Edge";
+"dev.flag.routeAIThroughEdge.subtitle" = "Call the Supabase Edge Function instead of DeepSeek directly.";
+"dev.flag.proMultiRingExplore.title" = "Multi-ring Explore (Pro)";
+"dev.flag.proMultiRingExplore.subtitle" = "4-ring radial schedule for Explore Here.";
+"dev.flag.deepDiveEnrichment.title" = "Deep-dive enrichment";
+"dev.flag.deepDiveEnrichment.subtitle" = "Cross-reference places across Overpass, MapKit, and Foursquare.";
+"dev.flag.webSearchEnrichment.title" = "Web search enrichment";
+"dev.flag.webSearchEnrichment.subtitle" = "Extra AI call to verify hours, website, and phone.";
+"dev.flag.companion.title" = "Companion mode";
+"dev.flag.companion.subtitle" = "Friends, DMs, and companion discovery.";
+"dev.flag.companionLayer.title" = "Companion map layer";
+"dev.flag.companionLayer.subtitle" = "In-map toggle for nearby presence cells.";
+
+"dev.tools.header" = "Debug Tools";
+"dev.tools.entitlement" = "Force entitlement";
+"dev.tools.resetOnboarding" = "Reset onboarding";
+"dev.tools.resetOnboarding.done" = "Onboarding will show on next launch.";
+"dev.tools.resetOverrides" = "Reset all overrides";
+"dev.tools.resetOverrides.confirm" = "Reset every feature-flag override to its default?";
+"dev.tools.resetOverrides.done" = "All overrides cleared.";
+
+"dev.lock" = "Lock developer options";
+"dev.lock.footer" = "Hides this panel until you unlock again with a tester email. Your Pro access is kept.";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -2093,3 +2093,58 @@
 "solo.agent.bubble.dismiss" = "关掉";
 "solo.agent.bubble.diagnostics.cta" = "问 Solo 怎么修 →";
 "solo.agent.bubble.diagnostics.subtitle.multi" = "还有 %d 个问题,点开我一起说。";
+
+/* MARK: - 开发者选项（仅测试邮箱解锁后可见） */
+"dev.header" = "开发者";
+"dev.footer" = "面向测试者和开发者的工具。此处的更改仅影响本设备。";
+"dev.title" = "开发者选项";
+"dev.entry.subtitle" = "API、功能开关与调试工具";
+
+"dev.status.header" = "状态";
+"dev.status.footer" = "当前构建的只读诊断信息。";
+"dev.status.build" = "构建";
+"dev.status.version" = "版本";
+"dev.status.entitlement" = "会员权益";
+"dev.status.aiModel" = "AI 模型";
+"dev.status.backendSync" = "后端同步";
+
+"dev.value.on" = "开";
+"dev.value.off" = "关";
+"dev.value.default" = "默认";
+
+"dev.api.header" = "API 配置";
+"dev.api.footer" = "覆盖内置密钥，让 App 使用你自己的账号进行调试。留空则使用内置默认值。即时生效，无需重新构建。";
+"dev.api.notSet" = "未设置";
+"dev.api.foursquare" = "Foursquare 密钥";
+"dev.api.openWeather" = "OpenWeather 密钥";
+"dev.api.amap" = "高德（Amap）密钥";
+"dev.api.placeholder" = "粘贴密钥以覆盖默认值";
+"dev.api.clear" = "清除覆盖";
+
+"dev.flags.header" = "功能开关";
+"dev.flags.footer" = "开启或关闭实验性功能。\"默认\"会恢复发布版本的取值。";
+"dev.flag.backendSync.title" = "后端同步";
+"dev.flag.backendSync.subtitle" = "Supabase 鉴权、同步与 Edge Functions。";
+"dev.flag.routeAIThroughEdge.title" = "AI 走 Edge 通道";
+"dev.flag.routeAIThroughEdge.subtitle" = "调用 Supabase Edge Function，而非直连 DeepSeek。";
+"dev.flag.proMultiRingExplore.title" = "多环探索（Pro）";
+"dev.flag.proMultiRingExplore.subtitle" = "「就近探索」采用 4 环径向调度。";
+"dev.flag.deepDiveEnrichment.title" = "深度富化";
+"dev.flag.deepDiveEnrichment.subtitle" = "跨 Overpass、MapKit 与 Foursquare 交叉核对地点。";
+"dev.flag.webSearchEnrichment.title" = "联网搜索富化";
+"dev.flag.webSearchEnrichment.subtitle" = "额外发起一次 AI 调用，核实营业时间、网址与电话。";
+"dev.flag.companion.title" = "同行模式";
+"dev.flag.companion.subtitle" = "好友、私信与同行发现。";
+"dev.flag.companionLayer.title" = "同行地图图层";
+"dev.flag.companionLayer.subtitle" = "地图内的附近在场单元开关。";
+
+"dev.tools.header" = "调试工具";
+"dev.tools.entitlement" = "强制会员权益";
+"dev.tools.resetOnboarding" = "重置引导流程";
+"dev.tools.resetOnboarding.done" = "下次启动将重新显示引导。";
+"dev.tools.resetOverrides" = "重置所有覆盖";
+"dev.tools.resetOverrides.confirm" = "将所有功能开关的覆盖重置为默认值？";
+"dev.tools.resetOverrides.done" = "已清除所有覆盖。";
+
+"dev.lock" = "锁定开发者选项";
+"dev.lock.footer" = "隐藏该面板，直到你再次用测试邮箱解锁。你的 Pro 权益会保留。";

--- a/apps/ios/SoloCompass/Services/FeatureFlags.swift
+++ b/apps/ios/SoloCompass/Services/FeatureFlags.swift
@@ -127,12 +127,85 @@ public enum FeatureFlags {
         return readBool("FF_COMPANION_LAYER_ENABLED", default: false)
     }
 
+    // MARK: - Developer override registry
+    //
+    // The Developer Options panel (revealed after a tester-email unlock) lets
+    // testers flip these flags at runtime without a rebuild. Overrides are
+    // stored in UserDefaults under the same `FF_` key and consulted by
+    // `readBool` — see the resolution order there. Kept as data so the UI can
+    // render the list generically and stays in sync as flags are added.
+
+    /// A single developer-toggleable flag, described for the Developer Options UI.
+    public struct DeveloperFlag: Identifiable, Sendable {
+        /// UserDefaults / env-var key (e.g. "FF_WEB_SEARCH_ENRICHMENT").
+        public let key: String
+        /// Localization key for the human-readable title.
+        public let titleKey: String
+        /// Localization key for the one-line explanation.
+        public let subtitleKey: String
+        /// The compiled-in default used when no override/plist value exists.
+        public let defaultValue: Bool
+        public var id: String { key }
+    }
+
+    /// Flags surfaced in Developer Options. Order = display order.
+    public static let developerFlags: [DeveloperFlag] = [
+        DeveloperFlag(key: "FF_BACKEND_SYNC", titleKey: "dev.flag.backendSync.title",
+                      subtitleKey: "dev.flag.backendSync.subtitle", defaultValue: false),
+        DeveloperFlag(key: "FF_ROUTE_AI_THROUGH_EDGE", titleKey: "dev.flag.routeAIThroughEdge.title",
+                      subtitleKey: "dev.flag.routeAIThroughEdge.subtitle", defaultValue: false),
+        DeveloperFlag(key: "FF_PRO_MULTI_RING_EXPLORE", titleKey: "dev.flag.proMultiRingExplore.title",
+                      subtitleKey: "dev.flag.proMultiRingExplore.subtitle", defaultValue: false),
+        DeveloperFlag(key: "FF_DEEP_DIVE_ENRICHMENT", titleKey: "dev.flag.deepDiveEnrichment.title",
+                      subtitleKey: "dev.flag.deepDiveEnrichment.subtitle", defaultValue: true),
+        DeveloperFlag(key: "FF_WEB_SEARCH_ENRICHMENT", titleKey: "dev.flag.webSearchEnrichment.title",
+                      subtitleKey: "dev.flag.webSearchEnrichment.subtitle", defaultValue: false),
+        DeveloperFlag(key: "FF_COMPANION", titleKey: "dev.flag.companion.title",
+                      subtitleKey: "dev.flag.companion.subtitle", defaultValue: false),
+        DeveloperFlag(key: "FF_COMPANION_LAYER_ENABLED", titleKey: "dev.flag.companionLayer.title",
+                      subtitleKey: "dev.flag.companionLayer.subtitle", defaultValue: false),
+    ]
+
+    /// The developer override currently stored for `key`, or nil when the
+    /// tester hasn't set one (so the plist/compiled default applies).
+    public static func override(for key: String) -> Bool? {
+        guard UserDefaults.standard.object(forKey: key) != nil else { return nil }
+        return UserDefaults.standard.bool(forKey: key)
+    }
+
+    /// Write (or clear, when `value == nil`) a developer override for `key`.
+    public static func setOverride(_ value: Bool?, for key: String) {
+        if let value {
+            UserDefaults.standard.set(value, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
+    /// Remove every developer override so all flags revert to their
+    /// plist/compiled defaults. Used by the "Reset overrides" action.
+    public static func clearAllOverrides() {
+        for flag in developerFlags {
+            UserDefaults.standard.removeObject(forKey: flag.key)
+        }
+    }
+
     // MARK: - Internals
 
     static func readBool(_ key: String, default fallback: Bool) -> Bool {
+        // 1. Environment variable — highest priority so CI / test schemes and
+        //    Xcode run-args stay deterministic.
         if let env = ProcessInfo.processInfo.environment[key] {
             return env == "1" || env.lowercased() == "true"
         }
+        // 2. Developer Options runtime override (UserDefaults). Only present
+        //    when a tester explicitly toggled the flag in the in-app panel, so
+        //    default installs are unaffected. Works in Release too, which is
+        //    what TestFlight testers run.
+        if let override = override(for: key) {
+            return override
+        }
+        // 3. Bundled FeatureFlags.plist for staged build-time config.
         guard let url = Bundle.main.url(forResource: "FeatureFlags", withExtension: "plist"),
               let data = try? Data(contentsOf: url),
               let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]

--- a/apps/ios/SoloCompass/Services/SubscriptionService.swift
+++ b/apps/ios/SoloCompass/Services/SubscriptionService.swift
@@ -91,6 +91,17 @@ public final class SubscriptionService {
     public private(set) var isLoading: Bool = false
     public private(set) var lastError: String?
 
+    /// True once the tester email unlock has succeeded at least once on this
+    /// device. Persisted in UserDefaults (not Keychain — it's a UI-gating flag,
+    /// not an entitlement) so the Developer Options entry in Settings stays
+    /// visible across relaunches without re-entering the tester email. Distinct
+    /// from `entitlement == .pro`: a StoreKit purchase grants Pro but must NOT
+    /// reveal the developer panel; only the allow-listed tester unlock does.
+    public private(set) var developerModeUnlocked: Bool {
+        didSet { UserDefaults.standard.set(developerModeUnlocked, forKey: Self.developerModeDefaultsKey) }
+    }
+    static let developerModeDefaultsKey = "com.solocompass.developerModeUnlocked"
+
     /// Renewal / trial-end date of the currently-active StoreKit transaction.
     /// `nil` when there is no active transaction (free / proExpired) or when
     /// running under the DEBUG force-Pro override. The Paywall and MeSheet
@@ -137,6 +148,10 @@ public final class SubscriptionService {
         } else {
             self.entitlement = .free
         }
+
+        // Restore the tester/developer unlock flag so the Developer Options
+        // entry survives relaunch once a tester email has unlocked the device.
+        self.developerModeUnlocked = UserDefaults.standard.bool(forKey: Self.developerModeDefaultsKey)
 
         // Spin up the transaction listener BEFORE the first product/
         // entitlement fetch, so we never miss a renewal that arrives
@@ -300,7 +315,18 @@ public final class SubscriptionService {
     public func unlockWithAdminEmail(_ email: String) -> Bool {
         guard Self.isAdminEmail(email) else { return false }
         setEntitlement(.pro)
+        // Reveal the Developer Options panel in Settings from now on. Persisted
+        // so the tester doesn't have to re-enter the email after every relaunch.
+        developerModeUnlocked = true
         return true
+    }
+
+    /// Hide the Developer Options panel again (tester tapped "Lock developer
+    /// options"). Leaves the Pro entitlement untouched — locking the panel is
+    /// purely a UI concern and must not revoke an unlock the tester already
+    /// earned.
+    public func lockDeveloperMode() {
+        developerModeUnlocked = false
     }
 
     // MARK: - Dependency injection (tests override these)

--- a/apps/ios/SoloCompass/Tests/DeveloperOptionsUnlockTest.swift
+++ b/apps/ios/SoloCompass/Tests/DeveloperOptionsUnlockTest.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import SoloCompass
+
+// Coverage for the Developer Options gating + runtime overrides added alongside
+// the tester-email unlock. Two surfaces:
+//   1. SubscriptionService.developerModeUnlocked — flips true only on a
+//      successful allow-listed unlock, persists across instances, and is
+//      independent of the Pro entitlement.
+//   2. FeatureFlags developer overrides — UserDefaults overrides take
+//      precedence over the compiled default and can be cleared back to it.
+@MainActor
+final class DeveloperOptionsUnlockTest: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Start each test from a known state — no lingering flag/overrides.
+        UserDefaults.standard.removeObject(forKey: SubscriptionService.developerModeDefaultsKey)
+        FeatureFlags.clearAllOverrides()
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: SubscriptionService.developerModeDefaultsKey)
+        FeatureFlags.clearAllOverrides()
+        super.tearDown()
+    }
+
+    // MARK: - developerModeUnlocked
+
+    func testAllowListedUnlockRevealsDeveloperMode() {
+        let service = SubscriptionService()
+        service._setEntitlementForTesting(.free)
+        XCTAssertFalse(service.developerModeUnlocked,
+                       "Developer mode must start hidden before any unlock")
+
+        let unlocked = service.unlockWithAdminEmail(SubscriptionService.adminEmails.first!)
+
+        XCTAssertTrue(unlocked)
+        XCTAssertTrue(service.developerModeUnlocked,
+                      "A successful tester unlock must reveal Developer Options")
+    }
+
+    func testRejectedUnlockKeepsDeveloperModeHidden() {
+        let service = SubscriptionService()
+        _ = service.unlockWithAdminEmail("stranger@example.com")
+        XCTAssertFalse(service.developerModeUnlocked,
+                       "A non-allow-listed email must not reveal Developer Options")
+    }
+
+    func testDeveloperModeSurvivesRelaunch() {
+        let first = SubscriptionService()
+        _ = first.unlockWithAdminEmail(SubscriptionService.adminEmails.first!)
+        XCTAssertTrue(first.developerModeUnlocked)
+
+        // A fresh instance simulates the next app launch reading persisted state.
+        let relaunched = SubscriptionService()
+        XCTAssertTrue(relaunched.developerModeUnlocked,
+                      "Developer mode must persist across launches once unlocked")
+    }
+
+    func testLockDeveloperModeHidesPanelButKeepsPro() {
+        let service = SubscriptionService()
+        _ = service.unlockWithAdminEmail(SubscriptionService.adminEmails.first!)
+        XCTAssertEqual(service.entitlement, .pro)
+        XCTAssertTrue(service.developerModeUnlocked)
+
+        service.lockDeveloperMode()
+
+        XCTAssertFalse(service.developerModeUnlocked,
+                       "Locking must hide the panel")
+        XCTAssertEqual(service.entitlement, .pro,
+                       "Locking the panel must NOT revoke the earned Pro entitlement")
+
+        // The hidden state persists too.
+        let relaunched = SubscriptionService()
+        XCTAssertFalse(relaunched.developerModeUnlocked)
+    }
+
+    // MARK: - FeatureFlags developer overrides
+
+    func testOverrideTakesPrecedenceOverDefault() {
+        // webSearchEnrichment ships OFF; a developer override flips it ON.
+        XCTAssertFalse(FeatureFlags.webSearchEnrichment,
+                       "Precondition: web search enrichment defaults off")
+
+        FeatureFlags.setOverride(true, for: "FF_WEB_SEARCH_ENRICHMENT")
+        XCTAssertTrue(FeatureFlags.webSearchEnrichment,
+                      "A true override must turn the flag on at runtime")
+
+        FeatureFlags.setOverride(false, for: "FF_WEB_SEARCH_ENRICHMENT")
+        XCTAssertFalse(FeatureFlags.webSearchEnrichment,
+                       "A false override must turn a flag off even if its default were on")
+    }
+
+    func testClearAllOverridesRestoresDefaults() {
+        FeatureFlags.setOverride(false, for: "FF_DEEP_DIVE_ENRICHMENT") // default is true
+        XCTAssertFalse(FeatureFlags.deepDiveEnrichment)
+
+        FeatureFlags.clearAllOverrides()
+
+        XCTAssertNil(FeatureFlags.override(for: "FF_DEEP_DIVE_ENRICHMENT"),
+                     "Clearing must remove the stored override")
+        XCTAssertTrue(FeatureFlags.deepDiveEnrichment,
+                      "With the override gone, the flag returns to its shipped default (on)")
+    }
+
+    func testEveryDeveloperFlagKeyIsUnique() {
+        let keys = FeatureFlags.developerFlags.map(\.key)
+        XCTAssertEqual(Set(keys).count, keys.count, "Developer flag keys must be unique")
+    }
+}

--- a/apps/ios/SoloCompass/Views/Settings/DeveloperOptionsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/DeveloperOptionsView.swift
@@ -1,0 +1,392 @@
+import SwiftUI
+
+/// Developer / tester tooling, reachable from Settings only after a successful
+/// tester-email unlock (`SubscriptionService.developerModeUnlocked`).
+///
+/// Three jobs:
+///   1. **API configuration** — override the baked-in keys (AI provider,
+///      Foursquare, OpenWeather, Amap) at runtime so testers can point the app
+///      at their own accounts for debugging. Written straight to the same
+///      `UserDefaults` keys the `Secrets.resolved*` accessors already prefer
+///      over the compiled defaults, so changes take effect without a rebuild.
+///   2. **Feature flags** — flip the `FeatureFlags.developerFlags` on/off (or
+///      back to default) at runtime to trial not-yet-shipped surfaces.
+///   3. **Debug tools** — force an entitlement tier, reset onboarding, clear
+///      overrides, and lock the panel back up.
+///
+/// Nothing here is reachable by a normal user: the entry point in
+/// `SettingsView` is gated on `developerModeUnlocked`, which only the
+/// allow-listed tester unlock sets.
+struct DeveloperOptionsView: View {
+    @Environment(UserPreferences.self) private var preferences
+    @Environment(SubscriptionService.self) private var subscriptionService
+    @Environment(\.dismiss) private var dismiss
+
+    // Local mirror of the entitlement picker so it reflects immediately.
+    @State private var entitlementSelection: SubscriptionService.Entitlement = .free
+    // Bump to force the flag rows to re-read their UserDefaults override after
+    // "Reset overrides" clears them all at once.
+    @State private var flagsRevision = 0
+    @State private var showingResetConfirm = false
+    @State private var toast: String?
+
+    var body: some View {
+        List {
+            statusSection
+            apiConfigSection
+            featureFlagsSection
+            debugToolsSection
+            lockSection
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(NSLocalizedString("dev.title", comment: "Developer Options"))
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { entitlementSelection = subscriptionService.entitlement }
+        .alert(
+            toast ?? "",
+            isPresented: Binding(get: { toast != nil }, set: { if !$0 { toast = nil } })
+        ) {
+            Button(NSLocalizedString("common.ok", comment: "OK")) { toast = nil }
+        }
+    }
+
+    // MARK: - Status
+
+    private var statusSection: some View {
+        Section {
+            infoRow(icon: "hammer", color: .gray,
+                    label: NSLocalizedString("dev.status.build", comment: "Build configuration"),
+                    value: buildConfiguration)
+            infoRow(icon: "number", color: .gray,
+                    label: NSLocalizedString("dev.status.version", comment: "App version"),
+                    value: appVersion)
+            infoRow(icon: "crown", color: .yellow,
+                    label: NSLocalizedString("dev.status.entitlement", comment: "Entitlement"),
+                    value: subscriptionService.entitlement.rawValue)
+            infoRow(icon: "brain", color: .blue,
+                    label: NSLocalizedString("dev.status.aiModel", comment: "Resolved AI model"),
+                    value: resolvedAIModel)
+            infoRow(icon: "icloud", color: .teal,
+                    label: NSLocalizedString("dev.status.backendSync", comment: "Backend sync"),
+                    value: onOff(FeatureFlags.backendSync))
+        } header: {
+            header("info.circle", NSLocalizedString("dev.status.header", comment: "Status"))
+        } footer: {
+            Text(NSLocalizedString("dev.status.footer", comment: "Read-only diagnostics footer"))
+        }
+    }
+
+    // MARK: - API configuration
+
+    private var apiConfigSection: some View {
+        Section {
+            NavigationLink {
+                AIProviderSettingsView()
+                    .environment(preferences)
+            } label: {
+                iconLabel(icon: "brain.head.profile", color: aiKeyConfigured ? .green : .orange,
+                          title: NSLocalizedString("settings.aiProvider", comment: "AI Provider"),
+                          subtitle: aiKeyConfigured
+                            ? preferences.aiProvider.displayName
+                            : NSLocalizedString("dev.api.notSet", comment: "Not set"))
+            }
+
+            APIKeyOverrideField(
+                defaultsKey: Secrets.RuntimeKeys.foursquareApiKey,
+                icon: "mappin.and.ellipse", color: .pink,
+                title: NSLocalizedString("dev.api.foursquare", comment: "Foursquare API key"))
+            APIKeyOverrideField(
+                defaultsKey: Secrets.RuntimeKeys.openWeatherApiKey,
+                icon: "cloud.sun", color: .cyan,
+                title: NSLocalizedString("dev.api.openWeather", comment: "OpenWeather API key"))
+            APIKeyOverrideField(
+                defaultsKey: Secrets.RuntimeKeys.amapApiKey,
+                icon: "map", color: .green,
+                title: NSLocalizedString("dev.api.amap", comment: "Amap API key"))
+        } header: {
+            header("key.fill", NSLocalizedString("dev.api.header", comment: "API configuration"))
+        } footer: {
+            Text(NSLocalizedString("dev.api.footer", comment: "API override footer"))
+        }
+    }
+
+    // MARK: - Feature flags
+
+    private var featureFlagsSection: some View {
+        Section {
+            ForEach(FeatureFlags.developerFlags) { flag in
+                FeatureFlagRow(flag: flag)
+                    .id("\(flag.key)-\(flagsRevision)")
+            }
+        } header: {
+            header("flag", NSLocalizedString("dev.flags.header", comment: "Feature flags"))
+        } footer: {
+            Text(NSLocalizedString("dev.flags.footer", comment: "Feature flags footer"))
+        }
+    }
+
+    // MARK: - Debug tools
+
+    private var debugToolsSection: some View {
+        Section {
+            Picker(
+                NSLocalizedString("dev.tools.entitlement", comment: "Force entitlement"),
+                selection: $entitlementSelection
+            ) {
+                ForEach(SubscriptionService.Entitlement.allCases, id: \.self) { tier in
+                    Text(tier.rawValue).tag(tier)
+                }
+            }
+            .onChange(of: entitlementSelection) { _, newValue in
+                subscriptionService._setEntitlementForTesting(newValue)
+                Haptics.selection()
+            }
+
+            Button {
+                preferences.hasCompletedOnboarding = false
+                Haptics.notify(.success)
+                toast = NSLocalizedString("dev.tools.resetOnboarding.done", comment: "Onboarding reset toast")
+            } label: {
+                iconLabel(icon: "arrow.counterclockwise", color: .orange,
+                          title: NSLocalizedString("dev.tools.resetOnboarding", comment: "Reset onboarding"),
+                          subtitle: nil)
+            }
+            .foregroundStyle(.primary)
+
+            Button(role: .destructive) {
+                showingResetConfirm = true
+            } label: {
+                iconLabel(icon: "trash", color: .red,
+                          title: NSLocalizedString("dev.tools.resetOverrides", comment: "Reset overrides"),
+                          subtitle: nil)
+            }
+            .confirmationDialog(
+                NSLocalizedString("dev.tools.resetOverrides.confirm", comment: "Reset overrides confirm"),
+                isPresented: $showingResetConfirm,
+                titleVisibility: .visible
+            ) {
+                Button(NSLocalizedString("dev.tools.resetOverrides", comment: "Reset overrides"), role: .destructive) {
+                    FeatureFlags.clearAllOverrides()
+                    flagsRevision += 1
+                    Haptics.notify(.success)
+                    toast = NSLocalizedString("dev.tools.resetOverrides.done", comment: "Overrides reset toast")
+                }
+                Button(NSLocalizedString("common.cancel", comment: "Cancel"), role: .cancel) {}
+            }
+        } header: {
+            header("wrench.and.screwdriver", NSLocalizedString("dev.tools.header", comment: "Debug tools"))
+        }
+    }
+
+    // MARK: - Lock
+
+    private var lockSection: some View {
+        Section {
+            Button(role: .destructive) {
+                subscriptionService.lockDeveloperMode()
+                Haptics.impact(.medium)
+                // Pop back to Settings; the entry row is now gone (the flag is
+                // observed) so there's nothing to return to here.
+                dismiss()
+            } label: {
+                iconLabel(icon: "lock", color: .secondary,
+                          title: NSLocalizedString("dev.lock", comment: "Lock developer options"),
+                          subtitle: nil)
+            }
+        } footer: {
+            Text(NSLocalizedString("dev.lock.footer", comment: "Lock footer"))
+        }
+    }
+
+    // MARK: - Derived values
+
+    private var buildConfiguration: String {
+        #if DEBUG
+        return "DEBUG"
+        #else
+        return "RELEASE"
+        #endif
+    }
+
+    private var appVersion: String {
+        let v = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+        let b = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+        return "\(v) (\(b))"
+    }
+
+    private var resolvedAIModel: String {
+        preferences.aiModelName.isEmpty ? preferences.aiProvider.defaultModel : preferences.aiModelName
+    }
+
+    private var aiKeyConfigured: Bool { !preferences.aiApiKey.isEmpty }
+
+    private func onOff(_ value: Bool) -> String {
+        value
+            ? NSLocalizedString("dev.value.on", comment: "On")
+            : NSLocalizedString("dev.value.off", comment: "Off")
+    }
+
+    // MARK: - Row builders
+
+    private func header(_ symbol: String, _ label: String) -> some View {
+        Label(label, systemImage: symbol)
+            .font(.subheadline.weight(.medium))
+            .foregroundStyle(.secondary)
+    }
+
+    private func infoRow(icon: String, color: Color, label: String, value: String) -> some View {
+        HStack {
+            Image(systemName: icon)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(.white)
+                .frame(width: 30, height: 30)
+                .background(color, in: RoundedRectangle(cornerRadius: 7))
+            Text(label)
+            Spacer()
+            Text(value)
+                .foregroundStyle(.secondary)
+                .font(.callout)
+                .monospaced()
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+
+    private func iconLabel(icon: String, color: Color, title: String, subtitle: String?) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(.white)
+                .frame(width: 30, height: 30)
+                .background(color, in: RoundedRectangle(cornerRadius: 7))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.body)
+                if let subtitle {
+                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - APIKeyOverrideField
+
+/// A SecureField bound to a `UserDefaults` string key, with a trailing clear
+/// button that removes the override so the compiled-in default resumes. Used
+/// for the Foursquare / OpenWeather / Amap runtime key overrides.
+private struct APIKeyOverrideField: View {
+    let defaultsKey: String
+    let icon: String
+    let color: Color
+    let title: String
+
+    @State private var value: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                Image(systemName: icon)
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(.white)
+                    .frame(width: 30, height: 30)
+                    .background(color, in: RoundedRectangle(cornerRadius: 7))
+                Text(title).font(.body)
+                Spacer()
+                if !value.isEmpty {
+                    Button {
+                        value = ""
+                        UserDefaults.standard.removeObject(forKey: defaultsKey)
+                        Haptics.selection()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(NSLocalizedString("dev.api.clear", comment: "Clear override"))
+                }
+            }
+            SecureField(
+                NSLocalizedString("dev.api.placeholder", comment: "Paste key placeholder"),
+                text: $value
+            )
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .monospaced()
+            .font(.callout)
+            .onChange(of: value) { _, newValue in
+                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmed.isEmpty {
+                    UserDefaults.standard.removeObject(forKey: defaultsKey)
+                } else {
+                    UserDefaults.standard.set(trimmed, forKey: defaultsKey)
+                }
+            }
+        }
+        .onAppear {
+            value = UserDefaults.standard.string(forKey: defaultsKey) ?? ""
+        }
+    }
+}
+
+// MARK: - FeatureFlagRow
+
+/// Tri-state control for one developer flag: Default / On / Off. "Default"
+/// clears the override so the flag falls back to its plist/compiled value.
+private struct FeatureFlagRow: View {
+    let flag: FeatureFlags.DeveloperFlag
+
+    private enum State3: Hashable { case defaultValue, on, off }
+
+    @State private var selection: State3 = .defaultValue
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(NSLocalizedString(flag.titleKey, comment: "Feature flag title"))
+                    .font(.body)
+                Text(NSLocalizedString(flag.subtitleKey, comment: "Feature flag subtitle"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Picker("", selection: $selection) {
+                Text(defaultLabel).tag(State3.defaultValue)
+                Text(NSLocalizedString("dev.value.on", comment: "On")).tag(State3.on)
+                Text(NSLocalizedString("dev.value.off", comment: "Off")).tag(State3.off)
+            }
+            .pickerStyle(.segmented)
+            .onChange(of: selection) { _, newValue in
+                switch newValue {
+                case .defaultValue: FeatureFlags.setOverride(nil, for: flag.key)
+                case .on: FeatureFlags.setOverride(true, for: flag.key)
+                case .off: FeatureFlags.setOverride(false, for: flag.key)
+                }
+                Haptics.selection()
+            }
+        }
+        .padding(.vertical, 2)
+        .onAppear {
+            switch FeatureFlags.override(for: flag.key) {
+            case .some(true): selection = .on
+            case .some(false): selection = .off
+            case .none: selection = .defaultValue
+            }
+        }
+    }
+
+    /// "Default (On)" / "Default (Off)" so the tester can see what falling back
+    /// to the compiled default actually means for this flag.
+    private var defaultLabel: String {
+        let base = NSLocalizedString("dev.value.default", comment: "Default")
+        let hint = flag.defaultValue
+            ? NSLocalizedString("dev.value.on", comment: "On")
+            : NSLocalizedString("dev.value.off", comment: "Off")
+        return "\(base) (\(hint))"
+    }
+}
+
+#Preview {
+    NavigationStack {
+        DeveloperOptionsView()
+            .environment(UserPreferences())
+            .environment(SubscriptionService())
+    }
+}

--- a/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
@@ -99,6 +99,8 @@ public struct SettingsView: View {
                 exportSection
                 // Section: Subscription
                 subscriptionSection
+                // Section: Developer Options — only after a tester-email unlock
+                developerSection
                 // Section: Companion (US-012) — experimental opt-in
                 companionSection
                 // Section: About / Stats / Data
@@ -845,6 +847,44 @@ public struct SettingsView: View {
             }
         } message: {
             Text(NSLocalizedString("settings.adminUnlock.message", comment: "Admin unlock message"))
+        }
+    }
+
+    // MARK: - Developer Options
+
+    /// Entry point to `DeveloperOptionsView`. Only rendered once a tester email
+    /// has unlocked the device (`SubscriptionService.developerModeUnlocked`) —
+    /// a plain StoreKit Pro purchase does NOT reveal it. `@ViewBuilder` so the
+    /// section fully disappears (no empty row) for everyone else.
+    @ViewBuilder
+    private var developerSection: some View {
+        if subscriptionService.developerModeUnlocked {
+            Section {
+                NavigationLink {
+                    DeveloperOptionsView()
+                        .environment(preferences)
+                        .environment(subscriptionService)
+                } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "hammer.fill")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(.white)
+                            .frame(width: 30, height: 30)
+                            .background(Color.gray, in: RoundedRectangle(cornerRadius: 7))
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(NSLocalizedString("dev.title", comment: "Developer Options"))
+                                .font(.body)
+                            Text(NSLocalizedString("dev.entry.subtitle", comment: "Developer options subtitle"))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            } header: {
+                settingsSectionHeader("hammer", label: NSLocalizedString("dev.header", comment: "Developer section header"))
+            } footer: {
+                Text(NSLocalizedString("dev.footer", comment: "Developer section footer"))
+            }
         }
     }
 


### PR DESCRIPTION
## What

Adds a **Developer Options** screen in Settings that appears only after a successful tester-email unlock, giving testers runtime API-key overrides, feature-flag toggles, and debug tools.

## Why

Internal testers and the project owner already unlock Pro with an allow-listed email (`unlockWithAdminEmail`). This PR reuses that trust boundary to expose a debugging surface normal users never see: pointing the app at your own API accounts, trialling not-yet-shipped features, and forcing app state — all without a rebuild. It builds on the existing `Secrets.resolved*` override chain (UserDefaults key → baked default) so the panel just writes the keys those accessors already prefer.

Highlights:

- **`SubscriptionService`** — persists a `developerModeUnlocked` flag (UserDefaults) set on a successful `unlockWithAdminEmail`; survives relaunch and is kept independent of the Pro entitlement. Adds `lockDeveloperMode()` to hide the panel again without revoking Pro.
- **`FeatureFlags`** — `readBool` now consults a UserDefaults override (order: env → override → plist → default) so testers can flip flags at runtime, including in Release/TestFlight builds. Adds a `developerFlags` registry plus `override(for:)` / `setOverride` / `clearAllOverrides` helpers.
- **`DeveloperOptionsView`** — status diagnostics (build config, version, entitlement, resolved AI model, backend-sync state); runtime API-key overrides for Foursquare / OpenWeather / Amap with clear-to-default, plus a link to the existing AI provider screen; tri-state (Default / On / Off) feature-flag rows; debug tools (force entitlement tier, reset onboarding, reset all overrides, lock panel).
- **`SettingsView`** — renders the entry only when `developerModeUnlocked` is set.
- Localized every new string in **en** and **zh-Hans**.

Closes #

## Three-pillar check

- [x] **Map-First** — no change; Developer Options lives in the existing Settings sheet.
- [x] **Experience-as-Unit** — no new "place"/"POI" domain concepts.
- [x] **AI doesn't decide** — no recommendation logic touched; only debug configuration of existing AI plumbing.

## Schema impact

- [x] No schema change — all state lives in UserDefaults / the existing `UserPreferences` blob; `packages/core` untouched.

## Testing

- Added `DeveloperOptionsUnlockTest` (XCTest): allow-listed unlock reveals developer mode; rejected email keeps it hidden; the flag persists across a fresh `SubscriptionService`; locking hides the panel but keeps Pro; feature-flag overrides take precedence over defaults and clear back cleanly; flag keys are unique.
- Ran `check-zh-punctuation.sh` (no new offenders), `check-localization.ts` (no missing `dev.*` keys), and `anti-pattern-lint.ts` (clean) locally. iOS build/test runs on `macos-latest` CI.

## Screenshots / video

<!-- Simulator screenshots to follow; UI mirrors the existing InsetGrouped Settings styling. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H68KApMyNdYVcWo5WYxmdB)_