### PR TITLE
fix(ios): stop the user-location marker jittering on noisy GPS fixes

### DIFF
--- a/apps/ios/SoloCompass/Services/LocationService.swift
+++ b/apps/ios/SoloCompass/Services/LocationService.swift
@@ -41,12 +41,17 @@ public final class LocationService: NSObject {
         self.authorizationStatus = manager.authorizationStatus
         super.init()
         self.manager.delegate = self
-        // Tighter accuracy + shorter distance filter so the blue "you are here"
-        // marker doesn't jitter on every noisy fix. Combined with the
-        // horizontalAccuracy filter in didUpdateLocations this keeps the pin
-        // visually stable.
+        // Tighter accuracy so we don't burn battery chasing sub-10m fixes the
+        // map never needs. The distance filter is deliberately *small* (5m) —
+        // not large — so Core Location still hands us the stream of drifting
+        // fixes while the traveler stands still, and the accuracy-aware
+        // `shouldPublish` gate in `didUpdateLocations` decides which ones are
+        // real movement versus GPS jitter. A large OS-level `distanceFilter`
+        // can't tell drift from motion (a 25m noise jump looks like a 25m walk),
+        // so the smoothing has to live in our gate, and the gate needs the
+        // samples to smooth.
         self.manager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
-        self.manager.distanceFilter = 20 // refresh after 20m of movement
+        self.manager.distanceFilter = 5
     }
 
     /// Ask the user for location access, escalating from when-in-use to
@@ -246,23 +251,75 @@ extension LocationService: CLLocationManagerDelegate {
     }
 
     /// Receives a fresh GPS fix and publishes it as the traveler's current
-    /// location for the map and distance calculations.
-    ///
-    /// Noisy fixes are filtered out so the blue "you are here" marker does
-    /// not visually drift back and forth:
-    ///   * `horizontalAccuracy <= 0`  → invalid reading, ignore
-    ///   * `horizontalAccuracy > 100` → too coarse (typical of a stale
-    ///     cell tower fix while GPS is still warming up)
-    ///   * fix older than 15s        → cached / replayed sample from
-    ///     Core Location's ring buffer, not a real "now" position
+    /// location for the map and distance calculations — but only when
+    /// `shouldPublish` decides the fix is a valid, non-jittery reading. Every
+    /// suppressed fix leaves `currentLocation` untouched, so the SwiftUI map
+    /// marker (and the `onChange(of: currentLocation)` observers) never fire
+    /// for GPS noise, which is what keeps the "you are here" pin planted
+    /// instead of blinking and hopping around.
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let last = locations.last else { return }
-        guard last.horizontalAccuracy > 0 else { return }
-        guard last.horizontalAccuracy <= 100 else { return }
-        guard abs(last.timestamp.timeIntervalSinceNow) < 15 else { return }
         Task { @MainActor in
+            guard Self.shouldPublish(candidate: last, over: self.currentLocation) else { return }
             self.currentLocation = last
         }
+    }
+
+    // MARK: - Jitter rejection
+
+    /// Fixes coarser than this (metres) are discarded — typically a stale cell
+    /// tower fix while GPS is still warming up.
+    static let maxAcceptableAccuracy: CLLocationDistance = 100
+    /// Fixes older than this (seconds) are discarded as cached / replayed
+    /// samples from Core Location's ring buffer, not a real "now" position.
+    static let maxFixAge: TimeInterval = 15
+    /// Movement below this (metres) is always treated as noise, even when the
+    /// two fixes report pinpoint accuracy — GPS never truly holds still, so a
+    /// sub-`jitterFloor` "move" is drift, not walking.
+    static let jitterFloor: CLLocationDistance = 8
+    /// A fix at least this many metres tighter than the current one is accepted
+    /// even without real movement, so the pin converges onto better readings as
+    /// the GPS warms up rather than staying stuck on the first coarse fix.
+    static let accuracyImprovementThreshold: CLLocationDistance = 15
+    /// Upper bound on the drift-rejection radius so a spell of poor accuracy
+    /// (large error circles) can't freeze the marker while the traveler is
+    /// genuinely moving.
+    static let maxJitterRadius: CLLocationDistance = 40
+
+    /// Pure decision: should `candidate` replace `current` as the published
+    /// location, or be suppressed as noise? Kept static and side-effect-free so
+    /// the jitter policy is unit-testable without a live `CLLocationManager`.
+    ///
+    /// Order of rules:
+    ///   1. Reject invalid (`horizontalAccuracy <= 0`), too-coarse, or stale
+    ///      fixes outright.
+    ///   2. Always accept the first fix — there's nothing to compare against.
+    ///   3. Accept a meaningfully tighter fix even if it barely moved, so the
+    ///      pin can converge onto a better reading.
+    ///   4. Otherwise accept only when the traveler moved beyond the noise
+    ///      floor: the two fixes' error circles must have pulled apart
+    ///      (`distance > combined accuracy`) by at least `jitterFloor`, capped
+    ///      at `maxJitterRadius`. Movement inside that radius is
+    ///      indistinguishable from drift, so the marker stays put.
+    static func shouldPublish(
+        candidate: CLLocation,
+        over current: CLLocation?,
+        now: Date = Date()
+    ) -> Bool {
+        guard candidate.horizontalAccuracy > 0 else { return false }
+        guard candidate.horizontalAccuracy <= maxAcceptableAccuracy else { return false }
+        guard abs(candidate.timestamp.timeIntervalSince(now)) < maxFixAge else { return false }
+
+        guard let current else { return true }
+
+        if candidate.horizontalAccuracy + accuracyImprovementThreshold < current.horizontalAccuracy {
+            return true
+        }
+
+        let moved = candidate.distance(from: current)
+        let combinedError = candidate.horizontalAccuracy + current.horizontalAccuracy
+        let noiseRadius = min(maxJitterRadius, max(jitterFloor, combinedError))
+        return moved > noiseRadius
     }
 
     /// Records a location-tracking failure so the UI can surface a

--- a/apps/ios/SoloCompass/Tests/LocationServiceTests.swift
+++ b/apps/ios/SoloCompass/Tests/LocationServiceTests.swift
@@ -123,4 +123,101 @@ final class LocationServiceTests: XCTestCase {
         let svc = LocationService()
         XCTAssertNil(svc.relativeBearing(to: sensoji))
     }
+
+    // MARK: - Jitter rejection (shouldPublish)
+
+    private let base = CLLocationCoordinate2D(latitude: 35.0, longitude: 139.0)
+    private let ref = Date(timeIntervalSinceReferenceDate: 700_000_000)
+
+    /// A fix `metresNorth` of `base`, with the given accuracy and age.
+    private func fix(
+        metresNorth: Double = 0,
+        accuracy: CLLocationAccuracy,
+        ageSeconds: TimeInterval = 0
+    ) -> CLLocation {
+        let dLat = metresNorth / 111_320.0
+        let coord = CLLocationCoordinate2D(latitude: base.latitude + dLat, longitude: base.longitude)
+        return CLLocation(
+            coordinate: coord,
+            altitude: 0,
+            horizontalAccuracy: accuracy,
+            verticalAccuracy: 1,
+            timestamp: ref.addingTimeInterval(-ageSeconds)
+        )
+    }
+
+    func test_shouldPublish_firstFix_isAccepted() {
+        XCTAssertTrue(LocationService.shouldPublish(
+            candidate: fix(accuracy: 10), over: nil, now: ref
+        ))
+    }
+
+    func test_shouldPublish_invalidAccuracy_isRejected() {
+        XCTAssertFalse(LocationService.shouldPublish(
+            candidate: fix(accuracy: -1), over: nil, now: ref
+        ))
+        XCTAssertFalse(LocationService.shouldPublish(
+            candidate: fix(accuracy: 0), over: nil, now: ref
+        ))
+    }
+
+    func test_shouldPublish_tooCoarse_isRejected() {
+        XCTAssertFalse(LocationService.shouldPublish(
+            candidate: fix(accuracy: 150), over: nil, now: ref
+        ))
+    }
+
+    func test_shouldPublish_staleFix_isRejected() {
+        // 20s old > maxFixAge (15s).
+        XCTAssertFalse(LocationService.shouldPublish(
+            candidate: fix(accuracy: 10, ageSeconds: 20), over: nil, now: ref
+        ))
+    }
+
+    func test_shouldPublish_stationaryDrift_isSuppressed() {
+        // current & candidate both ±10m accuracy → noise radius 20m.
+        // A 12m "move" is within the combined error → treated as drift.
+        let current = fix(accuracy: 10)
+        let drift = fix(metresNorth: 12, accuracy: 10)
+        XCTAssertFalse(LocationService.shouldPublish(candidate: drift, over: current, now: ref))
+    }
+
+    func test_shouldPublish_realMovement_isAccepted() {
+        // 30m move clears the 20m noise radius → real travel.
+        let current = fix(accuracy: 10)
+        let moved = fix(metresNorth: 30, accuracy: 10)
+        XCTAssertTrue(LocationService.shouldPublish(candidate: moved, over: current, now: ref))
+    }
+
+    func test_shouldPublish_tighterFix_convergesWithoutMoving() {
+        // Coarse current (±50m), a much tighter candidate at (nearly) the same
+        // spot is accepted so the pin snaps onto the better reading.
+        let current = fix(accuracy: 50)
+        let tighter = fix(metresNorth: 2, accuracy: 10)
+        XCTAssertTrue(LocationService.shouldPublish(candidate: tighter, over: current, now: ref))
+    }
+
+    func test_shouldPublish_pinpointFixes_stillHonorJitterFloor() {
+        // Even with 1m accuracy each (noise radius floored at 8m), a 5m nudge
+        // is suppressed, but a 12m step is real.
+        let current = fix(accuracy: 1)
+        XCTAssertFalse(LocationService.shouldPublish(
+            candidate: fix(metresNorth: 5, accuracy: 1), over: current, now: ref
+        ))
+        XCTAssertTrue(LocationService.shouldPublish(
+            candidate: fix(metresNorth: 12, accuracy: 1), over: current, now: ref
+        ))
+    }
+
+    func test_shouldPublish_poorAccuracy_radiusIsCapped() {
+        // Both fixes ±100m → combined 200m, but the radius caps at 40m so a
+        // real 45m walk isn't frozen out, while a 35m wobble still is.
+        let current = fix(accuracy: 100)
+        XCTAssertFalse(LocationService.shouldPublish(
+            candidate: fix(metresNorth: 35, accuracy: 100), over: current, now: ref
+        ))
+        XCTAssertTrue(LocationService.shouldPublish(
+            candidate: fix(metresNorth: 45, accuracy: 100), over: current, now: ref
+        ))
+    }
 }


### PR DESCRIPTION
## What

Add an accuracy-aware jitter-rejection gate to `LocationService` so the map's "you are here" marker stops hopping and flickering while the traveler stands still.

## Why

The centre location marker frequently jumped and blinked even when the user wasn't moving. Root cause: `LocationService.didUpdateLocations` published **every** GPS fix that cleared a few coarse guards (accuracy ≤ 100m, not stale). Ordinary stationary GPS drift therefore kept rewriting `currentLocation`, and each write repositioned the SwiftUI `Annotation` and re-fired the `onChange(of: currentLocation)` observers — producing the visible jump + flicker. The OS-level `distanceFilter` (was 20m) can't fix this because it can't distinguish a 25m drift jump from a real 25m walk; the smoothing has to live in our own gate.

The fix moves the decision into a pure, unit-testable function:

- Lower `distanceFilter` to 5m so Core Location still delivers the drift samples the gate needs to smooth, rather than masking them behind a large OS filter.
- Add `shouldPublish(candidate:over:now:)` — suppresses a fix unless it's the first fix, a meaningfully tighter reading (so the pin converges as GPS warms up), or real movement beyond the two fixes' combined error circle (floored at 8m, capped at 40m so poor accuracy can't freeze a genuinely moving marker). Drift inside that radius leaves `currentLocation` untouched, so the marker stays planted.

## Three-pillar check

- [x] **Map-First** — keeps the user on the map; makes the map's own location pin stable
- [x] **Experience-as-Unit** — no domain changes
- [x] **AI doesn't decide** — unaffected

## Schema impact

- [x] No schema change

## Testing

Added `LocationServiceTests` cases for the new gate: first fix accepted; invalid / too-coarse / stale fixes rejected; stationary drift suppressed; real movement accepted; convergence onto a tighter fix; the pinpoint-accuracy jitter floor; and the poor-accuracy radius cap. (iOS build/test run on `macos-latest` via `ios-ci.yml`; not runnable from this Linux environment.)

## Screenshots / video

N/A — behavioural fix (marker no longer drifts); no static-frame difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H76zBa15Dgun72ZtJS3bAY)_