### PR TITLE
fix(ios): persist admin-email Pro unlock across relaunch

### DIFF
--- a/apps/ios/SoloCompass/Services/SubscriptionService.swift
+++ b/apps/ios/SoloCompass/Services/SubscriptionService.swift
@@ -102,6 +102,25 @@ public final class SubscriptionService {
     }
     static let developerModeDefaultsKey = "com.solocompass.developerModeUnlocked"
 
+    /// True once an allow-listed tester/admin email has unlocked Pro on this
+    /// device. Persisted in UserDefaults so the unlock survives relaunch.
+    ///
+    /// This is the linchpin that keeps the unlock sticky: the admin unlock
+    /// bypasses StoreKit, so there is no `Transaction` backing it. Without this
+    /// flag, `refreshEntitlement()` — called on every launch — would walk
+    /// `Transaction.currentEntitlements`, find nothing, resolve `.free`, and
+    /// clobber the persisted `.pro`, forcing the tester to re-enter their email
+    /// after every relaunch. `refreshEntitlement()` checks this flag and refuses
+    /// to downgrade an admin-unlocked device.
+    ///
+    /// Distinct from `developerModeUnlocked`: locking the Developer Options
+    /// panel (`lockDeveloperMode()`) hides the dev UI but must NOT revoke the
+    /// earned Pro entitlement, so this flag stays set through that.
+    public private(set) var adminUnlockActive: Bool {
+        didSet { UserDefaults.standard.set(adminUnlockActive, forKey: Self.adminUnlockDefaultsKey) }
+    }
+    static let adminUnlockDefaultsKey = "com.solocompass.adminUnlockActive"
+
     /// Renewal / trial-end date of the currently-active StoreKit transaction.
     /// `nil` when there is no active transaction (free / proExpired) or when
     /// running under the DEBUG force-Pro override. The Paywall and MeSheet
@@ -152,6 +171,10 @@ public final class SubscriptionService {
         // Restore the tester/developer unlock flag so the Developer Options
         // entry survives relaunch once a tester email has unlocked the device.
         self.developerModeUnlocked = UserDefaults.standard.bool(forKey: Self.developerModeDefaultsKey)
+
+        // Restore the admin-unlock flag so refreshEntitlement() below (and on
+        // future launches) won't downgrade a tester-unlocked device to .free.
+        self.adminUnlockActive = UserDefaults.standard.bool(forKey: Self.adminUnlockDefaultsKey)
 
         // Spin up the transaction listener BEFORE the first product/
         // entitlement fetch, so we never miss a renewal that arrives
@@ -210,6 +233,15 @@ public final class SubscriptionService {
             return
         }
         #endif
+        // Tester/admin email unlock bypasses StoreKit and has no backing
+        // Transaction. Honour the persisted unlock so the currentEntitlements
+        // walk below (which sees nothing) can't reset an unlocked device to
+        // .free on every launch. Restore/purchase still layer real StoreKit
+        // entitlements on top for genuine subscribers.
+        if adminUnlockActive {
+            if entitlement != .pro { setEntitlement(.pro) }
+            return
+        }
         var resolved: Entitlement = .free
         var latestTransaction: Transaction?
         var resolvedExpiration: Date?
@@ -314,6 +346,11 @@ public final class SubscriptionService {
     @discardableResult
     public func unlockWithAdminEmail(_ email: String) -> Bool {
         guard Self.isAdminEmail(email) else { return false }
+        // Mark the device admin-unlocked BEFORE flipping the entitlement so the
+        // sticky flag is persisted first. This is what makes the unlock survive
+        // relaunch: refreshEntitlement() reads it and refuses to downgrade to
+        // .free when there's no backing StoreKit transaction.
+        adminUnlockActive = true
         setEntitlement(.pro)
         // Reveal the Developer Options panel in Settings from now on. Persisted
         // so the tester doesn't have to re-enter the email after every relaunch.

--- a/apps/ios/SoloCompass/Tests/DeveloperOptionsUnlockTest.swift
+++ b/apps/ios/SoloCompass/Tests/DeveloperOptionsUnlockTest.swift
@@ -15,11 +15,13 @@ final class DeveloperOptionsUnlockTest: XCTestCase {
         super.setUp()
         // Start each test from a known state — no lingering flag/overrides.
         UserDefaults.standard.removeObject(forKey: SubscriptionService.developerModeDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: SubscriptionService.adminUnlockDefaultsKey)
         FeatureFlags.clearAllOverrides()
     }
 
     override func tearDown() {
         UserDefaults.standard.removeObject(forKey: SubscriptionService.developerModeDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: SubscriptionService.adminUnlockDefaultsKey)
         FeatureFlags.clearAllOverrides()
         super.tearDown()
     }
@@ -73,6 +75,64 @@ final class DeveloperOptionsUnlockTest: XCTestCase {
         // The hidden state persists too.
         let relaunched = SubscriptionService()
         XCTAssertFalse(relaunched.developerModeUnlocked)
+    }
+
+    // MARK: - adminUnlockActive (sticky Pro across relaunch)
+
+    func testAllowListedUnlockSetsAdminUnlockActive() {
+        let service = SubscriptionService()
+        service._setEntitlementForTesting(.free)
+        XCTAssertFalse(service.adminUnlockActive,
+                       "Admin-unlock flag must start clear before any unlock")
+
+        _ = service.unlockWithAdminEmail(SubscriptionService.adminEmails.first!)
+
+        XCTAssertTrue(service.adminUnlockActive,
+                      "A successful tester unlock must mark the device admin-unlocked")
+    }
+
+    func testAdminUnlockActiveSurvivesRelaunch() {
+        let first = SubscriptionService()
+        _ = first.unlockWithAdminEmail(SubscriptionService.adminEmails.first!)
+        XCTAssertTrue(first.adminUnlockActive)
+
+        // A fresh instance simulates the next app launch reading persisted state.
+        let relaunched = SubscriptionService()
+        XCTAssertTrue(relaunched.adminUnlockActive,
+                      "Admin unlock must persist across launches so refreshEntitlement " +
+                      "won't downgrade the tester back to .free")
+    }
+
+    func testRefreshEntitlementDoesNotDowngradeAdminUnlock() async {
+        // Regression: the tester-email unlock has no backing StoreKit
+        // transaction, so a plain currentEntitlements walk resolves .free.
+        // refreshEntitlement() must keep .pro for an admin-unlocked device
+        // instead of clobbering it on every launch (the bug that forced a
+        // re-unlock each time the app reopened).
+        let service = SubscriptionService()
+        _ = service.unlockWithAdminEmail(SubscriptionService.adminEmails.first!)
+        XCTAssertEqual(service.entitlement, .pro)
+
+        // Simulate what a relaunch does: recompute entitlement from StoreKit,
+        // which sees no admin-unlock transaction.
+        await service.refreshEntitlement()
+
+        XCTAssertEqual(service.entitlement, .pro,
+                       "refreshEntitlement must NOT downgrade an admin-unlocked device to .free")
+        XCTAssertTrue(service.entitlement.isActive)
+    }
+
+    func testLockDeveloperModeKeepsAdminUnlockActive() {
+        let service = SubscriptionService()
+        _ = service.unlockWithAdminEmail(SubscriptionService.adminEmails.first!)
+        XCTAssertTrue(service.adminUnlockActive)
+
+        service.lockDeveloperMode()
+
+        XCTAssertTrue(service.adminUnlockActive,
+                      "Hiding the dev panel must not clear the admin unlock — Pro must " +
+                      "still survive the next relaunch")
+        XCTAssertEqual(service.entitlement, .pro)
     }
 
     // MARK: - FeatureFlags developer overrides


### PR DESCRIPTION
## What

Make the tester/admin email Pro unlock survive app relaunch so the Explore / Explore Here gate stays unlocked.

## Why

After unlocking Pro with an allow-listed tester email, the unlock was lost on every subsequent launch — the Explore / Explore Here button kept reappearing as locked and the tester had to re-enter their email each time.

Root cause: `unlockWithAdminEmail` flipped the entitlement to `.pro` and cached it in Keychain, but on launch `SoloCompassApp` calls `refreshEntitlement()`. In Release builds (where the `#if DEBUG` force-Pro override is stripped), that walks `Transaction.currentEntitlements`, finds **no StoreKit transaction** backing the admin unlock — it bypasses StoreKit on purpose — resolves `.free`, and overwrites the persisted `.pro`. That re-locked the AI-gated surfaces (`MapViewModel.entitlement.isActive`) on every launch.

Fix: add a persisted `adminUnlockActive` flag set by `unlockWithAdminEmail`, and have `refreshEntitlement()` short-circuit on it (mirroring the existing DEBUG force-Pro short-circuit) so an admin-unlocked device is never downgraded to `.free`. Locking the Developer Options panel keeps the flag set, so Pro still survives.

Closes #

## Three-pillar check

- [x] **Map-First** — no change to navigation; keeps the map/Explore surface working as intended
- [x] **Experience-as-Unit** — no domain changes
- [x] **AI doesn't decide** — no change to recommendation behavior

## Schema impact

- [x] No schema change

## Testing

Added regression coverage in `DeveloperOptionsUnlockTest`:
- `testAllowListedUnlockSetsAdminUnlockActive` — unlock sets the sticky flag
- `testAdminUnlockActiveSurvivesRelaunch` — flag persists to a fresh instance
- `testRefreshEntitlementDoesNotDowngradeAdminUnlock` — `refreshEntitlement()` keeps `.pro` for an admin-unlocked device instead of clobbering it to `.free`
- `testLockDeveloperModeKeepsAdminUnlockActive` — hiding the dev panel does not revoke the sticky unlock

Also cleared the new UserDefaults key in the test `setUp`/`tearDown` to avoid cross-test leakage.

## Screenshots / video

N/A — no visible UI change; behavior fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4DptDfb4gGQg43JgLHbe5)_