### PR TITLE
fix(ios): skeleton tagline branches on Amap vs OSM provenance

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -755,7 +755,9 @@
 "location.error.banner" = "Can't find your location — showing a default area. Check Location permissions in Settings.";
 "location.banner.openSettings" = "Open Settings";
 "explore.skeleton.oneLiner" = "A real spot pulled from OpenStreetMap.";
+"explore.skeleton.oneLiner.amap" = "A real spot pulled from AutoNavi (Amap).";
 "explore.skeleton.why" = "We don't have a curated story for this place yet. Visit, then add what you found.";
+"explore.skeleton.why.amap" = "We don't have a curated story for this place yet. Visit, then add what you found.";
 "explore.quota.dailyLimit" = "Daily AI limit reached. Showing real places without enrichment until tomorrow.";
 "explore.toast.addedNamed" = "Now exploring %1$@ · %2$d places added";
 "explore.toast.added" = "%d places added near you";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -429,7 +429,9 @@
 "location.error.banner" = "无法获取你的位置 — 已显示默认区域。请在「设置」中检查定位权限。";
 "location.banner.openSettings" = "打开设置";
 "explore.skeleton.oneLiner" = "一处来自 OpenStreetMap 的真实地点。";
+"explore.skeleton.oneLiner.amap" = "一处来自高德地图的真实地点。";
 "explore.skeleton.why" = "我们还没有这个地方的精选故事。去看看，然后告诉我们你发现了什么。";
+"explore.skeleton.why.amap" = "我们还没有这个地方的精选故事。去看看，然后告诉我们你发现了什么。";
 "explore.quota.dailyLimit" = "今日 AI 调用次数已达上限。明天恢复前会展示真实地点但不再增强。";
 "explore.toast.addedNamed" = "正在探索 %1$@ · 新增 %2$d 处地点";
 "explore.toast.added" = "附近新增 %d 处地点";

--- a/apps/ios/SoloCompass/Services/AIService.swift
+++ b/apps/ios/SoloCompass/Services/AIService.swift
@@ -2023,6 +2023,7 @@ public final class AIService {
         let now = Date()
         let category = OverpassService.category(for: poi.tags)
         let displayName = poi.nameEn ?? poi.name
+        let isAmapPOI = poi.tags["source"] == "amap"
         let breakdown = SoloScore.Breakdown(
             seatingFriendly: 7, soloPatronRatio: 7, staffPressure: 7,
             soloPortioning: 7, ambianceFit: 7, safety: 7
@@ -2030,8 +2031,19 @@ public final class AIService {
         return Experience(
             id: "exp_osm_\(poi.osmId)",
             title: displayName,
-            oneLiner: NSLocalizedString("explore.skeleton.oneLiner", comment: "Generic OSM POI tagline"),
-            whyItMatters: NSLocalizedString("explore.skeleton.why", comment: "Generic OSM POI rationale"),
+            // Provenance-honest tagline: mainland-CN POIs come from AutoNavi/Amap,
+            // not OpenStreetMap. The attribution + TrustBadge branches on the
+            // same signal (poi.tags["source"] == "amap"); the tagline had been
+            // hard-coded to the OSM copy, so Amap cards read "一处来自
+            // OpenStreetMap 的真实地点" while their badge said AutoNavi.
+            oneLiner: NSLocalizedString(
+                isAmapPOI ? "explore.skeleton.oneLiner.amap" : "explore.skeleton.oneLiner",
+                comment: "Generic POI tagline"
+            ),
+            whyItMatters: NSLocalizedString(
+                isAmapPOI ? "explore.skeleton.why.amap" : "explore.skeleton.why",
+                comment: "Generic POI rationale"
+            ),
             category: category,
             location: enrichedLocation(from: poi, cityCode: cityCode),
             bestTimes: [TimeWindow(startHour: 9, endHour: 21)],
@@ -2042,24 +2054,21 @@ public final class AIService {
             sources: [
                 // Same provenance-honesty fix as the AI-enriched path — the
                 // skeleton fallback used to also mislabel Amap POIs as .user.
-                {
-                    let isAmap = poi.tags["source"] == "amap"
-                    return InformationSource(
-                        type: isAmap ? .amap : .user,
-                        url: isAmap
-                            ? nil
-                            : URL(string: "https://www.openstreetmap.org/node/\(poi.osmId)"),
-                        attribution: isAmap
-                            ? "© AutoNavi (Amap)"
-                            : "© OpenStreetMap contributors",
-                        verifiedAt: now
-                    )
-                }()
+                InformationSource(
+                    type: isAmapPOI ? .amap : .user,
+                    url: isAmapPOI
+                        ? nil
+                        : URL(string: "https://www.openstreetmap.org/node/\(poi.osmId)"),
+                    attribution: isAmapPOI
+                        ? "© AutoNavi (Amap)"
+                        : "© OpenStreetMap contributors",
+                    verifiedAt: now
+                )
             ],
             confidence: Confidence(
                 level: 1,
                 lastVerifiedAt: now,
-                reason: (poi.tags["source"] == "amap")
+                reason: isAmapPOI
                     ? "Amap entry, no AI enrichment"
                     : "OpenStreetMap entry, no AI enrichment",
                 signals: .init(aiScrapeAgeDays: 0, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)


### PR DESCRIPTION
## Summary
- `skeletonExperience` (AI-unavailable fallback) hard-coded `oneLiner` / `whyItMatters` to the OpenStreetMap localized string, so mainland-CN POIs coming from AutoNavi/Amap read "一处来自 OpenStreetMap 的真实地点。" while their TrustBadge + attribution correctly said AutoNavi.
- Split the tagline on the same `poi.tags["source"] == "amap"` signal the attribution + `confidence.reason` branches already use. Collapsed three duplicate `poi.tags["source"] == "amap"` checks into one `isAmapPOI` local.
- New localized keys `explore.skeleton.oneLiner.amap` / `explore.skeleton.why.amap` in en + zh-Hans.

## Test plan
- [x] `xcodebuild build -project SoloCompass.xcodeproj -scheme SoloCompass -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest'` → exit 0
- [ ] Manually check: mainland POI (Amap source) skeleton card reads "来自高德地图" and TrustBadge is AutoNavi blue
- [ ] Manually check: OSM POI skeleton card still reads "来自 OpenStreetMap" (existing behavior preserved)

No schema, signature, or persistence changes.