### PR TITLE
fix(ios): narrow bindToLocation guard to Simulator-SF-only

### DIFF
--- a/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
+++ b/apps/ios/SoloCompass/Tests/SoloCompassTests.swift
@@ -586,6 +586,58 @@ final class SoloCompassTests: XCTestCase {
                        "Second bind on the same GPS fix must be a no-op (hasAutoCentered guard)")
     }
 
+    /// Regression for the "current location looks offset" report: a real user
+    /// far from every seeded city (Beijing here — >1 900 km from SZX, the
+    /// closest entry in `knownCityCenters`) used to have their cold-start
+    /// GPS fix silently dropped by the old Beta-P0-F 200 km guard, leaving
+    /// the map stuck on the Chiang Mai seed. The narrowed guard only
+    /// suppresses the Simulator SF default, so this real-world coordinate
+    /// must now flow into `autoExploreIfEmpty`. We observe the invocation
+    /// counter that V-007 already exposes (`autoExploreInvocationCount`)
+    /// instead of `isShowingExploreConsent`, because the downstream consent
+    /// gate lives in an async Task whose ordering is currently flaky in
+    /// baseline (see `testAutoExploreFiresInDataSparseArea`). The counter
+    /// is the crisp signal that the guard actually let the fix through.
+    #if DEBUG
+    @MainActor
+    func testBindToLocationAcceptsFixOutsideKnownCities() throws {
+        // The DEBUG-only `-startCity` launch arg lives on UserDefaults.standard
+        // and persists across test runs; if a prior UI test left a value there
+        // this VM would start with a preset selectedCity and the guard would
+        // (correctly) skip GPS-anchored auto-explore. Clear it first so the
+        // "no preset city, real GPS fix" scenario is faithfully reproduced.
+        UserDefaults.standard.removeObject(forKey: "startCity")
+        let locationService = LocationService()
+        let prefs = UserPreferences()
+        prefs.hasAcceptedExploreConsent = false
+        prefs.lastSelectedCity = nil
+        let viewModel = MapViewModel(
+            locationService: locationService,
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: prefs
+        )
+
+        // Beijing — real city with no seed data anywhere near it. Distances
+        // to every knownCityCenters entry are well above 200 km (closest is
+        // SZX at ~1 900 km great-circle), so this coordinate is the crispest
+        // proof that the guard no longer rejects legitimate far-from-seed
+        // GPS fixes.
+        let beijing = CLLocationCoordinate2D(latitude: 39.9042, longitude: 116.4074)
+        locationService.simulate(location: CLLocation(
+            latitude: beijing.latitude,
+            longitude: beijing.longitude
+        ))
+
+        XCTAssertEqual(viewModel.autoExploreInvocationCount, 0,
+                       "Pre-bind: auto-explore must not have been invoked")
+        viewModel.bindToLocation()
+
+        XCTAssertEqual(viewModel.autoExploreInvocationCount, 1,
+                       "A real GPS fix outside every seeded city must still be handed to autoExploreIfEmpty, not dropped as 'out of region'")
+    }
+    #endif
+
     // MARK: - US-011 auto-explore on empty category
 
     /// Picking a category that yields zero visible experiences inside a

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -399,15 +399,19 @@ public final class MapViewModel {
         // A user who picked a city wants that city; GPS-anchored auto-explore is
         // only appropriate when we're actually following GPS (no city selected).
         let cityOwnsCamera = (selectedCity.map { !$0.hasPrefix("custom_") }) ?? false
-        // Beta-P0-F: a first-launch user with no persisted city used to land
-        // on the simulator's San Francisco fix even when the GPS reading was
-        // clearly outside any seeded city. We additionally guard auto-recenter
-        // by checking that the fix sits within the radius of one of our
-        // known city centers; otherwise we keep the seed default (Chiang Mai)
-        // so the cold-start screen always shows real Experiences instead of
-        // an empty SF map.
-        let isWithinKnownCity = Self.coordinateIsNearKnownCityCenter(coordinate)
-        if !cityOwnsCamera && isWithinKnownCity {
+        // Beta-P0-F (narrowed): the original guard rejected any fix outside a
+        // ~200 km radius of our 8 seeded cities, but that silently threw away
+        // legitimate GPS on real devices anywhere else (Guangzhou, Beijing,
+        // London, ...) and left the map stuck on the Chiang Mai default —
+        // exactly the "current location looks offset" report we're fixing.
+        // The original bug was specifically the Simulator defaulting to
+        // Apple's San Francisco fix (37.7749, -122.4194), so restrict the
+        // suppression to that case: only when we're in the simulator AND the
+        // fix is on top of that default do we hold the seed camera. Real
+        // devices are always trusted.
+        let looksLikeSimulatorDefault = Self.isSimulatorDefaultSanFrancisco(coordinate)
+        let suppressGPS = looksLikeSimulatorDefault
+        if !cityOwnsCamera && !suppressGPS {
             recenter(on: coordinate)
             autoExploreIfEmpty(at: coordinate)
         }
@@ -417,27 +421,32 @@ public final class MapViewModel {
             context: [
                 "selectedCity": selectedCity ?? "nil",
                 "cityOwnsCamera": cityOwnsCamera,
-                "withinKnownCity": isWithinKnownCity,
+                "suppressGPS": suppressGPS,
+                "simulatorDefaultSF": looksLikeSimulatorDefault,
                 "lat": coordinate.latitude,
                 "lon": coordinate.longitude
             ]
         )
     }
 
-    /// Beta-P0-F: returns true when `coordinate` sits within ~200 km of any
-    /// city we ship seed Experiences for. Used to suppress auto-recenter on
-    /// a clearly out-of-region GPS fix (the typical simulator SF case for
-    /// users whose actual cold-start city is Chiang Mai or Vientiane).
-    private static func coordinateIsNearKnownCityCenter(_ coordinate: CLLocationCoordinate2D) -> Bool {
-        let user = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
-        let limitMeters: CLLocationDistance = 200_000
-        for (_, center) in Self.knownCityCenters {
-            let centerLoc = CLLocation(latitude: center.latitude, longitude: center.longitude)
-            if user.distance(from: centerLoc) <= limitMeters {
-                return true
-            }
-        }
+    /// Returns true only for the iOS Simulator default location (Apple HQ /
+    /// downtown SF, 37.7749, -122.4194) within a tight ~2 km radius. Used by
+    /// `bindToLocation` to hold the seed camera when the app is launched in
+    /// the Simulator with no location override — the previous broad "must be
+    /// near a seed city" guard misfired on real devices anywhere else in the
+    /// world. Real users at (37.7749, -122.4194) will still be treated as
+    /// simulator-default; the trade-off is fine because SF is also a seed
+    /// city (`san-francisco` in `knownCityCenters`) so the outcome is the
+    /// same regardless.
+    private static func isSimulatorDefaultSanFrancisco(_ coordinate: CLLocationCoordinate2D) -> Bool {
+        #if targetEnvironment(simulator)
+        let sf = CLLocation(latitude: 37.7749, longitude: -122.4194)
+        let here = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+        return here.distance(from: sf) <= 2_000
+        #else
+        _ = coordinate
         return false
+        #endif
     }
 
     /// Whether a GPS fix is available right now — drives the custom recenter


### PR DESCRIPTION
## Summary
- The Beta-P0-F guard dropped any GPS fix outside ~200 km of the 8 seeded cities, so real users in Guangzhou / Beijing / London cold-started onto the Chiang Mai seed camera and saw their "current location" as far away — the "position looks offset" report.
- Narrow the guard to trip **only** when running in the Simulator **and** the fix sits within 2 km of Apple's default SF coordinate (37.7749, -122.4194). Every real-device fix is now trusted.
- Suppression is behind `#if targetEnvironment(simulator)`, so Release never pays the check.

## Changes
- Rename `coordinateIsNearKnownCityCenter` → `isSimulatorDefaultSanFrancisco`.
- Sentry breadcrumb: `withinKnownCity` → `suppressGPS` + `simulatorDefaultSF`.
- New regression test: Beijing cold-start must hand the fix to `autoExploreIfEmpty` (V-007 DEBUG counter). Test scrubs `-startCity` UserDefault first, otherwise leaked `selectedCity` preset → `cityOwnsCamera` returns early → false green.

## Test plan
- [x] `xcodebuild test` — new Beijing regression test passes
- [x] Baseline-red tests `testAutoExploreFiresInDataSparseArea` / `testAutoExploreOnlyFiresOnFirstGPSFix` remain red on `main` (pre-existing, unrelated — consent gate downstream doesn't flip synchronously); **not** regressions of this change
- [ ] Manual smoke on device in Guangzhou / Beijing: cold-start centers on real GPS, not Chiang Mai