### PR TITLE
fix(ios): journey-audit P0s — saved-route visibility + re-compile downgrade guard

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -443,6 +443,7 @@
 		CF4221E2BFFB71F398C13EA6 /* AmapShenzhen5kmExperienceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F11E116B808FF8DFA0A179 /* AmapShenzhen5kmExperienceTests.swift */; };
 		CF5CF2D0A6C8DBDC4B552DF8 /* BestNowChipState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD552D1AF526F0F468EE84F /* BestNowChipState.swift */; };
 		CF8B2BDE6D707CE2537C8688 /* ExperienceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B8BA7FFBD93A01E54B7E4A /* ExperienceDetailView.swift */; };
+		D14D5D265523094962A53B44 /* JourneyAuditP0RegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EBBF97536F80B36291DB787 /* JourneyAuditP0RegressionTests.swift */; };
 		D16BF7975651516861B9771F /* MergedPOI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A1C430911A739A1127CDC3 /* MergedPOI.swift */; };
 		D2BCD302B16BBC174B71F84A /* CityPillHitTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 308B7A34171C74B1CF2DE3F9 /* CityPillHitTargetTests.swift */; };
 		D2E9B20230FDE14CB1029DC3 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535B5FA4ADF216CEC74FE056 /* RouteTests.swift */; };
@@ -884,6 +885,7 @@
 		8D41862432A45DC023C96B8D /* FilterNowMapAnimationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterNowMapAnimationTest.swift; sourceTree = "<group>"; };
 		8D52416277C10558C0CD7096 /* SoloCompassActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassActivityAttributes.swift; sourceTree = "<group>"; };
 		8E055BAC372B75F743428920 /* MyHostedRoutesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyHostedRoutesListView.swift; sourceTree = "<group>"; };
+		8EBBF97536F80B36291DB787 /* JourneyAuditP0RegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneyAuditP0RegressionTests.swift; sourceTree = "<group>"; };
 		8F1F20B36F8441905A909DC2 /* ChatHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryStore.swift; sourceTree = "<group>"; };
 		8FDFA5F3503B8ABC4B5CB086 /* SoloCompassTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SoloCompassTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9055347887EF473171916120 /* AttachmentBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentBubble.swift; sourceTree = "<group>"; };
@@ -1354,6 +1356,7 @@
 				9BFF9ECB175F4D2219406952 /* IOS18AvailabilityGuardTest.swift */,
 				BBD7871A003B28A7C46AC8D7 /* ItineraryStoreTests.swift */,
 				1D951F9EC55C09A219D97D55 /* JoinRequestValidationTest.swift */,
+				8EBBF97536F80B36291DB787 /* JourneyAuditP0RegressionTests.swift */,
 				24C070BDAE248990A4E7909B /* LiveActivityServiceTests.swift */,
 				555AA83E46CA214D7F71D811 /* LocalizationCoverageTest.swift */,
 				855D26F5B252465BECA18981 /* LocationBannerActionTest.swift */,
@@ -2293,6 +2296,7 @@
 				FD8737CAF16433F4E205EDA8 /* InviteFriendsSheetTest.swift in Sources */,
 				9F8D8133FC74C4E206A11DB9 /* ItineraryStoreTests.swift in Sources */,
 				86DF801B6190A051C8B47712 /* JoinRequestValidationTest.swift in Sources */,
+				D14D5D265523094962A53B44 /* JourneyAuditP0RegressionTests.swift in Sources */,
 				3C79D606DA56C1251AD58BC3 /* LiveActivityServiceTests.swift in Sources */,
 				C48ABACD6775568202229577 /* LocalizationCoverageTest.swift in Sources */,
 				F23184AE3D476EB8DBF5E8BF /* LocationBannerActionTest.swift in Sources */,

--- a/apps/ios/SoloCompass/Models/Experience.swift
+++ b/apps/ios/SoloCompass/Models/Experience.swift
@@ -670,6 +670,16 @@ public struct Experience: Codable, Hashable, Identifiable {
         sources.contains { ($0.attribution ?? "").localizedCaseInsensitiveContains("AI") }
     }
 
+    /// True for hand-curated seed entries: not user-created, not discovered via
+    /// OSM/Amap, and without multi-source verification. Mirrors the `.curated`
+    /// fallback in `trustBadgeLevel`. These cards carry human-written copy and
+    /// scores, so the silent auto-upgrade path must never overwrite them.
+    public var isCuratedSeed: Bool {
+        guard !isUserCreated, !isFromOpenStreetMap else { return false }
+        let distinctTypes = Set(sources.map(\.type))
+        return distinctTypes.count < 2 && !distinctTypes.contains(.amap)
+    }
+
     /// Returns a new Experience with selected fields overridden. Use this when
     /// mutating tracked stats/status/location/etc. without rewriting all 18 init
     /// args. `location` lets callers swap in an enriched location (e.g. photos

--- a/apps/ios/SoloCompass/Services/Agents/EnrichmentAgent.swift
+++ b/apps/ios/SoloCompass/Services/Agents/EnrichmentAgent.swift
@@ -382,17 +382,67 @@ public final class EnrichmentAgent {
                 let d = origin.distance(from: CLLocation(latitude: c.latitude, longitude: c.longitude))
                 return (candidate, d)
             }
-            .min { $0.1 < $1.1 }?
-            .0
+            .min { $0.1 < $1.1 }
 
-        guard let enrichedMatch = best else { return nil }
+        guard let (enrichedMatch, matchDistance) = best else { return nil }
 
         // Only return an upgrade if it actually went through AI synthesis with
         // real cross-source signals. A skeleton fallback is not an upgrade.
         guard enrichedMatch.isAIEnriched else { return nil }
 
+        guard Self.shouldAdoptRecompiled(
+            original: experience,
+            candidate: enrichedMatch,
+            distanceMeters: matchDistance
+        ) else {
+            Self.logger.info("Re-compile match rejected for \(experience.id, privacy: .public): different venue or lower quality")
+            return nil
+        }
+
         return experience.adoptingContent(of: enrichedMatch)
     }
+
+    /// Whether a re-compiled candidate may replace the original card. Guards
+    /// the two failure modes a re-compile can introduce: identity drift (the
+    /// closest POI in the ring is a *different* venue, so adopting it would
+    /// silently turn the card into another place) and quality downgrades (the
+    /// synthesis produced a thinner card than what the user already has).
+    nonisolated static func shouldAdoptRecompiled(
+        original: Experience,
+        candidate: Experience,
+        distanceMeters: Double
+    ) -> Bool {
+        // Same venue: physically colocated, or names clearly refer to the
+        // same place (coordinates from different providers drift).
+        let sameVenue = distanceMeters <= Self.sameVenueMaxDistanceMeters
+            || namesLikelyMatch(original, candidate)
+        guard sameVenue else { return false }
+        // Never downgrade: a re-compile is an upgrade or a no-op. The small
+        // tolerance lets re-scored cards through while blocking the
+        // curated-9.7 → skeleton-7.0 collapse seen in the field audit.
+        return candidate.soloScore.overall >= original.soloScore.overall - Self.recompileScoreTolerance
+    }
+
+    /// Case/whitespace-insensitive containment across title and place names,
+    /// in either direction — "旧天堂书店" vs "旧天堂书店（华侨城店）" matches.
+    nonisolated private static func namesLikelyMatch(_ a: Experience, _ b: Experience) -> Bool {
+        func names(_ e: Experience) -> [String] {
+            [e.title, e.location.placeNameLocal, e.location.placeNameRomanized]
+                .compactMap { $0 }
+                .map { $0.lowercased().filter { !$0.isWhitespace } }
+                .filter { $0.count >= 2 }
+        }
+        let lhs = names(a), rhs = names(b)
+        return lhs.contains { l in rhs.contains { r in l.contains(r) || r.contains(l) } }
+    }
+
+    /// Max distance between the original coordinate and the best re-compile
+    /// candidate to still count as the same physical venue without a name match.
+    public static let sameVenueMaxDistanceMeters: Double = 60
+
+    /// How far a candidate's solo score may sit below the original before the
+    /// re-compile is treated as a downgrade and dropped.
+    public static let recompileScoreTolerance: Double = 0.5
 
     /// Tight radius for single-entry re-compile. Smaller than `enrich`'s
     /// default because we already know exactly where the place is.

--- a/apps/ios/SoloCompass/Tests/JourneyAuditP0RegressionTests.swift
+++ b/apps/ios/SoloCompass/Tests/JourneyAuditP0RegressionTests.swift
@@ -1,0 +1,213 @@
+import XCTest
+import CoreLocation
+@testable import SoloCompass
+
+/// Regression harness for the two P0s from the compile→route→invite journey
+/// audit. Each test locks in one behavior so a refactor that reintroduces the
+/// bug fails in CI instead of the next field run:
+///
+///   P0-A  a hand-saved route must be visible on the Now shelf right away
+///         (bestStartHour anchored to save time; isBestNow window honors it)
+///   P0-B  re-compile must never swap a card for a different venue or a
+///         lower-quality synthesis, and the silent auto-upgrade must skip
+///         curated seed cards entirely
+final class JourneyAuditP0RegressionTests: XCTestCase {
+
+    // MARK: - P0-A · saved route visibility
+
+    func testMakeRoutePassesBestStartHourThrough() {
+        let route = RouteBuilder.makeRoute(
+            id: RouteId(rawValue: "r-p0a"),
+            title: "Afternoon Walk",
+            summary: "",
+            orderedExperiences: [exp("a", lon: 114.05, lat: 22.54)],
+            cityCode: "SZX",
+            source: .userCreated,
+            bestStartHour: 14
+        )
+        XCTAssertEqual(route.bestStartHour, 14)
+        XCTAssertTrue(
+            route.isBestNow(at: date(hour: 14)),
+            "A route anchored to the save hour must pass the Now shelf filter immediately"
+        )
+        XCTAssertTrue(route.isBestNow(at: date(hour: 16)), "still inside the 3h window")
+        XCTAssertFalse(route.isBestNow(at: date(hour: 20)), "outside the window")
+    }
+
+    func testRouteWithoutBestStartHourFallsBackToBestNowFlag() {
+        let route = RouteBuilder.makeRoute(
+            id: RouteId(rawValue: "r-p0a-nil"),
+            title: "Legacy",
+            summary: "",
+            orderedExperiences: [],
+            cityCode: "SZX",
+            source: .userCreated
+        )
+        XCTAssertNil(route.bestStartHour)
+        XCTAssertFalse(
+            route.isBestNow(at: date(hour: 14)),
+            "No anchor + bestNow=false is exactly the invisible-route bug; makeRoute callers for user saves must pass bestStartHour"
+        )
+    }
+
+    // MARK: - P0-B · re-compile adoption guard
+
+    func testRecompileRejectsDifferentVenueBeyondDistance() {
+        let original = exp("exp_test_bookstore", title: "旧天堂书店", solo: 9.7)
+        let candidate = exp("exp_osm_other", title: "福家小书房", solo: 9.9)
+        XCTAssertFalse(
+            EnrichmentAgent.shouldAdoptRecompiled(original: original, candidate: candidate, distanceMeters: 300),
+            "A distant, differently-named POI is another venue — adopting it drifts the card's identity"
+        )
+    }
+
+    func testRecompileRejectsQualityDowngrade() {
+        let original = exp("exp_test_bookstore", title: "旧天堂书店", solo: 9.7)
+        let candidate = exp("exp_osm_same", title: "旧天堂书店", solo: 7.0)
+        XCTAssertFalse(
+            EnrichmentAgent.shouldAdoptRecompiled(original: original, candidate: candidate, distanceMeters: 10),
+            "Same venue but a much thinner synthesis must not replace curated content (the 9.7 → 7.0 collapse)"
+        )
+    }
+
+    func testRecompileAcceptsColocatedUpgrade() {
+        let original = exp("exp_test_bookstore", title: "旧天堂书店", solo: 8.0)
+        let candidate = exp("exp_osm_same", title: "Old Heaven Books", solo: 8.4)
+        XCTAssertTrue(
+            EnrichmentAgent.shouldAdoptRecompiled(original: original, candidate: candidate, distanceMeters: 10)
+        )
+    }
+
+    func testRecompileAcceptsNameMatchDespiteCoordinateDrift() {
+        let original = exp("exp_test_bookstore", title: "旧天堂书店", solo: 8.0)
+        let candidate = exp("exp_osm_same", title: "旧天堂书店（华侨城店）", solo: 8.0)
+        XCTAssertTrue(
+            EnrichmentAgent.shouldAdoptRecompiled(original: original, candidate: candidate, distanceMeters: 200),
+            "Provider coordinates drift; a clear name containment match is the same venue"
+        )
+    }
+
+    func testRecompileToleratesSmallScoreDip() {
+        let original = exp("exp_test_cafe", title: "Same Cafe", solo: 8.0)
+        let candidate = exp("exp_osm_same", title: "Same Cafe", solo: 7.6)
+        XCTAssertTrue(
+            EnrichmentAgent.shouldAdoptRecompiled(original: original, candidate: candidate, distanceMeters: 10),
+            "Re-scoring within tolerance is not a downgrade"
+        )
+    }
+
+    // MARK: - P0-B · curated seed detection
+
+    func testSingleSourceNonDiscoveredEntryIsCuratedSeed() {
+        let e = exp(
+            "exp_test_seed", title: "Seed",
+            sources: [InformationSource(type: .wikivoyage, attribution: "Wikivoyage", verifiedAt: Date())]
+        )
+        XCTAssertTrue(e.isCuratedSeed)
+    }
+
+    func testOSMAmapAndMultiSourceEntriesAreNotCuratedSeeds() {
+        let osm = exp(
+            "exp_osm_123", title: "OSM",
+            sources: [InformationSource(type: .user, attribution: "© OpenStreetMap contributors", verifiedAt: Date())]
+        )
+        XCTAssertFalse(osm.isCuratedSeed)
+
+        let amap = exp(
+            "exp_test_amap", title: "Amap",
+            sources: [InformationSource(type: .amap, attribution: "© AutoNavi (Amap) + AI", verifiedAt: Date())]
+        )
+        XCTAssertFalse(amap.isCuratedSeed)
+
+        let multi = exp(
+            "exp_test_multi", title: "Verified",
+            sources: [
+                InformationSource(type: .wikivoyage, attribution: "Wikivoyage", verifiedAt: Date()),
+                InformationSource(type: .reddit, attribution: "Reddit", verifiedAt: Date()),
+            ]
+        )
+        XCTAssertFalse(multi.isCuratedSeed)
+    }
+
+    // MARK: - P0-B · silent auto-upgrade skips curated seeds
+
+    @MainActor
+    func testAutoUpgradeSkipsCuratedSeedButAllowsSkeleton() {
+        let viewModel = makeViewModel()
+        let curated = exp(
+            "exp_test_seed", title: "Curated 9.7", solo: 9.7,
+            sources: [InformationSource(type: .wikivoyage, attribution: "Wikivoyage", verifiedAt: Date())]
+        )
+        XCTAssertFalse(
+            viewModel.shouldAutoUpgrade(curated),
+            "The silent path must never risk overwriting a curated seed card"
+        )
+
+        let skeleton = exp(
+            "exp_osm_skeleton", title: "Skeleton",
+            sources: [InformationSource(type: .user, attribution: "© OpenStreetMap contributors", verifiedAt: Date())]
+        )
+        XCTAssertTrue(
+            viewModel.shouldAutoUpgrade(skeleton),
+            "Non-AI OSM skeletons remain auto-upgrade candidates"
+        )
+    }
+
+    // MARK: - Fixtures
+
+    /// A date pinned to a given local hour today.
+    private func date(hour: Int) -> Date {
+        Calendar.current.date(bySettingHour: hour, minute: 0, second: 0, of: Date())!
+    }
+
+    @MainActor
+    private func makeViewModel() -> MapViewModel {
+        let suite = "journey-audit-p0-tests"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let prefs = UserPreferences(defaults: defaults)
+        return MapViewModel(
+            locationService: LocationService(),
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: prefs
+        )
+    }
+
+    private func exp(
+        _ id: String,
+        title: String = "Fixture",
+        lon: Double = 114.05,
+        lat: Double = 22.54,
+        solo: Double = 8.0,
+        sources: [InformationSource] = []
+    ) -> Experience {
+        let now = Date()
+        return Experience(
+            id: id, title: title,
+            oneLiner: "one", whyItMatters: "why",
+            category: .coffee,
+            location: ExperienceLocation(coordinates: [lon, lat], cityCode: "SZX"),
+            bestTimes: [TimeWindow(startHour: 9, endHour: 21)],
+            durationMinutes: .init(min: 30, max: 60),
+            howTo: [], realInconveniences: [],
+            soloScore: SoloScore(
+                overall: solo,
+                breakdown: .init(
+                    seatingFriendly: 7, soloPatronRatio: 7, staffPressure: 7,
+                    soloPortioning: 7, ambianceFit: 7, safety: 7
+                ),
+                basedOnCount: 1
+            ),
+            sources: sources,
+            confidence: Confidence(
+                level: 1, lastVerifiedAt: now, reason: "test",
+                signals: .init(aiScrapeAgeDays: 0, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)
+            ),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .active,
+            createdAt: now, updatedAt: now
+        )
+    }
+}

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -294,8 +294,14 @@ public final class MapViewModel {
     /// True iff `experience` is a candidate for the on-demand auto-upgrade:
     /// it carries no AI-authored cross-source content yet and we haven't
     /// already upgraded it this session. Read by the detail view on appear.
+    /// Curated seed cards are excluded — they already carry human-written
+    /// copy and scores, and the silent path must never risk replacing them
+    /// with a nearby-POI mismatch. Manual re-compile stays available and is
+    /// protected by `EnrichmentAgent.shouldAdoptRecompiled`.
     public func shouldAutoUpgrade(_ experience: Experience) -> Bool {
-        !experience.isAIEnriched && !recompiledThisSession.contains(experience.id)
+        !experience.isAIEnriched
+            && !experience.isCuratedSeed
+            && !recompiledThisSession.contains(experience.id)
     }
 
     /// Manual deep cross-compile of a single experience (Approach A). Reuses

--- a/apps/ios/SoloCompass/Views/Companion/CreateRouteView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/CreateRouteView.swift
@@ -292,9 +292,15 @@ struct CreateRouteView: View {
             orderedExperiences: orderedSelection,
             cityCode: cityCode,
             pace: pace,
-            source: aiSummary == nil ? .userCreated : .coCreated
+            source: aiSummary == nil ? .userCreated : .coCreated,
+            // A hand-built route is for *today*: anchor it to the current hour
+            // so the Now shelf's `isBestNow()` filter shows it immediately
+            // instead of silently hiding the route the user just made.
+            bestStartHour: Double(Calendar.current.component(.hour, from: Date()))
         )
         onSave(route)
-        dismiss()
+        // No dismiss() here: the presenting map swaps this sheet's content
+        // from .create to .detail in place, and dismissing would tear that
+        // detail view down before the user ever sees the saved route.
     }
 }


### PR DESCRIPTION
## Summary

Fixes the two P0s from the compile→route→invite full-journey field audit (SZX, real DeepSeek AI, report scored 69/100):

**P0-A · Saved routes were invisible.** `CreateRouteView.save()` built the route without `bestStartHour` (→ `isBestNow()` false → filtered off the Now shelf, the only place the routes section renders) and then called `dismiss()`, killing the presenting map's in-place `.create → .detail` sheet swap. The user built a route and could never find it. Now the route is anchored to the save hour and the parent owns the sheet transition — the detail opens immediately after save, and the route shows on the Now shelf.

**P0-B · Re-compile silently downgraded curated cards.** The detail view's silent auto-upgrade (and manual deep cross-compile) re-enriched a 400m ring and adopted the *physically closest* POI with no identity or quality check — observed in the field turning the curated 9.7 旧天堂书店 card into a 7.0 template card about a different venue (福家小书房). Three guards now:

- `EnrichmentAgent.shouldAdoptRecompiled` (nonisolated pure fn): same venue required (≤60m or clear name-containment match) **and** no meaningful score drop (0.5 tolerance);
- `Experience.isCuratedSeed` mirroring the trust badge's curated fallback;
- `MapViewModel.shouldAutoUpgrade` skips curated seeds entirely — the silent path never gambles with human-written content; manual re-compile stays available behind the adoption guard.

## Test plan

- [x] New `JourneyAuditP0RegressionTests` — 10 tests covering bestStartHour passthrough + Now-window, adoption guard (distant venue rejected, 9.7→7.0 downgrade rejected, colocated upgrade accepted, name-match absorbs coordinate drift, small re-score dip tolerated), curated-seed detection, auto-upgrade skip.
- [x] Adjacent suites `RouteBuilderTests` + `O1FixesRegressionTests` still green (24/24 executed, 0 failures, iPhone 17 Pro sim).
- [x] xcodegen re-run for the new test file.

Origin: full-journey audit report (artifact ee575c41), 2026-07-05.