### PR TITLE
feat(ios): City OS v2 — 落地包 · 在地 · agent 接入(PRD §4-5,万象 Live 打透)

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		0B77739CFA29BF6CE2A12F45 /* SoloCompassTips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98EFEBC6789178136BCFDC39 /* SoloCompassTips.swift */; };
 		0B7CC2BD1359B8AB3E4A590D /* HapticServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4609B3C2E77F98A59871C26E /* HapticServiceTests.swift */; };
 		0C0580E1BF61F5C02C2EE640 /* BottomSheetUnifiedScrollGuardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E41DCA29798B5D8E49B7CA /* BottomSheetUnifiedScrollGuardTest.swift */; };
+		0C910AC3F463BC15AE61B602 /* ComplianceBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0059E8B90B93210D7C505BFD /* ComplianceBanner.swift */; };
 		0CAAE3EBA0298FD3E1AD9485 /* V1_9SchemaRecordsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F99B043981C964178CBECE0 /* V1_9SchemaRecordsTests.swift */; };
 		0DE8ECCE242F2FDFFD69C199 /* VoiceInterruptionToastTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E7AFBAAF6E42AE8043F476D /* VoiceInterruptionToastTest.swift */; };
 		0EAA3D2EEA89D212150A6B57 /* ExploreConsentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8B58A4F608F9951CBDF3C /* ExploreConsentSheet.swift */; };
@@ -39,6 +40,7 @@
 		15A48470CBEBB6D31C2201D9 /* Configuration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = D4C10384834D53FE83113D51 /* Configuration.storekit */; };
 		160DDEADA76E50A05D4F76EE /* VoiceProcessingToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EDF4F9F84F50797290FF9E0 /* VoiceProcessingToast.swift */; };
 		16B059DFB0D658D2DC38C972 /* RoutePolylineShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0C9228AD213C6D5FE01FCE /* RoutePolylineShape.swift */; };
+		16BA72195E948AA8C4384581 /* LiveSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABE29FC4F9EBBBF8C3C61C4 /* LiveSheet.swift */; };
 		170EE2C7E7B721383B5E999F /* POIMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565FEEE2744AFE1F200FFA1C /* POIMerger.swift */; };
 		171F68BA49B6592409268664 /* BragCardTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2B86E74F80D035429A5EE1 /* BragCardTemplateTests.swift */; };
 		1770F177C97F9C71598B2EDE /* SoloScoreBadgeScaleTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E212233396693C6264237B11 /* SoloScoreBadgeScaleTest.swift */; };
@@ -46,6 +48,7 @@
 		1917588F1289C48C928ACF6C /* CompanionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8062A7E6BA3EE88C6DAF02 /* CompanionService.swift */; };
 		193FE8EBE03520DF740EE78D /* PaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92F9A65ACFD3B9518A364B0 /* PaywallView.swift */; };
 		1961D53326B8AF67585215F7 /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CD4C674431C0702AD8AED3 /* Color+Hex.swift */; };
+		1964F1B56FDCF7880F068967 /* EventMarkerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6403180DDFFFF4CAEA300C7 /* EventMarkerView.swift */; };
 		19854243C91C98ACF43679C1 /* BlindboxRecapCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9613435A44E9A29C68317A52 /* BlindboxRecapCard.swift */; };
 		19AAF9D13B929174D04ADF84 /* ExperiencePreviewCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF52264EDAC06D283132721 /* ExperiencePreviewCard.swift */; };
 		1A112C6424DF5155C64A61DE /* DataSourceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B129B3B50E3C3ABE05717FDF /* DataSourceSettings.swift */; };
@@ -63,12 +66,14 @@
 		1DF5877BF77C262224C1FD1B /* ArchiveSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD9439F2BA19FE7A56182B7 /* ArchiveSnapshotTests.swift */; };
 		20423B565A01DBAAF1BD9A5C /* FriendshipStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213FE51765A7760838EC4FCE /* FriendshipStateMachine.swift */; };
 		214AF641496E8E50E3EC5FE4 /* MicroSurveySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA6E405C780A5A12A9FC1D6 /* MicroSurveySheet.swift */; };
+		216BA52386A50FF740EED857 /* CityBriefService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9052079680AA5EA57B014D93 /* CityBriefService.swift */; };
 		217F30D0C177D27828B5661E /* AddFriendSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DFC61CD1B433E92301FB18 /* AddFriendSheetTests.swift */; };
 		219718C8521B1013D17AE22F /* UserCompletionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CC4BB6965F17D1B62F01A1 /* UserCompletionRecord.swift */; };
 		21C35B398039470348D5E04D /* HitTargetSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362DB30A847EE598631A10B2 /* HitTargetSizeTests.swift */; };
 		22DC23D3CB176D63BC30DA01 /* MapDensityLODTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F494ACF8BB53CF5EEB1D4FB8 /* MapDensityLODTests.swift */; };
 		2307D6D429E5E3922600AEDE /* UserDirectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE945F792AFD68B33B7E8B5 /* UserDirectoryTests.swift */; };
 		23B40396E9D7B59CB71FBCD9 /* LocationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8509E525DD268E88ED3AD4FD /* LocationCard.swift */; };
+		23BEE650EBEF3AD8DB8B8E5B /* ComplianceMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E209FB046A4102A5DFAA5E /* ComplianceMathTests.swift */; };
 		23C6D8147AA0FFE2C7F2DC32 /* MyProfileEditPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64F0D1D5DC5D6850EE482C8 /* MyProfileEditPersistenceTests.swift */; };
 		240FFFC4A2B2B8F941129783 /* ConfidenceBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8F9EFD56A2C839428AA92D /* ConfidenceBadge.swift */; };
 		2456D74F765B987172F399F8 /* CompassMapViewBodyTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC366DD24E9174448BF06A2D /* CompassMapViewBodyTypeTests.swift */; };
@@ -103,6 +108,7 @@
 		31DAB367EE76F147742B2B3E /* ChatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E8E3F1E2D1A0382CC5D9A6 /* ChatService.swift */; };
 		31F9538643C362D7EEF64C6B /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7919EAFDE363B49C4B4C47 /* LocationService.swift */; };
 		321C062B9C6CA3558BC88C91 /* VerifiedBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2891DAE62909FE55324494D7 /* VerifiedBadge.swift */; };
+		324DDA18D0735678D2024BE0 /* ComplianceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE431CB74D7AB2703998BA4 /* ComplianceService.swift */; };
 		3253E70A5F98389A985CA7B9 /* RouteCardRecruitMiniTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EAB2E028C69B7C63DCAF860 /* RouteCardRecruitMiniTest.swift */; };
 		32C5B270129CEC0562C6D640 /* RouteShareCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF934B8ECFB7BB99C9C4791 /* RouteShareCardView.swift */; };
 		337CAFC8B35CF36D175B27CF /* CompareTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F836182A03FC067C4A9AB9 /* CompareTokens.swift */; };
@@ -111,6 +117,7 @@
 		34F2006B922A8F29F62B7317 /* FarAwayDistanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA7C71C5E9C16456C7A65D2 /* FarAwayDistanceTest.swift */; };
 		352247C1FBF4C8F901D17F32 /* ApprovalTrustSignalTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804618047547A9D7F3F8EAAA /* ApprovalTrustSignalTest.swift */; };
 		36E1316045802B2F642A9623 /* LocalAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C89CB8D3309FD5646E23434 /* LocalAttachment.swift */; };
+		37273BCDAED53D5F49CD756D /* CityBriefServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDD92E055336925881B13C67 /* CityBriefServiceTests.swift */; };
 		378B1344A5EE8001D033035F /* ChatMessageRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50C2F35BCC11F93944A83B9 /* ChatMessageRecord.swift */; };
 		37D5A0FD622C9649308BD14D /* FavoriteFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA17ED8FE9ABA2F5CC1D557E /* FavoriteFilterTests.swift */; };
 		38569000AFC1017483C20063 /* DiscoverPostDetailRenderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA75549DB586E5FB6689BEAE /* DiscoverPostDetailRenderTest.swift */; };
@@ -154,6 +161,7 @@
 		48C924FB49F596D91D67A3B2 /* CustomCityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2B85A119750C65697903E0 /* CustomCityStore.swift */; };
 		48DF93F42CDDB1329B038865 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6556C23BF1B228BF686C5500 /* KeychainStore.swift */; };
 		490E37AACCD3ABF25F694101 /* ExploreHandoffCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C903ACE494B3348EEDAEE27 /* ExploreHandoffCard.swift */; };
+		4927CDD0A8222F7510DFD8B9 /* CityOSToolRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7A43265755D995975812D62 /* CityOSToolRouterTests.swift */; };
 		49C48BE7027B3D172A0BD9B1 /* ReviewsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6F9AAA8749FA23B91F7C93 /* ReviewsServiceTests.swift */; };
 		49DE5F0AC0458584B67F3E78 /* ChatHistoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFAB38A4600C667B8D7CD2B /* ChatHistoryListView.swift */; };
 		49E7F4783C47BB3872F0F816 /* ChatHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1F20B36F8441905A909DC2 /* ChatHistoryStore.swift */; };
@@ -167,7 +175,9 @@
 		4EA0F8BCA612494B1CC49B15 /* RubricReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E620A87D721B6282E6C298 /* RubricReport.swift */; };
 		4EF2AA197499B2D40A9A5848 /* MusicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA38159B41E3E998455E922 /* MusicService.swift */; };
 		4F41DD68CF55AD05090B0AF9 /* ObsidianTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81530191ED4AA4BFC7FF2A29 /* ObsidianTheme.swift */; };
+		4F441FA4E8F16937EA5F02D5 /* EventMarkerReduceMotionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ED6C94D089C98C5E4AEB281 /* EventMarkerReduceMotionTest.swift */; };
 		4F85ADCAE47D7654A6A91068 /* MyRequestsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98E594C5575B41E32382209 /* MyRequestsListView.swift */; };
+		4FEA8F9301FFC1427DE6A223 /* CityBriefHealthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953772A59B51A407DC0D305C /* CityBriefHealthTests.swift */; };
 		50140E7D5FFAC2588C141A3F /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = EE5F70FDF5F3A929496EC981 /* Supabase */; };
 		50495257AD65A0507DD43D41 /* PlacePhotoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F55E299C99F8D9916E0BA1 /* PlacePhotoStore.swift */; };
 		5148EFD1A860D54B6F1CB8CB /* ToolOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EF938F0BC8381E7CC299E57 /* ToolOutcome.swift */; };
@@ -180,7 +190,9 @@
 		53C4F7B11856CF3D1313A228 /* ColorExtensionScopeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00295FF044E4D732D1EB2EA /* ColorExtensionScopeTest.swift */; };
 		53DCB14922F854A1F432B003 /* ArchiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A09052BA81B46EE372258E /* ArchiveView.swift */; };
 		53FB06EED514C3F3C7CB43E1 /* MapViewModelCityRegionSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FF87CCF00DEEE87B290812 /* MapViewModelCityRegionSyncTests.swift */; };
+		541F7B63BB9364C0E768C6AC /* KitSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294D570FD35987EDF2DA50FB /* KitSheet.swift */; };
 		546A552C93C3537B9A070220 /* ObsidianThemeContrastTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7D0A1F8E3B8909F465194C /* ObsidianThemeContrastTest.swift */; };
+		54941425223B5EBAC714ADE9 /* CityOSInterruptionBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58E512BB0C51F4C5887108 /* CityOSInterruptionBudget.swift */; };
 		54952646C79E8F29AF89F4D6 /* VoiceAgentToolRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20208D92E4F564C474E8AEED /* VoiceAgentToolRouter.swift */; };
 		5544DD796A2D4987A7CB9DC9 /* WebSearchEnrichmentSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 977F66FB36894EA4088C2905 /* WebSearchEnrichmentSource.swift */; };
 		561418100F2F7D4D88DE1BC4 /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086B3C207483BA0EBD27451F /* MessageBubble.swift */; };
@@ -192,12 +204,15 @@
 		58EC3C9838462DCD66F11975 /* RouteRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6BAB6EA03E81F52D00CCD59 /* RouteRecordTests.swift */; };
 		59A9E2DAC8378384BBCD8A57 /* RouteShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4181409CE6A219B1C07502 /* RouteShareSheet.swift */; };
 		5A0A16C0E997E1C0A8FD8BFE /* AmapPOIServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE165B6335EEBF5DDED2C47 /* AmapPOIServiceTests.swift */; };
+		5A9323A635F6E38C05E3C1D2 /* ComplianceBannerArbitrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBFA931C11A30D500343248 /* ComplianceBannerArbitrationTests.swift */; };
 		5B22BAF4AD26B9941361351B /* CompanionCrossTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA531A7BAD8A34652BA4801 /* CompanionCrossTests.swift */; };
+		5B7BA2C36A50D7B1D44D1B4A /* CityOSInterruptionBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07765108DFDB705B49FAD8D /* CityOSInterruptionBudgetTests.swift */; };
 		5C05B87EA78458094612AC01 /* BottomInfoBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13350B81187FB64B252B8A46 /* BottomInfoBar.swift */; };
 		5DB0B5A0529235F670434A4A /* DetailHeroBadgeRenderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC42E0ED29538A28E51BD4D /* DetailHeroBadgeRenderTest.swift */; };
 		5F3ACD03660F3E8B88814C56 /* MyHostedRoutesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E055BAC372B75F743428920 /* MyHostedRoutesListView.swift */; };
 		5FBA4A615BD008DC38174609 /* LiveActivityLockScreenPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5851D15E5E0C0A25A014F186 /* LiveActivityLockScreenPreview.swift */; };
 		60D39CDEAEF16ADA45BE5A84 /* ForEachStringIDStabilityTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B54F95BDD9FB4A3CF8C5B1 /* ForEachStringIDStabilityTest.swift */; };
+		60F28EDBE48C8D4A058781A3 /* CityDrawerTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BAAA9FA3D1B194212550B4D /* CityDrawerTabs.swift */; };
 		60FA57D3A56ED061C1F9B899 /* PresenceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BF40BDAD5E085808BE633E /* PresenceService.swift */; };
 		61183D492854C69DDFFA3F06 /* RouteShareCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEF9ECFBFF7B7CE5246F37B /* RouteShareCardTests.swift */; };
 		615FCA91C2260950BFE3E4F3 /* ShareCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30705AFFEB819044661EC871 /* ShareCardView.swift */; };
@@ -240,6 +255,7 @@
 		7428B9017BC39BE7BAA4946A /* BottomInfoSheetHandleHitTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88553B5578C07FA890183A0D /* BottomInfoSheetHandleHitTargetTests.swift */; };
 		75B727F4A7C24DF157FFBBAB /* PeekSummaryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554BDD1F80E1A3D35F7FDF2B /* PeekSummaryCard.swift */; };
 		75DA4CEC616274115C0A0A2D /* DiagnosticsRequestCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40E9E2485E877580F0E1915 /* DiagnosticsRequestCard.swift */; };
+		76049112A5F17F05AA50D6A8 /* CityOSComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C9C19E24DF2E4DFE6C61EF2 /* CityOSComponents.swift */; };
 		76D52B9DC55D969BB9D51B9E /* ArchiveViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D6FF8E955C80F89779A0F9A /* ArchiveViewModelTests.swift */; };
 		76F57DBD1B6F0020E8BF91E5 /* RecruitingModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612BA64E761957615DD63D34 /* RecruitingModule.swift */; };
 		774B752EDCAEED08EA039231 /* RubricScorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA4701227E80FF989B91EE7 /* RubricScorer.swift */; };
@@ -296,6 +312,7 @@
 		905A93A872B2942AE13B7F08 /* PersistenceDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511EDFCCBC74626702DDCE8C /* PersistenceDecoding.swift */; };
 		90C2EC1E98DDE7C3D3A5B4E9 /* GroupConversationAutoCreateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48ADAE2497800574C4E8819B /* GroupConversationAutoCreateTests.swift */; };
 		915E4532026427BA9F00B39D /* ModerationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71031524B916484E4C152E6 /* ModerationView.swift */; };
+		9260A79D1F643E59A55A4401 /* CityBrief.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05F48898F445A18234B6979 /* CityBrief.swift */; };
 		92C0C68AE15DFE4AF0DFE012 /* UndoPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C03A30AB5CD426978E8C72 /* UndoPill.swift */; };
 		95389B7D23017957CB6C69E0 /* RouteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66273C940FD90B51EBCD97BC /* RouteBuilder.swift */; };
 		953C7BD48AF4AF55608145A6 /* LanguageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87002BB6D344B384A3FDFBFD /* LanguageService.swift */; };
@@ -316,6 +333,7 @@
 		99E3055C98F6477EF46D260C /* ChatCardViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7989FA184B0EFCE68C961241 /* ChatCardViews.swift */; };
 		9A4260E9DE8D58FBE83DE16F /* SoloOrb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB591CFC39832612F07EB88 /* SoloOrb.swift */; };
 		9A6B147D089D0942438D8972 /* BestTimesSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3645957E10E52142EBF468C0 /* BestTimesSignal.swift */; };
+		9A7151F34DE0156868DE3189 /* ModePlaceholderCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112AE9791A5032033EEDC882 /* ModePlaceholderCards.swift */; };
 		9A7AAC7B68BA10A53CAC0A8B /* VoiceServiceActorIsolationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F10413877E80238BD52F34C /* VoiceServiceActorIsolationTest.swift */; };
 		9B906CA9BF24104FB2BF7773 /* RouteCardWalkedByTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9FE3BB447D84732CCE0B07 /* RouteCardWalkedByTest.swift */; };
 		9BEDEF446F2D554A7F1ABA6F /* PreviewCardLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AED8B43F4C4059CD005C0A /* PreviewCardLifecycleTests.swift */; };
@@ -353,6 +371,7 @@
 		AB3893CB92AAA26B58302023 /* CompanionPhase3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB612E3F9DD324EF3F308FFA /* CompanionPhase3Tests.swift */; };
 		AB8E6644540AE90657471002 /* BottomSheetDetentDynamicTypeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C63BC4737C3134075574125E /* BottomSheetDetentDynamicTypeTest.swift */; };
 		AC44E44D1AC48E33145DF0F0 /* ToolRouterContractPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFE15D19AA0F8BAB7426AED /* ToolRouterContractPreview.swift */; };
+		AC96592EE251F5FD659D5B54 /* CityOSStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016B15E49242CF08822EF3DF /* CityOSStore.swift */; };
 		ACBA4CEE6B78AA04DBD26709 /* PendingCheckInRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA0BAEC05B72704552C0906 /* PendingCheckInRecord.swift */; };
 		ADD51496532A0B763048AF5B /* ReviewsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746139AC01A1D37CE002BFCF /* ReviewsService.swift */; };
 		AE7EF0304E8E72DAE72E90E7 /* AttachmentDraftStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A6F8B0FC9EB2CABDA75A0B /* AttachmentDraftStrip.swift */; };
@@ -363,6 +382,7 @@
 		B2C98BCF4E0193B5740C7762 /* FriendsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7202B977A555239F367D02 /* FriendsListView.swift */; };
 		B32CCADAF2919BAFA66D9C94 /* SFSymbolExistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA9968E168052C0DC0E1B36 /* SFSymbolExistenceTests.swift */; };
 		B42207A02271655D3498B723 /* NoProductionPrintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE95C3399C8616CBDE8B44BE /* NoProductionPrintTests.swift */; };
+		B44FE0FADDB12E8EA6A3083C /* CityBriefCacheRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723CD4AED8D9F9074DAC2F7D /* CityBriefCacheRecord.swift */; };
 		B478C92BB2249C0D5009AABD /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6163572F4644BF852B35FDA4 /* SyncService.swift */; };
 		B4A33EDD3C85BBA89CD4EC05 /* ThemeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AF85DC8F90CA4721DDAEA6 /* ThemeService.swift */; };
 		B58C1EFCD6EFEB5FAA609145 /* AIObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = E934CD39C814AF280C2483DF /* AIObservability.swift */; };
@@ -383,6 +403,7 @@
 		BAD5DD88DEA26FC3F5E4E304 /* RoutesSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176E799668057C7DD5C559AD /* RoutesSectionView.swift */; };
 		BB0BC19A9BE687E947C48034 /* VoiceAgentOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94EF0AA0049BDCC88E125164 /* VoiceAgentOrchestrator.swift */; };
 		BB2B54BC5A41E7956362E1CE /* MarkerClosingSoonStyleTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC34BA3586B5607F63F86CC0 /* MarkerClosingSoonStyleTest.swift */; };
+		BB34E346EFB5F570DED6B039 /* seed_city_brief_vte.json in Resources */ = {isa = PBXBuildFile; fileRef = FB52A67C323F1302895C0C67 /* seed_city_brief_vte.json */; };
 		BB684C82CF82A2EB3F924C75 /* SystemTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1B839F9F82AFDD50655AAE /* SystemTheme.swift */; };
 		BBE039B8956CD8FA50C8F79F /* V_NEXT_ServiceSkeletonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF01C7BBEC4B125B7938ABA /* V_NEXT_ServiceSkeletonTests.swift */; };
 		BC5673F20B57CA6567972838 /* FriendshipRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4CE01B80793852F97DBC89 /* FriendshipRecord.swift */; };
@@ -407,6 +428,7 @@
 		C306F7501DA85110BE3C85B5 /* NavigationLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07ACA7C1A1574A244E73796 /* NavigationLauncher.swift */; };
 		C3A87993F509B921A9F7FE06 /* NowCountCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D68F42114231582501CB90 /* NowCountCacheTests.swift */; };
 		C44A8B8ED9626205C55A0B4B /* FriendProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC6DF782C123E76E2F02EEEA /* FriendProfileView.swift */; };
+		C4529604A378FA8EABBF6EF5 /* CityOSStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13607F78187BF3ABDD080DC7 /* CityOSStoreTests.swift */; };
 		C485F7BEDA3727C3C26BFBAB /* SupabaseRouteCompanionRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520EDA3B7A8A6136FB0355A4 /* SupabaseRouteCompanionRemote.swift */; };
 		C48ABACD6775568202229577 /* LocalizationCoverageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555AA83E46CA214D7F71D811 /* LocalizationCoverageTest.swift */; };
 		C4FE64920461E93F76D76919 /* QRScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3EE8D38604D12055F9E94C /* QRScannerView.swift */; };
@@ -580,8 +602,10 @@
 
 /* Begin PBXFileReference section */
 		001EB4B0431ADF64A02B47F8 /* AIUsageRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIUsageRecord.swift; sourceTree = "<group>"; };
+		0059E8B90B93210D7C505BFD /* ComplianceBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplianceBanner.swift; sourceTree = "<group>"; };
 		0106B882E4C406402FB16889 /* TurnPlannerLiveIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnPlannerLiveIntegrationTests.swift; sourceTree = "<group>"; };
 		013CB7ADB0525E4F4E8EE959 /* DiscoverRecruitingRoutesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverRecruitingRoutesView.swift; sourceTree = "<group>"; };
+		016B15E49242CF08822EF3DF /* CityOSStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityOSStore.swift; sourceTree = "<group>"; };
 		023CB5AE8B0D41EBB5E17DAC /* ReportBlockSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportBlockSheet.swift; sourceTree = "<group>"; };
 		02AED8B43F4C4059CD005C0A /* PreviewCardLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCardLifecycleTests.swift; sourceTree = "<group>"; };
 		0364599CF5416C94D9711120 /* TermsConsentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsConsentSheet.swift; sourceTree = "<group>"; };
@@ -605,10 +629,12 @@
 		0A0997D8150E77F70A4B8C64 /* ExploreProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreProgressBar.swift; sourceTree = "<group>"; };
 		0A4CE01B80793852F97DBC89 /* FriendshipRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendshipRecord.swift; sourceTree = "<group>"; };
 		0B29F2D28E1751AE7B5454B5 /* VisitedMarkerStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitedMarkerStateTests.swift; sourceTree = "<group>"; };
+		0BE431CB74D7AB2703998BA4 /* ComplianceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplianceService.swift; sourceTree = "<group>"; };
 		0C04A7D4DE12B98E4801D7C4 /* NowScoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowScoreTests.swift; sourceTree = "<group>"; };
 		0C6FC4A3B60FA8D9DC3A4779 /* SoloScoreRadarA11yTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloScoreRadarA11yTest.swift; sourceTree = "<group>"; };
 		0CB5FD37267074EF4015F95D /* ConversationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListView.swift; sourceTree = "<group>"; };
 		0E0157D30FF53B21FF31D519 /* MarkerIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerIconView.swift; sourceTree = "<group>"; };
+		0EBFA931C11A30D500343248 /* ComplianceBannerArbitrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplianceBannerArbitrationTests.swift; sourceTree = "<group>"; };
 		0EF938F0BC8381E7CC299E57 /* ToolOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolOutcome.swift; sourceTree = "<group>"; };
 		0F1A75C3B221367255908953 /* NearbyExperienceRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyExperienceRow.swift; sourceTree = "<group>"; };
 		0FB591CFC39832612F07EB88 /* SoloOrb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloOrb.swift; sourceTree = "<group>"; };
@@ -616,6 +642,7 @@
 		10F48D7FA14E29D606FD11EA /* RouteCompanionStateMachineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCompanionStateMachineTests.swift; sourceTree = "<group>"; };
 		112319E8315F5F6961C95264 /* VoiceAgentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAgentSession.swift; sourceTree = "<group>"; };
 		112365ED9467BFB0994BC0A0 /* CompanionProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionProfile.swift; sourceTree = "<group>"; };
+		112AE9791A5032033EEDC882 /* ModePlaceholderCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModePlaceholderCards.swift; sourceTree = "<group>"; };
 		1157BB60848F9C74D7E8C14E /* TravelerNoteRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelerNoteRecord.swift; sourceTree = "<group>"; };
 		11A51666D1564BE942593139 /* ChatDisplayType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDisplayType.swift; sourceTree = "<group>"; };
 		11CCB9E36FDC56604136090F /* IslandPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IslandPalette.swift; sourceTree = "<group>"; };
@@ -625,6 +652,7 @@
 		130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingCheckInBanner.swift; sourceTree = "<group>"; };
 		13350B81187FB64B252B8A46 /* BottomInfoBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomInfoBar.swift; sourceTree = "<group>"; };
 		13554AD53D06DCDA79E46575 /* SeedImportRubricProbeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedImportRubricProbeTest.swift; sourceTree = "<group>"; };
+		13607F78187BF3ABDD080DC7 /* CityOSStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityOSStoreTests.swift; sourceTree = "<group>"; };
 		13B54F95BDD9FB4A3CF8C5B1 /* ForEachStringIDStabilityTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForEachStringIDStabilityTest.swift; sourceTree = "<group>"; };
 		14392FEFAE7F1E9596DCCA53 /* PushTokenServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTokenServiceTests.swift; sourceTree = "<group>"; };
 		143FF1379DE02FC9B0D637CA /* ToolRouterOutcomeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolRouterOutcomeTests.swift; sourceTree = "<group>"; };
@@ -655,6 +683,7 @@
 		24C070BDAE248990A4E7909B /* LiveActivityServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityServiceTests.swift; sourceTree = "<group>"; };
 		271284A1F632E444E85EF589 /* ProvisionalCardWiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvisionalCardWiringTests.swift; sourceTree = "<group>"; };
 		2891DAE62909FE55324494D7 /* VerifiedBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedBadge.swift; sourceTree = "<group>"; };
+		294D570FD35987EDF2DA50FB /* KitSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KitSheet.swift; sourceTree = "<group>"; };
 		295A9108AFAF3BEE4EFF7524 /* HeartBurstView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeartBurstView.swift; sourceTree = "<group>"; };
 		2A96C378147BDD0B232F0ADB /* BestTimeOpensInTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BestTimeOpensInTests.swift; sourceTree = "<group>"; };
 		2B33B0431703DD49E0228D33 /* MemoryDigestServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDigestServiceTests.swift; sourceTree = "<group>"; };
@@ -665,6 +694,7 @@
 		2D52E68EDCAB1AEF0737B201 /* AvatarStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarStack.swift; sourceTree = "<group>"; };
 		2DA6E405C780A5A12A9FC1D6 /* MicroSurveySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicroSurveySheet.swift; sourceTree = "<group>"; };
 		2E15D735F5BB23210B7753FA /* ChatReasoningRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatReasoningRecord.swift; sourceTree = "<group>"; };
+		2ED6C94D089C98C5E4AEB281 /* EventMarkerReduceMotionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMarkerReduceMotionTest.swift; sourceTree = "<group>"; };
 		2EFE48683692E4C00E0A2DC5 /* PressableButtonStyleHapticTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PressableButtonStyleHapticTest.swift; sourceTree = "<group>"; };
 		2F99B043981C964178CBECE0 /* V1_9SchemaRecordsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V1_9SchemaRecordsTests.swift; sourceTree = "<group>"; };
 		30705AFFEB819044661EC871 /* ShareCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareCardView.swift; sourceTree = "<group>"; };
@@ -719,6 +749,7 @@
 		48FF87CCF00DEEE87B290812 /* MapViewModelCityRegionSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModelCityRegionSyncTests.swift; sourceTree = "<group>"; };
 		49F36F9AC9ED0AE7E3F0E5EA /* NotificationServiceHandleURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceHandleURLTests.swift; sourceTree = "<group>"; };
 		4A5F0C6695E934C430648EA4 /* PrintFulfillmentClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintFulfillmentClient.swift; sourceTree = "<group>"; };
+		4ABE29FC4F9EBBBF8C3C61C4 /* LiveSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveSheet.swift; sourceTree = "<group>"; };
 		4B5D9508FCA9CDB8EA088D76 /* OpenForCompanionsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenForCompanionsSheet.swift; sourceTree = "<group>"; };
 		4C32FC4B073B393E96C59C62 /* StartupDiagnosticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupDiagnosticsService.swift; sourceTree = "<group>"; };
 		4C3EE8D38604D12055F9E94C /* QRScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerView.swift; sourceTree = "<group>"; };
@@ -801,6 +832,7 @@
 		6982D2F9E150319AA0E1000F /* SoloCompassLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassLiveActivity.swift; sourceTree = "<group>"; };
 		69C8C17C79CD2B4EAE72F385 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		6B992B0BD7DC5870366A3B7A /* TurnPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnPlan.swift; sourceTree = "<group>"; };
+		6BAAA9FA3D1B194212550B4D /* CityDrawerTabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityDrawerTabs.swift; sourceTree = "<group>"; };
 		6C5CA5533D846B39EF16CDFA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6CA38159B41E3E998455E922 /* MusicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicService.swift; sourceTree = "<group>"; };
 		6CE165B6335EEBF5DDED2C47 /* AmapPOIServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmapPOIServiceTests.swift; sourceTree = "<group>"; };
@@ -814,6 +846,7 @@
 		70AF2705AB2F24B69DE8CB4F /* PerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		710E82F0D31AB629848EA729 /* PeekSummarySelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeekSummarySelectionTests.swift; sourceTree = "<group>"; };
 		7112C1C0DEDB8C518D83CC18 /* SettingsViewQuerySortTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewQuerySortTest.swift; sourceTree = "<group>"; };
+		723CD4AED8D9F9074DAC2F7D /* CityBriefCacheRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityBriefCacheRecord.swift; sourceTree = "<group>"; };
 		724256EB3296F1C59266389C /* ExploreSessionDimModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreSessionDimModifier.swift; sourceTree = "<group>"; };
 		7295DF9392F0361C0B2E313D /* AIProviderSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderSettingsView.swift; sourceTree = "<group>"; };
 		72F48906724062C4636DE947 /* MyWalkedRoutesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyWalkedRoutesListView.swift; sourceTree = "<group>"; };
@@ -836,6 +869,7 @@
 		7B88A8CA4BEE6CDF6D7C5DEF /* RouteCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCard.swift; sourceTree = "<group>"; };
 		7BA4701227E80FF989B91EE7 /* RubricScorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RubricScorer.swift; sourceTree = "<group>"; };
 		7BA9EA4E29955D78499E3AAC /* RouteCompanionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCompanionTests.swift; sourceTree = "<group>"; };
+		7C9C19E24DF2E4DFE6C61EF2 /* CityOSComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityOSComponents.swift; sourceTree = "<group>"; };
 		7CB0F8921D16545D7234EF2F /* SettingsLanguageSwitchRestartTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLanguageSwitchRestartTest.swift; sourceTree = "<group>"; };
 		7D194A2740848FA0C9D4BA3D /* TasteUpdateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasteUpdateService.swift; sourceTree = "<group>"; };
 		7D3D7AE265D80F76BA9BB28B /* OnboardingCityStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCityStep.swift; sourceTree = "<group>"; };
@@ -888,6 +922,7 @@
 		8EBBF97536F80B36291DB787 /* JourneyAuditP0RegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneyAuditP0RegressionTests.swift; sourceTree = "<group>"; };
 		8F1F20B36F8441905A909DC2 /* ChatHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryStore.swift; sourceTree = "<group>"; };
 		8FDFA5F3503B8ABC4B5CB086 /* SoloCompassTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SoloCompassTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9052079680AA5EA57B014D93 /* CityBriefService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityBriefService.swift; sourceTree = "<group>"; };
 		9055347887EF473171916120 /* AttachmentBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentBubble.swift; sourceTree = "<group>"; };
 		907EA19EC9B84B93AB110C70 /* ColdStartExperienceLoadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColdStartExperienceLoadTests.swift; sourceTree = "<group>"; };
 		90B0465B31ABD4A057EE984F /* UserDirectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDirectory.swift; sourceTree = "<group>"; };
@@ -899,6 +934,7 @@
 		94EF0AA0049BDCC88E125164 /* VoiceAgentOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAgentOrchestrator.swift; sourceTree = "<group>"; };
 		9504D49E879C4D2BB34F99E9 /* Geohash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Geohash.swift; sourceTree = "<group>"; };
 		9523A96A3D4F48D1670E0590 /* CapsuleComposeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapsuleComposeView.swift; sourceTree = "<group>"; };
+		953772A59B51A407DC0D305C /* CityBriefHealthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityBriefHealthTests.swift; sourceTree = "<group>"; };
 		9613435A44E9A29C68317A52 /* BlindboxRecapCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlindboxRecapCard.swift; sourceTree = "<group>"; };
 		9748B0A808BC06F6EDED3C3B /* RecentExploreRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentExploreRegion.swift; sourceTree = "<group>"; };
 		977F66FB36894EA4088C2905 /* WebSearchEnrichmentSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchEnrichmentSource.swift; sourceTree = "<group>"; };
@@ -942,7 +978,9 @@
 		A50FBDC4170E55259CBB3FC7 /* CoordinateConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateConverterTests.swift; sourceTree = "<group>"; };
 		A5435FBA9527C07A9FB07D46 /* SoloCompassModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassModelContainer.swift; sourceTree = "<group>"; };
 		A582931FC4E74C77DA1DEEA2 /* ProvisionalCardLedger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvisionalCardLedger.swift; sourceTree = "<group>"; };
+		A5E209FB046A4102A5DFAA5E /* ComplianceMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplianceMathTests.swift; sourceTree = "<group>"; };
 		A5F2BB13078B86C9BEDE7ADD /* WeatherCacheRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherCacheRecord.swift; sourceTree = "<group>"; };
+		A6403180DDFFFF4CAEA300C7 /* EventMarkerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMarkerView.swift; sourceTree = "<group>"; };
 		A644911E7B2824A7ABBA4D6F /* SeedRoutesParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedRoutesParityTests.swift; sourceTree = "<group>"; };
 		A6F061EC88D5CC60CDEE2515 /* PushTokenService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTokenService.swift; sourceTree = "<group>"; };
 		A71031524B916484E4C152E6 /* ModerationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationView.swift; sourceTree = "<group>"; };
@@ -961,6 +999,9 @@
 		AEDB30483C5FCCD42CA92A00 /* LiveActivityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityService.swift; sourceTree = "<group>"; };
 		AEFAE8B83CF381DAF5FF64E0 /* RecallMemoryToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecallMemoryToolTests.swift; sourceTree = "<group>"; };
 		AF007DB5F72E30021CADA555 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
+		AF58E512BB0C51F4C5887108 /* CityOSInterruptionBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityOSInterruptionBudget.swift; sourceTree = "<group>"; };
+		B05F48898F445A18234B6979 /* CityBrief.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityBrief.swift; sourceTree = "<group>"; };
+		B07765108DFDB705B49FAD8D /* CityOSInterruptionBudgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityOSInterruptionBudgetTests.swift; sourceTree = "<group>"; };
 		B129B3B50E3C3ABE05717FDF /* DataSourceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSourceSettings.swift; sourceTree = "<group>"; };
 		B14FE2118ED82DD0593F5C3C /* StringsParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringsParityTests.swift; sourceTree = "<group>"; };
 		B28321E2C450664BF8B05147 /* FriendCodeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendCodeRow.swift; sourceTree = "<group>"; };
@@ -1098,6 +1139,7 @@
 		F50C2F35BCC11F93944A83B9 /* ChatMessageRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageRecord.swift; sourceTree = "<group>"; };
 		F63FDD874A8F533F0717132A /* UserPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPreferences.swift; sourceTree = "<group>"; };
 		F75EF3DD190DDA1D8F41DA63 /* HalfExpandedEmptyVisualTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfExpandedEmptyVisualTest.swift; sourceTree = "<group>"; };
+		F7A43265755D995975812D62 /* CityOSToolRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityOSToolRouterTests.swift; sourceTree = "<group>"; };
 		F7FB43528F45882868CCC203 /* NavigationLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLauncherTests.swift; sourceTree = "<group>"; };
 		F7FBBB5591547E793D2961D3 /* OstShareCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OstShareCard.swift; sourceTree = "<group>"; };
 		F8547EB44AE47A5D653D3994 /* FavoritesBounceAvailabilityTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesBounceAvailabilityTest.swift; sourceTree = "<group>"; };
@@ -1111,8 +1153,10 @@
 		F9DC82A84F82B684AFCDF89D /* FriendRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendRequest.swift; sourceTree = "<group>"; };
 		FADDD17473F138874328A33E /* DiscoverListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverListView.swift; sourceTree = "<group>"; };
 		FAFFA243BC698EF20C6BC1EF /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
+		FB52A67C323F1302895C0C67 /* seed_city_brief_vte.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = seed_city_brief_vte.json; sourceTree = "<group>"; };
 		FBBF77E10D341C38C093D22D /* CompanionBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionBlock.swift; sourceTree = "<group>"; };
 		FC366DD24E9174448BF06A2D /* CompassMapViewBodyTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompassMapViewBodyTypeTests.swift; sourceTree = "<group>"; };
+		FDD92E055336925881B13C67 /* CityBriefServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityBriefServiceTests.swift; sourceTree = "<group>"; };
 		FF401E3F554B9E2948A64ABC /* ForgetMeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgetMeService.swift; sourceTree = "<group>"; };
 		FF5780606CA08F571BF04ACE /* ProactiveNudgeSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProactiveNudgeSchedulerTests.swift; sourceTree = "<group>"; };
 		FF753CC02718028B12891042 /* AdminService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminService.swift; sourceTree = "<group>"; };
@@ -1306,6 +1350,11 @@
 				1FF5100EFECEC87BDC2B007B /* ChatBubbleContrastTest.swift */,
 				C504FA7911B469792541F323 /* ChatCardRenderVisualTest.swift */,
 				CB511F86191D72DBCBCB5A01 /* ChatRedesignVisualTest.swift */,
+				953772A59B51A407DC0D305C /* CityBriefHealthTests.swift */,
+				FDD92E055336925881B13C67 /* CityBriefServiceTests.swift */,
+				B07765108DFDB705B49FAD8D /* CityOSInterruptionBudgetTests.swift */,
+				13607F78187BF3ABDD080DC7 /* CityOSStoreTests.swift */,
+				F7A43265755D995975812D62 /* CityOSToolRouterTests.swift */,
 				308B7A34171C74B1CF2DE3F9 /* CityPillHitTargetTests.swift */,
 				907EA19EC9B84B93AB110C70 /* ColdStartExperienceLoadTests.swift */,
 				A00295FF044E4D732D1EB2EA /* ColorExtensionScopeTest.swift */,
@@ -1315,6 +1364,8 @@
 				0535B15C19B134898D9880BE /* CompassMapViewLayerToggleTests.swift */,
 				56AF27F0567AACEA9E6D916E /* CompiledPlaceTests.swift */,
 				649ECD409B685D38E30527FD /* CompletionMomentTests.swift */,
+				0EBFA931C11A30D500343248 /* ComplianceBannerArbitrationTests.swift */,
+				A5E209FB046A4102A5DFAA5E /* ComplianceMathTests.swift */,
 				EC5B6016449DF7A639F54DE3 /* ConversationListRenderTest.swift */,
 				2CEFD2E522C2D9FFF8EF0B0B /* ConversationTests.swift */,
 				A50FBDC4170E55259CBB3FC7 /* CoordinateConverterTests.swift */,
@@ -1326,6 +1377,7 @@
 				DA75549DB586E5FB6689BEAE /* DiscoverPostDetailRenderTest.swift */,
 				763DF01F638C99097DD5FE20 /* EmptyStateAnnouncementTest.swift */,
 				BCE4DB6455FBF5257A3709D9 /* EmptyStateCitySuggestionTest.swift */,
+				2ED6C94D089C98C5E4AEB281 /* EventMarkerReduceMotionTest.swift */,
 				F28FE205E7AA6068F6E0C837 /* ExperienceImageServiceTests.swift */,
 				97CFC524C0531291FC21FE47 /* ExperienceRecordHighlightsRoundTripTests.swift */,
 				86AEAFC3C13D4A82B3C55154 /* ExperienceRepositoryExportTests.swift */,
@@ -1488,6 +1540,7 @@
 		349E26E71AF3FA04CA5CC24C /* JSON */ = {
 			isa = PBXGroup;
 			children = (
+				FB52A67C323F1302895C0C67 /* seed_city_brief_vte.json */,
 				61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */,
 				88C4087271547E494464570E /* seed_experiences.json.backup */,
 				1F39081CF797874064A33814 /* seed_routes.json */,
@@ -1571,6 +1624,7 @@
 				F50C2F35BCC11F93944A83B9 /* ChatMessageRecord.swift */,
 				2E15D735F5BB23210B7753FA /* ChatReasoningRecord.swift */,
 				4F7AE422ACCFA23FCA7DF90D /* ChatSessionRecord.swift */,
+				723CD4AED8D9F9074DAC2F7D /* CityBriefCacheRecord.swift */,
 				C12888843433B2A00D7CAB18 /* ConversationRecord.swift */,
 				CE05EF69960CBB73431A6F2F /* DiscoveredCityRecord.swift */,
 				E03076AD221F78BBDE981C3A /* ExperienceRecord.swift */,
@@ -1612,6 +1666,7 @@
 				9F32B7DE32405561C4159843 /* ChatMessage.swift */,
 				0709110B381DEDA32C3292AE /* ChatUIState.swift */,
 				6DFBC1C003B8745713588A23 /* City.swift */,
+				B05F48898F445A18234B6979 /* CityBrief.swift */,
 				FBBF77E10D341C38C093D22D /* CompanionBlock.swift */,
 				431DC31A80132F719AFEE471 /* CompanionPost.swift */,
 				112365ED9467BFB0994BC0A0 /* CompanionProfile.swift */,
@@ -1671,7 +1726,11 @@
 				9A8808D601B162DF2F87F1C0 /* CapsuleStore.swift */,
 				AA96BC45388A8EC99F3B29ED /* ChatAttachmentService.swift */,
 				A7E8E3F1E2D1A0382CC5D9A6 /* ChatService.swift */,
+				9052079680AA5EA57B014D93 /* CityBriefService.swift */,
+				AF58E512BB0C51F4C5887108 /* CityOSInterruptionBudget.swift */,
+				016B15E49242CF08822EF3DF /* CityOSStore.swift */,
 				1A8062A7E6BA3EE88C6DAF02 /* CompanionService.swift */,
+				0BE431CB74D7AB2703998BA4 /* ComplianceService.swift */,
 				7B2B85A119750C65697903E0 /* CustomCityStore.swift */,
 				39637DC278B491AE596B169E /* DataSourceProbe.swift */,
 				B129B3B50E3C3ABE05717FDF /* DataSourceSettings.swift */,
@@ -1886,6 +1945,7 @@
 				7851E3536106F0D7077C3874 /* Brag */,
 				7B46D9593F9E31DA66D5A80B /* Capsule */,
 				78E954A36C9CA4C8D59A4CD8 /* Chat */,
+				E17A4AE157D48E09CB2DC9E2 /* CityOS */,
 				1E97D71FC3AACEBF3EAB70F0 /* Companion */,
 				0807CE55F43B61AC22836519 /* Experience */,
 				B1E73913322B5353D1A98672 /* Filter */,
@@ -2002,6 +2062,20 @@
 				F7FBBB5591547E793D2961D3 /* OstShareCard.swift */,
 			);
 			path = Ost;
+			sourceTree = "<group>";
+		};
+		E17A4AE157D48E09CB2DC9E2 /* CityOS */ = {
+			isa = PBXGroup;
+			children = (
+				6BAAA9FA3D1B194212550B4D /* CityDrawerTabs.swift */,
+				7C9C19E24DF2E4DFE6C61EF2 /* CityOSComponents.swift */,
+				0059E8B90B93210D7C505BFD /* ComplianceBanner.swift */,
+				A6403180DDFFFF4CAEA300C7 /* EventMarkerView.swift */,
+				294D570FD35987EDF2DA50FB /* KitSheet.swift */,
+				4ABE29FC4F9EBBBF8C3C61C4 /* LiveSheet.swift */,
+				112AE9791A5032033EEDC882 /* ModePlaceholderCards.swift */,
+			);
+			path = CityOS;
 			sourceTree = "<group>";
 		};
 		E8145B11DE65BF09C059E7B9 /* SoloCompassWidgets */ = {
@@ -2168,6 +2242,7 @@
 				F3461FC7F38900F40A880255 /* Localizable.stringsdict in Resources */,
 				8B4F2A6E8F3C6EAD0F9A8E32 /* PrivacyInfo.xcprivacy in Resources */,
 				84C7525626CF30AF8AD92C19 /* Secrets.plist in Resources */,
+				BB34E346EFB5F570DED6B039 /* seed_city_brief_vte.json in Resources */,
 				D7CC906B358ED5337880A942 /* seed_experiences.json in Resources */,
 				D3D6DD13C4BE1230C9A5F5E5 /* seed_experiences.json.backup in Resources */,
 				EAFABF90D77B4D5E00D6BDFC /* seed_routes.json in Resources */,
@@ -2246,6 +2321,11 @@
 				B5D2608A5B16B07B6E9005DC /* ChatBubbleContrastTest.swift in Sources */,
 				FEC4BF6E3C7FA92D982C0B4F /* ChatCardRenderVisualTest.swift in Sources */,
 				2F00F874A1B50C113AC8CA55 /* ChatRedesignVisualTest.swift in Sources */,
+				4FEA8F9301FFC1427DE6A223 /* CityBriefHealthTests.swift in Sources */,
+				37273BCDAED53D5F49CD756D /* CityBriefServiceTests.swift in Sources */,
+				5B7BA2C36A50D7B1D44D1B4A /* CityOSInterruptionBudgetTests.swift in Sources */,
+				C4529604A378FA8EABBF6EF5 /* CityOSStoreTests.swift in Sources */,
+				4927CDD0A8222F7510DFD8B9 /* CityOSToolRouterTests.swift in Sources */,
 				D2BCD302B16BBC174B71F84A /* CityPillHitTargetTests.swift in Sources */,
 				81470D06CD0593B278B110CC /* ColdStartExperienceLoadTests.swift in Sources */,
 				53C4F7B11856CF3D1313A228 /* ColorExtensionScopeTest.swift in Sources */,
@@ -2255,6 +2335,8 @@
 				3A91B128119A6288C6C9A9D9 /* CompassMapViewLayerToggleTests.swift in Sources */,
 				259F1E0030F914782D632794 /* CompiledPlaceTests.swift in Sources */,
 				1130F4E1887551F856FCB9DB /* CompletionMomentTests.swift in Sources */,
+				5A9323A635F6E38C05E3C1D2 /* ComplianceBannerArbitrationTests.swift in Sources */,
+				23BEE650EBEF3AD8DB8B8E5B /* ComplianceMathTests.swift in Sources */,
 				0AF933A2FC20BD18F71ECDCA /* ConversationListRenderTest.swift in Sources */,
 				AA5C5AEBFB7B2266A4781877 /* ConversationTests.swift in Sources */,
 				F63277D514DA77058B9A2EF4 /* CoordinateConverterTests.swift in Sources */,
@@ -2266,6 +2348,7 @@
 				38569000AFC1017483C20063 /* DiscoverPostDetailRenderTest.swift in Sources */,
 				30293CB7BCCE6B600A82C292 /* EmptyStateAnnouncementTest.swift in Sources */,
 				6B06E0141358CBC81CB3ADB2 /* EmptyStateCitySuggestionTest.swift in Sources */,
+				4F441FA4E8F16937EA5F02D5 /* EventMarkerReduceMotionTest.swift in Sources */,
 				DC8EEFCE455618DDDF900B28 /* ExperienceImageServiceTests.swift in Sources */,
 				80D6C58420D8D1E463936E47 /* ExperienceRecordHighlightsRoundTripTests.swift in Sources */,
 				3145E76B60141EB5F7E6C5B0 /* ExperienceRepositoryExportTests.swift in Sources */,
@@ -2477,7 +2560,14 @@
 				9D81327AE55FA8142F9E5B8D /* ChatUIState.swift in Sources */,
 				BD97CA8F6A722075F84930C7 /* ChatView.swift in Sources */,
 				397C20402788F9B63F06A01A /* City.swift in Sources */,
+				9260A79D1F643E59A55A4401 /* CityBrief.swift in Sources */,
+				B44FE0FADDB12E8EA6A3083C /* CityBriefCacheRecord.swift in Sources */,
+				216BA52386A50FF740EED857 /* CityBriefService.swift in Sources */,
 				A0C1702CF2CB823849D31BE0 /* CityCodexView.swift in Sources */,
+				60F28EDBE48C8D4A058781A3 /* CityDrawerTabs.swift in Sources */,
+				76049112A5F17F05AA50D6A8 /* CityOSComponents.swift in Sources */,
+				54941425223B5EBAC714ADE9 /* CityOSInterruptionBudget.swift in Sources */,
+				AC96592EE251F5FD659D5B54 /* CityOSStore.swift in Sources */,
 				7D2B6DE6C27E0307CA998A5F /* CityPickerSheet.swift in Sources */,
 				CA5A2B58111A59382070CA09 /* ClusterAnnotationView.swift in Sources */,
 				1961D53326B8AF67585215F7 /* Color+Hex.swift in Sources */,
@@ -2495,6 +2585,8 @@
 				EF7C549F31EDA5ABE2B95FE8 /* CompiledPlace.swift in Sources */,
 				A93EEDF38B969D10CC369C59 /* CompletionCelebrationView.swift in Sources */,
 				89E009AABEDECE319C331924 /* CompletionMoment.swift in Sources */,
+				0C910AC3F463BC15AE61B602 /* ComplianceBanner.swift in Sources */,
+				324DDA18D0735678D2024BE0 /* ComplianceService.swift in Sources */,
 				240FFFC4A2B2B8F941129783 /* ConfidenceBadge.swift in Sources */,
 				65E57E8B02E7889BD8EE8DD4 /* ContextManager.swift in Sources */,
 				C09361B1A5560755F3C5DD67 /* Conversation.swift in Sources */,
@@ -2518,6 +2610,7 @@
 				EDBD7B0E715165E71BC0C17D /* DiscoveredCityRecord.swift in Sources */,
 				F11FDDDC600A1EF9C08E8193 /* EnrichmentAgent.swift in Sources */,
 				EC922EEF8917DDACE1388F06 /* EntitlementBanner.swift in Sources */,
+				1964F1B56FDCF7880F068967 /* EventMarkerView.swift in Sources */,
 				0A830B26D4A18948D16F3A42 /* Experience.swift in Sources */,
 				56F3055416F4A5316100F9B2 /* ExperienceCardView.swift in Sources */,
 				CF8B2BDE6D707CE2537C8688 /* ExperienceDetailView.swift in Sources */,
@@ -2574,9 +2667,11 @@
 				DFD30C301916759761F315CE /* ItineraryStore.swift in Sources */,
 				98245881AB35CB7BB16688FC /* JoinRouteRequestSheet.swift in Sources */,
 				48DF93F42CDDB1329B038865 /* KeychainStore.swift in Sources */,
+				541F7B63BB9364C0E768C6AC /* KitSheet.swift in Sources */,
 				953C7BD48AF4AF55608145A6 /* LanguageService.swift in Sources */,
 				5FBA4A615BD008DC38174609 /* LiveActivityLockScreenPreview.swift in Sources */,
 				C2073015CFF96A49C31767C8 /* LiveActivityService.swift in Sources */,
+				16BA72195E948AA8C4384581 /* LiveSheet.swift in Sources */,
 				36E1316045802B2F642A9623 /* LocalAttachment.swift in Sources */,
 				D52FCC8C2C36D630A8845DA6 /* LocalRouteCompanionRemote.swift in Sources */,
 				23B40396E9D7B59CB71FBCD9 /* LocationCard.swift in Sources */,
@@ -2600,6 +2695,7 @@
 				561418100F2F7D4D88DE1BC4 /* MessageBubble.swift in Sources */,
 				C7F4A9BD252AC60BDBD74585 /* MicroSurveyRecord.swift in Sources */,
 				214AF641496E8E50E3EC5FE4 /* MicroSurveySheet.swift in Sources */,
+				9A7151F34DE0156868DE3189 /* ModePlaceholderCards.swift in Sources */,
 				915E4532026427BA9F00B39D /* ModerationView.swift in Sources */,
 				8DE5E04B19F3047050C69D91 /* MonthlyInsightService.swift in Sources */,
 				4EF2AA197499B2D40A9A5848 /* MusicService.swift in Sources */,

--- a/apps/ios/SoloCompass/Models/ChatCard.swift
+++ b/apps/ios/SoloCompass/Models/ChatCard.swift
@@ -21,11 +21,16 @@ public enum ChatCard: Identifiable, Equatable {
     /// A proposed walk the agent strung together. NOT yet saved — the user taps
     /// "采用这条路线" on the card to persist it and open its detail.
     case route(id: UUID, RouteProposal)
+    /// City OS v2: 在地 events the agent found (via `find_local_events`).
+    /// Rendered as a stack of `ChatEventCard`s; tapping "在地图上看" jumps to
+    /// the event on the map.
+    case events(id: UUID, [CityEvent])
 
     public var id: UUID {
         switch self {
         case let .experiences(id, _): return id
         case let .route(id, _): return id
+        case let .events(id, _): return id
         }
     }
 

--- a/apps/ios/SoloCompass/Models/CityBrief.swift
+++ b/apps/ios/SoloCompass/Models/CityBrief.swift
@@ -1,0 +1,308 @@
+import Foundation
+
+// MARK: - City OS v2 · city-brief value types (PRD solo-city-os-v2 §4–5)
+//
+// Server truth lives in Supabase `city_kits` / `city_events` (public-read RLS,
+// written only by the compile-city-brief pipeline). These value types decode
+// the server row shape directly — CodingKeys below ARE the column names — so
+// the same decoder handles both the bundled seed JSON and the REST payload.
+
+/// The traveler's relationship with a city: currently there, planning a visit,
+/// or looking back after leaving. Switching mode switches the whole aggregation
+/// context (PRD §4.1) — it is not a filter.
+public enum CityMode: String, Codable, Sendable, CaseIterable {
+    case live
+    case plan
+    case recall
+}
+
+/// A structured action attached to a landing-kit row, interpreted by the
+/// client (e.g. schedule a visa-expiry reminder, render tappable emergency
+/// numbers). Mirrors the `action` jsonb column of `city_kits`.
+public struct CityKitAction: Codable, Equatable, Sendable {
+    /// One dialable emergency contact, kept offline-usable (PRD §5.2).
+    public struct EmergencyNumber: Codable, Equatable, Sendable {
+        /// Display label, e.g. "警察".
+        public let label: String
+        /// Dialable number string, e.g. "191".
+        public let number: String
+
+        /// Creates an emergency contact entry.
+        public init(label: String, number: String) {
+            self.label = label
+            self.number = number
+        }
+    }
+
+    /// Action discriminator: `"visa_reminder"` or `"emergency_numbers"`.
+    public let type: String
+    /// Visa validity in days for `visa_reminder` actions (e.g. 30 for 落地签).
+    public let visaDays: Int?
+    /// Tax-residency threshold in days for `visa_reminder` actions (183).
+    public let taxLineDays: Int?
+    /// Dialable contacts for `emergency_numbers` actions.
+    public let numbers: [EmergencyNumber]?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case visaDays = "visa_days"
+        case taxLineDays = "tax_line_days"
+        case numbers
+    }
+
+    /// Creates a kit-row action.
+    public init(type: String, visaDays: Int? = nil, taxLineDays: Int? = nil, numbers: [EmergencyNumber]? = nil) {
+        self.type = type
+        self.visaDays = visaDays
+        self.taxLineDays = taxLineDays
+        self.numbers = numbers
+    }
+}
+
+/// One row of the 落地包 landing kit: a curated, solo-lens-annotated essential
+/// (connectivity / money / visa / safety) with verification provenance.
+/// Decodes a `city_kits` server row (CodingKeys = column names).
+public struct CityKitItem: Codable, Equatable, Sendable, Identifiable {
+    /// The four kit sections. Raw values match the `city_kits.section`
+    /// check constraint exactly — do not rename.
+    public enum Kind: String, Codable, Sendable, CaseIterable {
+        case net
+        case money
+        case visa
+        case safety
+
+        /// SF Symbol used for the row icon.
+        public var symbolName: String {
+            switch self {
+            case .net:    return "wifi"
+            case .money:  return "dollarsign.circle"
+            case .visa:   return "person.text.rectangle"
+            case .safety: return "shield"
+            }
+        }
+    }
+
+    /// Stable identity: one row per (city, section).
+    public var id: String { "\(cityCode).\(kind.rawValue)" }
+
+    /// Lowercase city code, e.g. "vte" (DB convention; iOS canonical "VTE"
+    /// is lowercased before queries).
+    public let cityCode: String
+    /// Which of the four kit sections this row is.
+    public let kind: Kind
+    /// Row title, e.g. "联网".
+    public let name: String
+    /// Main copy, e.g. "Airalo 老挝 eSIM · 或 Unitel 门店".
+    public let main: String
+    /// 独行透镜 one-liner — judgment applied to the sourced facts.
+    public let lens: String?
+    /// Server-declared health ("green"/"yellow"/"red"/"gray"). Advisory only;
+    /// render via `CityBriefHealth.health(lastVerifiedAt:serverHealth:now:)`.
+    public let serverHealth: String?
+    /// When the pipeline (or a curator) last re-verified this row.
+    public let lastVerifiedAt: Date?
+    /// Optional deep link (Airalo / Wise / GeoSure …).
+    public let linkURL: URL?
+    /// Short label for the deep link, used in the "已为你打开 …" toast.
+    public let linkLabel: String?
+    /// Optional structured action (visa reminder, emergency numbers).
+    public let action: CityKitAction?
+
+    enum CodingKeys: String, CodingKey {
+        case cityCode = "city_code"
+        case kind = "section"
+        case name
+        case main = "body"
+        case lens = "lens_line"
+        case serverHealth = "health"
+        case lastVerifiedAt = "last_verified_at"
+        case linkURL = "link_url"
+        case linkLabel = "link_label"
+        case action
+    }
+
+    /// Creates a kit row (primarily for tests and previews).
+    public init(
+        cityCode: String,
+        kind: Kind,
+        name: String,
+        main: String,
+        lens: String? = nil,
+        serverHealth: String? = nil,
+        lastVerifiedAt: Date? = nil,
+        linkURL: URL? = nil,
+        linkLabel: String? = nil,
+        action: CityKitAction? = nil
+    ) {
+        self.cityCode = cityCode
+        self.kind = kind
+        self.name = name
+        self.main = main
+        self.lens = lens
+        self.serverHealth = serverHealth
+        self.lastVerifiedAt = lastVerifiedAt
+        self.linkURL = linkURL
+        self.linkLabel = linkLabel
+        self.action = action
+    }
+}
+
+/// One 在地 local happening — event, festival, market, or a travel-affecting
+/// notice — with a solo-friendliness judgment and honest provenance.
+/// Decodes a `city_events` server row (CodingKeys = column names).
+public struct CityEvent: Codable, Equatable, Sendable, Identifiable {
+    /// Deterministic server id: `evt_{city}_{slug}_{yyyymmdd}`.
+    public let id: String
+    /// Lowercase city code, e.g. "vte".
+    public let cityCode: String
+    /// Event name as sourced, e.g. "那伽火球节前导市集".
+    public let name: String
+    /// Display time string in the traveler's terms, e.g. "周五傍晚".
+    public let whenLabel: String
+    /// Event start, when the source stated one.
+    public let startsAt: Date?
+    /// Event end — drives client-side expiry (`CityBriefHealth.isExpired`).
+    public let endsAt: Date?
+    /// Solo-friendliness 0–10 (SoloScore rubric applied to the event);
+    /// nil for notices.
+    public let soloScore: Double?
+    /// One-line "一个人去合不合适" judgment.
+    public let soloNote: String?
+    /// Server-declared health; advisory only (see `CityBriefHealth`).
+    public let serverHealth: String?
+    /// Provenance label, e.g. "主办方页面 · 7月3日" or "人工策展".
+    public let seenLabel: String?
+    /// Map latitude; nil for events without a fixed venue.
+    public let lat: Double?
+    /// Map longitude; nil for events without a fixed venue.
+    public let lng: Double?
+    /// Limited-time chip text, e.g. "仅本周".
+    public let limitedLabel: String?
+    /// Category slug ("culture"/"market"/…/"notice").
+    public let category: String?
+    /// The source page this item was curated from (anti-hallucination invariant).
+    public let sourceURL: URL?
+
+    /// True for travel-affecting notices (road closures, strikes) — rendered
+    /// in the warning treatment, never scored for solo-friendliness.
+    public var isNotice: Bool { category == "notice" }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case cityCode = "city_code"
+        case name
+        case whenLabel = "when_label"
+        case startsAt = "starts_at"
+        case endsAt = "ends_at"
+        case soloScore = "solo_score"
+        case soloNote = "solo_note"
+        case serverHealth = "health"
+        case seenLabel = "seen_label"
+        case lat
+        case lng
+        case limitedLabel = "limited_label"
+        case category
+        case sourceURL = "source_url"
+    }
+
+    /// Creates an event (primarily for tests and previews).
+    public init(
+        id: String,
+        cityCode: String,
+        name: String,
+        whenLabel: String,
+        startsAt: Date? = nil,
+        endsAt: Date? = nil,
+        soloScore: Double? = nil,
+        soloNote: String? = nil,
+        serverHealth: String? = nil,
+        seenLabel: String? = nil,
+        lat: Double? = nil,
+        lng: Double? = nil,
+        limitedLabel: String? = nil,
+        category: String? = nil,
+        sourceURL: URL? = nil
+    ) {
+        self.id = id
+        self.cityCode = cityCode
+        self.name = name
+        self.whenLabel = whenLabel
+        self.startsAt = startsAt
+        self.endsAt = endsAt
+        self.soloScore = soloScore
+        self.soloNote = soloNote
+        self.serverHealth = serverHealth
+        self.seenLabel = seenLabel
+        self.lat = lat
+        self.lng = lng
+        self.limitedLabel = limitedLabel
+        self.category = category
+        self.sourceURL = sourceURL
+    }
+}
+
+// MARK: - Pure health / expiry / daily-pick logic
+
+/// Client-side freshness rules for city-brief content. Pure and clock-injected
+/// so every threshold is unit-testable (mirrors `Confidence.health`, which the
+/// PRD's "信心贯穿一切" rule extends to kit rows and events).
+public enum CityBriefHealth {
+    /// Combines server-declared health with local age decay. The server value
+    /// is a floor that can only be *downgraded* by staleness, never upgraded:
+    /// - no `lastVerifiedAt` → `.questioned` (unverifiable is dishonest to green-light)
+    /// - older than 60 days → `.mayBeGone` (same cliff as `Confidence.health`)
+    /// - fresher than 30 days → the server floor (green→healthy, yellow→fading,
+    ///   red→questioned, gray/unknown→fading)
+    /// - 30–60 days → capped at `.fading` (except red, which stays `.questioned`)
+    public static func health(lastVerifiedAt: Date?, serverHealth: String?, now: Date = Date()) -> HealthStatus {
+        guard let verified = lastVerifiedAt else { return .questioned }
+        let ageDays = now.timeIntervalSince(verified) / 86_400
+        if ageDays > 60 { return .mayBeGone }
+        let floor: HealthStatus
+        switch serverHealth {
+        case "green":  floor = .healthy
+        case "yellow": floor = .fading
+        case "red":    floor = .questioned
+        default:       floor = .fading
+        }
+        if ageDays < 30 { return floor }
+        return floor == .questioned ? .questioned : .fading
+    }
+
+    /// Whether an event should no longer be shown. Past `endsAt` → expired;
+    /// with no `endsAt`, falls back to `startsAt` + 1 day; with neither, the
+    /// event is kept (the server schema makes `ends_at` NOT NULL, so this is
+    /// belt-and-braces for hand-written fixtures).
+    public static func isExpired(_ event: CityEvent, now: Date = Date()) -> Bool {
+        if let ends = event.endsAt { return ends < now }
+        if let starts = event.startsAt { return starts.addingTimeInterval(86_400) < now }
+        return false
+    }
+
+    /// The deterministic 今日城市签 pick: among unexpired, non-notice events,
+    /// prefer the highest solo score; break ties with a stable FNV-1a hash of
+    /// `(event.id + local day key)` so the pick is identical all day and across
+    /// launches (Swift's `hashValue` is process-seeded and unusable here).
+    public static func dailyPick(from events: [CityEvent], now: Date = Date(), calendar: Calendar = .current) -> CityEvent? {
+        let candidates = events.filter { !isExpired($0, now: now) && !$0.isNotice }
+        guard !candidates.isEmpty else { return nil }
+        let comps = calendar.dateComponents([.year, .month, .day], from: now)
+        let dayKey = String(format: "%04d-%02d-%02d", comps.year ?? 0, comps.month ?? 0, comps.day ?? 0)
+        return candidates.max { lhs, rhs in
+            let lhsScore = lhs.soloScore ?? 0
+            let rhsScore = rhs.soloScore ?? 0
+            if lhsScore != rhsScore { return lhsScore < rhsScore }
+            return stableHash(lhs.id + dayKey) < stableHash(rhs.id + dayKey)
+        }
+    }
+
+    /// FNV-1a 64-bit — deterministic across processes, unlike `Hasher`.
+    static func stableHash(_ string: String) -> UInt64 {
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in string.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x100000001b3
+        }
+        return hash
+    }
+}

--- a/apps/ios/SoloCompass/Models/UserPreferences.swift
+++ b/apps/ios/SoloCompass/Models/UserPreferences.swift
@@ -88,6 +88,14 @@ public final class UserPreferences {
         // stored so an A/B test can set it without a code change.
         var companionModuleStrengthRaw: String = ModuleStrength.restrained.rawValue
 
+        // City OS v2 (PRD solo-city-os-v2 §4–5): visa self-computation inputs,
+        // once-per-city kit auto-surface bookkeeping, and per-city mode.
+        var visaEntryDate: Date?
+        var visaLengthDays: Int?
+        var visaReminderEnabled: Bool = false
+        var kitSeenCities: Set<String> = []
+        var cityModesRaw: [String: String] = [:]
+
         // swiftlint:disable:next nesting
         enum CodingKeys: String, CodingKey {
             case preferredCategories, dislikedCategories, soloTravelStyle, maxDistanceKm
@@ -104,6 +112,8 @@ public final class UserPreferences {
             case hasAcceptedCompanionConsent, companionConsentGivenAt
             case companionEnabled
             case companionModuleStrengthRaw
+            case visaEntryDate, visaLengthDays, visaReminderEnabled
+            case kitSeenCities, cityModesRaw
         }
 
         init() {}
@@ -146,7 +156,12 @@ public final class UserPreferences {
             hasAcceptedCompanionConsent: Bool = false,
             companionConsentGivenAt: Date? = nil,
             companionEnabled: Bool = false,
-            companionModuleStrengthRaw: String = ModuleStrength.restrained.rawValue
+            companionModuleStrengthRaw: String = ModuleStrength.restrained.rawValue,
+            visaEntryDate: Date? = nil,
+            visaLengthDays: Int? = nil,
+            visaReminderEnabled: Bool = false,
+            kitSeenCities: Set<String> = [],
+            cityModesRaw: [String: String] = [:]
         ) {
             self.preferredCategories = preferredCategories
             self.dislikedCategories = dislikedCategories
@@ -186,6 +201,11 @@ public final class UserPreferences {
             self.companionConsentGivenAt = companionConsentGivenAt
             self.companionEnabled = companionEnabled
             self.companionModuleStrengthRaw = companionModuleStrengthRaw
+            self.visaEntryDate = visaEntryDate
+            self.visaLengthDays = visaLengthDays
+            self.visaReminderEnabled = visaReminderEnabled
+            self.kitSeenCities = kitSeenCities
+            self.cityModesRaw = cityModesRaw
         }
 
         init(from decoder: Decoder) throws {
@@ -229,6 +249,11 @@ public final class UserPreferences {
             self.companionConsentGivenAt = try container.decodeIfPresent(Date.self, forKey: .companionConsentGivenAt)
             self.companionEnabled = try container.decodeIfPresent(Bool.self, forKey: .companionEnabled) ?? false
             self.companionModuleStrengthRaw = try container.decodeIfPresent(String.self, forKey: .companionModuleStrengthRaw) ?? ModuleStrength.restrained.rawValue
+            self.visaEntryDate = try container.decodeIfPresent(Date.self, forKey: .visaEntryDate)
+            self.visaLengthDays = try container.decodeIfPresent(Int.self, forKey: .visaLengthDays)
+            self.visaReminderEnabled = try container.decodeIfPresent(Bool.self, forKey: .visaReminderEnabled) ?? false
+            self.kitSeenCities = try container.decodeIfPresent(Set<String>.self, forKey: .kitSeenCities) ?? []
+            self.cityModesRaw = try container.decodeIfPresent([String: String].self, forKey: .cityModesRaw) ?? [:]
         }
     }
 
@@ -349,6 +374,23 @@ public final class UserPreferences {
         set { companionModuleStrengthRaw = newValue.rawValue }
     }
 
+    // City OS v2 (PRD solo-city-os-v2 §4–5)
+
+    /// The day the traveler entered the current country — the sole input to
+    /// the visa / 183-day self-computation (`ComplianceMath`). Local-only;
+    /// nil until the user fills the kit's visa row.
+    public var visaEntryDate: Date? { didSet { persist() } }
+    /// Visa validity in days (e.g. 30 for 落地签). Nil until the user sets it.
+    public var visaLengthDays: Int? { didSet { persist() } }
+    /// Whether the local visa-expiry reminder notification is enabled.
+    public var visaReminderEnabled: Bool { didSet { persist() } }
+    /// Lowercase city codes whose landing kit has already auto-surfaced once —
+    /// the kit only ever pushes itself on first arrival (PRD §4.3).
+    public var kitSeenCities: Set<String> { didSet { persist() } }
+    /// Per-city mode (`CityMode.rawValue`) keyed by lowercase city code.
+    /// Read/written through `CityOSStore`; default is `live`.
+    public var cityModesRaw: [String: String] { didSet { persist() } }
+
     /// Typed access to the selected AI provider. Reads/writes `aiProviderRaw`.
     public var aiProvider: AIProvider {
         get { AIProvider(rawValue: aiProviderRaw) ?? .deepseek }
@@ -405,6 +447,11 @@ public final class UserPreferences {
         self.companionConsentGivenAt = snapshot.companionConsentGivenAt
         self.companionEnabled = snapshot.companionEnabled
         self.companionModuleStrengthRaw = snapshot.companionModuleStrengthRaw
+        self.visaEntryDate = snapshot.visaEntryDate
+        self.visaLengthDays = snapshot.visaLengthDays
+        self.visaReminderEnabled = snapshot.visaReminderEnabled
+        self.kitSeenCities = snapshot.kitSeenCities
+        self.cityModesRaw = snapshot.cityModesRaw
 
         // One-time migration: bump the historical 5 km default to the new 8 km
         // cold-start default for users who never touched the distance slider.
@@ -471,7 +518,12 @@ public final class UserPreferences {
             hasAcceptedCompanionConsent: hasAcceptedCompanionConsent,
             companionConsentGivenAt: companionConsentGivenAt,
             companionEnabled: companionEnabled,
-            companionModuleStrengthRaw: companionModuleStrengthRaw
+            companionModuleStrengthRaw: companionModuleStrengthRaw,
+            visaEntryDate: visaEntryDate,
+            visaLengthDays: visaLengthDays,
+            visaReminderEnabled: visaReminderEnabled,
+            kitSeenCities: kitSeenCities,
+            cityModesRaw: cityModesRaw
         )
         do {
             let data = try JSONEncoder.iso8601Encoder.encode(snapshot)

--- a/apps/ios/SoloCompass/Persistence/Models/CityBriefCacheRecord.swift
+++ b/apps/ios/SoloCompass/Persistence/Models/CityBriefCacheRecord.swift
@@ -1,0 +1,24 @@
+import Foundation
+import SwiftData
+
+/// Cached city-brief content (落地包 kit rows + 在地 events) for one city,
+/// keyed by lowercase city code. Used by `CityBriefService` so the kit and
+/// events render instantly and stay offline-usable between refreshes.
+///
+/// Whole-payload JSON blobs (same idiom as `WeatherCacheRecord`): the cache
+/// survives value-type shape changes, and there is no per-row mapping code to
+/// drift. `fetchedAt` drives the service's refresh TTL.
+@Model
+public final class CityBriefCacheRecord {
+    @Attribute(.unique) public var cityCode: String
+    public var kitJSON: Data
+    public var eventsJSON: Data
+    public var fetchedAt: Date
+
+    public init(cityCode: String, kitJSON: Data, eventsJSON: Data, fetchedAt: Date = Date()) {
+        self.cityCode = cityCode
+        self.kitJSON = kitJSON
+        self.eventsJSON = eventsJSON
+        self.fetchedAt = fetchedAt
+    }
+}

--- a/apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift
+++ b/apps/ios/SoloCompass/Persistence/SoloCompassModelContainer.swift
@@ -236,7 +236,19 @@ public enum SoloCompassSchemaV1_9: VersionedSchema {
     }
 }
 
-/// Migration plan stitching v1.0 → v1.1 → … → v1.9. Each change is additive (an
+/// v1.10 — City OS v2 (PRD solo-city-os-v2): per-city cached 落地包 kit rows +
+/// 在地 events. Additive table only — lightweight.
+public enum SoloCompassSchemaV1_10: VersionedSchema {
+    public static var versionIdentifier: Schema.Version { .init(1, 10, 0) }
+
+    public static var models: [any PersistentModel.Type] {
+        SoloCompassSchemaV1_9.models + [
+            CityBriefCacheRecord.self,
+        ]
+    }
+}
+
+/// Migration plan stitching v1.0 → v1.1 → … → v1.10. Each change is additive (an
 /// optional `Data?` column, new @Model tables) or a NOT NULL relaxation, so every
 /// hop is a lightweight migration.
 public enum SoloCompassMigrationPlan: SchemaMigrationPlan {
@@ -252,6 +264,7 @@ public enum SoloCompassMigrationPlan: SchemaMigrationPlan {
             SoloCompassSchemaV1_7.self,
             SoloCompassSchemaV1_8.self,
             SoloCompassSchemaV1_9.self,
+            SoloCompassSchemaV1_10.self,
         ]
     }
 
@@ -292,6 +305,10 @@ public enum SoloCompassMigrationPlan: SchemaMigrationPlan {
             .lightweight(
                 fromVersion: SoloCompassSchemaV1_8.self,
                 toVersion: SoloCompassSchemaV1_9.self
+            ),
+            .lightweight(
+                fromVersion: SoloCompassSchemaV1_9.self,
+                toVersion: SoloCompassSchemaV1_10.self
             ),
         ]
     }
@@ -361,6 +378,8 @@ public enum SoloCompassModelContainer {
                 TasteProfile.self,
                 TimeCapsule.self,
                 AgentMemorySnapshot.self,
+                // v1.10 — City OS v2 city-brief cache.
+                CityBriefCacheRecord.self,
                 configurations: config
             )
             // Tag the SQLite store + WAL/SHM siblings with
@@ -424,6 +443,8 @@ public enum SoloCompassModelContainer {
                 TasteProfile.self,
                 TimeCapsule.self,
                 AgentMemorySnapshot.self,
+                // v1.10 — City OS v2 city-brief cache.
+                CityBriefCacheRecord.self,
                 configurations: config
             )
         } catch {

--- a/apps/ios/SoloCompass/Resources/JSON/seed_city_brief_vte.json
+++ b/apps/ios/SoloCompass/Resources/JSON/seed_city_brief_vte.json
@@ -1,0 +1,111 @@
+{
+  "kit": [
+    {
+      "city_code": "vte",
+      "section": "net",
+      "name": "联网",
+      "body": "Airalo 老挝 eSIM · 或 Unitel 门店",
+      "lens_line": "机场到市区先用 eSIM，别机场柜台换卡",
+      "health": "green",
+      "last_verified_at": "2026-07-01T00:00:00Z",
+      "link_url": "https://www.airalo.com/laos-esim",
+      "link_label": "Airalo",
+      "action": null
+    },
+    {
+      "city_code": "vte",
+      "section": "money",
+      "name": "钱",
+      "body": "Wise 汇率最优 · ATM 每笔手续费高，建议一次多取",
+      "lens_line": "多数咖啡馆只收现金；本地扫码用 BCEL One",
+      "health": "yellow",
+      "last_verified_at": "2026-06-20T00:00:00Z",
+      "link_url": "https://wise.com/currency-converter/usd-to-lak-rate",
+      "link_label": "Wise",
+      "action": null
+    },
+    {
+      "city_code": "vte",
+      "section": "visa",
+      "name": "签证 / 税务",
+      "body": "落地签 30 天 · 入境日只记在本机 · 183 天税务线自算",
+      "lens_line": "落地签窗口备好现金与照片；计时离线可用",
+      "health": "green",
+      "last_verified_at": "2026-07-01T00:00:00Z",
+      "link_url": null,
+      "link_label": null,
+      "action": { "type": "visa_reminder", "visa_days": 30, "tax_line_days": 183 }
+    },
+    {
+      "city_code": "vte",
+      "section": "safety",
+      "name": "安全",
+      "body": "市中心 / 湄公河岸独自较稳 · 夜间避开偏僻河堤",
+      "lens_line": "急救号码离线常驻，一键可拨",
+      "health": "green",
+      "last_verified_at": "2026-07-01T00:00:00Z",
+      "link_url": "https://www.geosureglobal.com",
+      "link_label": "GeoSure",
+      "action": {
+        "type": "emergency_numbers",
+        "numbers": [
+          { "label": "警察", "number": "191" },
+          { "label": "旅游警察", "number": "1195" }
+        ]
+      }
+    }
+  ],
+  "events": [
+    {
+      "id": "evt_vte_naga_fireball_market_20260710",
+      "city_code": "vte",
+      "name": "那伽火球节前导市集",
+      "category": "market",
+      "when_label": "周五 17:00–21:00",
+      "starts_at": "2026-07-10T10:00:00Z",
+      "ends_at": "2026-07-10T14:00:00Z",
+      "solo_score": 8.5,
+      "solo_note": "适合一个人逛，摊位间距大，不会被裹挟",
+      "health": "green",
+      "seen_label": "人工策展 · 7月5日",
+      "lat": 17.9648,
+      "lng": 102.6108,
+      "limited_label": "本周五限时",
+      "source_url": "https://www.tourismlaos.org/events"
+    },
+    {
+      "id": "evt_vte_thatluang_night_market_20260706",
+      "city_code": "vte",
+      "name": "塔銮周边夜市",
+      "category": "market",
+      "when_label": "本周每晚",
+      "starts_at": "2026-07-06T11:00:00Z",
+      "ends_at": "2026-07-12T15:30:00Z",
+      "solo_score": 8.0,
+      "solo_note": "摊贩不推销，独自吃一圈无压力",
+      "health": "yellow",
+      "seen_label": "人工策展 · 7月5日",
+      "lat": 17.9764,
+      "lng": 102.6350,
+      "limited_label": null,
+      "source_url": "https://www.tourismlaos.org/vientiane"
+    },
+    {
+      "id": "evt_vte_riverside_road_notice_20260708",
+      "city_code": "vte",
+      "name": "湄公河岸步道段整修封闭",
+      "category": "notice",
+      "when_label": "周三起 · 全天",
+      "starts_at": "2026-07-07T17:00:00Z",
+      "ends_at": "2026-07-13T17:00:00Z",
+      "solo_score": null,
+      "solo_note": "傍晚散步改走 Chao Anouvong 公园一侧",
+      "health": "green",
+      "seen_label": "本地新闻 · 7月4日",
+      "lat": 17.9614,
+      "lng": 102.6070,
+      "limited_label": "临时",
+      "source_url": "https://www.vientianetimes.org.la"
+    }
+  ]
+}

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -2187,6 +2187,12 @@
 "dev.flag.companion.subtitle" = "Friends, DMs, and companion discovery.";
 "dev.flag.companionLayer.title" = "Companion map layer";
 "dev.flag.companionLayer.subtitle" = "In-map toggle for nearby presence cells.";
+"dev.flag.cityOS.title" = "City OS";
+"dev.flag.cityOS.subtitle" = "Landing kit, local events, compliance banner, and city modes.";
+
+/* City OS v2: visa-expiry local reminder (PRD §5.2) */
+"cityos.visa.reminder.title" = "Visa reminder";
+"cityos.visa.reminder.body" = "%d days left on your visa — time to decide: extend, or book the next leg.";
 
 "dev.tools.header" = "Debug Tools";
 "dev.tools.entitlement" = "Force entitlement";

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -896,6 +896,7 @@
 /* Reasoning trace (elegant "thinking" panel) */
 "agent.trace.foundPlaces" = "Found %d place(s) that fit";
 "agent.trace.builtRoute" = "Strung %d stops into a walk";
+"agent.trace.foundEvents" = "Found %d local event(s)";
 "chat.thinking.title" = "Thinking it through";
 "chat.thinking.a11y" = "Solo Compass is thinking";
 
@@ -2193,6 +2194,52 @@
 /* City OS v2: visa-expiry local reminder (PRD §5.2) */
 "cityos.visa.reminder.title" = "Visa reminder";
 "cityos.visa.reminder.body" = "%d days left on your visa — time to decide: extend, or book the next leg.";
+
+/* City OS v2: landing kit (落地包) */
+"cityos.kit.title" = "Landing Kit";
+"cityos.kit.link.open" = "Open";
+"cityos.kit.link.open.a11y" = "Open %@";
+"cityos.kit.link.toast" = "Opened %@ · come back to continue";
+"cityos.kit.call.a11y" = "Call %1$@ at %2$@";
+"cityos.health.unverified" = "unverified";
+
+/* City OS v2: visa / 183-day compliance */
+"cityos.visa.daysLeft" = "days of visa left";
+"cityos.visa.taxLine" = "days to the 183-day tax line";
+"cityos.visa.reminder.toggle" = "Expiry reminder";
+"cityos.visa.entryDate" = "Entry date";
+"cityos.visa.length" = "Visa %d days";
+"cityos.compliance.prefix" = "Visa: ";
+"cityos.compliance.suffix" = " days left";
+"cityos.compliance.overstay" = "Overstayed by %d days";
+"cityos.compliance.handle" = "Handle";
+"cityos.compliance.a11y" = "Visa: %d days remaining";
+
+/* City OS v2: local events (在地 · 本周) */
+"cityos.live.title" = "Local · This Week";
+"cityos.live.solo" = "Solo %@";
+"cityos.live.showOnMap" = "Show on map";
+"cityos.live.showOnMap.a11y" = "Show %@ on the map";
+"cityos.live.empty.title" = "Nothing on this week";
+"cityos.live.empty.hint" = "Check back — the city brief refreshes twice a week.";
+"cityos.event.marker.a11y" = "Event: %1$@, %2$@";
+
+/* City OS v2: drawer tabs + modes */
+"cityos.tab.kit" = "Landing Kit";
+"cityos.tab.live" = "Local · This Week";
+"cityos.mode.thisCity" = "This city";
+"cityos.picker.mode.section" = "City mode";
+"cityos.mode.live.tag" = "Here now";
+"cityos.mode.plan.tag" = "Plan";
+"cityos.mode.plan.title" = "%@ · Planning";
+"cityos.mode.plan.body" = "Pre-trip checklist, visa timing, and what to line up before you land — coming soon.";
+"cityos.mode.plan.cta" = "See the landing kit";
+"cityos.mode.recall.tag" = "Recall";
+"cityos.mode.recall.title" = "%@ · Looking back";
+"cityos.mode.recall.body" = "Your walks, moments, and what this city was like for you — coming soon.";
+
+/* City OS v2: today's city omen (今日城市签) */
+"cityos.omen.line" = "Today's city omen · %@";
 
 "dev.tools.header" = "Debug Tools";
 "dev.tools.entitlement" = "Force entitlement";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1018,6 +1018,7 @@
 "agent.step.buildRoute" = "🧭 正在为你串联路线…";
 "agent.trace.foundPlaces" = "找到 %d 个合适的地方";
 "agent.trace.builtRoute" = "把 %d 个站点串成了一条路线";
+"agent.trace.foundEvents" = "找到 %d 场在地活动";
 "chat.thinking.title" = "正在思考";
 "chat.thinking.a11y" = "Solo Compass 正在思考";
 "agent.trace.summary.steps" = "推理了 %d 步";
@@ -2203,6 +2204,52 @@
 /* City OS v2: visa-expiry local reminder (PRD §5.2) */
 "cityos.visa.reminder.title" = "签证提醒";
 "cityos.visa.reminder.body" = "签证还剩 %d 天 —— 该决定续签，还是订下一程了。";
+
+/* City OS v2: 落地包 landing kit */
+"cityos.kit.title" = "落地包";
+"cityos.kit.link.open" = "打开";
+"cityos.kit.link.open.a11y" = "打开 %@";
+"cityos.kit.link.toast" = "已为你打开 %@ · 回来继续";
+"cityos.kit.call.a11y" = "拨打 %1$@ %2$@";
+"cityos.health.unverified" = "未核实";
+
+/* City OS v2: 签证 / 183 天税务 */
+"cityos.visa.daysLeft" = "剩 N 天签证";
+"cityos.visa.taxLine" = "距 183 天税务线";
+"cityos.visa.reminder.toggle" = "到期提醒";
+"cityos.visa.entryDate" = "入境日期";
+"cityos.visa.length" = "签证 %d 天";
+"cityos.compliance.prefix" = "签证还剩 ";
+"cityos.compliance.suffix" = " 天";
+"cityos.compliance.overstay" = "已逾期 %d 天";
+"cityos.compliance.handle" = "处理";
+"cityos.compliance.a11y" = "签证还剩 %d 天";
+
+/* City OS v2: 在地 · 本周 local events */
+"cityos.live.title" = "在地 · 本周";
+"cityos.live.solo" = "Solo %@";
+"cityos.live.showOnMap" = "在地图上看";
+"cityos.live.showOnMap.a11y" = "在地图上查看 %@";
+"cityos.live.empty.title" = "本周暂无在地活动";
+"cityos.live.empty.hint" = "过些天再来看看 —— 城市简报每周更新两次。";
+"cityos.event.marker.a11y" = "活动：%1$@，%2$@";
+
+/* City OS v2: 抽屉药丸与城市模式 */
+"cityos.tab.kit" = "落地包";
+"cityos.tab.live" = "在地 · 本周";
+"cityos.mode.thisCity" = "这座城市";
+"cityos.picker.mode.section" = "城市模式";
+"cityos.mode.live.tag" = "在此城";
+"cityos.mode.plan.tag" = "计划";
+"cityos.mode.plan.title" = "%@ · 计划中";
+"cityos.mode.plan.body" = "行前清单、签证时点、落地前该安排好的事 —— 即将上线。";
+"cityos.mode.plan.cta" = "先看落地包";
+"cityos.mode.recall.tag" = "回顾";
+"cityos.mode.recall.title" = "%@ · 回顾";
+"cityos.mode.recall.body" = "你走过的路、停留的瞬间、这座城市于你的样子 —— 即将上线。";
+
+/* City OS v2: 今日城市签 daily omen */
+"cityos.omen.line" = "今日城市签 · %@";
 
 "dev.tools.header" = "调试工具";
 "dev.tools.entitlement" = "强制会员权益";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -2197,6 +2197,12 @@
 "dev.flag.companion.subtitle" = "好友、私信与同行发现。";
 "dev.flag.companionLayer.title" = "同行地图图层";
 "dev.flag.companionLayer.subtitle" = "地图内的附近在场单元开关。";
+"dev.flag.cityOS.title" = "城市 OS";
+"dev.flag.cityOS.subtitle" = "落地包、在地活动、合规横幅与城市模式。";
+
+/* City OS v2: visa-expiry local reminder (PRD §5.2) */
+"cityos.visa.reminder.title" = "签证提醒";
+"cityos.visa.reminder.body" = "签证还剩 %d 天 —— 该决定续签，还是订下一程了。";
 
 "dev.tools.header" = "调试工具";
 "dev.tools.entitlement" = "强制会员权益";

--- a/apps/ios/SoloCompass/Services/CityBriefService.swift
+++ b/apps/ios/SoloCompass/Services/CityBriefService.swift
@@ -1,0 +1,207 @@
+import Foundation
+import Observation
+import SwiftData
+import os
+
+/// City OS v2 content plane (PRD §5.2–5.3): loads the 落地包 kit rows and
+/// 在地 events for the selected city.
+///
+/// Read path is strictly cache-first and offline-honest:
+/// 1. publish the SwiftData cache immediately (`CityBriefCacheRecord`),
+/// 2. if the cache is stale (>6h) and backend sync is on, refresh from the
+///    public-read `city_kits` / `city_events` tables and republish,
+/// 3. with neither cache nor network, fall back to the bundled Vientiane
+///    seed so DEBUG/simulator and fresh installs still render every surface.
+///
+/// Any failed or short-circuited fetch (offline, `FF_BACKEND_SYNC` off →
+/// empty `Data`, not signed in) means "no update" — it must NEVER clear the
+/// cache. Freshness honesty comes from `CityBriefHealth`, not from hiding
+/// content.
+@MainActor
+@Observable
+public final class CityBriefService {
+    private static let logger = Logger(subsystem: "com.solocompass", category: "CityBriefService")
+    private static let refreshTTL: TimeInterval = 6 * 3_600
+
+    /// Kit rows for the currently loaded city (empty until `load` runs).
+    public private(set) var kit: [CityKitItem] = []
+    /// All cached events for the currently loaded city, including ones that
+    /// have expired since fetch — render through `activeEvents(now:)`.
+    public private(set) var events: [CityEvent] = []
+    /// Lowercase code of the currently loaded city.
+    public private(set) var loadedCityCode: String?
+
+    private let modelContext: ModelContext
+    private let supabase: SupabaseClient
+    private let seedLoader: (String) -> Data?
+
+    /// Creates the service.
+    /// - Parameters:
+    ///   - container: SwiftData container (tests pass `makeInMemory()`).
+    ///   - supabase: REST client (defaults to the shared singleton).
+    ///   - seedLoader: bundled-seed lookup by lowercase city code; the default
+    ///     reads `seed_city_brief_<code>.json` from the main bundle.
+    public init(
+        container: ModelContainer = SoloCompassModelContainer.shared,
+        supabase: SupabaseClient = .shared,
+        seedLoader: ((String) -> Data?)? = nil
+    ) {
+        self.modelContext = ModelContext(container)
+        self.supabase = supabase
+        self.seedLoader = seedLoader ?? { code in
+            guard let url = Bundle.main.url(forResource: "seed_city_brief_\(code)", withExtension: "json") else {
+                return nil
+            }
+            return try? Data(contentsOf: url)
+        }
+    }
+
+    /// Whether any kit content exists for the city (cache or bundled seed) —
+    /// the auto-surface guard checks this before pushing the sheet.
+    public func hasKit(for cityCode: String) -> Bool {
+        let code = CityOSStore.normalizedCityKey(cityCode)
+        if loadedCityCode == code { return !kit.isEmpty }
+        if let record = cachedRecord(for: code) {
+            return !((try? Self.decoder.decode([CityKitItem].self, from: record.kitJSON))?.isEmpty ?? true)
+        }
+        return seedLoader(code) != nil
+    }
+
+    /// Events that are still current (unexpired), for map markers and sheets.
+    public func activeEvents(now: Date = Date()) -> [CityEvent] {
+        events.filter { !CityBriefHealth.isExpired($0, now: now) }
+    }
+
+    /// The deterministic 今日城市签 pick for the loaded city.
+    public func dailyPick(now: Date = Date()) -> CityEvent? {
+        CityBriefHealth.dailyPick(from: events, now: now)
+    }
+
+    /// Loads content for a city: cache first, then a TTL-gated network
+    /// refresh, then the bundled seed as last resort.
+    public func load(cityCode: String, now: Date = Date()) async {
+        let code = CityOSStore.normalizedCityKey(cityCode)
+        loadedCityCode = code
+
+        var cacheFetchedAt: Date?
+        if let record = cachedRecord(for: code) {
+            publish(kitJSON: record.kitJSON, eventsJSON: record.eventsJSON, cityCode: code)
+            cacheFetchedAt = record.fetchedAt
+        } else {
+            kit = []
+            events = []
+        }
+
+        let cacheIsFresh = cacheFetchedAt.map { now.timeIntervalSince($0) < Self.refreshTTL } ?? false
+        if !cacheIsFresh {
+            await refresh(code: code, now: now)
+        }
+
+        // Neither cache nor network produced anything → bundled seed.
+        if kit.isEmpty && events.isEmpty, let seed = seedLoader(code) {
+            applySeed(seed, cityCode: code)
+        }
+    }
+
+    // MARK: - Network refresh
+
+    private func refresh(code: String, now: Date) async {
+        let kitResult = await supabase.get(table: "city_kits", query: [
+            URLQueryItem(name: "city_code", value: "eq.\(code)"),
+            URLQueryItem(name: "select", value: "*"),
+            URLQueryItem(name: "order", value: "section"),
+        ])
+        let nowISO = ISO8601DateFormatter().string(from: now)
+        let eventsResult = await supabase.get(table: "city_events", query: [
+            URLQueryItem(name: "city_code", value: "eq.\(code)"),
+            URLQueryItem(name: "status", value: "eq.active"),
+            URLQueryItem(name: "ends_at", value: "gt.\(nowISO)"),
+            URLQueryItem(name: "select", value: "*"),
+            URLQueryItem(name: "order", value: "starts_at.asc.nullsfirst"),
+        ])
+
+        guard case let .success(kitData) = kitResult,
+              case let .success(eventsData) = eventsResult,
+              !kitData.isEmpty || !eventsData.isEmpty else {
+            // Offline / flag-off short-circuit (empty Data) / not signed in:
+            // no update — keep whatever the cache or seed already gave us.
+            return
+        }
+
+        guard let freshKit = try? Self.decoder.decode([CityKitItem].self, from: kitData),
+              let freshEvents = try? Self.decoder.decode([CityEvent].self, from: eventsData) else {
+            Self.logger.error("city-brief decode failed for \(code, privacy: .public) — keeping cache")
+            return
+        }
+        guard !freshKit.isEmpty || !freshEvents.isEmpty else { return }
+
+        kit = freshKit
+        events = freshEvents
+        upsertCache(code: code, kitJSON: kitData, eventsJSON: eventsData, fetchedAt: now)
+    }
+
+    // MARK: - Cache / seed plumbing
+
+    private func cachedRecord(for code: String) -> CityBriefCacheRecord? {
+        let descriptor = FetchDescriptor<CityBriefCacheRecord>(
+            predicate: #Predicate { $0.cityCode == code }
+        )
+        return try? modelContext.fetch(descriptor).first
+    }
+
+    private func upsertCache(code: String, kitJSON: Data, eventsJSON: Data, fetchedAt: Date) {
+        if let record = cachedRecord(for: code) {
+            record.kitJSON = kitJSON
+            record.eventsJSON = eventsJSON
+            record.fetchedAt = fetchedAt
+        } else {
+            modelContext.insert(CityBriefCacheRecord(cityCode: code, kitJSON: kitJSON, eventsJSON: eventsJSON, fetchedAt: fetchedAt))
+        }
+        do {
+            try modelContext.save()
+        } catch {
+            Self.logger.error("city-brief cache save failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    private func publish(kitJSON: Data, eventsJSON: Data, cityCode: String) {
+        kit = (try? Self.decoder.decode([CityKitItem].self, from: kitJSON)) ?? []
+        events = (try? Self.decoder.decode([CityEvent].self, from: eventsJSON)) ?? []
+    }
+
+    /// Bundled seed format: `{"kit": [<city_kits rows>], "events": [<city_events rows>]}` —
+    /// the exact server row shape, so one decoder serves both paths.
+    private struct SeedPayload: Decodable {
+        let kit: [CityKitItem]
+        let events: [CityEvent]
+    }
+
+    private func applySeed(_ data: Data, cityCode: String) {
+        guard let payload = try? Self.decoder.decode(SeedPayload.self, from: data) else {
+            Self.logger.error("bundled city-brief seed decode failed for \(cityCode, privacy: .public)")
+            return
+        }
+        kit = payload.kit
+        events = payload.events
+    }
+
+    /// PostgREST timestamps come back as ISO 8601, sometimes with fractional
+    /// seconds ("2026-07-06T12:34:56.789+00:00") — plain `.iso8601` rejects
+    /// the fractional form, so try both.
+    static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let raw = try container.decode(String.self)
+            if let date = fractional.date(from: raw) ?? plain.date(from: raw) {
+                return date
+            }
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unparseable ISO 8601 date: \(raw)")
+        }
+        return decoder
+    }()
+}

--- a/apps/ios/SoloCompass/Services/CityOSInterruptionBudget.swift
+++ b/apps/ios/SoloCompass/Services/CityOSInterruptionBudget.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// City OS v2 interruption budget (PRD §4.3): all *proactive* City-OS surfaces
+/// combined — the one-time kit auto-surface and the compliance banner's first
+/// appearance of a day — may fire at most twice per local day. This is the
+/// quantified form of the "不做 engagement loop" anti-goal.
+///
+/// Same UserDefaults day-ring pattern as `LiveActivityService.consumeDailyBudget`
+/// and `ProactiveNudgeScheduler.budgetKey`; the dailyOmen Live Activity keeps
+/// its own separate 1/day budget and is intentionally NOT counted here.
+public enum CityOSInterruptionBudget {
+    /// Maximum proactive City-OS surfacings per local day.
+    public static let maxProactivePerDay = 2
+
+    /// Attempts to consume one unit of today's budget. Returns false (and
+    /// consumes nothing) when the budget is exhausted — callers must then
+    /// stay silent.
+    @discardableResult
+    public static func consumeProactive(now: Date = Date(), calendar: Calendar = .current, defaults: UserDefaults = .standard) -> Bool {
+        let key = budgetKey(for: now, calendar: calendar)
+        let used = defaults.integer(forKey: key)
+        guard used < maxProactivePerDay else { return false }
+        defaults.set(used + 1, forKey: key)
+        return true
+    }
+
+    /// How many proactive surfacings remain today (0...maxProactivePerDay).
+    public static func remainingToday(now: Date = Date(), calendar: Calendar = .current, defaults: UserDefaults = .standard) -> Int {
+        max(0, maxProactivePerDay - defaults.integer(forKey: budgetKey(for: now, calendar: calendar)))
+    }
+
+    /// UserDefaults key for the given local day, e.g.
+    /// `com.solocompass.cityos.proactive.2026-07-06.v1`.
+    static func budgetKey(for date: Date, calendar: Calendar) -> String {
+        let comps = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(
+            format: "com.solocompass.cityos.proactive.%04d-%02d-%02d.v1",
+            comps.year ?? 0, comps.month ?? 0, comps.day ?? 0
+        )
+    }
+}

--- a/apps/ios/SoloCompass/Services/CityOSStore.swift
+++ b/apps/ios/SoloCompass/Services/CityOSStore.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Observation
+
+/// City OS v2 root-state store (PRD §4.1): the traveler's per-city mode
+/// (Live / Plan / Recall) plus the once-per-city kit auto-surface bookkeeping.
+///
+/// Deliberately NOT part of `MapViewModel` (already a 3k-line camera/POI
+/// object) — this is relationship state, not map state. Raw persistence lives
+/// in the `UserPreferences` blob (`cityModesRaw` / `kitSeenCities`); this
+/// store owns the semantics.
+@MainActor
+@Observable
+public final class CityOSStore {
+    private let preferences: UserPreferences
+
+    /// Creates the store over the given preferences blob.
+    public init(preferences: UserPreferences) {
+        self.preferences = preferences
+    }
+
+    /// Canonical storage key for a city code: trimmed + lowercased, matching
+    /// the DB's lowercase convention (iOS surfaces use uppercase "VTE").
+    public static func normalizedCityKey(_ code: String) -> String {
+        code.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    /// The mode for a city; unknown/nil cities default to `.live` — mode is
+    /// an enhancement, never a gate that hides content.
+    public func mode(for cityCode: String?) -> CityMode {
+        guard let cityCode, !cityCode.isEmpty else { return .live }
+        let key = Self.normalizedCityKey(cityCode)
+        guard let raw = preferences.cityModesRaw[key], let mode = CityMode(rawValue: raw) else {
+            return .live
+        }
+        return mode
+    }
+
+    /// Sets the mode for a city (persists via the preferences blob).
+    public func setMode(_ mode: CityMode, for cityCode: String) {
+        let key = Self.normalizedCityKey(cityCode)
+        var raw = preferences.cityModesRaw
+        raw[key] = mode.rawValue
+        preferences.cityModesRaw = raw
+    }
+
+    /// Whether the landing kit has already auto-surfaced for this city.
+    public func hasSeenKit(_ cityCode: String) -> Bool {
+        preferences.kitSeenCities.contains(Self.normalizedCityKey(cityCode))
+    }
+
+    /// Records that the landing kit auto-surfaced once for this city — it
+    /// never pushes itself again (PRD §4.3); the drawer tab remains the way
+    /// back in.
+    public func markKitSeen(_ cityCode: String) {
+        var seen = preferences.kitSeenCities
+        seen.insert(Self.normalizedCityKey(cityCode))
+        preferences.kitSeenCities = seen
+    }
+}

--- a/apps/ios/SoloCompass/Services/ComplianceService.swift
+++ b/apps/ios/SoloCompass/Services/ComplianceService.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Observation
+
+// MARK: - City OS v2 · visa / 183-day tax compliance (PRD §5.2)
+//
+// The one part of the landing kit that is self-computed, offline-usable, and
+// therefore rendered in mono big digits — it must be exactly right. All math
+// lives in `ComplianceMath` (pure, calendar-injected) so tests can pin every
+// boundary; `ComplianceService` is a thin @MainActor reader over
+// `UserPreferences`.
+
+/// Pure visa / tax-day arithmetic. Day counting is calendar-day based
+/// (startOfDay to startOfDay) and treats the entry day as day 1, matching the
+/// "落地签 30 天 · 已停留 3 天 · 剩 27 天" convention in the PRD.
+public enum ComplianceMath {
+    /// The tax-residency threshold in days (the "183-day rule").
+    public static let taxLineDays = 183
+
+    /// Days stayed including the entry day: entering today = 1.
+    /// Returns 0 when `entryDate` is in the future.
+    public static func daysStayed(entryDate: Date, now: Date, calendar: Calendar = .current) -> Int {
+        let start = calendar.startOfDay(for: entryDate)
+        let today = calendar.startOfDay(for: now)
+        guard let diff = calendar.dateComponents([.day], from: start, to: today).day, diff >= 0 else {
+            return 0
+        }
+        return diff + 1
+    }
+
+    /// Visa days remaining: length − stayed. Negative means overstayed.
+    public static func visaDaysRemaining(entryDate: Date, visaLengthDays: Int, now: Date, calendar: Calendar = .current) -> Int {
+        visaLengthDays - daysStayed(entryDate: entryDate, now: now, calendar: calendar)
+    }
+
+    /// Days left before crossing the 183-day tax-residency line, floored at 0.
+    public static func taxDaysRemaining(daysStayed: Int) -> Int {
+        max(0, taxLineDays - daysStayed)
+    }
+
+    /// The compliance banner surfaces only when the situation is critical:
+    /// 7 days or fewer remaining (including overstay). PRD §4.3 interruption
+    /// budget applies on top of this.
+    public static func shouldShowBanner(daysRemaining: Int) -> Bool {
+        daysRemaining <= 7
+    }
+}
+
+/// Reads the traveler's locally stored entry date + visa length and exposes
+/// render-ready compliance state. Never talks to the network — privacy-first
+/// per PRD §5.2 ("纯本地自算").
+@MainActor
+@Observable
+public final class ComplianceService {
+    private let preferences: UserPreferences
+
+    /// Creates the service over the given preferences store.
+    public init(preferences: UserPreferences) {
+        self.preferences = preferences
+    }
+
+    /// Snapshot of the visa/tax counters for rendering, nil until the user
+    /// has entered their entry date.
+    public struct State: Equatable, Sendable {
+        /// Days stayed including entry day.
+        public let daysStayed: Int
+        /// Visa days remaining (negative = overstayed).
+        public let visaDaysRemaining: Int
+        /// Days until the 183-day tax line, floored at 0.
+        public let taxDaysRemaining: Int
+        /// Whether the critical banner condition (≤7 days) holds.
+        public let isCritical: Bool
+    }
+
+    /// Current compliance state, or nil when no entry date is recorded.
+    public func state(now: Date = Date()) -> State? {
+        guard let entry = preferences.visaEntryDate, let length = preferences.visaLengthDays else {
+            return nil
+        }
+        let stayed = ComplianceMath.daysStayed(entryDate: entry, now: now)
+        let remaining = ComplianceMath.visaDaysRemaining(entryDate: entry, visaLengthDays: length, now: now)
+        return State(
+            daysStayed: stayed,
+            visaDaysRemaining: remaining,
+            taxDaysRemaining: ComplianceMath.taxDaysRemaining(daysStayed: stayed),
+            isCritical: ComplianceMath.shouldShowBanner(daysRemaining: remaining)
+        )
+    }
+
+    /// Re-schedules (or cancels) the local visa-expiry reminder to match the
+    /// user's toggle. Uses a fixed identifier so repeated calls replace the
+    /// pending notification instead of stacking.
+    public func syncVisaReminder(now: Date = Date()) async {
+        guard preferences.visaReminderEnabled,
+              let state = state(now: now),
+              state.visaDaysRemaining > 0 else {
+            await NotificationService.shared.cancelVisaExpiryReminder()
+            return
+        }
+        await NotificationService.shared.scheduleVisaExpiryReminder(daysRemaining: state.visaDaysRemaining)
+    }
+}

--- a/apps/ios/SoloCompass/Services/FeatureFlags.swift
+++ b/apps/ios/SoloCompass/Services/FeatureFlags.swift
@@ -104,6 +104,32 @@ public enum FeatureFlags {
         #endif
     }
 
+    /// City OS v2 master gate (PRD solo-city-os-v2 §4–5): the 落地包 landing
+    /// kit, 在地 local-events module, compliance banner, city modes
+    /// (Live/Plan/Recall), event map markers, the two chat tools
+    /// (get_city_kit / find_local_events) and the 今日城市签 daily omen feed.
+    /// Content still requires `backendSync` for network refresh — with it off,
+    /// the bundled Vientiane seed keeps every surface functional offline.
+    ///
+    /// DEBUG builds default ON so the whole Live-mode loop is exercisable in
+    /// the Simulator; Release reads plist/env (`FF_CITY_OS`) and defaults OFF
+    /// for a staged rollout. Override in DEBUG without rebuilding:
+    ///
+    ///     defaults write <app-bundle-id> FF_CITY_OS -bool NO
+    public static var cityOS: Bool {
+        #if DEBUG
+        if UserDefaults.standard.object(forKey: "FF_CITY_OS") != nil {
+            return UserDefaults.standard.bool(forKey: "FF_CITY_OS")
+        }
+        if let env = ProcessInfo.processInfo.environment["FF_CITY_OS"] {
+            return env == "1" || env.lowercased() == "true"
+        }
+        return true
+        #else
+        return readBool("FF_CITY_OS", default: false)
+        #endif
+    }
+
     /// US-009: Master gate for the in-map Companion *layer* toggle (the
     /// floating control that overlays nearby blurred presence cells). The
     /// underlying discovery still returns nil today, so the toggle is a dead
@@ -164,6 +190,8 @@ public enum FeatureFlags {
                       subtitleKey: "dev.flag.companion.subtitle", defaultValue: false),
         DeveloperFlag(key: "FF_COMPANION_LAYER_ENABLED", titleKey: "dev.flag.companionLayer.title",
                       subtitleKey: "dev.flag.companionLayer.subtitle", defaultValue: false),
+        DeveloperFlag(key: "FF_CITY_OS", titleKey: "dev.flag.cityOS.title",
+                      subtitleKey: "dev.flag.cityOS.subtitle", defaultValue: false),
     ]
 
     /// The developer override currently stored for `key`, or nil when the

--- a/apps/ios/SoloCompass/Services/NotificationService.swift
+++ b/apps/ios/SoloCompass/Services/NotificationService.swift
@@ -218,6 +218,34 @@ public final class NotificationService {
         await deliver(content, id: "ai-now-\(deepLinkExperienceId ?? UUID().uuidString)", after: 2)
     }
 
+    // MARK: - City OS v2: visa-expiry reminder (PRD §5.2)
+
+    /// Schedules the local visa-expiry reminder. Fires when the stay enters
+    /// its last 7 days (or within seconds if it already has). Fixed identifier
+    /// so re-scheduling replaces the pending request instead of stacking —
+    /// call `cancelVisaExpiryReminder()` when the user turns the toggle off.
+    public func scheduleVisaExpiryReminder(daysRemaining: Int) async {
+        guard isAuthorized else { return }
+        let content = UNMutableNotificationContent()
+        content.title = NSLocalizedString("cityos.visa.reminder.title", comment: "Visa expiry reminder title")
+        let daysAtFire = min(daysRemaining, 7)
+        content.body = String(
+            format: NSLocalizedString("cityos.visa.reminder.body", comment: "Visa expiry reminder body with day count"),
+            daysAtFire
+        )
+        content.sound = .default
+        content.userInfo = ["kind": "visa-expiry"]
+        // Fire at the 7-days-left mark; already inside the window → fire shortly.
+        let seconds = daysRemaining > 7 ? TimeInterval(daysRemaining - 7) * 86_400 : 5
+        await deliver(content, id: "visa-expiry", after: seconds)
+    }
+
+    /// Removes any pending visa-expiry reminder (user disabled the toggle or
+    /// cleared their entry date).
+    public func cancelVisaExpiryReminder() async {
+        await center.removePendingNotificationRequests(withIdentifiers: ["visa-expiry"])
+    }
+
     /// ② 出发提醒 (time-sensitive) — "30 分钟后集合" with "我已出发 / 查看路线"
     /// quick actions. Time-sensitive so it can break through Focus when the
     /// group is about to set off. Fires at `fireDate` (e.g. 30 min before the

--- a/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
@@ -167,7 +167,9 @@ public final class VoiceAgentOrchestrator: Identifiable {
         preferences: UserPreferences,
         contextManager: (any ContextManager)? = nil,
         historyStore: ChatHistoryStore? = nil,
-        memoryDigest: MemoryDigestService? = nil
+        memoryDigest: MemoryDigestService? = nil,
+        cityBriefService: CityBriefService? = nil,
+        complianceService: ComplianceService? = nil
     ) {
         self.aiService = aiService
         self.voiceService = voiceService
@@ -179,7 +181,11 @@ public final class VoiceAgentOrchestrator: Identifiable {
             mapViewModel: mapViewModel,
             preferences: preferences,
             // Wire the AI service so `build_route` can string a walk together.
-            aiService: aiService
+            aiService: aiService,
+            // City OS v2: wire the content plane + visa math so get_city_kit /
+            // find_local_events resolve real facts (nil in legacy/test callers).
+            cityBriefService: cityBriefService,
+            complianceService: complianceService
         )
         self.planner = TurnPlanner(aiService: aiService)
     }
@@ -770,6 +776,16 @@ public final class VoiceAgentOrchestrator: Identifiable {
                     proposal.stops.count
                 )
             ))
+        case let .events(list):
+            guard !list.isEmpty else { return }
+            card = .events(id: UUID(), list)
+            reasoningTrace.append(ReasoningStep(
+                kind: .insight,
+                label: String(
+                    format: NSLocalizedString("agent.trace.foundEvents", comment: "Found N local events"),
+                    list.count
+                )
+            ))
         }
         provisionalCards.append(card: card, to: messageId, at: Date())
         syncCardsSnapshot()
@@ -1071,6 +1087,8 @@ public final class VoiceAgentOrchestrator: Identifiable {
         6. search_places(query, latitude, longitude, radius_meters) — Search for a specific type or named place (e.g. "ramen", "7-Eleven", "rooftop bar"). Returns newly discovered experiences as cards. Like explore_nearby, it AUTOMATICALLY widens the radius when the first ring is empty, so don't give up early.
         7. navigate_to(experience_id) — Open the user's preferred map app with walking directions. ONLY when the user explicitly asks to go / get directions.
         8. build_route(experience_ids?) — String nearby places into ONE walkable route, ordered into a sensible walk, with a "why now" line reflecting the time, weather, and which places the user has or hasn't visited. The route appears as a card the user can adopt — it is NOT saved until they tap adopt. Use when the user asks you to plan a walk or string places together.
+        9. get_city_kit(city_code?, kinds?) — Return the 落地包 landing-kit essentials for the current city: connectivity, money, visa/tax, safety. Use for "how do I get online / get cash / visa rules / days left / emergency numbers". Visa day counts come from the user's own stored data — if `visa_setup_needed` is returned, tell them to set their entry date in the 落地包; NEVER invent day counts.
+        10. find_local_events(city_code?, within_days?, solo_score_min?, query?) — Find 在地 local happenings this week with a solo-friendliness score and a "good to go alone?" note. Results appear as tappable cards the user can jump to on the map. Use for "what's on this weekend / anything happening / something to do alone".
 
         PLAN BLOCKS (① plan-execute-reflect):
         - Some turns will be preceded by a `<plan>...</plan>` system block containing a JSON plan with an ordered `steps` array.

--- a/apps/ios/SoloCompass/Services/VoiceAgentToolRouter.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentToolRouter.swift
@@ -83,17 +83,32 @@ public final class VoiceAgentToolRouter {
     public enum ToolEffect: Equatable {
         case experiences([Experience])
         case route(RouteProposal)
+        /// City OS v2: 在地 events surfaced by `find_local_events`, rendered as
+        /// `ChatEventCard`s the user can tap to jump to on the map.
+        case events([CityEvent])
     }
     public private(set) var lastEffect: ToolEffect?
+
+    /// City OS v2 content plane — resolves `get_city_kit` / `find_local_events`.
+    /// Weak so the router can't outlive the view's services; a nil service
+    /// yields the standard dependency-unavailable envelope.
+    private weak var cityBriefService: CityBriefService?
+    /// City OS v2 visa math — `get_city_kit`'s visa numbers come from here, so
+    /// the model never invents day counts.
+    private weak var complianceService: ComplianceService?
 
     public init(
         mapViewModel: MapViewModel,
         preferences: UserPreferences,
-        aiService: AIService? = nil
+        aiService: AIService? = nil,
+        cityBriefService: CityBriefService? = nil,
+        complianceService: ComplianceService? = nil
     ) {
         self.mapViewModel = mapViewModel
         self.preferences = preferences
         self.aiService = aiService
+        self.cityBriefService = cityBriefService
+        self.complianceService = complianceService
     }
 
     // MARK: - Tool catalog
@@ -369,6 +384,39 @@ public final class VoiceAgentToolRouter {
             }
             """#
         ),
+
+        // City OS v2 (PRD solo-city-os-v2 §5.2–5.3): the landing kit + local
+        // events for the current city. Content is city-shared and pre-compiled
+        // server-side; these tools READ it and return compact facts — the model
+        // never invents kit copy, visa numbers, or events.
+        .init(
+            name: "get_city_kit",
+            description: "Return the 落地包 landing-kit essentials for the current city — connectivity (net), money, visa/tax, and safety. Use when the user asks how to get online, get cash, visa rules, days left, emergency numbers, or 'what do I need to know landing here'. Visa day counts come from the user's own stored entry date; if none is set, the visa numbers are omitted and you should tell them to set their entry date in the 落地包.",
+            parametersJSON: #"""
+            {
+              "type": "object",
+              "properties": {
+                "city_code": {"type": "string", "description": "Optional; defaults to the current map city."},
+                "kinds": {"type": "array", "items": {"type": "string", "enum": ["net","money","visa","safety"]}, "description": "Optional subset of kit sections to return; omit for all four."}
+              }
+            }
+            """#
+        ),
+        .init(
+            name: "find_local_events",
+            description: "Find 在地 local happenings this week for the current city — festivals, markets, and travel notices — each with a solo-friendliness score and a one-line 'is it good to go alone' note. Use when the user asks what's on, what to do this weekend, or wants something happening nearby. Results appear as tappable cards the user can jump to on the map. Notices (road closures, strikes) are included but have no solo score.",
+            parametersJSON: #"""
+            {
+              "type": "object",
+              "properties": {
+                "city_code": {"type": "string", "description": "Optional; defaults to the current map city."},
+                "within_days": {"type": "integer", "minimum": 1, "maximum": 30, "default": 7, "description": "Only include events starting within this many days."},
+                "solo_score_min": {"type": "number", "minimum": 0, "maximum": 10, "description": "Optional minimum solo-friendliness score (notices are always kept)."},
+                "query": {"type": "string", "description": "Optional keyword to match against event name + solo note."}
+              }
+            }
+            """#
+        ),
     ]
 
     // MARK: - Execution
@@ -422,6 +470,12 @@ public final class VoiceAgentToolRouter {
                 return try executeRecallLocalScene(args: call.argumentsJSON)
             case "recall_memory":
                 return try executeRecallMemory(args: call.argumentsJSON)
+
+            // City OS v2 kit / events.
+            case "get_city_kit":
+                return try await executeGetCityKit(args: call.argumentsJSON)
+            case "find_local_events":
+                return try await executeFindLocalEvents(args: call.argumentsJSON)
 
             default:
                 throw RouterError.unknownTool(call.name)
@@ -1164,5 +1218,144 @@ public final class VoiceAgentToolRouter {
             hint: "Cite the surfaced episodes with a natural aside — 'you mentioned X last time' — before your recommendation. Don't dump the full body verbatim."
         )
         return outcome.encodeForModel()
+    }
+
+    // MARK: - City OS v2 (get_city_kit / find_local_events)
+
+    private struct GetCityKitArgs: Decodable {
+        let city_code: String?
+        let kinds: [String]?
+    }
+
+    /// Resolve the current city (arg or map selection), load the brief, and
+    /// return the requested kit sections as compact facts. Visa day counts come
+    /// ONLY from `ComplianceService` (never invented by the model); when the
+    /// user hasn't set an entry date, the visa row carries a `visa_setup_needed`
+    /// flag instead of numbers.
+    private func executeGetCityKit(args: String) async throws -> String {
+        let parsed: GetCityKitArgs = try Self.decode(args, tool: "get_city_kit")
+        let service = try requireCityBrief(tool: "get_city_kit")
+        let code = try resolveCityCode(param: parsed.city_code, tool: "get_city_kit")
+        await service.load(cityCode: code)
+
+        let wanted: Set<String>? = parsed.kinds.map(Set.init)
+        let rows = service.kit.filter { wanted?.contains($0.kind.rawValue) ?? true }
+        guard !rows.isEmpty else {
+            return Self.successJSON([
+                "city_code": code,
+                "sections": [String](),
+                "note": "no_kit_for_city",
+            ])
+        }
+
+        let sections: [[String: Any]] = rows.map { item in
+            var dict: [String: Any] = [
+                "section": item.kind.rawValue,
+                "name": item.name,
+                "body": item.main,
+            ]
+            if let lens = item.lens { dict["lens"] = lens }
+            if let label = item.linkLabel { dict["link_label"] = label }
+            if item.kind == .visa {
+                if let state = complianceService?.state() {
+                    dict["visa_days_remaining"] = state.visaDaysRemaining
+                    dict["tax_days_remaining"] = state.taxDaysRemaining
+                    dict["days_stayed"] = state.daysStayed
+                } else {
+                    dict["visa_setup_needed"] = true
+                }
+            }
+            if item.kind == .safety, let numbers = item.action?.numbers {
+                dict["emergency_numbers"] = numbers.map { ["label": $0.label, "number": $0.number] }
+            }
+            return dict
+        }
+        return Self.successJSON(["city_code": code, "sections": sections])
+    }
+
+    private struct FindLocalEventsArgs: Decodable {
+        let city_code: String?
+        let within_days: Int?
+        let solo_score_min: Double?
+        let query: String?
+    }
+
+    /// Filter the city's active events by window / solo score / keyword and set
+    /// a `.events` effect so the chat surface renders tappable event cards.
+    /// Notices are always kept (a road closure isn't scored but matters).
+    private func executeFindLocalEvents(args: String) async throws -> String {
+        let parsed: FindLocalEventsArgs = try Self.decode(args, tool: "find_local_events")
+        let service = try requireCityBrief(tool: "find_local_events")
+        let code = try resolveCityCode(param: parsed.city_code, tool: "find_local_events")
+        await service.load(cityCode: code)
+
+        let now = Date()
+        let withinDays = max(1, min(30, parsed.within_days ?? 7))
+        let horizon = Calendar.current.date(byAdding: .day, value: withinDays, to: now) ?? now
+        let queryLower = parsed.query?.lowercased()
+
+        let matches = service.activeEvents(now: now).filter { event in
+            // Window: keep events with no start date, or starting before horizon.
+            if let starts = event.startsAt, starts > horizon { return false }
+            // Notices bypass the solo-score floor.
+            if !event.isNotice, let floor = parsed.solo_score_min {
+                guard let score = event.soloScore, score >= floor else { return false }
+            }
+            if let q = queryLower, !q.isEmpty {
+                let haystack = (event.name + " " + (event.soloNote ?? "")).lowercased()
+                guard haystack.contains(q) else { return false }
+            }
+            return true
+        }
+
+        if !matches.isEmpty {
+            lastEffect = .events(matches)
+        }
+
+        let payload: [[String: Any]] = matches.map { event in
+            var dict: [String: Any] = [
+                "id": event.id,
+                "name": event.name,
+                "when": event.whenLabel,
+                "is_notice": event.isNotice,
+            ]
+            if let score = event.soloScore { dict["solo_score"] = score }
+            if let note = event.soloNote { dict["solo_note"] = note }
+            if event.lat != nil && event.lng != nil { dict["has_map_location"] = true }
+            return dict
+        }
+        return Self.successJSON([
+            "city_code": code,
+            "count": matches.count,
+            "within_days": withinDays,
+            "events": payload,
+        ])
+    }
+
+    /// City OS content plane or the standard dependency-unavailable envelope.
+    private func requireCityBrief(tool: String) throws -> CityBriefService {
+        guard let service = cityBriefService else {
+            throw RouterError.dependencyUnavailable(
+                tool: tool,
+                dependency: "cityBriefService",
+                hint: "City OS content isn't available this session. Answer from general knowledge and suggest the user open the 落地包 / 在地 tabs on the map."
+            )
+        }
+        return service
+    }
+
+    /// Resolve a lowercase city code from the tool arg or the map's selected
+    /// city. Throws when neither is available so the model asks the user.
+    private func resolveCityCode(param: String?, tool: String) throws -> String {
+        if let param, !param.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return CityOSStore.normalizedCityKey(param)
+        }
+        if let selected = mapViewModel?.selectedCity, !selected.isEmpty {
+            return CityOSStore.normalizedCityKey(selected)
+        }
+        throw RouterError.invalidArguments(
+            tool: tool,
+            reason: "no city_code given and no city is selected on the map — ask the user which city they mean"
+        )
     }
 }

--- a/apps/ios/SoloCompass/Tests/CityBriefHealthTests.swift
+++ b/apps/ios/SoloCompass/Tests/CityBriefHealthTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import SoloCompass
+
+/// City OS v2: pins the client-side freshness rules for kit rows and events —
+/// health decay thresholds (mirroring `Confidence.health`), event expiry, and
+/// the deterministic 今日城市签 daily pick.
+final class CityBriefHealthTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_780_000_000) // fixed clock
+
+    private func daysAgo(_ days: Double) -> Date {
+        now.addingTimeInterval(-days * 86_400)
+    }
+
+    // MARK: - health(lastVerifiedAt:serverHealth:now:)
+
+    func testNilLastVerifiedIsQuestioned() {
+        XCTAssertEqual(CityBriefHealth.health(lastVerifiedAt: nil, serverHealth: "green", now: now), .questioned)
+    }
+
+    func testFreshGreenIsHealthy() {
+        XCTAssertEqual(CityBriefHealth.health(lastVerifiedAt: daysAgo(2), serverHealth: "green", now: now), .healthy)
+    }
+
+    func testFreshYellowIsFading() {
+        XCTAssertEqual(CityBriefHealth.health(lastVerifiedAt: daysAgo(2), serverHealth: "yellow", now: now), .fading)
+    }
+
+    func testFreshRedIsQuestioned() {
+        XCTAssertEqual(CityBriefHealth.health(lastVerifiedAt: daysAgo(2), serverHealth: "red", now: now), .questioned)
+    }
+
+    func testFreshGrayDefaultsToFading() {
+        XCTAssertEqual(CityBriefHealth.health(lastVerifiedAt: daysAgo(2), serverHealth: "gray", now: now), .fading)
+        XCTAssertEqual(CityBriefHealth.health(lastVerifiedAt: daysAgo(2), serverHealth: nil, now: now), .fading)
+    }
+
+    func testStaleGreenIsCappedAtFading() {
+        // 30–60 days: staleness can only downgrade the server floor.
+        XCTAssertEqual(CityBriefHealth.health(lastVerifiedAt: daysAgo(45), serverHealth: "green", now: now), .fading)
+    }
+
+    func testStaleRedStaysQuestioned() {
+        XCTAssertEqual(CityBriefHealth.health(lastVerifiedAt: daysAgo(45), serverHealth: "red", now: now), .questioned)
+    }
+
+    func testOlderThanSixtyDaysIsMayBeGone() {
+        // Same cliff as Confidence.health, regardless of server floor.
+        XCTAssertEqual(CityBriefHealth.health(lastVerifiedAt: daysAgo(61), serverHealth: "green", now: now), .mayBeGone)
+    }
+
+    // MARK: - isExpired
+
+    private func event(id: String = "evt_vte_test_20260706", starts: Date? = nil, ends: Date? = nil, solo: Double? = nil, category: String? = "market") -> CityEvent {
+        CityEvent(id: id, cityCode: "vte", name: "测试事件", whenLabel: "本周", startsAt: starts, endsAt: ends, soloScore: solo, category: category)
+    }
+
+    func testEventPastEndsAtIsExpired() {
+        XCTAssertTrue(CityBriefHealth.isExpired(event(ends: daysAgo(0.1)), now: now))
+    }
+
+    func testEventBeforeEndsAtIsNotExpired() {
+        XCTAssertFalse(CityBriefHealth.isExpired(event(ends: now.addingTimeInterval(3_600)), now: now))
+    }
+
+    func testNilEndsAtFallsBackToStartsPlusOneDay() {
+        XCTAssertTrue(CityBriefHealth.isExpired(event(starts: daysAgo(2), ends: nil), now: now))
+        XCTAssertFalse(CityBriefHealth.isExpired(event(starts: daysAgo(0.5), ends: nil), now: now))
+    }
+
+    func testEventWithNoDatesIsKept() {
+        XCTAssertFalse(CityBriefHealth.isExpired(event(starts: nil, ends: nil), now: now))
+    }
+
+    // MARK: - dailyPick
+
+    func testDailyPickPrefersHighestSoloScore() {
+        let events = [
+            event(id: "evt_a", ends: now.addingTimeInterval(86_400), solo: 7.0),
+            event(id: "evt_b", ends: now.addingTimeInterval(86_400), solo: 9.0),
+        ]
+        XCTAssertEqual(CityBriefHealth.dailyPick(from: events, now: now)?.id, "evt_b")
+    }
+
+    func testDailyPickExcludesNoticesAndExpired() {
+        let events = [
+            event(id: "evt_notice", ends: now.addingTimeInterval(86_400), solo: nil, category: "notice"),
+            event(id: "evt_gone", ends: daysAgo(1), solo: 9.9),
+        ]
+        XCTAssertNil(CityBriefHealth.dailyPick(from: events, now: now))
+    }
+
+    func testDailyPickIsDeterministicWithinADay() {
+        // Tied scores resolve via the stable hash — same inputs, same pick,
+        // in whatever order the events arrive.
+        let a = event(id: "evt_a", ends: now.addingTimeInterval(86_400), solo: 8.0)
+        let b = event(id: "evt_b", ends: now.addingTimeInterval(86_400), solo: 8.0)
+        let pick1 = CityBriefHealth.dailyPick(from: [a, b], now: now)?.id
+        let pick2 = CityBriefHealth.dailyPick(from: [b, a], now: now)?.id
+        XCTAssertNotNil(pick1)
+        XCTAssertEqual(pick1, pick2)
+    }
+
+    func testStableHashIsProcessIndependent() {
+        // FNV-1a of "a" must always be the same constant — this is what makes
+        // the daily pick reproducible across launches.
+        XCTAssertEqual(CityBriefHealth.stableHash("a"), 0xaf63dc4c8601ec8c)
+    }
+
+    func testEmptyEventsYieldNoPick() {
+        XCTAssertNil(CityBriefHealth.dailyPick(from: [], now: now))
+    }
+}

--- a/apps/ios/SoloCompass/Tests/CityBriefServiceTests.swift
+++ b/apps/ios/SoloCompass/Tests/CityBriefServiceTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+import SwiftData
+@testable import SoloCompass
+
+/// City OS v2: CityBriefService decode / cache / seed-fallback / expiry
+/// behavior over an in-memory container (also proves `CityBriefCacheRecord`
+/// is registered in the schema — same pattern as `V1_9SchemaRecordsTests`).
+@MainActor
+final class CityBriefServiceTests: XCTestCase {
+    /// One `city_kits` row exactly as PostgREST returns it — snake_case keys
+    /// and a fractional-seconds timestamptz, which `.iso8601` alone rejects.
+    private let kitRowsJSON = Data("""
+    [
+      {
+        "city_code": "vte",
+        "section": "net",
+        "name": "联网",
+        "body": "Airalo 老挝 eSIM · 或 Unitel 门店",
+        "lens_line": "机场到市区先用 eSIM，别机场柜台换卡",
+        "health": "green",
+        "last_verified_at": "2026-07-01T00:00:00.123456+00:00",
+        "link_url": "https://www.airalo.com/laos-esim",
+        "link_label": "Airalo",
+        "action": { "type": "visa_reminder", "visa_days": 30, "tax_line_days": 183 }
+      }
+    ]
+    """.utf8)
+
+    private func eventsJSON(endsAt: String) -> Data {
+        Data("""
+        [
+          {
+            "id": "evt_vte_test_20260710",
+            "city_code": "vte",
+            "name": "测试市集",
+            "category": "market",
+            "when_label": "周五傍晚",
+            "starts_at": "2026-07-10T10:00:00Z",
+            "ends_at": "\(endsAt)",
+            "solo_score": 8.5,
+            "solo_note": "一个人逛正好",
+            "health": "green",
+            "seen_label": "人工策展",
+            "lat": 17.9648,
+            "lng": 102.6108,
+            "limited_label": "本周五限时",
+            "source_url": "https://www.tourismlaos.org/events"
+          }
+        ]
+        """.utf8)
+    }
+
+    private func makeService(seed: Data? = nil) -> CityBriefService {
+        CityBriefService(
+            container: SoloCompassModelContainer.makeInMemory(),
+            seedLoader: { _ in seed }
+        )
+    }
+
+    // MARK: - Decoding
+
+    func testDecodesServerRowShape() throws {
+        let rows = try CityBriefService.decoder.decode([CityKitItem].self, from: kitRowsJSON)
+        XCTAssertEqual(rows.count, 1)
+        let row = try XCTUnwrap(rows.first)
+        XCTAssertEqual(row.kind, .net)
+        XCTAssertEqual(row.main, "Airalo 老挝 eSIM · 或 Unitel 门店")
+        XCTAssertEqual(row.lens, "机场到市区先用 eSIM，别机场柜台换卡")
+        XCTAssertEqual(row.linkLabel, "Airalo")
+        XCTAssertNotNil(row.lastVerifiedAt, "fractional-seconds timestamptz must decode")
+        XCTAssertEqual(row.action?.visaDays, 30)
+        XCTAssertEqual(row.id, "vte.net")
+    }
+
+    func testDecodesEventRowAndNoticeFlag() throws {
+        let events = try CityBriefService.decoder.decode([CityEvent].self, from: eventsJSON(endsAt: "2026-07-10T14:00:00Z"))
+        let event = try XCTUnwrap(events.first)
+        XCTAssertEqual(event.soloScore, 8.5)
+        XCTAssertFalse(event.isNotice)
+        XCTAssertEqual(event.sourceURL?.host, "www.tourismlaos.org")
+    }
+
+    // MARK: - Cache path
+
+    func testLoadPublishesFromFreshCacheWithoutSeed() async throws {
+        let container = SoloCompassModelContainer.makeInMemory()
+        let context = ModelContext(container)
+        context.insert(CityBriefCacheRecord(
+            cityCode: "vte",
+            kitJSON: kitRowsJSON,
+            eventsJSON: eventsJSON(endsAt: "2100-01-01T00:00:00Z"),
+            fetchedAt: Date() // fresh — no refresh attempt
+        ))
+        try context.save()
+
+        let service = CityBriefService(container: container, seedLoader: { _ in nil })
+        await service.load(cityCode: "VTE") // uppercase in, lowercase storage
+        XCTAssertEqual(service.loadedCityCode, "vte")
+        XCTAssertEqual(service.kit.count, 1)
+        XCTAssertEqual(service.events.count, 1)
+    }
+
+    func testActiveEventsFiltersExpired() async throws {
+        let container = SoloCompassModelContainer.makeInMemory()
+        let context = ModelContext(container)
+        context.insert(CityBriefCacheRecord(
+            cityCode: "vte",
+            kitJSON: kitRowsJSON,
+            eventsJSON: eventsJSON(endsAt: "2020-01-01T00:00:00Z"), // long past
+            fetchedAt: Date()
+        ))
+        try context.save()
+
+        let service = CityBriefService(container: container, seedLoader: { _ in nil })
+        await service.load(cityCode: "vte")
+        XCTAssertEqual(service.events.count, 1, "cache keeps the row")
+        XCTAssertTrue(service.activeEvents().isEmpty, "expired events never render")
+    }
+
+    // MARK: - Seed fallback
+
+    func testSeedFallbackWhenCacheAndNetworkEmpty() async {
+        let seed = Data("""
+        { "kit": \(String(data: kitRowsJSON, encoding: .utf8)!),
+          "events": \(String(data: eventsJSON(endsAt: "2100-01-01T00:00:00Z"), encoding: .utf8)!) }
+        """.utf8)
+        let service = makeService(seed: seed)
+        await service.load(cityCode: "vte")
+        XCTAssertEqual(service.kit.count, 1, "bundled seed must fill the void")
+        XCTAssertEqual(service.events.count, 1)
+        XCTAssertTrue(service.hasKit(for: "VTE"))
+    }
+
+    func testBundledVteSeedResourceDecodes() throws {
+        // The real bundled seed must stay decodable — this is the offline
+        // first-run experience for 万象.
+        let bundle = Bundle(for: type(of: self))
+        let url = Bundle.main.url(forResource: "seed_city_brief_vte", withExtension: "json")
+            ?? bundle.url(forResource: "seed_city_brief_vte", withExtension: "json")
+        guard let url else {
+            throw XCTSkip("seed_city_brief_vte.json not bundled into this test host")
+        }
+        let data = try Data(contentsOf: url)
+        struct SeedShape: Decodable {
+            let kit: [CityKitItem]
+            let events: [CityEvent]
+        }
+        let seed = try CityBriefService.decoder.decode(SeedShape.self, from: data)
+        XCTAssertEqual(seed.kit.count, 4, "kit is exactly the four sections")
+        XCTAssertEqual(Set(seed.kit.map(\.kind)), Set(CityKitItem.Kind.allCases))
+        XCTAssertGreaterThanOrEqual(seed.events.count, 3)
+        XCTAssertTrue(seed.events.contains(where: \.isNotice), "seed carries one notice")
+    }
+}

--- a/apps/ios/SoloCompass/Tests/CityOSInterruptionBudgetTests.swift
+++ b/apps/ios/SoloCompass/Tests/CityOSInterruptionBudgetTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import SoloCompass
+
+/// City OS v2 §4.3: the ≤2/day proactive-surfacing budget — the quantified
+/// "不做 engagement loop" anti-goal. Uses an isolated UserDefaults suite so
+/// runs never bleed into the standard defaults (same pattern as
+/// `LiveActivityService` budget tests).
+final class CityOSInterruptionBudgetTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private let suiteName = "CityOSInterruptionBudgetTests"
+    private var calendar: Calendar { Calendar(identifier: .gregorian) }
+    private let day1 = Date(timeIntervalSince1970: 1_780_000_000)
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    func testTwoPerDayCapEnforced() {
+        XCTAssertTrue(CityOSInterruptionBudget.consumeProactive(now: day1, calendar: calendar, defaults: defaults))
+        XCTAssertTrue(CityOSInterruptionBudget.consumeProactive(now: day1, calendar: calendar, defaults: defaults))
+        XCTAssertFalse(CityOSInterruptionBudget.consumeProactive(now: day1, calendar: calendar, defaults: defaults),
+                       "第 3 次主动浮现必须被预算拒绝")
+    }
+
+    func testRemainingTodayCountsDown() {
+        XCTAssertEqual(CityOSInterruptionBudget.remainingToday(now: day1, calendar: calendar, defaults: defaults), 2)
+        CityOSInterruptionBudget.consumeProactive(now: day1, calendar: calendar, defaults: defaults)
+        XCTAssertEqual(CityOSInterruptionBudget.remainingToday(now: day1, calendar: calendar, defaults: defaults), 1)
+    }
+
+    func testDayRolloverResetsBudget() {
+        CityOSInterruptionBudget.consumeProactive(now: day1, calendar: calendar, defaults: defaults)
+        CityOSInterruptionBudget.consumeProactive(now: day1, calendar: calendar, defaults: defaults)
+        let day2 = day1.addingTimeInterval(86_400)
+        XCTAssertTrue(CityOSInterruptionBudget.consumeProactive(now: day2, calendar: calendar, defaults: defaults))
+        XCTAssertEqual(CityOSInterruptionBudget.remainingToday(now: day2, calendar: calendar, defaults: defaults), 1)
+    }
+
+    func testFailedConsumeDoesNotSpendBudget() {
+        CityOSInterruptionBudget.consumeProactive(now: day1, calendar: calendar, defaults: defaults)
+        CityOSInterruptionBudget.consumeProactive(now: day1, calendar: calendar, defaults: defaults)
+        CityOSInterruptionBudget.consumeProactive(now: day1, calendar: calendar, defaults: defaults) // rejected
+        XCTAssertEqual(CityOSInterruptionBudget.remainingToday(now: day1, calendar: calendar, defaults: defaults), 0)
+    }
+
+    func testBudgetKeyIsDayScoped() {
+        let key = CityOSInterruptionBudget.budgetKey(for: day1, calendar: calendar)
+        XCTAssertTrue(key.hasPrefix("com.solocompass.cityos.proactive."))
+        XCTAssertTrue(key.hasSuffix(".v1"))
+    }
+}

--- a/apps/ios/SoloCompass/Tests/CityOSStoreTests.swift
+++ b/apps/ios/SoloCompass/Tests/CityOSStoreTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import SoloCompass
+
+/// City OS v2 §4.1: per-city mode state machine + once-only kit bookkeeping,
+/// persisted through the `UserPreferences` blob.
+@MainActor
+final class CityOSStoreTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private let suiteName = "CityOSStoreTests"
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    private func makeStore() -> (CityOSStore, UserPreferences) {
+        let prefs = UserPreferences(defaults: defaults)
+        return (CityOSStore(preferences: prefs), prefs)
+    }
+
+    func testDefaultModeIsLive() {
+        let (store, _) = makeStore()
+        XCTAssertEqual(store.mode(for: "VTE"), .live)
+        XCTAssertEqual(store.mode(for: nil), .live)
+        XCTAssertEqual(store.mode(for: ""), .live)
+    }
+
+    func testSetModePersistsAcrossStoreReload() {
+        let (store, _) = makeStore()
+        store.setMode(.plan, for: "cmi")
+        // A fresh store over a fresh prefs instance reads the same defaults.
+        let (reloaded, _) = makeStore()
+        XCTAssertEqual(reloaded.mode(for: "cmi"), .plan)
+    }
+
+    func testCityKeyIsCaseInsensitive() {
+        let (store, _) = makeStore()
+        store.setMode(.recall, for: "VTE")
+        XCTAssertEqual(store.mode(for: "vte"), .recall, "iOS 大写城市码与 DB 小写约定必须互通")
+        XCTAssertEqual(CityOSStore.normalizedCityKey(" VTE "), "vte")
+    }
+
+    func testCorruptModeRawFallsBackToLive() {
+        let (store, prefs) = makeStore()
+        prefs.cityModesRaw = ["vte": "teleport"] // unknown raw value
+        XCTAssertEqual(store.mode(for: "vte"), .live)
+    }
+
+    func testKitSeenIsOnceOnlyPerCity() {
+        let (store, _) = makeStore()
+        XCTAssertFalse(store.hasSeenKit("VTE"))
+        store.markKitSeen("VTE")
+        XCTAssertTrue(store.hasSeenKit("vte"))
+        XCTAssertFalse(store.hasSeenKit("cmi"), "别的城市不受影响")
+    }
+}

--- a/apps/ios/SoloCompass/Tests/CityOSToolRouterTests.swift
+++ b/apps/ios/SoloCompass/Tests/CityOSToolRouterTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import SoloCompass
+
+/// City OS v2 (PRD §5.2–5.3): end-to-end router tests for the two agent tools
+/// `get_city_kit` / `find_local_events`. Mirrors `RecallMemoryToolTests` — pins
+/// the wire envelope, the compliance-backed visa numbers, the effect emission,
+/// the solo-score filter, and the dependency-unavailable surface.
+@MainActor
+final class CityOSToolRouterTests: XCTestCase {
+
+    private func makeIsolatedDefaults() -> UserDefaults {
+        let suite = "cityos.router.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    /// A seed payload (server row shape) so the injected `CityBriefService` has
+    /// deterministic content without any network.
+    private static let seedJSON = """
+    {
+      "kit": [
+        {"city_code":"vte","section":"visa","name":"签证 / 税务","body":"落地签 30 天","lens_line":"计时离线可用","health":"green","last_verified_at":"2026-07-01T00:00:00Z","link_url":null,"link_label":null,"action":{"type":"visa_reminder","visa_days":30,"tax_line_days":183}},
+        {"city_code":"vte","section":"safety","name":"安全","body":"市中心较稳","lens_line":"急救号码常驻","health":"green","last_verified_at":"2026-07-01T00:00:00Z","link_url":null,"link_label":null,"action":{"type":"emergency_numbers","numbers":[{"label":"警察","number":"191"}]}}
+      ],
+      "events": [
+        {"id":"evt_vte_market","city_code":"vte","name":"夜市","category":"market","when_label":"本周每晚","starts_at":"2026-07-06T11:00:00Z","ends_at":"2999-01-01T00:00:00Z","solo_score":8.0,"solo_note":"独自逛无压力","health":"green","seen_label":"人工策展","lat":17.97,"lng":102.63,"limited_label":null,"source_url":"https://example.org"},
+        {"id":"evt_vte_low","city_code":"vte","name":"喧闹派对","category":"music","when_label":"周六","starts_at":"2026-07-06T11:00:00Z","ends_at":"2999-01-01T00:00:00Z","solo_score":3.0,"solo_note":"人多","health":"green","seen_label":"人工策展","lat":17.98,"lng":102.64,"limited_label":null,"source_url":"https://example.org"},
+        {"id":"evt_vte_notice","city_code":"vte","name":"步道封闭","category":"notice","when_label":"周三起","starts_at":"2026-07-06T11:00:00Z","ends_at":"2999-01-01T00:00:00Z","solo_score":null,"solo_note":"改走别处","health":"green","seen_label":"本地新闻","lat":17.96,"lng":102.60,"limited_label":"临时","source_url":"https://example.org"}
+      ]
+    }
+    """
+
+    /// Retains every collaborator: the router holds `cityBriefService` /
+    /// `complianceService` weakly, so the fixture must keep strong refs or they
+    /// deallocate the moment `makeFixture` returns and the tools see a nil
+    /// dependency.
+    private struct Fixture {
+        let router: VoiceAgentToolRouter
+        let vm: MapViewModel
+        let prefs: UserPreferences
+        let brief: CityBriefService
+        let compliance: ComplianceService
+    }
+
+    private func makeFixture(withVisaEntry: Bool) -> Fixture {
+        let prefs = UserPreferences(defaults: makeIsolatedDefaults())
+        prefs.lastSelectedCity = "VTE"
+        if withVisaEntry {
+            prefs.visaEntryDate = Date().addingTimeInterval(-2 * 86_400) // 3 days stayed
+            prefs.visaLengthDays = 30
+        }
+        let vm = MapViewModel(
+            locationService: LocationService(),
+            experienceService: ExperienceService(seed: []),
+            aiService: AIService(),
+            preferences: prefs
+        )
+        vm.selectCity("VTE")
+        let compliance = ComplianceService(preferences: prefs)
+        let seedData = Data(Self.seedJSON.utf8)
+        let brief = CityBriefService(
+            container: SoloCompassModelContainer.makeInMemory(),
+            seedLoader: { _ in seedData }
+        )
+        let router = VoiceAgentToolRouter(
+            mapViewModel: vm,
+            preferences: prefs,
+            aiService: nil,
+            cityBriefService: brief,
+            complianceService: compliance
+        )
+        return Fixture(router: router, vm: vm, prefs: prefs, brief: brief, compliance: compliance)
+    }
+
+    private func call(_ router: VoiceAgentToolRouter, _ name: String, _ args: String) async -> String {
+        await router.execute(VoiceAgentSession.ToolCall(id: "1", name: name, argumentsJSON: args))
+    }
+
+    // MARK: - get_city_kit
+
+    func testGetCityKitReturnsSectionsWithVisaNumbersFromCompliance() async throws {
+        let fx = makeFixture(withVisaEntry: true)
+        let json = await call(fx.router, "get_city_kit", "{}")
+        let obj = try XCTUnwrap(parse(json))
+        XCTAssertEqual(obj["ok"] as? Bool, true)
+        XCTAssertEqual(obj["city_code"] as? String, "vte")
+        let sections = try XCTUnwrap(obj["sections"] as? [[String: Any]])
+        let visa = try XCTUnwrap(sections.first { ($0["section"] as? String) == "visa" })
+        // 30-day visa, 3 days stayed → 27 remaining, 180 to the tax line.
+        XCTAssertEqual(visa["visa_days_remaining"] as? Int, 27)
+        XCTAssertEqual(visa["tax_days_remaining"] as? Int, 180)
+        // Safety row surfaces the dialable numbers verbatim.
+        let safety = try XCTUnwrap(sections.first { ($0["section"] as? String) == "safety" })
+        let numbers = try XCTUnwrap(safety["emergency_numbers"] as? [[String: Any]])
+        XCTAssertEqual(numbers.first?["number"] as? String, "191")
+    }
+
+    func testGetCityKitFlagsVisaSetupWhenNoEntryDate() async throws {
+        let fx = makeFixture(withVisaEntry: false)
+        let json = await call(fx.router, "get_city_kit", "{\"kinds\":[\"visa\"]}")
+        let obj = try XCTUnwrap(parse(json))
+        let sections = try XCTUnwrap(obj["sections"] as? [[String: Any]])
+        let visa = try XCTUnwrap(sections.first)
+        XCTAssertEqual(visa["visa_setup_needed"] as? Bool, true)
+        XCTAssertNil(visa["visa_days_remaining"])
+    }
+
+    // MARK: - find_local_events
+
+    func testFindLocalEventsSetsEventsEffectAndKeepsNotices() async throws {
+        let fx = makeFixture(withVisaEntry: false)
+        let json = await call(fx.router, "find_local_events", "{}")
+        let obj = try XCTUnwrap(parse(json))
+        XCTAssertEqual(obj["ok"] as? Bool, true)
+        // All three (market 8.0, music 3.0, notice) pass with no floor.
+        XCTAssertEqual(obj["count"] as? Int, 3)
+        guard case let .events(list)? = fx.router.lastEffect else {
+            return XCTFail("expected .events effect")
+        }
+        XCTAssertEqual(list.count, 3)
+    }
+
+    func testFindLocalEventsSoloScoreFloorFiltersButKeepsNotices() async throws {
+        let fx = makeFixture(withVisaEntry: false)
+        let json = await call(fx.router, "find_local_events", "{\"solo_score_min\":7}")
+        let obj = try XCTUnwrap(parse(json))
+        // market (8.0) passes, music (3.0) filtered, notice always kept → 2.
+        XCTAssertEqual(obj["count"] as? Int, 2)
+    }
+
+    func testFindLocalEventsQueryMatchesNameAndNote() async throws {
+        let fx = makeFixture(withVisaEntry: false)
+        let json = await call(fx.router, "find_local_events", "{\"query\":\"夜市\"}")
+        let obj = try XCTUnwrap(parse(json))
+        XCTAssertEqual(obj["count"] as? Int, 1)
+    }
+
+    // MARK: - dependency unavailable
+
+    func testMissingCityBriefServiceYieldsDependencyEnvelope() async throws {
+        let prefs = UserPreferences(defaults: makeIsolatedDefaults())
+        let vm = MapViewModel(
+            locationService: LocationService(),
+            experienceService: ExperienceService(seed: []),
+            aiService: AIService(),
+            preferences: prefs
+        )
+        vm.selectCity("VTE")
+        // No cityBriefService injected.
+        let router = VoiceAgentToolRouter(mapViewModel: vm, preferences: prefs, aiService: nil)
+        let json = await call(router, "get_city_kit", "{}")
+        // The structured fatal envelope carries the dependency reason.
+        XCTAssertTrue(json.contains("dependency_unavailable") || json.contains("cityBriefService"),
+                      "expected dependency-unavailable envelope, got: \(json)")
+    }
+
+    // MARK: - helpers
+
+    private func parse(_ json: String) -> [String: Any]? {
+        guard let data = json.data(using: .utf8) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+}

--- a/apps/ios/SoloCompass/Tests/ComplianceBannerArbitrationTests.swift
+++ b/apps/ios/SoloCompass/Tests/ComplianceBannerArbitrationTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import SoloCompass
+
+/// City OS v2 §4.3: the top-banner arbitration ladder is offline > POI loading >
+/// compliance. `CompassMapContentView.showsComplianceBanner` is the pure rung
+/// for the compliance banner; every combination is pinned here so a future edit
+/// to the banner block can't silently let it stack with the offline / loading
+/// pills or show outside Live mode.
+final class ComplianceBannerArbitrationTests: XCTestCase {
+
+    private func shows(
+        offline: Bool = false,
+        fetching: Bool = false,
+        cityOSEnabled: Bool = true,
+        critical: Bool = true,
+        dismissed: Bool = false,
+        isLive: Bool = true
+    ) -> Bool {
+        CompassMapContentView.showsComplianceBanner(
+            offline: offline,
+            fetching: fetching,
+            cityOSEnabled: cityOSEnabled,
+            critical: critical,
+            dismissed: dismissed,
+            isLive: isLive
+        )
+    }
+
+    func testShowsWhenCriticalLiveAndUndismissed() {
+        XCTAssertTrue(shows())
+    }
+
+    func testOfflineWinsOverCompliance() {
+        XCTAssertFalse(shows(offline: true))
+    }
+
+    func testLoadingWinsOverCompliance() {
+        XCTAssertFalse(shows(fetching: true))
+    }
+
+    func testHiddenWhenFlagOff() {
+        XCTAssertFalse(shows(cityOSEnabled: false))
+    }
+
+    func testHiddenWhenNotCritical() {
+        XCTAssertFalse(shows(critical: false))
+    }
+
+    func testHiddenWhenDismissed() {
+        XCTAssertFalse(shows(dismissed: true))
+    }
+
+    func testHiddenOutsideLiveMode() {
+        XCTAssertFalse(shows(isLive: false))
+    }
+}

--- a/apps/ios/SoloCompass/Tests/ComplianceMathTests.swift
+++ b/apps/ios/SoloCompass/Tests/ComplianceMathTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import SoloCompass
+
+/// City OS v2 §5.2: the visa / 183-day counters are the kit's only
+/// self-computed numbers — every boundary is pinned here.
+final class ComplianceMathTests: XCTestCase {
+    private var calendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "Asia/Vientiane")! // UTC+7, no DST
+        return cal
+    }()
+
+    private func date(_ y: Int, _ m: Int, _ d: Int, hour: Int = 12) -> Date {
+        calendar.date(from: DateComponents(year: y, month: m, day: d, hour: hour))!
+    }
+
+    func testEntryDayCountsAsDayOne() {
+        XCTAssertEqual(ComplianceMath.daysStayed(entryDate: date(2026, 7, 6), now: date(2026, 7, 6), calendar: calendar), 1)
+    }
+
+    func testPRDExampleStayedThreeDays() {
+        // "落地签 30 天 · 已停留 3 天 · 剩 27 天 · 距 183 天税务线 180 天"
+        let entry = date(2026, 7, 4)
+        let now = date(2026, 7, 6)
+        let stayed = ComplianceMath.daysStayed(entryDate: entry, now: now, calendar: calendar)
+        XCTAssertEqual(stayed, 3)
+        XCTAssertEqual(ComplianceMath.visaDaysRemaining(entryDate: entry, visaLengthDays: 30, now: now, calendar: calendar), 27)
+        XCTAssertEqual(ComplianceMath.taxDaysRemaining(daysStayed: stayed), 180)
+    }
+
+    func testCalendarDayBoundaryNotTwentyFourHours() {
+        // 23:00 → 01:00 next day is 2 calendar days despite being 2 hours apart.
+        let entry = date(2026, 7, 5, hour: 23)
+        let now = date(2026, 7, 6, hour: 1)
+        XCTAssertEqual(ComplianceMath.daysStayed(entryDate: entry, now: now, calendar: calendar), 2)
+    }
+
+    func testFutureEntryDateIsZeroDays() {
+        XCTAssertEqual(ComplianceMath.daysStayed(entryDate: date(2026, 8, 1), now: date(2026, 7, 6), calendar: calendar), 0)
+    }
+
+    func testOverstayGoesNegative() {
+        let entry = date(2026, 6, 1)
+        let now = date(2026, 7, 6) // stayed 36 days on a 30-day visa
+        XCTAssertEqual(ComplianceMath.visaDaysRemaining(entryDate: entry, visaLengthDays: 30, now: now, calendar: calendar), -6)
+    }
+
+    func testTaxDaysFloorAtZero() {
+        XCTAssertEqual(ComplianceMath.taxDaysRemaining(daysStayed: 200), 0)
+    }
+
+    func testBannerBoundaryAtSeven() {
+        XCTAssertTrue(ComplianceMath.shouldShowBanner(daysRemaining: 7))
+        XCTAssertFalse(ComplianceMath.shouldShowBanner(daysRemaining: 8))
+        XCTAssertTrue(ComplianceMath.shouldShowBanner(daysRemaining: 0))
+        XCTAssertTrue(ComplianceMath.shouldShowBanner(daysRemaining: -3)) // overstay stays critical
+    }
+}

--- a/apps/ios/SoloCompass/Tests/EventMarkerReduceMotionTest.swift
+++ b/apps/ios/SoloCompass/Tests/EventMarkerReduceMotionTest.swift
@@ -1,0 +1,48 @@
+import XCTest
+import UIKit
+@testable import SoloCompass
+
+/// City OS v2 §5.3: the 在地 event marker's category→icon mapping is pure and
+/// every icon it can emit must be a real SF Symbol (a ghost symbol renders as a
+/// blank glyph with no error). The rotating ring is gated by an `animatesRing`
+/// init param defaulting to the environment's Reduce Motion, so the view can be
+/// constructed in both states without an environment injection.
+@MainActor
+final class EventMarkerReduceMotionTest: XCTestCase {
+
+    func testCategoryIconMappingIsStable() {
+        XCTAssertEqual(EventMarkerView.categoryIcon(for: "culture"), "theatermasks")
+        XCTAssertEqual(EventMarkerView.categoryIcon(for: "market"), "basket")
+        XCTAssertEqual(EventMarkerView.categoryIcon(for: "wellness"), "figure.run")
+        XCTAssertEqual(EventMarkerView.categoryIcon(for: "music"), "music.note")
+        XCTAssertEqual(EventMarkerView.categoryIcon(for: "sports"), "sportscourt")
+        XCTAssertEqual(EventMarkerView.categoryIcon(for: "food"), "fork.knife")
+        XCTAssertEqual(EventMarkerView.categoryIcon(for: "notice"), "exclamationmark.triangle")
+    }
+
+    func testUnknownCategoryFallsBackToCalendar() {
+        XCTAssertEqual(EventMarkerView.categoryIcon(for: "nonsense"), "calendar")
+        XCTAssertEqual(EventMarkerView.categoryIcon(for: nil), "calendar")
+    }
+
+    func testEveryEmittedIconIsARealSFSymbol() {
+        let categories = ["culture", "market", "wellness", "music", "sports", "food", "notice", nil, "??"]
+        for c in categories {
+            let name = EventMarkerView.categoryIcon(for: c)
+            XCTAssertNotNil(
+                UIImage(systemName: name),
+                "EventMarkerView.categoryIcon(for: \(c ?? "nil")) → '\(name)' is not a real SF Symbol"
+            )
+        }
+    }
+
+    func testMarkerConstructsInBothMotionStates() {
+        let event = CityEvent(
+            id: "evt_test", cityCode: "vte", name: "夜市", whenLabel: "本周每晚",
+            soloScore: 8.0, category: "market", sourceURL: nil
+        )
+        // Both explicit ring states must build without trapping.
+        _ = EventMarkerView(event: event, animatesRing: true, onTap: {})
+        _ = EventMarkerView(event: event, animatesRing: false, onTap: {})
+    }
+}

--- a/apps/ios/SoloCompass/Tests/SFSymbolExistenceTests.swift
+++ b/apps/ios/SoloCompass/Tests/SFSymbolExistenceTests.swift
@@ -24,6 +24,14 @@ final class SFSymbolExistenceTests: XCTestCase {
         "Views/Map/CompassMapView.swift",
         "Views/Map/BottomInfoSheet.swift",
         "Views/Experience/LocationCard.swift",
+        // City OS v2 surfaces — catch a ghost SF Symbol before it ships blank.
+        "Views/CityOS/EventMarkerView.swift",
+        "Views/CityOS/KitSheet.swift",
+        "Views/CityOS/LiveSheet.swift",
+        "Views/CityOS/CityDrawerTabs.swift",
+        "Views/CityOS/ComplianceBanner.swift",
+        "Views/CityOS/ModePlaceholderCards.swift",
+        "Views/CityOS/CityOSComponents.swift",
     ]
 
     func testNoGhostSFSymbolsInScannedViews() throws {

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -1030,6 +1030,10 @@ public final class MapViewModel {
     private var emptyStateExpandTried: Bool = false
 
     public var selectedExperience: Experience?
+    /// City OS v2: the id of the 在地 event whose map marker is highlighted (set
+    /// when the user taps "在地图上看" in the live sheet or a chat event card).
+    /// Purely a render cue for `EventMarkerView.isHighlighted`; nil = none.
+    public var highlightedEventId: String?
     public var isShowingDetail: Bool = false
     /// True when the current detail sheet was opened *directly* by a tap (map
     /// pin / Nearby row) with no floating preview card behind it. Backing out

--- a/apps/ios/SoloCompass/Views/Chat/ChatCardStack.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatCardStack.swift
@@ -15,6 +15,9 @@ struct ChatCardStack: View {
     let cards: [ChatCard]
     let onSelectExperience: (Experience) -> Void
     let onAdoptRoute: (RouteProposal) -> Void
+    /// City OS v2: user tapped "在地图上看" on an event card. nil (default) drops
+    /// the affordance for callers that don't support map jumps.
+    var onShowEventOnMap: ((CityEvent) -> Void)? = nil
 
     /// Slice B: parallel projection with per-card `.provisional/.committed`
     /// state so the pill can render its countdown. Must be aligned to
@@ -50,6 +53,8 @@ struct ChatCardStack: View {
                     onAdopt: { onAdoptRoute(proposal) },
                     onTapStop: onSelectExperience
                 )
+            case let .events(_, list):
+                eventResults(list)
             }
         }
         // Slice B: overlay the undo pill only while the entry is
@@ -89,6 +94,18 @@ struct ChatCardStack: View {
         VStack(alignment: .leading, spacing: 8) {
             ForEach(list) { exp in
                 ChatExperienceCard(experience: exp) { onSelectExperience(exp) }
+            }
+        }
+    }
+
+    /// City OS v2: vertical stack of 在地 event cards from `find_local_events`.
+    @ViewBuilder
+    private func eventResults(_ list: [CityEvent]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(list) { event in
+                ChatEventCard(event: event) { tapped in
+                    onShowEventOnMap?(tapped)
+                }
             }
         }
     }

--- a/apps/ios/SoloCompass/Views/Chat/ChatCardViews.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatCardViews.swift
@@ -339,6 +339,28 @@ struct ChatRouteProposalCard: View {
     }
 }
 
+// MARK: - ChatEventCard (City OS v2)
+
+/// In-chat card for a 在地 event the agent surfaced via `find_local_events`.
+/// Reuses `LiveEventCard` so the chat + live-sheet event surfaces are visually
+/// identical; the "在地图上看" button dismisses the chat and jumps to the
+/// event on the map (the agent never seizes the map on its own).
+@MainActor
+struct ChatEventCard: View {
+    let event: CityEvent
+    /// User tapped "在地图上看" — hand the event up to recenter + highlight.
+    let onShowOnMap: (CityEvent) -> Void
+
+    var body: some View {
+        LiveEventCard(
+            event: event,
+            onShowOnMap: event.lat != nil && event.lng != nil
+                ? { onShowOnMap(event) }
+                : nil
+        )
+    }
+}
+
 private extension Optional where Wrapped == String {
     var isNilOrEmpty: Bool {
         switch self {

--- a/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
@@ -25,6 +25,9 @@ public struct ChatSheet: View {
     public let onSelectExperience: (Experience) -> Void
     /// User tapped "采用这条路线" on a proposed-route card — persist + open it.
     public let onAdoptRoute: (RouteProposal) -> Void
+    /// City OS v2: user tapped "在地图上看" on an event card — dismiss the chat,
+    /// recenter the map on the event, and highlight its marker.
+    public let onShowEventOnMap: (CityEvent) -> Void
 
     /// Optional binding to the host sheet's selected detent. When provided, the
     /// sheet auto-expands to `.large` as soon as the agent starts working so the
@@ -91,6 +94,7 @@ public struct ChatSheet: View {
         onDismiss: @escaping () -> Void,
         onSelectExperience: @escaping (Experience) -> Void = { _ in },
         onAdoptRoute: @escaping (RouteProposal) -> Void = { _ in },
+        onShowEventOnMap: @escaping (CityEvent) -> Void = { _ in },
         detent: Binding<PresentationDetent> = .constant(.large),
         historyStore: ChatHistoryStore? = nil,
         initialUserPrompt: String? = nil
@@ -101,6 +105,7 @@ public struct ChatSheet: View {
         self.onDismiss = onDismiss
         self.onSelectExperience = onSelectExperience
         self.onAdoptRoute = onAdoptRoute
+        self.onShowEventOnMap = onShowEventOnMap
         self._detent = detent
         self.historyStore = historyStore
         self.initialUserPrompt = initialUserPrompt
@@ -390,6 +395,7 @@ public struct ChatSheet: View {
                                     cards: cards,
                                     onSelectExperience: handleSelectExperience,
                                     onAdoptRoute: handleAdoptRoute,
+                                    onShowEventOnMap: handleShowEventOnMap,
                                     // Slice B: hand the ledger-state
                                     // projection down so each provisional
                                     // card gets a countdown + undo pill.
@@ -1389,6 +1395,15 @@ public struct ChatSheet: View {
         teardownVoiceStream()
         onDismiss()
         onAdoptRoute(proposal)
+    }
+
+    /// City OS v2: user tapped "在地图上看" on an event card → dismiss the chat
+    /// so the map is visible, then hand the event up to recenter + highlight it.
+    private func handleShowEventOnMap(_ event: CityEvent) {
+        Haptics.impact(.light)
+        teardownVoiceStream()
+        onDismiss()
+        onShowEventOnMap(event)
     }
 
     // MARK: - Voice handling

--- a/apps/ios/SoloCompass/Views/CityOS/CityDrawerTabs.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/CityDrawerTabs.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// City OS v2 · the two glass drawer tabs floating just above the peek sheet in
+/// Live mode (PRD §5.2–5.3): 「落地包」and 「在地 · 本周」. They are the way
+/// back into the kit sheet (which only auto-surfaces once) and the live-events
+/// sheet. Shown only at the peek detent, in Live mode, with no card selected —
+/// so they never compete with the Now card or an active selection.
+struct CityDrawerTabs: View {
+    let kitCount: Int
+    let eventCount: Int
+    let onOpenKit: () -> Void
+    let onOpenLive: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            tab(
+                title: NSLocalizedString("cityos.tab.kit", comment: "落地包"),
+                symbol: "backpack",
+                count: nil,
+                action: onOpenKit
+            )
+            tab(
+                title: NSLocalizedString("cityos.tab.live", comment: "在地 · 本周"),
+                symbol: "calendar",
+                count: eventCount > 0 ? eventCount : nil,
+                action: onOpenLive
+            )
+        }
+    }
+
+    private func tab(title: String, symbol: String, count: Int?, action: @escaping () -> Void) -> some View {
+        Button {
+            Haptics.impact(.light)
+            action()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: symbol)
+                    .font(.system(size: 12, weight: .semibold))
+                Text(title)
+                    .font(CT.body(13, .semibold))
+                if let count {
+                    Text("\(count)")
+                        .font(CT.mono(11, .semibold))
+                        .foregroundStyle(CT.accent)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 1)
+                        .background(Capsule().fill(CT.accentSoft))
+                }
+            }
+            .foregroundStyle(CT.fgPrimary)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+            .background(
+                Capsule()
+                    .fill(.ultraThinMaterial)
+                    .overlay(Capsule().strokeBorder(CT.borderSubtle, lineWidth: 0.5))
+            )
+            .shadow(color: CT.scrimShadow, radius: 6, y: 2)
+        }
+        .buttonStyle(PressableButtonStyle(pressedScale: 0.96))
+        .accessibilityLabel(Text(count.map { "\(title), \($0)" } ?? title))
+    }
+}

--- a/apps/ios/SoloCompass/Views/CityOS/CityOSComponents.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/CityOSComponents.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+// MARK: - City OS v2 · shared render primitives (PRD §5.2–5.3)
+//
+// The kit sheet, live sheet, and chat event card all need the same two honest
+// signals — a health dot (never color-only) and a relative "last verified"
+// caption — so they live here once. Both are pure presentational leaves.
+
+/// A confidence/freshness dot for a City-OS row. Renders `HealthStatus.color`
+/// with the shape-coded `accessibilitySymbol` overlaid, so colorblind users can
+/// tell states apart by glyph, never by hue alone (the "可信 = 健康度点" axiom).
+struct HealthDot: View {
+    let status: HealthStatus
+    var size: CGFloat = 9
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(status.color)
+                .frame(width: size, height: size)
+            if let symbol = status.accessibilitySymbol {
+                Image(systemName: symbol)
+                    .font(.system(size: size * 0.6, weight: .bold))
+                    .foregroundStyle(.white)
+            }
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+/// A monospaced "last verified N days ago" caption. `RelativeDateTimeFormatter`
+/// keeps it locale-correct (中文 "3天前" / English "3 days ago"). Shows a
+/// dedicated "unverifiable" string when the timestamp is missing — matching the
+/// `.questioned` health `CityBriefHealth` assigns to an un-verified row.
+struct RelativeTimeText: View {
+    let date: Date?
+    var now: Date = Date()
+
+    private static let formatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .short
+        return f
+    }()
+
+    private var label: String {
+        guard let date else {
+            return NSLocalizedString("cityos.health.unverified", comment: "Freshness unknown")
+        }
+        return Self.formatter.localizedString(for: date, relativeTo: now)
+    }
+
+    var body: some View {
+        Text(label)
+            .font(CT.mono(10.5))
+            .foregroundStyle(CT.fgSubtle)
+    }
+}
+
+/// Combines a `HealthDot` and its relative-time caption into the standard
+/// City-OS freshness footer (dot + "3天前"), with a combined VoiceOver label so
+/// the two read as one honest statement rather than two loose fragments.
+struct FreshnessFooter: View {
+    let status: HealthStatus
+    let lastVerifiedAt: Date?
+    var now: Date = Date()
+
+    var body: some View {
+        HStack(spacing: 5) {
+            HealthDot(status: status)
+            RelativeTimeText(date: lastVerifiedAt, now: now)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(a11y))
+    }
+
+    private var a11y: String {
+        let freshness = lastVerifiedAt.map {
+            RelativeDateTimeFormatter().localizedString(for: $0, relativeTo: now)
+        } ?? NSLocalizedString("cityos.health.unverified", comment: "Freshness unknown")
+        return "\(status.localizedDescription), \(freshness)"
+    }
+}

--- a/apps/ios/SoloCompass/Views/CityOS/ComplianceBanner.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/ComplianceBanner.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// City OS v2 · visa compliance banner (PRD §4.3). Surfaces at the top of the
+/// map when the traveler's visa has ≤7 days left. Warm amber, mono day count,
+/// a 「处理」 CTA that opens the kit sheet focused on the visa row, and a
+/// dismiss X. Deliberately NO haptic on appear — it's information, not an alarm;
+/// the interruption budget already gates how often it can show.
+struct ComplianceBanner: View {
+    let daysRemaining: Int
+    /// Open the landing kit focused on the visa row.
+    let onHandle: () -> Void
+    /// Session-scoped dismiss (reappears next day per the interruption budget).
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "person.text.rectangle")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(CT.warningText)
+
+            label
+
+            Spacer(minLength: 8)
+
+            Button(action: onHandle) {
+                Text(NSLocalizedString("cityos.compliance.handle", comment: "处理"))
+                    .font(CT.body(13, .semibold))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(Capsule().fill(CT.accent))
+            }
+            .buttonStyle(PressableButtonStyle(pressedScale: 0.96))
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(CT.fgMuted)
+                    .frame(width: 28, height: 28)
+            }
+            .accessibilityLabel(Text(NSLocalizedString("common.dismiss", comment: "Dismiss")))
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(CT.warningSoft)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(CT.warningText.opacity(0.2), lineWidth: 0.5)
+        )
+        .shadow(color: CT.scrimShadow, radius: 8, y: 2)
+        .padding(.horizontal, 16)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(a11yLabel))
+    }
+
+    /// "签证还剩 N 天" with the number in mono bold. Overstay (negative) reads
+    /// as its own line so it never looks like a normal countdown.
+    private var label: some View {
+        Group {
+            if daysRemaining < 0 {
+                Text(String(
+                    format: NSLocalizedString("cityos.compliance.overstay", comment: "已逾期 N 天"),
+                    abs(daysRemaining)
+                ))
+                .font(CT.body(13, .semibold))
+                .foregroundStyle(CT.warningText)
+            } else {
+                (
+                    Text(NSLocalizedString("cityos.compliance.prefix", comment: "签证还剩 "))
+                        .font(CT.body(13, .medium))
+                    + Text("\(daysRemaining)")
+                        .font(CT.mono(15, .bold))
+                    + Text(NSLocalizedString("cityos.compliance.suffix", comment: " 天"))
+                        .font(CT.body(13, .medium))
+                )
+                .foregroundStyle(CT.warningText)
+            }
+        }
+        .lineLimit(1)
+        .minimumScaleFactor(0.8)
+    }
+
+    private var a11yLabel: String {
+        if daysRemaining < 0 {
+            return String(
+                format: NSLocalizedString("cityos.compliance.overstay", comment: "已逾期 N 天"),
+                abs(daysRemaining)
+            )
+        }
+        return String(
+            format: NSLocalizedString("cityos.compliance.a11y", comment: "Visa: N days remaining"),
+            daysRemaining
+        )
+    }
+}

--- a/apps/ios/SoloCompass/Views/CityOS/EventMarkerView.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/EventMarkerView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+/// City OS v2 · 在地 event回流 map marker (PRD §5.3). A limited-time local
+/// happening drawn on the map as a burnt-orange core with a slowly rotating
+/// dashed "timer" ring — the ring reads as "this expires". Fully static under
+/// Reduce Motion (the ring stops rotating; nothing else changes), so the marker
+/// never animates for motion-sensitive users.
+///
+/// Lives on its OWN `Annotation` layer, never inside the clustered POI pipeline
+/// (marker-count perf tests guard that boundary).
+struct EventMarkerView: View {
+    let event: CityEvent
+    /// Scales the core up when this event is the one the user just tapped
+    /// "在地图上看" for (or picked in chat), so it stands out on arrival.
+    var isHighlighted: Bool = false
+    let onTap: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var spinning = false
+
+    /// Explicit ring-animation override (tests pin both states); nil resolves
+    /// from the environment's Reduce Motion value at render time.
+    private let explicitAnimates: Bool?
+
+    init(
+        event: CityEvent,
+        isHighlighted: Bool = false,
+        animatesRing: Bool? = nil,
+        onTap: @escaping () -> Void
+    ) {
+        self.event = event
+        self.isHighlighted = isHighlighted
+        self.explicitAnimates = animatesRing
+        self.onTap = onTap
+    }
+
+    /// Ring animates only when motion is allowed and the caller didn't force it
+    /// off. `explicitAnimates` (tests) overrides the environment.
+    private var resolvedAnimates: Bool {
+        explicitAnimates ?? !reduceMotion
+    }
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 3) {
+                markerBody
+                tag
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(accessibilityLabel))
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private var markerBody: some View {
+        ZStack {
+            // Rotating dashed timer ring — the "限时" signal.
+            Circle()
+                .strokeBorder(
+                    CT.eventLimited,
+                    style: StrokeStyle(lineWidth: 2, dash: [4, 3])
+                )
+                .frame(width: 40, height: 40)
+                .rotationEffect(.degrees(resolvedAnimates && spinning ? 360 : 0))
+                .animation(
+                    resolvedAnimates
+                        ? .linear(duration: 14).repeatForever(autoreverses: false)
+                        : nil,
+                    value: spinning
+                )
+                .onAppear { if resolvedAnimates { spinning = true } }
+
+            // Solid core.
+            Circle()
+                .fill(CT.eventLimited)
+                .frame(width: 28, height: 28)
+                .overlay(Circle().strokeBorder(.white, lineWidth: 2))
+                .overlay(
+                    Image(systemName: Self.categoryIcon(for: event.category))
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundStyle(.white)
+                )
+                .scaleEffect(isHighlighted ? 1.15 : 1.0)
+                .animation(
+                    reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.6),
+                    value: isHighlighted
+                )
+        }
+    }
+
+    private var tag: some View {
+        Text(event.limitedLabel ?? event.whenLabel)
+            .font(.system(size: 9, weight: .semibold, design: .monospaced))
+            .foregroundStyle(CT.eventLimited)
+            .lineLimit(1)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(.white))
+            .overlay(Capsule().strokeBorder(CT.eventLimited.opacity(0.4), lineWidth: 0.5))
+            .fixedSize()
+    }
+
+    private var accessibilityLabel: String {
+        String(
+            format: NSLocalizedString("cityos.event.marker.a11y", comment: "Event marker: %1$@, %2$@"),
+            event.name,
+            event.limitedLabel ?? event.whenLabel
+        )
+    }
+
+    /// Map an event category slug to an SF Symbol. Pure + static so it's unit
+    /// testable and reused by chat/live cards. Every returned symbol is verified
+    /// by `SFSymbolExistenceTests`; unknown categories fall back to "calendar".
+    static func categoryIcon(for category: String?) -> String {
+        switch category {
+        case "culture":  return "theatermasks"
+        case "market":   return "basket"
+        case "wellness": return "figure.run"
+        case "music":    return "music.note"
+        case "sports":   return "sportscourt"
+        case "food":     return "fork.knife"
+        case "notice":   return "exclamationmark.triangle"
+        default:         return "calendar"
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Views/CityOS/KitSheet.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/KitSheet.swift
@@ -1,0 +1,378 @@
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// City OS v2 · 落地包 · 万象 landing-kit sheet (PRD §5.2). Four curated
+/// essentials (联网 / 钱 / 签证税务 / 安全), each a warm card carrying its main
+/// copy, a 独行透镜 one-liner, a freshness dot, and — where it earns it — a
+/// deep-link pill, self-computed visa/183-day digits, or dialable emergency
+/// numbers. Everything the traveler needs the moment they land, offline-usable.
+struct KitSheet: View {
+    let kit: [CityKitItem]
+    @Bindable var preferences: UserPreferences
+    let complianceService: ComplianceService
+    /// When set (e.g. opened from the compliance banner), the visa row is
+    /// highlighted and scrolled to on appear.
+    var focusKind: CityKitItem.Kind?
+    let onDismiss: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+    /// A lightweight in-sheet toast for the "已为你打开 … · 回来继续" deep-link cue.
+    @State private var toast: String?
+
+    /// Kit rows ordered net → money → visa → safety regardless of server order,
+    /// so the sheet's shape is stable.
+    private var orderedKit: [CityKitItem] {
+        let rank: [CityKitItem.Kind: Int] = [.net: 0, .money: 1, .visa: 2, .safety: 3]
+        return kit.sorted { (rank[$0.kind] ?? 9) < (rank[$1.kind] ?? 9) }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(spacing: 12) {
+                        ForEach(orderedKit) { item in
+                            KitRowCard(
+                                item: item,
+                                preferences: preferences,
+                                complianceService: complianceService,
+                                isFocused: item.kind == focusKind,
+                                onOpenLink: openLink
+                            )
+                            .id(item.kind)
+                        }
+                    }
+                    .padding(16)
+                }
+                .background(groupBackground.ignoresSafeArea())
+                .onAppear {
+                    guard let focusKind else { return }
+                    withAnimation(.easeInOut(duration: 0.35)) {
+                        proxy.scrollTo(focusKind, anchor: .center)
+                    }
+                }
+            }
+            .navigationTitle(NSLocalizedString("cityos.kit.title", comment: "落地包 sheet title"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(NSLocalizedString("common.done", comment: "Done")) { onDismiss() }
+                }
+            }
+            .overlay(alignment: .bottom) { toastOverlay }
+        }
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+    }
+
+    private var groupBackground: Color {
+        colorScheme == .dark ? CT.warmSheetDark : CT.surfaceSunken
+    }
+
+    // MARK: - Deep link + toast
+
+    private func openLink(_ url: URL, label: String) {
+        #if canImport(UIKit)
+        UIApplication.shared.open(url)
+        #endif
+        let text = String(
+            format: NSLocalizedString("cityos.kit.link.toast", comment: "已为你打开 %@ · 回来继续"),
+            label
+        )
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) { toast = text }
+        Task {
+            try? await Task.sleep(for: .seconds(2.4))
+            withAnimation(.easeInOut(duration: 0.3)) { toast = nil }
+        }
+    }
+
+    @ViewBuilder
+    private var toastOverlay: some View {
+        if let toast {
+            Text(toast)
+                .font(CT.body(13, .medium))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .background(Capsule().fill(CT.accent))
+                .padding(.bottom, 24)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .accessibilityAddTraits(.updatesFrequently)
+        }
+    }
+}
+
+// MARK: - KitRowCard
+
+/// One landing-kit row. Common chrome (icon tile, title, main copy, lens line,
+/// freshness footer) plus a kind-specific trailer: deep-link pill (net/money),
+/// visa/183-day self-computation (visa), or dialable numbers (safety).
+private struct KitRowCard: View {
+    let item: CityKitItem
+    @Bindable var preferences: UserPreferences
+    let complianceService: ComplianceService
+    let isFocused: Bool
+    let onOpenLink: (URL, String) -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var health: HealthStatus {
+        CityBriefHealth.health(lastVerifiedAt: item.lastVerifiedAt, serverHealth: item.serverHealth)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            header
+            Text(item.main)
+                .font(CT.body(14))
+                .foregroundStyle(primaryText)
+                .fixedSize(horizontal: false, vertical: true)
+            if let lens = item.lens, !lens.isEmpty {
+                lensLine(lens)
+            }
+            trailer
+            FreshnessFooter(status: health, lastVerifiedAt: item.lastVerifiedAt)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(cardFill)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .strokeBorder(isFocused ? CT.accent : borderColor, lineWidth: isFocused ? 1.5 : 0.5)
+        )
+        .accessibilityElement(children: .contain)
+    }
+
+    private var header: some View {
+        HStack(spacing: 11) {
+            Image(systemName: item.kind.symbolName)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(CT.accent)
+                .frame(width: 34, height: 34)
+                .background(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(iconTileFill)
+                )
+            Text(item.name)
+                .font(CT.display(15, .bold))
+                .foregroundStyle(primaryText)
+            Spacer(minLength: 0)
+        }
+    }
+
+    /// The existing hint idiom: sparkle prefix + accentSoft capsule + accent text.
+    private func lensLine(_ lens: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Image(systemName: "sparkle")
+                .font(.system(size: 10, weight: .semibold))
+            Text(lens)
+                .font(CT.body(12.5, .medium))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .foregroundStyle(CT.accent)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(lensFill)
+        )
+    }
+
+    @ViewBuilder
+    private var trailer: some View {
+        switch item.kind {
+        case .visa:
+            VisaComplianceControl(preferences: preferences, complianceService: complianceService, kitAction: item.action)
+        case .safety:
+            if let numbers = item.action?.numbers, !numbers.isEmpty {
+                emergencyNumbers(numbers)
+            }
+            deepLinkPill
+        default:
+            deepLinkPill
+        }
+    }
+
+    @ViewBuilder
+    private var deepLinkPill: some View {
+        if let url = item.linkURL {
+            let label = item.linkLabel ?? url.host ?? NSLocalizedString("cityos.kit.link.open", comment: "Open")
+            Button {
+                Haptics.impact(.light)
+                onOpenLink(url, label)
+            } label: {
+                HStack(spacing: 5) {
+                    Image(systemName: "arrow.up.forward.app")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text(label)
+                        .font(CT.body(12.5, .semibold))
+                }
+                .foregroundStyle(CT.accent)
+                .padding(.horizontal, 11)
+                .padding(.vertical, 6)
+                .background(Capsule().fill(lensFill))
+            }
+            .buttonStyle(PressableButtonStyle(pressedScale: 0.96))
+            .accessibilityLabel(Text(String(
+                format: NSLocalizedString("cityos.kit.link.open.a11y", comment: "Open %@"),
+                label
+            )))
+        }
+    }
+
+    /// Dialable emergency numbers — plain `tel:` links, offline-usable.
+    private func emergencyNumbers(_ numbers: [CityKitAction.EmergencyNumber]) -> some View {
+        VStack(spacing: 6) {
+            ForEach(numbers, id: \.number) { entry in
+                if let url = URL(string: "tel:\(entry.number)") {
+                    Link(destination: url) {
+                        HStack(spacing: 8) {
+                            Image(systemName: "phone.fill")
+                                .font(.system(size: 12, weight: .semibold))
+                            Text(entry.label)
+                                .font(CT.body(13, .medium))
+                            Spacer(minLength: 0)
+                            Text(entry.number)
+                                .font(CT.mono(14, .semibold))
+                        }
+                        .foregroundStyle(CT.accent)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 9)
+                        .frame(maxWidth: .infinity)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                .fill(lensFill)
+                        )
+                    }
+                    .accessibilityLabel(Text(String(
+                        format: NSLocalizedString("cityos.kit.call.a11y", comment: "Call %1$@ at %2$@"),
+                        entry.label, entry.number
+                    )))
+                }
+            }
+        }
+    }
+
+    // MARK: - Colors
+
+    private var cardFill: Color { colorScheme == .dark ? CT.warmCardDark : CT.surfaceWhite }
+    private var iconTileFill: Color { colorScheme == .dark ? CT.warmSunkenDark : CT.accentSoft }
+    private var lensFill: Color { colorScheme == .dark ? CT.warmSunkenDark : CT.accentSoft }
+    private var borderColor: Color { colorScheme == .dark ? CT.warmBorderDark : CT.borderSubtle }
+    private var primaryText: Color { colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary }
+}
+
+// MARK: - VisaComplianceControl
+
+/// The visa/183-day self-computation trailer. When the traveler has entered
+/// their entry date, show the big mono counters + a reminder toggle; otherwise
+/// let them set entry date + visa length inline (the only kit input the app
+/// stores locally, PRD §5.2).
+private struct VisaComplianceControl: View {
+    @Bindable var preferences: UserPreferences
+    let complianceService: ComplianceService
+    let kitAction: CityKitAction?
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        if let state = complianceService.state() {
+            counters(state)
+        } else {
+            entrySetup
+        }
+    }
+
+    private func counters(_ state: ComplianceService.State) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 12) {
+                counter(
+                    value: state.visaDaysRemaining,
+                    label: NSLocalizedString("cityos.visa.daysLeft", comment: "剩 N 天签证"),
+                    isCritical: state.isCritical
+                )
+                counter(
+                    value: state.taxDaysRemaining,
+                    label: NSLocalizedString("cityos.visa.taxLine", comment: "距 183 天税务线 M 天"),
+                    isCritical: false
+                )
+            }
+            Toggle(isOn: $preferences.visaReminderEnabled) {
+                Text(NSLocalizedString("cityos.visa.reminder.toggle", comment: "到期提醒"))
+                    .font(CT.body(13, .medium))
+                    .foregroundStyle(primaryText)
+            }
+            .tint(CT.accent)
+            .onChange(of: preferences.visaReminderEnabled) { _, _ in
+                Task { await complianceService.syncVisaReminder() }
+            }
+        }
+    }
+
+    private func counter(value: Int, label: String, isCritical: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("\(value)")
+                .font(CT.mono(26, .bold))
+                .foregroundStyle(isCritical ? CT.warningText : CT.accent)
+                .contentTransition(.numericText())
+            Text(label)
+                .font(CT.body(10.5))
+                .foregroundStyle(CT.fgMuted)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text("\(label): \(value)"))
+    }
+
+    private var entrySetup: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            DatePicker(
+                NSLocalizedString("cityos.visa.entryDate", comment: "入境日期"),
+                selection: entryDateBinding,
+                displayedComponents: .date
+            )
+            .font(CT.body(13, .medium))
+            Stepper(
+                value: visaLengthBinding,
+                in: 1...365
+            ) {
+                Text(String(
+                    format: NSLocalizedString("cityos.visa.length", comment: "签证 N 天"),
+                    visaLengthBinding.wrappedValue
+                ))
+                .font(CT.body(13, .medium))
+                .foregroundStyle(primaryText)
+            }
+        }
+    }
+
+    /// Setting an entry date flips the row to counter mode (state becomes
+    /// non-nil once both entry date and length are stored).
+    private var entryDateBinding: Binding<Date> {
+        Binding(
+            get: { preferences.visaEntryDate ?? Date() },
+            set: { newValue in
+                preferences.visaEntryDate = newValue
+                if preferences.visaLengthDays == nil {
+                    preferences.visaLengthDays = kitAction?.visaDays ?? 30
+                }
+            }
+        )
+    }
+
+    private var visaLengthBinding: Binding<Int> {
+        Binding(
+            get: { preferences.visaLengthDays ?? kitAction?.visaDays ?? 30 },
+            set: { preferences.visaLengthDays = $0 }
+        )
+    }
+
+    private var primaryText: Color { colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary }
+}

--- a/apps/ios/SoloCompass/Views/CityOS/LiveSheet.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/LiveSheet.swift
@@ -1,0 +1,229 @@
+import SwiftUI
+
+/// City OS v2 · 在地 · 本周 local-events sheet (PRD §5.3). Lists this week's
+/// solo-scored happenings and travel notices for the city, each an honest card:
+/// name, limited-time chip, a Solo chip + one-line "一个人去合不合适" note, a
+/// freshness footer, and a "在地图上看" jump. Notices render in the warning
+/// treatment — no Solo score, just the heads-up.
+struct LiveSheet: View {
+    let events: [CityEvent]
+    /// Dismiss the sheet, recenter the map on the event, and highlight its marker.
+    let onShowOnMap: (CityEvent) -> Void
+    let onDismiss: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    /// Notices first (they affect movement today), then events by start time.
+    private var ordered: [CityEvent] {
+        events.sorted { lhs, rhs in
+            if lhs.isNotice != rhs.isNotice { return lhs.isNotice }
+            return (lhs.startsAt ?? .distantFuture) < (rhs.startsAt ?? .distantFuture)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if ordered.isEmpty {
+                    emptyState
+                } else {
+                    ScrollView {
+                        VStack(spacing: 12) {
+                            ForEach(ordered) { event in
+                                LiveEventCard(
+                                    event: event,
+                                    onShowOnMap: event.lat != nil && event.lng != nil
+                                        ? { onShowOnMap(event) }
+                                        : nil
+                                )
+                            }
+                        }
+                        .padding(16)
+                    }
+                    .background(background.ignoresSafeArea())
+                }
+            }
+            .navigationTitle(NSLocalizedString("cityos.live.title", comment: "在地 · 本周 sheet title"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(NSLocalizedString("common.done", comment: "Done")) { onDismiss() }
+                }
+            }
+        }
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+    }
+
+    private var background: Color {
+        colorScheme == .dark ? CT.warmSheetDark : CT.surfaceSunken
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "calendar")
+                .font(.system(size: 40))
+                .foregroundStyle(CT.fgSubtle)
+            Text(NSLocalizedString("cityos.live.empty.title", comment: "No local events this week"))
+                .font(CT.display(16, .semibold))
+                .foregroundStyle(colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary)
+            Text(NSLocalizedString("cityos.live.empty.hint", comment: "Check back — the city brief refreshes twice a week."))
+                .font(CT.body(13))
+                .foregroundStyle(CT.fgMuted)
+                .multilineTextAlignment(.center)
+        }
+        .padding(32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(background.ignoresSafeArea())
+    }
+}
+
+// MARK: - LiveEventCard
+
+/// One 在地 event card. Shared between `LiveSheet` and the chat `ChatEventCard`
+/// (B4) so the two surfaces stay visually identical. When `onShowOnMap` is nil
+/// (no coordinate), the map button is omitted.
+struct LiveEventCard: View {
+    let event: CityEvent
+    var onShowOnMap: (() -> Void)?
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    /// Events carry no `lastVerifiedAt` (the schema tracks freshness via
+    /// `seenLabel` + `endsAt`), so the dot maps the server health directly
+    /// rather than through the age-decay path, which would flag every event
+    /// `.questioned` for a missing timestamp.
+    private var health: HealthStatus {
+        switch event.serverHealth {
+        case "green":  return .healthy
+        case "yellow": return .fading
+        case "red":    return .questioned
+        default:       return .fading
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            titleRow
+            metaRow
+            if let note = event.soloNote, !note.isEmpty {
+                Text(note)
+                    .font(CT.body(13))
+                    .foregroundStyle(event.isNotice ? CT.warningText : primaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            footer
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(cardFill)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(borderColor, lineWidth: 0.5)
+        )
+        .accessibilityElement(children: .contain)
+    }
+
+    private var titleRow: some View {
+        HStack(alignment: .top, spacing: 8) {
+            if event.isNotice {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(CT.warningText)
+            }
+            Text(event.name)
+                .font(CT.displayRounded(15, .semibold))
+                .foregroundStyle(event.isNotice ? CT.warningText : primaryText)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+            if let limited = event.limitedLabel, !limited.isEmpty {
+                limitedChip(limited)
+            }
+        }
+    }
+
+    private func limitedChip(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 9.5, weight: .semibold, design: .monospaced))
+            .foregroundStyle(CT.eventLimited)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(CT.eventLimitedSoft))
+    }
+
+    private var metaRow: some View {
+        HStack(spacing: 8) {
+            Text(event.whenLabel)
+                .font(CT.mono(11))
+                .foregroundStyle(CT.fgMuted)
+            if !event.isNotice, let score = event.soloScore {
+                soloChip(score)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func soloChip(_ score: Double) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "person.fill")
+                .font(.system(size: 9, weight: .semibold))
+            Text(String(
+                format: NSLocalizedString("cityos.live.solo", comment: "Solo %@"),
+                String(format: "%.1f", score)
+            ))
+            .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
+        }
+        .foregroundStyle(CT.verifiedGreen)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(CT.successSoft))
+    }
+
+    private var footer: some View {
+        HStack(spacing: 8) {
+            HealthDot(status: health)
+            if let seen = event.seenLabel, !seen.isEmpty {
+                Text(seen)
+                    .font(CT.mono(9.5))
+                    .foregroundStyle(CT.fgSubtle)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 0)
+            if let onShowOnMap {
+                Button {
+                    Haptics.impact(.light)
+                    onShowOnMap()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "mappin.and.ellipse")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text(NSLocalizedString("cityos.live.showOnMap", comment: "在地图上看"))
+                            .font(CT.body(12, .semibold))
+                    }
+                    .foregroundStyle(CT.accent)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Capsule().fill(mapButtonFill))
+                }
+                .buttonStyle(PressableButtonStyle(pressedScale: 0.96))
+                .accessibilityLabel(Text(String(
+                    format: NSLocalizedString("cityos.live.showOnMap.a11y", comment: "Show %@ on the map"),
+                    event.name
+                )))
+            }
+        }
+    }
+
+    // MARK: - Colors
+
+    private var cardFill: Color {
+        if event.isNotice { return colorScheme == .dark ? CT.warmSunkenDark : CT.warningSoft }
+        return colorScheme == .dark ? CT.warmCardDark : CT.surfaceWhite
+    }
+    private var borderColor: Color { colorScheme == .dark ? CT.warmBorderDark : CT.borderSubtle }
+    private var mapButtonFill: Color { colorScheme == .dark ? CT.warmSunkenDark : CT.accentSoft }
+    private var primaryText: Color { colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary }
+}

--- a/apps/ios/SoloCompass/Views/CityOS/ModePlaceholderCards.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/ModePlaceholderCards.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+/// City OS v2 · Plan / Recall mode placeholder cards (PRD §4.1). The product
+/// decision for v2 is: Live mode is fully built; Plan and Recall get honest
+/// placeholder cards so the mode switch is real and legible, but they don't
+/// pretend to have features that aren't there yet. Each teases what the mode
+/// will hold and offers the one thing that IS live — the landing kit.
+struct PlanCard: View {
+    let cityName: String
+    let onOpenKit: () -> Void
+
+    var body: some View {
+        ModeCard(
+            tagText: NSLocalizedString("cityos.mode.plan.tag", comment: "计划"),
+            tagColor: CT.modePlanBlue,
+            title: String(
+                format: NSLocalizedString("cityos.mode.plan.title", comment: "%@ · 计划中"),
+                cityName
+            ),
+            bodyText: NSLocalizedString("cityos.mode.plan.body", comment: "Pre-trip checklist teaser"),
+            ctaText: NSLocalizedString("cityos.mode.plan.cta", comment: "先看落地包"),
+            onCTA: onOpenKit
+        )
+    }
+}
+
+/// The Recall-mode placeholder — muted, retrospective register.
+struct RecallCard: View {
+    let cityName: String
+    let onOpenKit: () -> Void
+
+    var body: some View {
+        ModeCard(
+            tagText: NSLocalizedString("cityos.mode.recall.tag", comment: "回顾"),
+            tagColor: CT.fgMuted,
+            title: String(
+                format: NSLocalizedString("cityos.mode.recall.title", comment: "%@ · 回顾"),
+                cityName
+            ),
+            bodyText: NSLocalizedString("cityos.mode.recall.body", comment: "Looking-back teaser"),
+            ctaText: nil,
+            onCTA: onOpenKit
+        )
+    }
+}
+
+// MARK: - ModeCard
+
+/// Shared chrome for the mode placeholder cards.
+private struct ModeCard: View {
+    let tagText: String
+    let tagColor: Color
+    let title: String
+    let bodyText: String
+    let ctaText: String?
+    let onCTA: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            tag
+            Text(title)
+                .font(CT.displayRounded(16, .semibold))
+                .foregroundStyle(primaryText)
+                .fixedSize(horizontal: false, vertical: true)
+            Text(bodyText)
+                .font(CT.body(13))
+                .foregroundStyle(CT.fgMuted)
+                .fixedSize(horizontal: false, vertical: true)
+            if let ctaText {
+                Button {
+                    Haptics.impact(.light)
+                    onCTA()
+                } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: "backpack")
+                            .font(.system(size: 12, weight: .semibold))
+                        Text(ctaText)
+                            .font(CT.body(13, .semibold))
+                    }
+                    .foregroundStyle(CT.accent)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(Capsule().fill(CT.accentSoft))
+                }
+                .buttonStyle(PressableButtonStyle(pressedScale: 0.96))
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(cardFill)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .strokeBorder(borderColor, lineWidth: 0.5)
+        )
+        .shadow(color: CT.scrimShadow, radius: 10, y: 3)
+        .accessibilityElement(children: .contain)
+    }
+
+    private var tag: some View {
+        Text(tagText)
+            .font(.system(size: 10, weight: .bold, design: .rounded))
+            .tracking(1.0)
+            .textCase(.uppercase)
+            .foregroundStyle(tagColor)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(tagColor.opacity(0.12)))
+    }
+
+    private var cardFill: Color { colorScheme == .dark ? CT.warmCardDark : CT.surfaceWhite }
+    private var borderColor: Color { colorScheme == .dark ? CT.warmBorderDark : CT.borderSubtle }
+    private var primaryText: Color { colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary }
+}

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -254,6 +254,10 @@ public struct BottomInfoSheet<Content: View>: View {
     /// the peek summary card; the pill is hidden when nil.
     private let onShuffle: (() -> Void)?
     private let onRefresh: (() async -> Void)?
+    /// City OS v2: mirrors the current detent out to the host so it can gate
+    /// peek-only floating overlays (drawer tabs / mode cards). Optional with a
+    /// nil default so every existing call site is byte-identical.
+    private let onDetentChange: ((BottomSheetDetent) -> Void)?
     private let content: (BottomSheetDetent, Binding<SortMode>) -> Content
 
     public init(
@@ -267,6 +271,7 @@ public struct BottomInfoSheet<Content: View>: View {
         isPreviewActive: Bool = false,
         onShuffle: (() -> Void)? = nil,
         onRefresh: (() async -> Void)? = nil,
+        onDetentChange: ((BottomSheetDetent) -> Void)? = nil,
         @ViewBuilder content: @escaping (BottomSheetDetent, Binding<SortMode>) -> Content
     ) {
         self.aiHint = aiHint
@@ -279,6 +284,7 @@ public struct BottomInfoSheet<Content: View>: View {
         self.isPreviewActive = isPreviewActive
         self.onShuffle = onShuffle
         self.onRefresh = onRefresh
+        self.onDetentChange = onDetentChange
         self.content = content
     }
 
@@ -414,7 +420,9 @@ public struct BottomInfoSheet<Content: View>: View {
         .animation(.spring(response: 0.3, dampingFraction: 0.85), value: currentDetent)
         .onChange(of: currentDetent) { _, newValue in
             if newValue != .peek { hasEverExpanded = true }
+            onDetentChange?(newValue)
         }
+        .onAppear { onDetentChange?(currentDetent) }
     }
 
     // MARK: - Peek content

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -172,6 +172,25 @@ struct CompassMapContentView: View {
     @State private var isShowingCityPicker: Bool = false
     @State private var surveyExperience: Experience? = nil
     @State private var isShowingFavorites: Bool = false
+
+    // MARK: - City OS v2 (PRD solo-city-os-v2 §4–5), all gated by FeatureFlags.cityOS
+    /// Per-city mode (Live/Plan/Recall) + kit auto-surface bookkeeping.
+    @State private var cityOSStore: CityOSStore
+    /// Landing-kit + local-events content plane (cache-first, seed fallback).
+    @State private var cityBriefService: CityBriefService
+    /// Visa / 183-day self-computation (pure-local).
+    @State private var complianceService: ComplianceService
+    @State private var isShowingKitSheet: Bool = false
+    /// When set, the kit sheet opens focused on this row (e.g. the visa row from
+    /// the compliance banner). Cleared on dismiss.
+    @State private var kitSheetFocus: CityKitItem.Kind? = nil
+    @State private var isShowingLiveSheet: Bool = false
+    /// Session-scoped dismissal of the compliance banner — it reappears next day
+    /// (a fresh interruption-budget day), never again this session.
+    @State private var complianceBannerDismissed: Bool = false
+    /// Mirror of the BottomInfoSheet's current detent, so the drawer tabs only
+    /// show at `.peek`. Threaded via `onDetentChange`.
+    @State private var sheetDetent: BottomSheetDetent = .peek
     @State private var voiceOrchestrator: VoiceAgentOrchestrator? = nil
     /// Selected detent for the chat sheet. Bound into `presentationDetents` so
     /// the sheet can auto-expand to `.large` while the agent is working (see
@@ -309,6 +328,13 @@ struct CompassMapContentView: View {
         )
         vm.attachSubscriptionService(subscriptionService)
         _viewModel = State(initialValue: vm)
+
+        // City OS v2: these three own the (city, mode) + brief content + visa
+        // math. Built here (not lazily) because they need `preferences` and,
+        // like `vm`, must be live for any write between launch and `onAppear`.
+        _cityOSStore = State(initialValue: CityOSStore(preferences: preferences))
+        _cityBriefService = State(initialValue: CityBriefService())
+        _complianceService = State(initialValue: ComplianceService(preferences: preferences))
     }
 
     /// Bottom inset for the floating selected-experience card so it rests
@@ -331,6 +357,133 @@ struct CompassMapContentView: View {
     private var controlBarBottomInset: CGFloat {
         let controlSheetGap: CGFloat = 8
         return sheetPeekClearance + controlSheetGap
+    }
+
+    // MARK: - City OS v2 helpers
+
+    /// Bottom inset for the City-OS drawer tabs so they float just above the
+    /// peek sheet. Slightly more gap than the control bar so the two glass
+    /// pills read as their own row, not stacked on the FAB.
+    private var drawerTabsBottomInset: CGFloat {
+        sheetPeekClearance + 8
+    }
+
+    /// The current city's mode (Live/Plan/Recall). Live is the default.
+    private var currentCityMode: CityMode {
+        cityOSStore.mode(for: viewModel.selectedCity)
+    }
+
+    /// Display name for the current city (for the mode placeholder cards),
+    /// falling back to the raw code, then a generic label.
+    private var currentCityDisplayName: String {
+        guard let code = viewModel.selectedCity else {
+            return NSLocalizedString("cityos.mode.thisCity", comment: "This city (unknown)")
+        }
+        return viewModel.availableCities.first { $0.code == code }?.name ?? code
+    }
+
+    /// Pure banner-arbitration ladder: offline > POI loading > compliance. The
+    /// compliance banner shows only when City OS is on, the visa is critical,
+    /// the banner hasn't been dismissed this session, and the city is in Live
+    /// mode. Extracted so `ComplianceBannerArbitrationTests` can pin every rung.
+    /// `nonisolated` (pure) so tests can call it off the main actor.
+    nonisolated static func showsComplianceBanner(
+        offline: Bool,
+        fetching: Bool,
+        cityOSEnabled: Bool,
+        critical: Bool,
+        dismissed: Bool,
+        isLive: Bool
+    ) -> Bool {
+        guard cityOSEnabled, !offline, !fetching else { return false }
+        return critical && !dismissed && isLive
+    }
+
+    /// Whether the compliance banner should render right now, consulting live
+    /// state. `showsComplianceBanner` holds the pure logic.
+    private var shouldShowComplianceBanner: Bool {
+        Self.showsComplianceBanner(
+            offline: !networkMonitor.isConnected,
+            fetching: viewModel.isFetchingPOIs,
+            cityOSEnabled: FeatureFlags.cityOS,
+            critical: complianceService.state()?.isCritical == true,
+            dismissed: complianceBannerDismissed,
+            isLive: currentCityMode == .live
+        )
+    }
+
+    /// Whether the City-OS drawer tabs should show: flag on, resting at peek,
+    /// Live mode, no experience selected, and kit content exists.
+    private var shouldShowDrawerTabs: Bool {
+        FeatureFlags.cityOS
+            && sheetDetent == .peek
+            && viewModel.selectedExperience == nil
+            && currentCityMode == .live
+            && !cityBriefService.kit.isEmpty
+    }
+
+    /// Load the landing kit + local events for a city and, when `autoSurface`
+    /// is true and the city is unseen + in Live mode + has kit content + the
+    /// interruption budget allows + no other sheet is up, push the kit sheet
+    /// once. Also fires the 今日城市签 daily omen (its own 1/day budget). Always
+    /// reloads content regardless of the auto-surface decision.
+    private func loadCityBrief(for cityCode: String?, autoSurface: Bool) {
+        guard FeatureFlags.cityOS, let cityCode, !cityCode.isEmpty else { return }
+        Task {
+            await cityBriefService.load(cityCode: cityCode)
+            guard currentCityMode == .live else { return }
+            startDailyOmenIfAvailable()
+            guard autoSurface,
+                  !cityOSStore.hasSeenKit(cityCode),
+                  cityBriefService.hasKit(for: cityCode),
+                  !anyCityOSSheetIsUp,
+                  CityOSInterruptionBudget.consumeProactive()
+            else { return }
+            cityOSStore.markKitSeen(cityCode)
+            kitSheetFocus = nil
+            isShowingKitSheet = true
+        }
+    }
+
+    /// True when any sheet that would collide with an auto-surfacing kit is
+    /// already presented — the kit must never shove itself in front of one.
+    private var anyCityOSSheetIsUp: Bool {
+        isShowingCityPicker || isShowingKitSheet || isShowingLiveSheet
+            || isShowingFavorites || isShowingMe || viewModel.isShowingDetail
+            || voiceOrchestrator != nil
+    }
+
+    /// Present today's 今日城市签 Live Activity for the loaded city's daily pick.
+    /// `startDailyOmen` owns the 1/day budget, so repeat calls are no-ops.
+    private func startDailyOmenIfAvailable() {
+        guard let pick = cityBriefService.dailyPick() else { return }
+        let line = String(
+            format: NSLocalizedString("cityos.omen.line", comment: "今日城市签 · %@"),
+            pick.name
+        )
+        LiveActivityService.shared.startDailyOmen(
+            line: line,
+            microTask: pick.soloNote ?? pick.whenLabel
+        )
+    }
+
+    /// Consume one interruption-budget unit the FIRST time the compliance banner
+    /// renders on a given local day — a per-day UserDefaults stamp ensures a
+    /// re-render within the same day doesn't double-charge. When the budget is
+    /// already spent, dismiss the banner for this session so it stays silent.
+    private func consumeComplianceBudgetOncePerDay() {
+        let key = Self.complianceBudgetStampKey(for: Date())
+        guard UserDefaults.standard.string(forKey: "cityos.compliance.banner.day") != key else { return }
+        UserDefaults.standard.set(key, forKey: "cityos.compliance.banner.day")
+        if !CityOSInterruptionBudget.consumeProactive() {
+            complianceBannerDismissed = true
+        }
+    }
+
+    /// Per-day stamp key (yyyy-MM-dd) for the compliance-banner budget guard.
+    private static func complianceBudgetStampKey(for date: Date) -> String {
+        let comps = Calendar.current.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", comps.year ?? 0, comps.month ?? 0, comps.day ?? 0)
     }
 
     /// The `BottomInfoSheet` peek height at the current Dynamic Type size — the
@@ -550,6 +703,10 @@ struct CompassMapContentView: View {
                     // lands directly on a city with seeded routes shows an empty
                     // Routes section, and 开始路线 is unreachable from the map.
                     refreshNearbyRoutes(cityCode: viewModel.selectedCity)
+                    // City OS v2: load the landing kit + local events for the
+                    // initial city and, on first cold start in a Live city, let
+                    // the kit auto-surface once (budget-gated).
+                    loadCityBrief(for: viewModel.selectedCity, autoSurface: true)
                     // #80: Cold-start resume. If RouteStore has an active route
                     // persisted from a previous session, rebuild the in-memory
                     // ActiveRoute @State so the polyline, numbered pins, and
@@ -578,6 +735,22 @@ struct CompassMapContentView: View {
                     if ProcessInfo.processInfo.arguments.contains("-triggerExplore") {
                         let center = viewModel.defaultCenterForSelectedCity
                         Task { await viewModel.exploreNearby(at: center) }
+                    }
+                    // City OS v2 screenshot-harness hooks: force-open the landing
+                    // kit or live sheet unconditionally, bypassing the "seen kit"
+                    // budget so an automated verification run always sees the same
+                    // surface. Small delay lets the picker resolve and the sheet
+                    // detent settle first.
+                    if ProcessInfo.processInfo.arguments.contains("-openKitSheet") {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                            kitSheetFocus = nil
+                            isShowingKitSheet = true
+                        }
+                    }
+                    if ProcessInfo.processInfo.arguments.contains("-openLiveSheet") {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                            isShowingLiveSheet = true
+                        }
                     }
                     // ④ Self-eval Rubric e2e hook: on cold start simulate one
                     // completed turn matching the "happy path" fixture and
@@ -709,6 +882,13 @@ struct CompassMapContentView: View {
                 if let active = activeRoute, active.route.cityCode != cityCode {
                     activeRoute = nil
                 }
+                // City OS v2: switching city always reloads the brief (content
+                // refresh); the kit may auto-surface once for a Live city not
+                // yet seen. Reset the highlight + banner dismissal for the new
+                // city so a stale marker glow / dismissed banner don't carry over.
+                viewModel.highlightedEventId = nil
+                complianceBannerDismissed = false
+                loadCityBrief(for: cityCode, autoSurface: true)
             }
             .onReceive(NotificationCenter.default.publisher(for: RouteStore.didChange)) { _ in
                 refreshNearbyRoutes(cityCode: viewModel.selectedCity)
@@ -731,6 +911,12 @@ struct CompassMapContentView: View {
             .sheet(isPresented: recordExperienceSheetBinding) { recordExperienceSheetContent }
             .sheet(isPresented: detailSheetBinding) { detailSheetContent }
             .sheet(isPresented: $isShowingCityPicker) { cityPickerSheetContent }
+            // City OS v2: KitSheet / LiveSheet presenters live on the OUTER
+            // mapContent chain (never the inner ZStack) — SwiftUI silently drops
+            // deeply-nested presenters when the outer chain already carries many
+            // sheets (see the L1180-ish stacked-sheets note).
+            .sheet(isPresented: $isShowingKitSheet, onDismiss: { kitSheetFocus = nil }) { kitSheetContent }
+            .sheet(isPresented: $isShowingLiveSheet) { liveSheetContent }
             .sheet(isPresented: $isShowingFavorites) { favoritesSheetContent }
             // Bind the chat sheet to the orchestrator itself instead of a
             // separate Bool. With `.sheet(isPresented:)` the content closure
@@ -831,6 +1017,16 @@ struct CompassMapContentView: View {
             // collides with the status bar.
             mapLayer(viewModel: viewModel)
                 .ignoresSafeArea()
+
+                // City OS v2: in Plan mode the whole map cools to a considered,
+                // "you're not here yet" register — a soft blue-white wash that
+                // crossfades in over 350ms and never blocks touches.
+                if FeatureFlags.cityOS && currentCityMode == .plan {
+                    CT.modePlanBlue.opacity(0.06)
+                        .ignoresSafeArea()
+                        .allowsHitTesting(false)
+                        .transition(.opacity)
+                }
 
                 MapOverlayView(
                     viewModel: viewModel,
@@ -951,6 +1147,27 @@ struct CompassMapContentView: View {
                         Spacer()
                     }
                     .animation(.easeInOut, value: viewModel.isFetchingPOIs)
+                } else if shouldShowComplianceBanner {
+                    // City OS v2 compliance banner (§4.3): the lowest rung of the
+                    // top-banner ladder (offline > POI loading > compliance) so it
+                    // never stacks with either. Its first appearance of the day
+                    // consumes the interruption budget in `.onAppear` below.
+                    VStack {
+                        ComplianceBanner(
+                            daysRemaining: complianceService.state()?.visaDaysRemaining ?? 0,
+                            onHandle: {
+                                kitSheetFocus = .visa
+                                isShowingKitSheet = true
+                            },
+                            onDismiss: {
+                                withAnimation(.easeInOut) { complianceBannerDismissed = true }
+                            }
+                        )
+                        .padding(.top, 8)
+                        .onAppear { consumeComplianceBudgetOncePerDay() }
+                        Spacer()
+                    }
+                    .transition(.move(edge: .top).combined(with: .opacity))
                 }
 
                 ZStack(alignment: .bottom) {
@@ -984,6 +1201,9 @@ struct CompassMapContentView: View {
                         },
                         onRefresh: {
                             viewModel.loadNearbyExperiences()
+                        },
+                        onDetentChange: { detent in
+                            if sheetDetent != detent { sheetDetent = detent }
                         }
                     ) { detent, sortMode in
                         if detent != .peek {
@@ -1156,6 +1376,46 @@ struct CompassMapContentView: View {
                     }
                 }
 
+                // City OS v2: the floating slot above the peek sheet holds either
+                // the two drawer tabs (Live mode) or a Plan/Recall placeholder
+                // card (other modes). Both sit clear of the peek sheet via the
+                // Dynamic-Type-aware inset and never coexist with a selection card
+                // (their guards are mutually exclusive with `selectedExperience`).
+                if FeatureFlags.cityOS {
+                    if shouldShowDrawerTabs {
+                        VStack {
+                            Spacer()
+                            CityDrawerTabs(
+                                kitCount: cityBriefService.kit.count,
+                                eventCount: cityBriefService.activeEvents().count,
+                                onOpenKit: {
+                                    kitSheetFocus = nil
+                                    isShowingKitSheet = true
+                                },
+                                onOpenLive: { isShowingLiveSheet = true }
+                            )
+                            .padding(.bottom, drawerTabsBottomInset)
+                        }
+                        .transition(.opacity)
+                    } else if currentCityMode != .live
+                        && sheetDetent == .peek
+                        && viewModel.selectedExperience == nil {
+                        VStack {
+                            Spacer()
+                            Group {
+                                if currentCityMode == .plan {
+                                    PlanCard(cityName: currentCityDisplayName, onOpenKit: { isShowingKitSheet = true })
+                                } else {
+                                    RecallCard(cityName: currentCityDisplayName, onOpenKit: { isShowingKitSheet = true })
+                                }
+                            }
+                            .padding(.horizontal, 20)
+                            .padding(.bottom, drawerTabsBottomInset)
+                        }
+                        .transition(.opacity)
+                    }
+                }
+
                 // Active-route banner: a pill naming the walk with an end button.
                 // Floats above the map; tapping ⨯ clears the polyline. It sits
                 // BELOW the city pill + filter bar (offset by the filter bar's
@@ -1267,6 +1527,9 @@ struct CompassMapContentView: View {
                 .zIndex(25)
             }
         }
+        // City OS v2: crossfade the Plan wash + the mode-dependent floating slot
+        // (drawer tabs ⇄ placeholder cards) when the traveler flips city mode.
+        .animation(.easeInOut(duration: 0.35), value: currentCityMode)
     }
 
     // MARK: - Sheet Bindings
@@ -1474,9 +1737,50 @@ struct CompassMapContentView: View {
 
     @ViewBuilder
     private var cityPickerSheetContent: some View {
-        LocationPickerSheet(viewModel: viewModel) {
+        LocationPickerSheet(
+            viewModel: viewModel,
+            cityOSStore: FeatureFlags.cityOS ? cityOSStore : nil
+        ) {
             isShowingCityPicker = false
         }
+    }
+
+    // MARK: - City OS v2 sheet content
+
+    @ViewBuilder
+    private var kitSheetContent: some View {
+        KitSheet(
+            kit: cityBriefService.kit,
+            preferences: preferences,
+            complianceService: complianceService,
+            focusKind: kitSheetFocus,
+            onDismiss: { isShowingKitSheet = false }
+        )
+    }
+
+    @ViewBuilder
+    private var liveSheetContent: some View {
+        LiveSheet(
+            events: cityBriefService.activeEvents(),
+            onShowOnMap: { event in
+                isShowingLiveSheet = false
+                focusEventOnMap(event)
+            },
+            onDismiss: { isShowingLiveSheet = false }
+        )
+    }
+
+    /// Recenter the camera on an event and highlight its marker (shared by the
+    /// live sheet and the chat event card).
+    private func focusEventOnMap(_ event: CityEvent) {
+        guard let lat = event.lat, let lng = event.lng else { return }
+        withAnimation(.easeInOut(duration: 0.4)) {
+            viewModel.cameraPosition = .region(MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: lat, longitude: lng),
+                span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+            ))
+        }
+        viewModel.highlightedEventId = event.id
     }
 
     @ViewBuilder
@@ -1857,7 +2161,11 @@ struct CompassMapContentView: View {
             // P2.0 #201/#202: hand the shared MemoryDigestService so the
             // agent injects the AgentMemorySnapshot into its system prompt
             // and refreshes the digest after each completed turn.
-            memoryDigest: MemoryDigestService.shared
+            memoryDigest: MemoryDigestService.shared,
+            // City OS v2: wire the content plane + visa math so the get_city_kit
+            // / find_local_events tools resolve real facts (gated by the flag).
+            cityBriefService: FeatureFlags.cityOS ? cityBriefService : nil,
+            complianceService: FeatureFlags.cityOS ? complianceService : nil
         )
         orch.start()
         voiceOrchestrator = orch
@@ -1905,6 +2213,11 @@ struct CompassMapContentView: View {
                 routeStore.save(proposal.route)
                 refreshNearbyRoutes(cityCode: viewModel.selectedCity)
                 routeSheet = .detail(proposal.route)
+            },
+            // City OS v2: tapping "在地图上看" on a chat event card recenters the
+            // map on the event and highlights its marker (chat already dismissed).
+            onShowEventOnMap: { event in
+                focusEventOnMap(event)
             },
             // Bound detent lets the sheet auto-expand to full height while the
             // agent is thinking, then the user can still drag it back down.
@@ -2069,6 +2382,26 @@ struct CompassMapContentView: View {
                                 format: NSLocalizedString("map.candidate.label", comment: "Candidate experience: %@"),
                                 cand.title
                             )))
+                        }
+                    }
+                }
+                // City OS v2: 在地 event回流 markers on their OWN Annotation
+                // layer — deliberately outside the clustered POI pipeline so the
+                // marker-count perf tests stay honest. Live mode only; each event
+                // with a coordinate gets a breathing (reduce-motion static) ring.
+                if FeatureFlags.cityOS && currentCityMode == .live {
+                    ForEach(cityBriefService.activeEvents()) { event in
+                        if let lat = event.lat, let lng = event.lng {
+                            Annotation("", coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lng)) {
+                                EventMarkerView(
+                                    event: event,
+                                    isHighlighted: viewModel.highlightedEventId == event.id,
+                                    onTap: {
+                                        viewModel.highlightedEventId = event.id
+                                        isShowingLiveSheet = true
+                                    }
+                                )
+                            }
                         }
                     }
                 }

--- a/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
@@ -8,6 +8,10 @@ import CoreLocation
 /// (drag-a-pin or type coordinates + save-as-city flow).
 struct LocationPickerSheet: View {
     @Bindable var viewModel: MapViewModel
+    /// City OS v2: when provided (flag on), the selected city gains a
+    /// Live/Plan/Recall mode control + rows carry a small mode tag. nil keeps
+    /// the sheet exactly as it shipped.
+    let cityOSStore: CityOSStore?
     let onDismiss: () -> Void
 
     @State private var state: LocationPickerState
@@ -17,8 +21,9 @@ struct LocationPickerSheet: View {
     @State private var customCityStore = CustomCityStore.shared
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    init(viewModel: MapViewModel, onDismiss: @escaping () -> Void) {
+    init(viewModel: MapViewModel, cityOSStore: CityOSStore? = nil, onDismiss: @escaping () -> Void) {
         self.viewModel = viewModel
+        self.cityOSStore = cityOSStore
         self.onDismiss = onDismiss
         let initial = viewModel.customCoordinates ?? viewModel.defaultCenterForSelectedCity
         self._state = State(initialValue: LocationPickerState(initialCoordinate: initial))
@@ -118,6 +123,20 @@ struct LocationPickerSheet: View {
     @ViewBuilder
     private func citiesContent(bs: Bindable<LocationPickerState>) -> some View {
         List {
+            // City OS v2: mode control for the currently selected city, so the
+            // traveler can flip Live / Plan / Recall (the aggregation context).
+            if let store = cityOSStore, let selected = viewModel.selectedCity {
+                Section(NSLocalizedString("cityos.picker.mode.section", comment: "City mode section title")) {
+                    CityModePicker(
+                        mode: store.mode(for: selected),
+                        onSelect: { newMode in
+                            commitHaptic()
+                            store.setMode(newMode, for: selected)
+                        }
+                    )
+                }
+            }
+
             // "All Cities" row
             Button {
                 commitHaptic()
@@ -690,6 +709,55 @@ private struct CoordinateField: View {
                 .keyboardType(.decimalPad)
                 .monospacedDigit()
                 .autocorrectionDisabled()
+        }
+    }
+}
+
+// MARK: - CityModePicker (City OS v2)
+
+/// A compact Live / Plan / Recall segmented control for the selected city.
+/// Live = 在此城 (warm), Plan = 计划 (cool blue), Recall = 回顾 (muted). Mode is
+/// the aggregation context, not a filter — switching it re-frames the whole
+/// city surface (PRD §4.1).
+private struct CityModePicker: View {
+    let mode: CityMode
+    let onSelect: (CityMode) -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(CityMode.allCases, id: \.self) { candidate in
+                Button {
+                    onSelect(candidate)
+                } label: {
+                    Text(Self.label(for: candidate))
+                        .font(CT.body(13, mode == candidate ? .semibold : .regular))
+                        .foregroundStyle(mode == candidate ? .white : Self.tint(for: candidate))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                        .background(
+                            Capsule().fill(mode == candidate ? Self.tint(for: candidate) : Self.tint(for: candidate).opacity(0.12))
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityAddTraits(mode == candidate ? [.isButton, .isSelected] : .isButton)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private static func label(for mode: CityMode) -> String {
+        switch mode {
+        case .live:   return NSLocalizedString("cityos.mode.live.tag", comment: "在此城")
+        case .plan:   return NSLocalizedString("cityos.mode.plan.tag", comment: "计划")
+        case .recall: return NSLocalizedString("cityos.mode.recall.tag", comment: "回顾")
+        }
+    }
+
+    private static func tint(for mode: CityMode) -> Color {
+        switch mode {
+        case .live:   return CT.sunGoldDeep
+        case .plan:   return CT.modePlanBlue
+        case .recall: return CT.fgMuted
         }
     }
 }

--- a/apps/ios/SoloCompass/Views/Shared/CompareTokens.swift
+++ b/apps/ios/SoloCompass/Views/Shared/CompareTokens.swift
@@ -94,6 +94,29 @@ public enum CT {
     public static let heatmapLow    = rgb(0xE6, 0xD9, 0xC3)
     public static let heatmapEmpty  = rgb(0xF0, 0xEB, 0xE3)
 
+    // MARK: - City OS v2 · sanctioned exceptions (PRD solo-city-os-v2 §2)
+    //
+    // The first color axiom is "don't invent new color semantics". These three
+    // are the ONLY exception, and they come from the claude.ai/design handoff
+    // bundle — not from an ad-hoc choice here:
+    //   • Limited-time events read as a distinct register from the warm map
+    //     (they expire — the timer ring on the回流 marker + the "仅本周" chip).
+    //     A burnt-orange, warmer and more urgent than sunGold, carries that
+    //     without leaving the amber family.
+    //   • Plan mode is a *different city context*, not a filter; its wash and
+    //     mode tag use a cool blue so the traveler feels the register flip from
+    //     Live (warm/amber) to Plan (cool/considered).
+    // Keep these disciplined: eventLimited* only on limited-time event surfaces;
+    // modePlanBlue only on Plan-mode chrome.
+
+    /// Limited-time event accent — #B5541A burnt orange, for the 回流 map
+    /// marker's breathing ring stroke and the "仅本周" limited chip text.
+    public static let eventLimited     = rgb(0xB5, 0x54, 0x1A)
+    /// Soft fill behind limited-event chips / notice bands — #FFEEDD.
+    public static let eventLimitedSoft = rgb(0xFF, 0xEE, 0xDD)
+    /// Plan-mode blue — #2F7DD1, for the Plan wash tint and mode tag.
+    public static let modePlanBlue     = rgb(0x2F, 0x7D, 0xD1)
+
     // MARK: - Scrims & overlays (audit H10)
     //
     // Use these tokens when the dim / wash / shadow is applied *over a


### PR DESCRIPTION
## 概要

实现 `tasks/prd-solo-city-os-v2.md` 的城市 OS 外壳(iOS 半场),对应 Claude Design **SoloCompass v3** 设计稿,万象(VTE)Live 模式打透,全部 gated by `FF_CITY_OS`(DEBUG 默认开 / Release 默认关):

- **落地包 KitSheet**(§5.2):联网/钱/签证税务/安全四行薄卡,独行透镜 lens 行(accentSoft 惯用法)、健康度点 + lastVerified 相对时间(mono)、深链 pill + 回链 toast;签证行 = 唯一本地自算部分(入境日期 + 183 天税务线,mono 大数字,ComplianceMath 纯函数)+ 到期提醒本地通知;急救号码 tel: 离线可拨
- **在地 LiveSheet**(§5.3):本周事件卡(Solo 分 chip + soloNote 独行判断 + 限时 chip + 来源标注),notice 类走 warningSoft 警示态;事件回流地图为独立 Annotation 层的虚线呼吸环 marker(reduce-motion 静止)
- **合规横幅**(§4.3):offline > loading > compliance 优先级梯,≤7 天临期才现身,无 haptic,受打扰预算约束
- **城市模式骨架**(§4.1):CityOSStore (city, mode) 状态机,LocationPickerSheet 加 Live/Plan/Recall 切换,Plan 罩 washLight,Plan/Recall 占位卡
- **抽屉双药丸**:「落地包」「在地 · 本周 N」浮于 peek 上缘,仅 Live+peek+无选中卡时显示;**peek 档 Now Card 寸土未动**(BottomInfoSheet 唯一改动 = 可选 onDetentChange 回调)
- **Agent 接入**:`get_city_kit` / `find_local_events` 两个 chat 工具(签证数字只出自 ComplianceMath,模型不得自造)、ChatCard.events 事件卡一键落图、dailyOmen 重定位「今日城市签」(复用既有 1/日预算)
- **打扰预算**(§4.3):落地包仅首次抵达自动浮现一次;所有主动浮现 ≤2/日(CityOSInterruptionBudget)
- **数据面**:CityBriefService 缓存优先(SwiftData v1.10)→ 6h TTL 走公读 REST(`city_kits`/`city_events`,配套服务端 PR)→ bundled 万象种子兜底;客户端健康度衰减(server health 只降不升)+ 事件过期过滤

## 设计公理合规
零新颜色语义(琥珀=独行 / sunGold=此刻 / 健康度点=可信 / mono=可证伪数字);仅新增设计交接包内的 3 个 token(eventLimited/eventLimitedSoft/modePlanBlue)。

## 测试
- 新增 8 个测试套件,独立复跑 **76/76 全绿**(xcresult 权威),含 BottomInfoSheetTests / CityPillHitTargetTests / PeekSummarySelectionTests / StringsParityTests 回归
- 模拟器 dogfood(iPhone 17 Pro,`-startCity VTE`):首次抵达落地包自动弹出 ✅ 只弹一次 ✅ 抽屉双药丸 ✅ 事件呼吸环 marker(市集『本周五限时』+ notice 警示)✅ Now Card 无回归 ✅ FF 关闭回退正常 ✅
- 已知:4 个 meta-test(LocalizationCoverage/NoProductionPrint/PublicAPIDocComment/ZhHansPunctuation)在分支基线即红(24/7/72/22 个存量违例,均不在本 PR 触碰文件内),留待独立清理 PR

## 关联
- PRD: tasks/prd-solo-city-os-v2.md(§5.1 此刻卡片已由 #590 完成,本 PR 补齐 §4.1-4.3、§5.2-5.3)
- 服务端搜索管线(Tavily+DeepSeek 策展 → city_kits/city_events)见配套 PR feat/city-brief-pipeline

https://claude.ai/code/session_017ora9WsVEikxfdz3Wh8HBz