### PR TITLE
feat(data): city-brief agent 管线 — Tavily 真实搜索 + DeepSeek 反幻觉策展

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,14 @@ DEEPSEEK_API_KEY=sk-replace-me
 DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
 DEEPSEEK_MODEL=deepseek-v4-pro
 
+# ─── Tavily (web search for the compile-city-brief Edge Function) ─────────────
+# Get a key at: https://app.tavily.com — used server-side only to source the
+# landing kit / live events. Never ships to clients.
+TAVILY_API_KEY=tvly-replace-me
+# Shared secret the GitHub `city-brief-refresh` cron sends as `x-cron-secret`
+# (the cron does not hold the service-role key). Also set as a Supabase secret.
+CITY_BRIEF_CRON_SECRET=replace-with-long-random-string
+
 # ─── Mapbox (web map rendering) ───────────────────────────────────────────────
 # Get one free: https://account.mapbox.com/access-tokens/
 MAPBOX_TOKEN=pk.eyJ...

--- a/.github/workflows/city-brief-refresh.yml
+++ b/.github/workflows/city-brief-refresh.yml
@@ -1,0 +1,118 @@
+name: City Brief Refresh
+
+# Refreshes the server-curated landing kit (落地包) and live/在地 events by
+# invoking the compile-city-brief Edge Function. Content is city-level and
+# shared, so this runs on a schedule rather than on user action:
+#   - events: Mondays & Thursdays 05:00 Asia/Vientiane (UTC+7) → 22:00 UTC prior day
+#   - kit:    weekly on Monday 06:00 Asia/Vientiane           → 23:00 UTC Sunday
+# The function enforces its own cooldown, so an extra manual run is harmless.
+#
+# The job only holds CITY_BRIEF_CRON_SECRET (sent as x-cron-secret); it never
+# needs the Supabase service-role key. Configure repo secrets:
+#   SUPABASE_PROJECT_REF, CITY_BRIEF_CRON_SECRET.
+on:
+  schedule:
+    # events — Mon & Thu 05:00 Asia/Vientiane (22:00 UTC the previous day).
+    - cron: "0 22 * * 0,3"
+    # kit — weekly, Monday 06:00 Asia/Vientiane (23:00 UTC Sunday).
+    - cron: "0 23 * * 0"
+  workflow_dispatch:
+    inputs:
+      city_code:
+        description: "City code (lowercase)"
+        required: true
+        default: "vte"
+        type: string
+      target:
+        description: "What to compile"
+        required: true
+        default: "both"
+        type: choice
+        options:
+          - both
+          - events
+          - kit
+      force:
+        description: "Bypass the cooldown"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    name: Invoke compile-city-brief
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Guard — required secrets present
+        env:
+          PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          CRON_SECRET: ${{ secrets.CITY_BRIEF_CRON_SECRET }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PROJECT_REF//[[:space:]]/}" ]; then
+            echo "::error::SUPABASE_PROJECT_REF secret is empty."
+            exit 1
+          fi
+          if [ -z "${CRON_SECRET//[[:space:]]/}" ]; then
+            echo "::error::CITY_BRIEF_CRON_SECRET secret is empty."
+            exit 1
+          fi
+
+      # Decide (city, target, force) from either the manual inputs or, on a
+      # schedule, from which cron expression fired: the 23:00-UTC Sunday tick
+      # refreshes the weekly kit; every other tick refreshes events.
+      - name: Resolve parameters
+        id: params
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SCHEDULE: ${{ github.event.schedule }}
+          IN_CITY: ${{ github.event.inputs.city_code }}
+          IN_TARGET: ${{ github.event.inputs.target }}
+          IN_FORCE: ${{ github.event.inputs.force }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            CITY="${IN_CITY:-vte}"
+            TARGET="${IN_TARGET:-both}"
+            FORCE="${IN_FORCE:-false}"
+          else
+            CITY="vte"
+            FORCE="false"
+            if [ "$SCHEDULE" = "0 23 * * 0" ]; then
+              TARGET="kit"
+            else
+              TARGET="events"
+            fi
+          fi
+          echo "city=$CITY"     >> "$GITHUB_OUTPUT"
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "force=$FORCE"   >> "$GITHUB_OUTPUT"
+          echo "Resolved → city=$CITY target=$TARGET force=$FORCE"
+
+      - name: Invoke compile-city-brief
+        env:
+          PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          CRON_SECRET: ${{ secrets.CITY_BRIEF_CRON_SECRET }}
+          CITY: ${{ steps.params.outputs.city }}
+          TARGET: ${{ steps.params.outputs.target }}
+          FORCE: ${{ steps.params.outputs.force }}
+        run: |
+          set -euo pipefail
+          URL="https://${PROJECT_REF}.functions.supabase.co/compile-city-brief"
+          echo "→ POST $URL  (city=$CITY target=$TARGET force=$FORCE)"
+          HTTP_CODE=$(curl -sS -o /tmp/city-brief-resp.json -w "%{http_code}" \
+            -X POST "$URL" \
+            -H "x-cron-secret: ${CRON_SECRET}" \
+            -H "Content-Type: application/json" \
+            --data "{\"city_code\":\"${CITY}\",\"target\":\"${TARGET}\",\"force\":${FORCE}}")
+          echo "HTTP $HTTP_CODE"
+          cat /tmp/city-brief-resp.json
+          echo
+          if [ "$HTTP_CODE" -ge 400 ]; then
+            echo "::error::compile-city-brief returned HTTP $HTTP_CODE"
+            exit 1
+          fi

--- a/infra/supabase/functions/_shared/city-brief-core.ts
+++ b/infra/supabase/functions/_shared/city-brief-core.ts
@@ -1,0 +1,616 @@
+// city-brief-core — pure, zero-dependency logic shared between the
+// compile-city-brief Edge Function (Deno) and its vitest unit tests (Node).
+//
+// NOTHING here imports anything: no supabase-js, no Deno globals, no fetch.
+// It is the deterministic core — query construction, prompt building, JSON
+// parsing, and the quality gates that keep model hallucinations out of the
+// city_kits / city_events tables. All network I/O lives in index.ts.
+//
+// Design mirrors packages/ai/src/prompts/structure-experience.ts:
+//   - sourced facts (name/date/place) must come from the snippet;
+//   - judgment (solo_score / solo_note) is applied ON TOP of those facts;
+//   - omit over invent; {"action":"refuse"} is allowed;
+//   - source_url must be EXACTLY one of the candidate URLs we handed the model.
+
+// ─── Shared types ────────────────────────────────────────────────────────────
+
+export type KitSection = "net" | "money" | "visa" | "safety";
+export type EventCategory =
+  | "culture"
+  | "wellness"
+  | "market"
+  | "music"
+  | "sports"
+  | "food"
+  | "notice";
+export type Health = "green" | "yellow" | "red" | "gray";
+export type CompileTarget = "kit" | "events";
+
+/** A normalized search result the model reads from. */
+export interface Candidate {
+  sourceId: string; // e.g. "tavily"
+  title: string;
+  rawText: string; // ≤ ~1200 chars
+  url: string;
+  fetchedAt: string; // ISO
+}
+
+/** Minimal city context the pure layer needs (no DB row type leaks in). */
+export interface CityContext {
+  cityCode: string; // lowercase, e.g. "vte"
+  nameEn: string;
+  nameZh: string;
+  timezone: string; // IANA
+}
+
+export interface DateWindow {
+  now: Date;
+  /** Inclusive lower bound for accepting an event's ends_at. */
+  earliest: Date;
+  /** Inclusive upper bound for accepting an event's ends_at. */
+  latest: Date;
+}
+
+/** A validated event ready to upsert. */
+export interface ValidatedEvent {
+  name: string;
+  category: EventCategory;
+  whenLabel: string;
+  startsAt: string | null;
+  endsAt: string;
+  soloScore: number | null;
+  soloNote: string | null;
+  seenLabel: string | null;
+  sourceUrl: string;
+  limitedLabel: string | null;
+  health: Health;
+}
+
+/** A validated kit section decision. */
+export type KitDecision =
+  | { section: KitSection; action: "confirm" }
+  | {
+      section: KitSection;
+      action: "update";
+      name: string;
+      body: string;
+      lensLine: string | null;
+      linkLabel: string | null;
+      sources: unknown[];
+      health: Health;
+    }
+  | { section: KitSection; action: "omit" };
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/** Superlative / hype blacklist — any hit rejects the item. */
+const SUPERLATIVE_RE = /必去|绝对|最棒|一生一次|must-see|best ever|once in a lifetime/i;
+
+/**
+ * Kit deep-link host allowlist. A kit link_url must resolve to one of these
+ * hosts (or be omitted). Keeps the model from linking to arbitrary blogs.
+ */
+const KIT_LINK_ALLOWLIST = ["airalo.com", "wise.com", "geosureglobal.com"];
+
+const MAX_SOLO_NOTE = 60;
+const MAX_WHEN_LABEL = 20;
+
+// ─── Tavily query construction ───────────────────────────────────────────────
+
+export interface TavilyQuery {
+  query: string;
+  /** Tavily topic; "news" narrows recency for notices. */
+  topic?: "general" | "news";
+  /** For news topic — how many days back to search. */
+  days?: number;
+  /** Which kit section this query serves (events queries omit this). */
+  section?: KitSection;
+}
+
+/**
+ * Build the Tavily search queries for a compile run.
+ *   - events: 3 queries (general this-week events, venue/market specific,
+ *     notices via news topic).
+ *   - kit:    4 queries, one per section.
+ */
+export function tavilyQueries(
+  city: CityContext,
+  target: CompileTarget,
+  dateWindow: DateWindow,
+): TavilyQuery[] {
+  const cityName = city.nameEn;
+  if (target === "events") {
+    const monthDay = `${dateWindow.now.getUTCFullYear()}-${pad2(dateWindow.now.getUTCMonth() + 1)}`;
+    return [
+      {
+        query: `${cityName} events festivals things to do this week ${monthDay}`,
+        topic: "general",
+      },
+      {
+        query: `${cityName} night market weekend market live music venue this week`,
+        topic: "general",
+      },
+      {
+        query: `${cityName} travel notice closure safety advisory`,
+        topic: "news",
+        days: 10,
+      },
+    ];
+  }
+
+  // kit — one query per section.
+  const perSection: Record<KitSection, string> = {
+    net: `${cityName} eSIM SIM card mobile data tourist connectivity`,
+    money: `${cityName} money exchange ATM fees cash card payment tips traveler`,
+    visa: `${cityName} visa on arrival tourist visa requirements days`,
+    safety: `${cityName} solo traveler safety emergency police number areas`,
+  };
+  return (Object.keys(perSection) as KitSection[]).map((section) => ({
+    query: perSection[section],
+    topic: "general",
+    section,
+  }));
+}
+
+// ─── Prompt construction ─────────────────────────────────────────────────────
+
+function candidateBlock(candidates: Candidate[]): string {
+  return candidates
+    .map((c, i) => `[${i + 1}] url=${c.url}\ntitle=${c.title}\ntext="""${c.rawText}"""`)
+    .join("\n\n");
+}
+
+/**
+ * Build the events-curation prompt. The model must ground every fact
+ * (name/date/place) in a candidate snippet and cite the EXACT candidate URL.
+ */
+export function buildEventsPrompt(city: CityContext, candidates: Candidate[]): string {
+  const urls = candidates.map((c) => c.url);
+  return `You are a solo-travel local-events curator for ${city.nameEn} (${city.nameZh}). Curate real, time-bound local events from the search snippets below, for a traveler exploring the city ALONE. Output zh-Hans.
+
+SOURCED FACTS vs JUDGMENT — keep them separate:
+  - SOURCED (must come from a snippet, never invented): name, dates, venue/location, whether it is limited-time.
+  - JUDGMENT (yours, applied on top of the facts): solo_score, solo_note, category.
+
+STRICT RULES — violating any is a critical failure:
+1. source_url MUST be copied EXACTLY from one of the candidate url= lines. If an event's facts are not clearly in a snippet, OMIT it. Do NOT invent a URL.
+2. Do NOT use superlatives or hype ("必去", "绝对", "最棒", "must-see"). Describe plainly.
+3. solo_score is 0–10 on this rubric: 安全感 / 单人自在 / 氛围 / 无需交谈. A "notice" (closure/advisory) carries solo_score = null.
+4. solo_note ≤ ${MAX_SOLO_NOTE} chars; when_label ≤ ${MAX_WHEN_LABEL} chars, human-facing (e.g. "本周五 傍晚").
+5. seen_label describes provenance from the snippet's source type + date (e.g. "官方 · 7月"); NEVER fake "已确认".
+6. ends_at is an ISO-8601 timestamp when the event is over. If only a date is known, use end-of-day. starts_at may be null.
+7. If nothing solid is present, return {"action":"refuse","reason":"…"}.
+
+CANDIDATE URLS (source_url must be one of these exactly):
+${urls.map((u) => `  - ${u}`).join("\n")}
+
+OUTPUT FORMAT — a JSON object, no markdown fences:
+{
+  "events": [
+    {
+      "name": string,
+      "category": "culture"|"wellness"|"market"|"music"|"sports"|"food"|"notice",
+      "when_label": string,
+      "starts_at": string|null,
+      "ends_at": string,
+      "solo_score": number|null,
+      "solo_note": string|null,
+      "seen_label": string|null,
+      "limited_label": string|null,
+      "source_url": string
+    }
+  ]
+}
+Or, if the snippets yield nothing solid: {"action":"refuse","reason": string}
+
+SEARCH SNIPPETS:
+${candidateBlock(candidates)}`;
+}
+
+/**
+ * Build the kit re-verification prompt. This is CONFIRM / UPDATE / OMIT mode:
+ * the model re-verifies existing rows against fresh snippets. It NEVER changes
+ * link_url — that field is owned by the pipeline, not the model.
+ */
+export function buildKitPrompt(
+  city: CityContext,
+  currentRows: Array<{ section: KitSection; name: string; body: string; lensLine: string | null }>,
+  candidates: Candidate[],
+): string {
+  const urls = candidates.map((c) => c.url);
+  const current = currentRows
+    .map((r) => `- section=${r.section} name="${r.name}" body="${r.body}" lens="${r.lensLine ?? ""}"`)
+    .join("\n");
+  return `You are re-verifying the landing kit for ${city.nameEn} (${city.nameZh}) against fresh search snippets. Output zh-Hans.
+
+This is CONFIRM / UPDATE / OMIT mode. For each EXISTING section below, decide:
+  - "confirm": the snippets still support the current copy → no text change, we just bump freshness.
+  - "update": the snippets contradict or improve the copy → return new name/body/lens_line/health.
+  - "omit": the snippets are silent or you cannot verify → leave the row untouched.
+
+STRICT RULES:
+1. You NEVER change link_url. It is not in your output. Do not invent links.
+2. SOURCED facts (prices, day counts, numbers) must come from a snippet. Judgment stays plain.
+3. No superlatives/hype ("必去", "绝对", "最棒", "must-see").
+4. Every "sources" entry's url must be EXACTLY one of the candidate url= lines below.
+5. health ∈ green|yellow|red|gray reflecting how current/reliable the info is.
+
+CANDIDATE URLS (any sources url must be one of these exactly):
+${urls.map((u) => `  - ${u}`).join("\n")}
+
+EXISTING SECTIONS:
+${current}
+
+OUTPUT FORMAT — a JSON object, no markdown fences:
+{
+  "decisions": [
+    { "section": "net"|"money"|"visa"|"safety", "action": "confirm" },
+    { "section": "...", "action": "update", "name": string, "body": string, "lens_line": string|null, "link_label": string|null, "health": "green"|"yellow"|"red"|"gray", "sources": [{"type": string, "url": string, "attribution": string|null}] },
+    { "section": "...", "action": "omit" }
+  ]
+}
+
+SEARCH SNIPPETS:
+${candidateBlock(candidates)}`;
+}
+
+// ─── JSON parsing ────────────────────────────────────────────────────────────
+
+/**
+ * Parse a model reply that should be a JSON object: strip markdown fences, then
+ * take the substring from the first "{" to the last "}". Returns null on failure.
+ */
+export function parseModelJSON(raw: string): Record<string, unknown> | null {
+  if (typeof raw !== "string") return null;
+  const stripped = raw
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```\s*$/i, "")
+    .trim();
+  const start = stripped.indexOf("{");
+  const end = stripped.lastIndexOf("}");
+  if (start === -1 || end === -1 || end < start) return null;
+  try {
+    const parsed = JSON.parse(stripped.slice(start, end + 1));
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Deterministic id / slug ─────────────────────────────────────────────────
+
+/**
+ * Slugify a name to lowercase ascii-ish tokens joined by underscore, ≤32 chars.
+ * Non-ascii (e.g. Chinese) is dropped; if nothing ascii remains, a short stable
+ * hash of the original stands in so distinct names never collide to "".
+ */
+export function slugify(name: string, maxLen = 32): string {
+  const ascii = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, maxLen);
+  if (ascii.length > 0) return ascii;
+  return `x${stableHash(name).slice(0, 8)}`;
+}
+
+/** yyyymmdd from an ISO/date string, in UTC. "00000000" if unparseable. */
+function yyyymmdd(dateish: string): string {
+  const t = Date.parse(dateish);
+  if (Number.isNaN(t)) return "00000000";
+  const d = new Date(t);
+  return `${d.getUTCFullYear()}${pad2(d.getUTCMonth() + 1)}${pad2(d.getUTCDate())}`;
+}
+
+/**
+ * Deterministic event id: evt_{city}_{slug≤32}_{yyyymmdd}. The date anchor is
+ * the event's start (or end when start is unknown), so the same real event
+ * re-curated later collapses onto the same row.
+ */
+export function eventId(cityCode: string, name: string, dateAnchor: string): string {
+  return `evt_${cityCode.toLowerCase()}_${slugify(name)}_${yyyymmdd(dateAnchor)}`;
+}
+
+/**
+ * Normalize a name for ±2-day dedup: lowercase, collapse whitespace, drop
+ * punctuation. Two events with the same normalized name within 2 days are the
+ * same event even if their ids differ by a day.
+ */
+export function normalizeName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[\s　]+/g, "")
+    .replace(/[·・.,!?，。！？、「」“”"'()（）\-—]+/g, "");
+}
+
+// ─── Validators (quality gates) ──────────────────────────────────────────────
+
+export interface EventValidation {
+  accepted: ValidatedEvent[];
+  rejected: Array<{ name: string; reason: string }>;
+}
+
+/**
+ * Validate & filter model-emitted events against the candidate URL whitelist
+ * and the quality gates. Also dedups by normalized name within ±2 days,
+ * keeping the earliest-seen (highest-priority) instance.
+ */
+export function validateEvents(
+  items: unknown,
+  candidateURLs: string[],
+  now: Date,
+): EventValidation {
+  const accepted: ValidatedEvent[] = [];
+  const rejected: Array<{ name: string; reason: string }> = [];
+  const urlSet = new Set(candidateURLs);
+
+  const earliest = new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000);
+  const latest = new Date(now.getTime() + 21 * 24 * 60 * 60 * 1000);
+
+  if (!Array.isArray(items)) return { accepted, rejected };
+
+  // For ±2-day dedup: normalized name → list of accepted end-times.
+  const seen: Array<{ norm: string; endMs: number }> = [];
+  const TWO_DAYS = 2 * 24 * 60 * 60 * 1000;
+
+  for (const raw of items) {
+    if (typeof raw !== "object" || raw === null) {
+      rejected.push({ name: "?", reason: "not an object" });
+      continue;
+    }
+    const e = raw as Record<string, unknown>;
+    const name = typeof e["name"] === "string" ? (e["name"] as string).trim() : "";
+    if (!name) {
+      rejected.push({ name: "?", reason: "missing name" });
+      continue;
+    }
+
+    const category = e["category"];
+    const validCats: EventCategory[] = [
+      "culture",
+      "wellness",
+      "market",
+      "music",
+      "sports",
+      "food",
+      "notice",
+    ];
+    if (typeof category !== "string" || !validCats.includes(category as EventCategory)) {
+      rejected.push({ name, reason: `invalid category ${String(category)}` });
+      continue;
+    }
+
+    const sourceUrl = typeof e["source_url"] === "string" ? (e["source_url"] as string) : "";
+    if (!urlSet.has(sourceUrl)) {
+      rejected.push({ name, reason: "source_url not in candidate whitelist" });
+      continue;
+    }
+
+    const combinedText = `${name} ${String(e["solo_note"] ?? "")} ${String(e["when_label"] ?? "")}`;
+    if (SUPERLATIVE_RE.test(combinedText)) {
+      rejected.push({ name, reason: "superlative/hype language" });
+      continue;
+    }
+
+    const endsAtRaw = typeof e["ends_at"] === "string" ? (e["ends_at"] as string) : "";
+    const endMs = Date.parse(endsAtRaw);
+    if (Number.isNaN(endMs)) {
+      rejected.push({ name, reason: "ends_at unparseable" });
+      continue;
+    }
+    if (endMs < earliest.getTime() || endMs > latest.getTime()) {
+      rejected.push({ name, reason: "ends_at outside [now-1d, now+21d]" });
+      continue;
+    }
+
+    let startsAt: string | null = null;
+    if (typeof e["starts_at"] === "string" && (e["starts_at"] as string).trim() !== "") {
+      const startMs = Date.parse(e["starts_at"] as string);
+      if (Number.isNaN(startMs)) {
+        rejected.push({ name, reason: "starts_at unparseable" });
+        continue;
+      }
+      if (endMs < startMs) {
+        rejected.push({ name, reason: "ends_at before starts_at" });
+        continue;
+      }
+      startsAt = new Date(startMs).toISOString();
+    }
+
+    // solo_score: notices carry null; others clamp to [0,10].
+    let soloScore: number | null = null;
+    const rawScore = e["solo_score"];
+    if (category === "notice") {
+      soloScore = null;
+    } else if (typeof rawScore === "number" && !Number.isNaN(rawScore)) {
+      soloScore = Math.min(10, Math.max(0, rawScore));
+    }
+
+    let soloNote = typeof e["solo_note"] === "string" ? (e["solo_note"] as string).trim() : null;
+    if (soloNote && soloNote.length > MAX_SOLO_NOTE) {
+      soloNote = soloNote.slice(0, MAX_SOLO_NOTE);
+    }
+
+    let whenLabel = typeof e["when_label"] === "string" ? (e["when_label"] as string).trim() : "";
+    if (!whenLabel) {
+      rejected.push({ name, reason: "missing when_label" });
+      continue;
+    }
+    if (whenLabel.length > MAX_WHEN_LABEL) whenLabel = whenLabel.slice(0, MAX_WHEN_LABEL);
+
+    // ±2-day dedup by normalized name.
+    const norm = normalizeName(name);
+    const dup = seen.find((s) => s.norm === norm && Math.abs(s.endMs - endMs) <= TWO_DAYS);
+    if (dup) {
+      rejected.push({ name, reason: "duplicate within ±2 days" });
+      continue;
+    }
+    seen.push({ norm, endMs });
+
+    accepted.push({
+      name,
+      category: category as EventCategory,
+      whenLabel,
+      startsAt,
+      endsAt: new Date(endMs).toISOString(),
+      soloScore,
+      soloNote,
+      seenLabel:
+        typeof e["seen_label"] === "string" ? (e["seen_label"] as string).trim() || null : null,
+      sourceUrl,
+      limitedLabel:
+        typeof e["limited_label"] === "string"
+          ? (e["limited_label"] as string).trim() || null
+          : null,
+      health: coerceHealth(e["health"]),
+    });
+  }
+
+  return { accepted, rejected };
+}
+
+export interface KitValidation {
+  decisions: KitDecision[];
+  rejected: Array<{ section: string; reason: string }>;
+}
+
+/**
+ * Validate model kit decisions. UPDATE decisions must pass the superlative
+ * blacklist and, if they carry sources, every source url must be both a
+ * candidate url and on the kit host allowlist. The model never supplies
+ * link_url; it is owned by the pipeline.
+ */
+export function validateKit(items: unknown, candidateURLs: string[]): KitValidation {
+  const decisions: KitDecision[] = [];
+  const rejected: Array<{ section: string; reason: string }> = [];
+  const urlSet = new Set(candidateURLs);
+  const validSections: KitSection[] = ["net", "money", "visa", "safety"];
+
+  if (!Array.isArray(items)) return { decisions, rejected };
+  const seenSections = new Set<string>();
+
+  for (const raw of items) {
+    if (typeof raw !== "object" || raw === null) {
+      rejected.push({ section: "?", reason: "not an object" });
+      continue;
+    }
+    const d = raw as Record<string, unknown>;
+    const section = d["section"];
+    if (typeof section !== "string" || !validSections.includes(section as KitSection)) {
+      rejected.push({ section: String(section), reason: "invalid section" });
+      continue;
+    }
+    if (seenSections.has(section)) {
+      rejected.push({ section, reason: "duplicate section" });
+      continue;
+    }
+    seenSections.add(section);
+
+    const action = d["action"];
+    if (action === "confirm") {
+      decisions.push({ section: section as KitSection, action: "confirm" });
+      continue;
+    }
+    if (action === "omit") {
+      decisions.push({ section: section as KitSection, action: "omit" });
+      continue;
+    }
+    if (action !== "update") {
+      rejected.push({ section, reason: `invalid action ${String(action)}` });
+      continue;
+    }
+
+    const name = typeof d["name"] === "string" ? (d["name"] as string).trim() : "";
+    const body = typeof d["body"] === "string" ? (d["body"] as string).trim() : "";
+    if (!name || !body) {
+      rejected.push({ section, reason: "update missing name/body" });
+      continue;
+    }
+    if (SUPERLATIVE_RE.test(`${name} ${body} ${String(d["lens_line"] ?? "")}`)) {
+      rejected.push({ section, reason: "superlative/hype language" });
+      continue;
+    }
+
+    // Sources: every url must be in the candidate whitelist AND host-allowlisted.
+    const rawSources = Array.isArray(d["sources"]) ? (d["sources"] as unknown[]) : [];
+    let badSource = false;
+    for (const s of rawSources) {
+      if (typeof s !== "object" || s === null) continue;
+      const url = (s as Record<string, unknown>)["url"];
+      if (typeof url === "string" && url.trim() !== "") {
+        if (!urlSet.has(url) || !isAllowlistedKitHost(url)) {
+          badSource = true;
+          break;
+        }
+      }
+    }
+    if (badSource) {
+      rejected.push({ section, reason: "source url not whitelisted/allowlisted" });
+      continue;
+    }
+
+    decisions.push({
+      section: section as KitSection,
+      action: "update",
+      name,
+      body,
+      lensLine: typeof d["lens_line"] === "string" ? (d["lens_line"] as string).trim() || null : null,
+      linkLabel:
+        typeof d["link_label"] === "string" ? (d["link_label"] as string).trim() || null : null,
+      sources: rawSources,
+      health: coerceHealth(d["health"]),
+    });
+  }
+
+  return { decisions, rejected };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+function coerceHealth(v: unknown): Health {
+  return v === "green" || v === "yellow" || v === "red" || v === "gray" ? v : "gray";
+}
+
+/**
+ * True when the URL's host is on the kit allowlist:
+ * airalo.com / wise.com / geosureglobal.com, or any *.gov / *.la host.
+ */
+export function isAllowlistedKitHost(url: string): boolean {
+  const host = hostOf(url);
+  if (host === null) return false;
+  if (KIT_LINK_ALLOWLIST.some((h) => host === h || host.endsWith(`.${h}`))) return true;
+  // *.gov (incl. gov.la etc.) and *.la country hosts.
+  const parts = host.split(".");
+  const tld = parts[parts.length - 1] ?? "";
+  if (tld === "la") return true;
+  if (parts.includes("gov")) return true;
+  return false;
+}
+
+/** Extract a lowercase host from a URL without the URL global (Deno/Node safe). */
+function hostOf(url: string): string | null {
+  const m = /^[a-z][a-z0-9+.-]*:\/\/([^/?#]+)/i.exec(url.trim());
+  if (!m || m[1] === undefined) return null;
+  let host = m[1].toLowerCase();
+  // strip userinfo and port
+  const at = host.lastIndexOf("@");
+  if (at !== -1) host = host.slice(at + 1);
+  const colon = host.indexOf(":");
+  if (colon !== -1) host = host.slice(0, colon);
+  return host || null;
+}
+
+/** Small deterministic 32-bit FNV-1a hash, hex. Used only for slug fallback. */
+function stableHash(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
+}

--- a/infra/supabase/functions/compile-city-brief/README.md
+++ b/infra/supabase/functions/compile-city-brief/README.md
@@ -1,0 +1,99 @@
+# compile-city-brief
+
+Server-side curation of a city's **landing kit** (落地包: net / money / visa /
+safety) and **live/在地 events**. Content is city-level and shared across all
+users, so this function is NOT user-triggered — a user "refresh" in the app is
+just a re-read of the `city_kits` / `city_events` tables. It is driven by the
+`city-brief-refresh` GitHub Actions cron, or invoked with the service-role key.
+
+Pipeline: Tavily search (advanced, ≤6 results/query) → normalize to candidates
+(dedup by URL, cap 18 / ~15k chars) → DeepSeek curation (`json_object`, one
+retry on invalid JSON) → quality gates in `../_shared/city-brief-core.ts` →
+upsert. Every run is accounted in `city_brief_runs` (search calls, token usage,
+items written, status `ok|partial|failed`).
+
+## Secrets
+
+```bash
+# from infra/supabase
+supabase link --project-ref <ref>
+supabase secrets set TAVILY_API_KEY=<tvly-…>
+supabase secrets set CITY_BRIEF_CRON_SECRET=<random-long-string>
+# DEEPSEEK_API_KEY is already set (shared with chat-proxy);
+# optional overrides — defaults shown:
+supabase secrets set DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
+supabase secrets set DEEPSEEK_MODEL=deepseek-chat
+```
+
+`SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are provided automatically by the
+Supabase runtime.
+
+## Deploy
+
+```bash
+supabase functions deploy compile-city-brief
+```
+
+## Contract
+
+`POST /functions/v1/compile-city-brief`
+
+Auth (either one):
+
+- `Authorization: Bearer <SUPABASE_SERVICE_ROLE_KEY>`, or
+- `x-cron-secret: <CITY_BRIEF_CRON_SECRET>` (what the GitHub cron uses — it does
+  not hold the service-role key).
+
+Request body:
+
+```json
+{ "city_code": "vte", "target": "both", "force": false }
+```
+
+- `city_code` — lowercase; the city must exist in `sc_cities` with
+  `brief_enabled = true`.
+- `target` — `"kit"`, `"events"`, or `"both"`.
+- `force` — optional; bypasses the cooldown (events 72h, kit 240h).
+
+| Status | Meaning                                             |
+| ------ | --------------------------------------------------- |
+| 200    | Compiled (see `outcomes[]` for per-target results)  |
+| 400    | Bad input (missing city_code / invalid target)      |
+| 401    | Missing / wrong service-role bearer AND cron secret |
+| 404    | City not found                                      |
+| 409    | `brief_enabled = false` for the city                |
+| 500    | Missing TAVILY_API_KEY / DEEPSEEK_API_KEY           |
+
+A `200` with `outcomes[].error = "cooldown"` means the target was skipped
+because a successful run happened inside the cooldown window.
+
+## Invoke examples
+
+Service-role (local/admin):
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"city_code":"vte","target":"both","force":true}' \
+  https://<project-ref>.functions.supabase.co/compile-city-brief | python3 -m json.tool
+```
+
+Cron secret (what the workflow sends):
+
+```bash
+curl -s -X POST \
+  -H "x-cron-secret: $CITY_BRIEF_CRON_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"city_code":"vte","target":"events"}' \
+  https://<project-ref>.functions.supabase.co/compile-city-brief
+```
+
+## Local
+
+```bash
+supabase functions serve compile-city-brief --env-file infra/supabase/.env.local
+# then run ./test.sh
+```
+
+See `test.sh` — it curls twice; the second call should hit the cooldown.

--- a/infra/supabase/functions/compile-city-brief/index.ts
+++ b/infra/supabase/functions/compile-city-brief/index.ts
@@ -1,0 +1,623 @@
+// Edge Function: compile-city-brief
+// Solo City OS v2 — server-side curation of the landing kit (落地包) and the
+// live/在地 events for a city. NOT user-triggered: content is city-level and
+// shared, so a user "refresh" is just a re-read of the tables. This function is
+// invoked by GitHub Actions cron (x-cron-secret) or with the service-role key.
+//
+// Flow:
+//   1. Auth: Authorization Bearer == SUPABASE_SERVICE_ROLE_KEY, OR
+//      x-cron-secret == CITY_BRIEF_CRON_SECRET. Else 401.
+//   2. Validate {city_code, target, force?}; city must exist + brief_enabled.
+//   3. Cooldown via city_brief_runs (events 72h / kit 240h) unless force.
+//   4. Tavily search (advanced, max_results 6) → normalize to Candidates,
+//      dedup by URL, cap 18 / ~15k chars.
+//   5. DeepSeek (json_object, retry once) → parse → quality gates in _shared.
+//   6. Upsert: kit confirm→bump last_verified_at+green; omit→untouched; then
+//      downgrade rows older than 45d to yellow. events upsert by deterministic
+//      id + normalized-name ±2d dedup; never delete (expiry is by status).
+//   7. Write a city_brief_runs row with usage numbers + status ok|partial|failed.
+//
+// Deploy: `supabase functions deploy compile-city-brief`
+// Secrets: TAVILY_API_KEY, DEEPSEEK_API_KEY, CITY_BRIEF_CRON_SECRET,
+//          (optional DEEPSEEK_BASE_URL, DEEPSEEK_MODEL). SUPABASE_URL /
+//          SUPABASE_SERVICE_ROLE_KEY are provided by the runtime.
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import {
+  tavilyQueries,
+  buildEventsPrompt,
+  buildKitPrompt,
+  parseModelJSON,
+  validateEvents,
+  validateKit,
+  eventId,
+  normalizeName,
+  type Candidate,
+  type CityContext,
+  type CompileTarget,
+  type KitSection,
+} from "../_shared/city-brief-core.ts";
+
+// ─── Budget constants ────────────────────────────────────────────────────────
+
+const TAVILY_URL = "https://api.tavily.com/search";
+const TAVILY_MAX_RESULTS = 6;
+const TAVILY_SEARCH_DEPTH = "advanced";
+const MAX_CANDIDATES = 18;
+const MAX_CANDIDATE_CHARS = 15_000;
+const MAX_RAWTEXT_CHARS = 1_200;
+const DEEPSEEK_MAX_TOKENS = 3_000;
+const COOLDOWN_EVENTS_MS = 72 * 60 * 60 * 1000; // 72h
+const COOLDOWN_KIT_MS = 240 * 60 * 60 * 1000; // 240h (10 days)
+const KIT_STALE_YELLOW_MS = 45 * 24 * 60 * 60 * 1000; // 45 days
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface RequestBody {
+  city_code: string;
+  target: CompileTarget | "both";
+  force?: boolean;
+}
+
+interface CityRow {
+  city_code: string;
+  name_en: string;
+  name_zh: string;
+  name_local: string;
+  timezone: string;
+  brief_enabled: boolean;
+}
+
+interface RunOutcome {
+  target: CompileTarget;
+  status: "ok" | "partial" | "failed";
+  searchCalls: number;
+  promptTokens: number;
+  outputTokens: number;
+  itemsWritten: number;
+  error?: string;
+}
+
+// ─── Entry ───────────────────────────────────────────────────────────────────
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const cronSecret = Deno.env.get("CITY_BRIEF_CRON_SECRET");
+  const tavilyKey = Deno.env.get("TAVILY_API_KEY");
+  const deepseekKey = Deno.env.get("DEEPSEEK_API_KEY");
+
+  // 1. Auth — service-role bearer OR cron secret header.
+  const authHeader = req.headers.get("Authorization") ?? "";
+  const bearer = authHeader.replace(/^Bearer /i, "");
+  const headerCronSecret = req.headers.get("x-cron-secret") ?? "";
+  const authOk =
+    (bearer.length > 0 && bearer === serviceKey) ||
+    (cronSecret != null && cronSecret.length > 0 && headerCronSecret === cronSecret);
+  if (!authOk) return json({ error: "unauthorized" }, 401);
+
+  if (!tavilyKey || !deepseekKey) return json({ error: "server misconfigured" }, 500);
+
+  // 2. Parse + validate input.
+  let body: RequestBody;
+  try {
+    body = (await req.json()) as RequestBody;
+  } catch {
+    return json({ error: "invalid json" }, 400);
+  }
+  const cityCode = (body.city_code ?? "").toLowerCase().trim();
+  if (!cityCode) return json({ error: "city_code required" }, 400);
+  const target = body.target;
+  if (target !== "kit" && target !== "events" && target !== "both") {
+    return json({ error: "target must be kit|events|both" }, 400);
+  }
+  const force = body.force === true;
+
+  const admin = createClient(supabaseUrl, serviceKey, { auth: { persistSession: false } });
+
+  // City must exist and be brief-enabled.
+  const { data: cityRow } = await admin
+    .from("sc_cities")
+    .select("city_code, name_en, name_zh, name_local, timezone, brief_enabled")
+    .eq("city_code", cityCode)
+    .maybeSingle();
+  const city = cityRow as CityRow | null;
+  if (!city) return json({ error: "city not found" }, 404);
+  if (!city.brief_enabled) return json({ error: "brief not enabled for city" }, 409);
+
+  const cityCtx: CityContext = {
+    cityCode: city.city_code,
+    nameEn: city.name_en,
+    nameZh: city.name_zh,
+    timezone: city.timezone,
+  };
+
+  const targets: CompileTarget[] = target === "both" ? ["events", "kit"] : [target];
+  const outcomes: RunOutcome[] = [];
+
+  for (const t of targets) {
+    // 3. Cooldown check (unless forced).
+    if (!force) {
+      const cooled = await withinCooldown(admin, cityCode, t);
+      if (cooled) {
+        outcomes.push({
+          target: t,
+          status: "ok",
+          searchCalls: 0,
+          promptTokens: 0,
+          outputTokens: 0,
+          itemsWritten: 0,
+          error: "cooldown",
+        });
+        continue;
+      }
+    }
+
+    const startedAt = new Date().toISOString();
+    let outcome: RunOutcome;
+    try {
+      outcome =
+        t === "events"
+          ? await compileEvents(admin, cityCtx, tavilyKey, deepseekKey)
+          : await compileKit(admin, cityCtx, tavilyKey, deepseekKey);
+    } catch (err) {
+      outcome = {
+        target: t,
+        status: "failed",
+        searchCalls: 0,
+        promptTokens: 0,
+        outputTokens: 0,
+        itemsWritten: 0,
+        error: (err as Error).message,
+      };
+    }
+    await writeRun(admin, cityCode, outcome, startedAt);
+    outcomes.push(outcome);
+  }
+
+  return json({ city_code: cityCode, outcomes });
+});
+
+// ─── Cooldown ────────────────────────────────────────────────────────────────
+
+async function withinCooldown(
+  admin: SupabaseAdmin,
+  cityCode: string,
+  target: CompileTarget,
+): Promise<boolean> {
+  const { data } = await admin
+    .from("city_brief_runs")
+    .select("started_at, status")
+    .eq("city_code", cityCode)
+    .eq("target", target)
+    .in("status", ["ok", "partial"])
+    .order("started_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (!data?.started_at) return false;
+  const last = Date.parse(data.started_at as string);
+  if (Number.isNaN(last)) return false;
+  const cooldownMs = target === "events" ? COOLDOWN_EVENTS_MS : COOLDOWN_KIT_MS;
+  return Date.now() - last < cooldownMs;
+}
+
+// ─── Tavily ──────────────────────────────────────────────────────────────────
+
+interface TavilyResult {
+  title?: string;
+  url?: string;
+  content?: string;
+}
+
+async function runTavily(
+  tavilyKey: string,
+  queries: ReturnType<typeof tavilyQueries>,
+): Promise<{ candidates: Candidate[]; calls: number }> {
+  const now = new Date().toISOString();
+  const byUrl = new Map<string, Candidate>();
+  let calls = 0;
+  let totalChars = 0;
+
+  for (const q of queries) {
+    if (byUrl.size >= MAX_CANDIDATES || totalChars >= MAX_CANDIDATE_CHARS) break;
+    const payload: Record<string, unknown> = {
+      query: q.query,
+      search_depth: TAVILY_SEARCH_DEPTH,
+      max_results: TAVILY_MAX_RESULTS,
+      topic: q.topic ?? "general",
+    };
+    if (q.topic === "news" && q.days) payload.days = q.days;
+
+    let res: Response;
+    try {
+      res = await fetch(TAVILY_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${tavilyKey}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+    } catch {
+      continue; // skip a failed query; others may still yield candidates
+    }
+    calls++;
+    if (!res.ok) continue;
+    const data = (await res.json()) as { results?: TavilyResult[] };
+    for (const r of data.results ?? []) {
+      const url = (r.url ?? "").trim();
+      if (!url || byUrl.has(url)) continue;
+      if (byUrl.size >= MAX_CANDIDATES || totalChars >= MAX_CANDIDATE_CHARS) break;
+      const rawText = (r.content ?? "").slice(0, MAX_RAWTEXT_CHARS);
+      totalChars += rawText.length;
+      byUrl.set(url, {
+        sourceId: "tavily",
+        title: r.title ?? "",
+        rawText,
+        url,
+        fetchedAt: now,
+      });
+    }
+  }
+
+  return { candidates: [...byUrl.values()], calls };
+}
+
+// ─── DeepSeek ────────────────────────────────────────────────────────────────
+
+interface DeepSeekUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+}
+
+async function callDeepSeek(
+  deepseekKey: string,
+  prompt: string,
+): Promise<{ content: string; usage: DeepSeekUsage }> {
+  const base = Deno.env.get("DEEPSEEK_BASE_URL") ?? "https://api.deepseek.com/v1";
+  const model = Deno.env.get("DEEPSEEK_MODEL") ?? "deepseek-chat";
+  const res = await fetch(`${base}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${deepseekKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: DEEPSEEK_MAX_TOKENS,
+      response_format: { type: "json_object" },
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`deepseek ${res.status}: ${text.slice(0, 200)}`);
+  }
+  const jsonRes = (await res.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+    usage?: DeepSeekUsage;
+  };
+  const content = jsonRes.choices?.[0]?.message?.content ?? "";
+  const usage = jsonRes.usage ?? { prompt_tokens: 0, completion_tokens: 0 };
+  return { content, usage };
+}
+
+/** Call DeepSeek, parse JSON, retry once on unparseable output. */
+async function deepSeekJSON(
+  deepseekKey: string,
+  prompt: string,
+): Promise<{ parsed: Record<string, unknown> | null; usage: DeepSeekUsage }> {
+  const first = await callDeepSeek(deepseekKey, prompt);
+  let parsed = parseModelJSON(first.content);
+  let usage = first.usage;
+  if (parsed === null) {
+    const retry = await callDeepSeek(
+      deepseekKey,
+      `${prompt}\n\nYour previous reply was not valid JSON. Reply with ONLY the JSON object.`,
+    );
+    parsed = parseModelJSON(retry.content);
+    usage = {
+      prompt_tokens: usage.prompt_tokens + retry.usage.prompt_tokens,
+      completion_tokens: usage.completion_tokens + retry.usage.completion_tokens,
+    };
+  }
+  return { parsed, usage };
+}
+
+// ─── Events compile ──────────────────────────────────────────────────────────
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function compileEvents(
+  admin: SupabaseAdmin,
+  city: CityContext,
+  tavilyKey: string,
+  deepseekKey: string,
+): Promise<RunOutcome> {
+  const now = new Date();
+  const queries = tavilyQueries(city, "events", {
+    now,
+    earliest: new Date(now.getTime() - DAY_MS),
+    latest: new Date(now.getTime() + 21 * DAY_MS),
+  });
+  const { candidates, calls } = await runTavily(tavilyKey, queries);
+  if (candidates.length === 0) {
+    return {
+      target: "events",
+      status: "failed",
+      searchCalls: calls,
+      promptTokens: 0,
+      outputTokens: 0,
+      itemsWritten: 0,
+      error: "no search candidates",
+    };
+  }
+
+  const prompt = buildEventsPrompt(city, candidates);
+  const { parsed, usage } = await deepSeekJSON(deepseekKey, prompt);
+  if (parsed === null) {
+    return {
+      target: "events",
+      status: "failed",
+      searchCalls: calls,
+      promptTokens: usage.prompt_tokens,
+      outputTokens: usage.completion_tokens,
+      itemsWritten: 0,
+      error: "model returned invalid JSON",
+    };
+  }
+  if (parsed["action"] === "refuse") {
+    return {
+      target: "events",
+      status: "ok",
+      searchCalls: calls,
+      promptTokens: usage.prompt_tokens,
+      outputTokens: usage.completion_tokens,
+      itemsWritten: 0,
+      error: "model refused",
+    };
+  }
+
+  const candidateURLs = candidates.map((c) => c.url);
+  const { accepted, rejected } = validateEvents(parsed["events"], candidateURLs, now);
+
+  // Fetch existing active events for this city for ±2-day normalized-name dedup.
+  const { data: existingRows } = await admin
+    .from("city_events")
+    .select("id, name, ends_at")
+    .eq("city_code", city.cityCode)
+    .eq("status", "active");
+  const existing = (existingRows ?? []) as Array<{ id: string; name: string; ends_at: string }>;
+
+  const model = Deno.env.get("DEEPSEEK_MODEL") ?? "deepseek-chat";
+  const nowIso = now.toISOString();
+  let written = 0;
+
+  for (const ev of accepted) {
+    const anchor = ev.startsAt ?? ev.endsAt;
+    let id = eventId(city.cityCode, ev.name, anchor);
+
+    // Secondary dedup: an existing active row with the same normalized name
+    // within ±2 days is the SAME event → update it in place rather than insert.
+    const norm = normalizeName(ev.name);
+    const endMs = Date.parse(ev.endsAt);
+    const twin = existing.find(
+      (r) =>
+        normalizeName(r.name) === norm &&
+        Math.abs(Date.parse(r.ends_at) - endMs) <= 2 * DAY_MS,
+    );
+    if (twin) id = twin.id;
+
+    const { error } = await admin.from("city_events").upsert(
+      {
+        id,
+        city_code: city.cityCode,
+        name: ev.name,
+        category: ev.category,
+        when_label: ev.whenLabel,
+        starts_at: ev.startsAt,
+        ends_at: ev.endsAt,
+        solo_score: ev.soloScore,
+        solo_note: ev.soloNote,
+        health: ev.health,
+        seen_label: ev.seenLabel,
+        limited_label: ev.limitedLabel,
+        source_url: ev.sourceUrl,
+        verified_at: nowIso,
+        model_name: model,
+        status: "active",
+      },
+      { onConflict: "id" },
+    );
+    if (!error) written++;
+  }
+
+  const status: RunOutcome["status"] =
+    written === 0 && accepted.length === 0 && rejected.length > 0 ? "partial" : "ok";
+
+  return {
+    target: "events",
+    status,
+    searchCalls: calls,
+    promptTokens: usage.prompt_tokens,
+    outputTokens: usage.completion_tokens,
+    itemsWritten: written,
+  };
+}
+
+// ─── Kit compile (re-verify) ─────────────────────────────────────────────────
+
+async function compileKit(
+  admin: SupabaseAdmin,
+  city: CityContext,
+  tavilyKey: string,
+  deepseekKey: string,
+): Promise<RunOutcome> {
+  const now = new Date();
+
+  // Existing kit rows are what we re-verify. If none exist, there is nothing to
+  // confirm/update — kit content is seeded first, then re-verified here.
+  const { data: kitRows } = await admin
+    .from("city_kits")
+    .select("section, name, body, lens_line, last_verified_at")
+    .eq("city_code", city.cityCode);
+  const current = (kitRows ?? []) as Array<{
+    section: KitSection;
+    name: string;
+    body: string;
+    lens_line: string | null;
+    last_verified_at: string | null;
+  }>;
+
+  if (current.length === 0) {
+    return {
+      target: "kit",
+      status: "ok",
+      searchCalls: 0,
+      promptTokens: 0,
+      outputTokens: 0,
+      itemsWritten: 0,
+      error: "no kit rows to verify (seed first)",
+    };
+  }
+
+  const queries = tavilyQueries(city, "kit", {
+    now,
+    earliest: new Date(now.getTime() - DAY_MS),
+    latest: new Date(now.getTime() + 21 * DAY_MS),
+  });
+  const { candidates, calls } = await runTavily(tavilyKey, queries);
+  if (candidates.length === 0) {
+    // Still run the 45-day downgrade sweep even without fresh candidates.
+    await downgradeStaleKit(admin, city.cityCode, now);
+    return {
+      target: "kit",
+      status: "partial",
+      searchCalls: calls,
+      promptTokens: 0,
+      outputTokens: 0,
+      itemsWritten: 0,
+      error: "no search candidates",
+    };
+  }
+
+  const prompt = buildKitPrompt(
+    city,
+    current.map((r) => ({
+      section: r.section,
+      name: r.name,
+      body: r.body,
+      lensLine: r.lens_line,
+    })),
+    candidates,
+  );
+  const { parsed, usage } = await deepSeekJSON(deepseekKey, prompt);
+  if (parsed === null) {
+    return {
+      target: "kit",
+      status: "failed",
+      searchCalls: calls,
+      promptTokens: usage.prompt_tokens,
+      outputTokens: usage.completion_tokens,
+      itemsWritten: 0,
+      error: "model returned invalid JSON",
+    };
+  }
+
+  const candidateURLs = candidates.map((c) => c.url);
+  const { decisions } = validateKit(parsed["decisions"], candidateURLs);
+  const model = Deno.env.get("DEEPSEEK_MODEL") ?? "deepseek-chat";
+  const nowIso = now.toISOString();
+  let written = 0;
+
+  for (const d of decisions) {
+    if (d.action === "omit") continue; // leave the row untouched
+
+    if (d.action === "confirm") {
+      // Bump freshness + health green; never touch link_url / body.
+      const { error } = await admin
+        .from("city_kits")
+        .update({ last_verified_at: nowIso, health: "green", model_name: model })
+        .eq("city_code", city.cityCode)
+        .eq("section", d.section);
+      if (!error) written++;
+      continue;
+    }
+
+    // update — refresh copy; link_url is intentionally NOT set here.
+    const patch: Record<string, unknown> = {
+      name: d.name,
+      body: d.body,
+      lens_line: d.lensLine,
+      health: d.health,
+      last_verified_at: nowIso,
+      model_name: model,
+    };
+    if (d.linkLabel != null) patch.link_label = d.linkLabel;
+    if (Array.isArray(d.sources) && d.sources.length > 0) patch.sources = d.sources;
+    const { error } = await admin
+      .from("city_kits")
+      .update(patch)
+      .eq("city_code", city.cityCode)
+      .eq("section", d.section);
+    if (!error) written++;
+  }
+
+  // Downgrade any kit row not re-verified in 45 days to yellow.
+  await downgradeStaleKit(admin, city.cityCode, now);
+
+  return {
+    target: "kit",
+    status: "ok",
+    searchCalls: calls,
+    promptTokens: usage.prompt_tokens,
+    outputTokens: usage.completion_tokens,
+    itemsWritten: written,
+  };
+}
+
+async function downgradeStaleKit(admin: SupabaseAdmin, cityCode: string, now: Date): Promise<void> {
+  const cutoff = new Date(now.getTime() - KIT_STALE_YELLOW_MS).toISOString();
+  await admin
+    .from("city_kits")
+    .update({ health: "yellow" })
+    .eq("city_code", cityCode)
+    .in("health", ["green"])
+    .lt("last_verified_at", cutoff);
+}
+
+// ─── Run accounting ──────────────────────────────────────────────────────────
+
+async function writeRun(
+  admin: SupabaseAdmin,
+  cityCode: string,
+  outcome: RunOutcome,
+  startedAt: string,
+): Promise<void> {
+  await admin.from("city_brief_runs").insert({
+    city_code: cityCode,
+    target: outcome.target,
+    status: outcome.status,
+    search_calls: outcome.searchCalls,
+    prompt_tokens: outcome.promptTokens,
+    output_tokens: outcome.outputTokens,
+    items_written: outcome.itemsWritten,
+    error: outcome.error ?? null,
+    started_at: startedAt,
+    finished_at: new Date().toISOString(),
+  });
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+// Loose alias so we don't depend on supabase-js generic types in Deno.
+type SupabaseAdmin = ReturnType<typeof createClient>;
+
+function json(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/infra/supabase/functions/compile-city-brief/test.sh
+++ b/infra/supabase/functions/compile-city-brief/test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Curl-based integration smoke test for compile-city-brief.
+#
+# Requires the project ref and ONE credential in env:
+#   PROJECT           — Supabase project ref
+#   CRON_SECRET       — value of CITY_BRIEF_CRON_SECRET, OR
+#   SERVICE_ROLE_KEY  — the service-role key
+# Optional:
+#   CITY              — city_code (default: vte)
+#   TARGET            — kit|events|both (default: events)
+#
+# It curls twice. The first call compiles; the second call (WITHOUT force)
+# should be skipped by the cooldown — look for outcomes[].error == "cooldown".
+
+set -euo pipefail
+
+: "${PROJECT:?Set PROJECT to your Supabase project ref}"
+
+CITY="${CITY:-vte}"
+TARGET="${TARGET:-events}"
+URL="https://${PROJECT}.functions.supabase.co/compile-city-brief"
+
+# Pick the auth header from whichever credential is provided.
+if [[ -n "${CRON_SECRET:-}" ]]; then
+  AUTH_HEADER=(-H "x-cron-secret: ${CRON_SECRET}")
+elif [[ -n "${SERVICE_ROLE_KEY:-}" ]]; then
+  AUTH_HEADER=(-H "Authorization: Bearer ${SERVICE_ROLE_KEY}")
+else
+  echo "Set CRON_SECRET or SERVICE_ROLE_KEY" >&2
+  exit 1
+fi
+
+echo "→ [1/2] POST $URL  (force=true — actually compiles)"
+curl -fsSL "$URL" \
+  "${AUTH_HEADER[@]}" \
+  -H "Content-Type: application/json" \
+  --data "{\"city_code\":\"${CITY}\",\"target\":\"${TARGET}\",\"force\":true}" \
+  | python3 -m json.tool
+
+echo
+echo "→ [2/2] POST $URL  (no force — expect cooldown skip)"
+curl -fsSL "$URL" \
+  "${AUTH_HEADER[@]}" \
+  -H "Content-Type: application/json" \
+  --data "{\"city_code\":\"${CITY}\",\"target\":\"${TARGET}\"}" \
+  | python3 -m json.tool

--- a/infra/supabase/migrations/0013_city_brief.sql
+++ b/infra/supabase/migrations/0013_city_brief.sql
@@ -1,0 +1,183 @@
+-- Solo City OS v2 — city-brief data pipeline (落地包 · 在地).
+--
+-- Apply with `supabase db push` after `supabase link --project-ref <ref>`.
+--
+-- Four tables backing the server-side city-brief pipeline:
+--   1. sc_cities      — city registry; brief_enabled gates the compile pipeline.
+--   2. city_kits      — the "landing kit" (4 sections: net/money/visa/safety),
+--                       re-verified periodically; health decays as rows age.
+--   3. city_events    — the "live/在地" module; time-bound local events with a
+--                       solo-friendliness score. Expired rows swept to 'expired'.
+--   4. city_brief_runs — compile-run accounting: cooldown + cost bookkeeping.
+--
+-- RLS mirrors synthesized_experiences from 0001: the first three tables are
+-- read-public; NONE has a public write policy — the service-role key used by the
+-- compile-city-brief Edge Function bypasses RLS, and that bypass IS the write
+-- boundary. city_brief_runs is internal: no public policies at all.
+--
+-- cityCode convention: lowercase (e.g. 'vte'), matching synthesized_experiences.
+
+begin;
+
+-- ─── 1. City registry ───────────────────────────────────────────────────────
+
+create table if not exists public.sc_cities (
+  city_code       text          primary key, -- lowercase, e.g. 'vte'
+  name_local      text          not null,    -- local-script name, e.g. 'ວຽງຈັນ'
+  name_zh         text          not null,    -- '万象'
+  name_en         text          not null,    -- 'Vientiane'
+  country_code    text          not null,    -- ISO 3166-1 alpha-2, e.g. 'LA'
+  lat             double precision not null,
+  lon             double precision not null,
+  timezone        text          not null,    -- IANA tz, e.g. 'Asia/Vientiane'
+  brief_enabled   boolean       not null default false,
+  created_at      timestamptz   not null default now(),
+  updated_at      timestamptz   not null default now()
+);
+
+-- ─── 2. Landing kit (net / money / visa / safety) ───────────────────────────
+
+create table if not exists public.city_kits (
+  city_code       text          not null references public.sc_cities(city_code) on delete cascade,
+  section         text          not null check (section in ('net', 'money', 'visa', 'safety')),
+  name            text          not null,    -- section headline, e.g. 'Airalo 老挝 eSIM'
+  body            text          not null,    -- main copy
+  lens_line       text,                       -- 独行透镜 one-liner
+  health          text          not null default 'gray' check (health in ('green', 'yellow', 'red', 'gray')),
+  last_verified_at timestamptz,
+  link_url        text,                       -- deep-link target (allowlisted host)
+  link_label      text,
+  action          jsonb,                      -- structured action, e.g. visa_reminder / emergency_numbers
+  sources         jsonb         not null default '[]'::jsonb,
+  model_name      text,                       -- null when human-curated
+  created_at      timestamptz   not null default now(),
+  updated_at      timestamptz   not null default now(),
+  primary key (city_code, section)
+);
+create index if not exists city_kits_city_idx on public.city_kits(city_code);
+
+-- ─── 3. Live events (在地) ──────────────────────────────────────────────────
+
+create table if not exists public.city_events (
+  id              text          primary key, -- deterministic: evt_{city}_{slug≤32}_{yyyymmdd}
+  city_code       text          not null references public.sc_cities(city_code) on delete cascade,
+  name            text          not null,
+  category        text          not null check (category in ('culture', 'wellness', 'market', 'music', 'sports', 'food', 'notice')),
+  when_label      text          not null,    -- human-facing, e.g. '本周五 傍晚'
+  starts_at       timestamptz,                -- nullable (all-week / recurring)
+  ends_at         timestamptz   not null,    -- expiry anchor
+  solo_score      double precision check (solo_score is null or (solo_score >= 0 and solo_score <= 10)),
+  solo_note       text,
+  health          text          not null default 'gray' check (health in ('green', 'yellow', 'red', 'gray')),
+  seen_label      text,                       -- provenance, e.g. '人工策展 · 7月5日'
+  lat             double precision,
+  lng             double precision,
+  limited_label   text,                       -- 限时 chip text, e.g. '仅本周'
+  source_url      text          not null,
+  verified_at     timestamptz,
+  model_name      text,                       -- null when human-curated
+  status          text          not null default 'active' check (status in ('active', 'expired')),
+  created_at      timestamptz   not null default now(),
+  updated_at      timestamptz   not null default now()
+);
+create index if not exists city_events_city_ends_idx on public.city_events(city_code, ends_at desc);
+
+-- ─── 4. Compile-run accounting ──────────────────────────────────────────────
+
+create table if not exists public.city_brief_runs (
+  id              uuid          primary key default gen_random_uuid(),
+  city_code       text          not null,
+  target          text          not null check (target in ('kit', 'events')),
+  status          text          not null check (status in ('ok', 'partial', 'failed')),
+  search_calls    integer       not null default 0,
+  prompt_tokens   integer       not null default 0,
+  output_tokens   integer       not null default 0,
+  items_written   integer       not null default 0,
+  error           text,
+  started_at      timestamptz   not null default now(),
+  finished_at     timestamptz
+);
+create index if not exists city_brief_runs_city_target_idx
+  on public.city_brief_runs(city_code, target, started_at desc);
+
+-- ─── RLS: read-public on the three content tables ───────────────────────────
+
+alter table public.sc_cities        enable row level security;
+alter table public.city_kits        enable row level security;
+alter table public.city_events      enable row level security;
+alter table public.city_brief_runs  enable row level security;
+
+create policy "sc_cities public-read" on public.sc_cities
+  for select using (true);
+
+create policy "city_kits public-read" on public.city_kits
+  for select using (true);
+
+create policy "city_events public-read" on public.city_events
+  for select using (true);
+
+-- Note: writes to sc_cities / city_kits / city_events happen ONLY via the
+-- service-role key inside the compile-city-brief Edge Function (and the seed
+-- script). Service role bypasses RLS, so no public INSERT/UPDATE/DELETE
+-- policies exist here on purpose — that's the security boundary.
+--
+-- city_brief_runs has RLS enabled but NO policies at all: it is internal
+-- accounting, unreadable by anon/authenticated clients.
+
+-- ─── updated_at touch triggers (reuse sc_touch_updated_at from 0001) ─────────
+
+create trigger sc_cities_touch      before update on public.sc_cities   for each row execute function public.sc_touch_updated_at();
+create trigger sc_city_kits_touch   before update on public.city_kits   for each row execute function public.sc_touch_updated_at();
+create trigger sc_city_events_touch before update on public.city_events for each row execute function public.sc_touch_updated_at();
+
+-- ─── Expiry sweep — mark past events 'expired'. ─────────────────────────────
+--
+-- Events whose ends_at is in the past become 'expired'. Returns the number of
+-- rows swept (useful for scheduled-job logging). SECURITY DEFINER so a
+-- scheduled invocation under a restricted role can still update across cities.
+--
+-- Schedule via pg_cron (hourly), e.g.:
+--   select cron.schedule('city-events-expire', '0 * * * *',
+--                        'select public.sc_expire_city_events()');
+
+create or replace function public.sc_expire_city_events()
+  returns int
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  swept int;
+begin
+  with expired as (
+    update public.city_events
+    set status = 'expired'
+    where status = 'active'
+      and ends_at < now()
+    returning 1
+  )
+  select count(*) into swept from expired;
+  return swept;
+end;
+$$;
+
+-- If pg_cron is available, register the hourly sweep idempotently. Skipped
+-- silently where the extension is absent (e.g. bare local Postgres). The
+-- iOS client also filters on ends_at as a second line of defence.
+do $$
+begin
+  if exists (select 1 from pg_extension where extname = 'pg_cron') then
+    perform cron.schedule(
+      'city-events-expire',
+      '0 * * * *',
+      'select public.sc_expire_city_events()'
+    );
+  end if;
+exception
+  when undefined_function or undefined_table or insufficient_privilege then
+    -- pg_cron present but not usable here; the function can still be called
+    -- by an external scheduler. Nothing to do.
+    null;
+end$$;
+
+commit;

--- a/infra/supabase/test_rls.ts
+++ b/infra/supabase/test_rls.ts
@@ -109,6 +109,70 @@ if (userA.data.user && userB.data.user) {
   await serviceClient.from("synthesized_experiences").delete().eq("id", probeId);
 }
 
+// --- 5. city-brief tables: anon reads kits/events, cannot write, runs hidden ---
+
+{
+  const { error: kitErr } = await anonClient.from("city_kits").select("section").limit(1);
+  assert(!kitErr, `anon select on city_kits succeeds: ${kitErr?.message ?? "ok"}`);
+
+  const { error: evErr } = await anonClient.from("city_events").select("id").limit(1);
+  assert(!evErr, `anon select on city_events succeeds: ${evErr?.message ?? "ok"}`);
+
+  // anon INSERT must be denied by RLS (no public write policy).
+  const { error: kitInsertErr } = await anonClient.from("city_kits").insert({
+    city_code: "test-rls",
+    section: "net",
+    name: "x",
+    body: "x",
+  });
+  assert(!!kitInsertErr, "anon insert on city_kits is denied (no write policy)");
+
+  const { error: evInsertErr } = await anonClient.from("city_events").insert({
+    id: `evt_test_rls_${Date.now()}`,
+    city_code: "test-rls",
+    name: "x",
+    category: "market",
+    when_label: "x",
+    ends_at: new Date(Date.now() + 86_400_000).toISOString(),
+    source_url: "https://example.com",
+  });
+  assert(!!evInsertErr, "anon insert on city_events is denied (no write policy)");
+
+  // city_brief_runs has RLS enabled with NO policies → anon reads see 0 rows.
+  const { data: runsData, error: runsErr } = await anonClient
+    .from("city_brief_runs")
+    .select("id")
+    .limit(1);
+  assert(
+    !runsErr && Array.isArray(runsData) && runsData.length === 0,
+    "anon select on city_brief_runs returns 0 rows (RLS, no policy)",
+  );
+
+  // service-role CAN write the content tables (write boundary).
+  const { error: svcCityErr } = await serviceClient.from("sc_cities").upsert({
+    city_code: "test-rls",
+    name_local: "x",
+    name_zh: "x",
+    name_en: "Test RLS",
+    country_code: "LA",
+    lat: 0,
+    lon: 0,
+    timezone: "Asia/Vientiane",
+  });
+  assert(!svcCityErr, `service-role upsert sc_cities succeeds: ${svcCityErr?.message ?? "ok"}`);
+
+  const { error: svcKitErr } = await serviceClient.from("city_kits").upsert({
+    city_code: "test-rls",
+    section: "net",
+    name: "probe",
+    body: "probe",
+  });
+  assert(!svcKitErr, `service-role upsert city_kits succeeds: ${svcKitErr?.message ?? "ok"}`);
+
+  // Cleanup (city_kits/city_events cascade on city delete).
+  await serviceClient.from("sc_cities").delete().eq("city_code", "test-rls");
+}
+
 // --- Result ----------------------------------------------------------------
 
 if (failures.length > 0) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md,json}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,md,json}\"",
     "seed:chiang-mai": "tsx scripts/seed-load.ts",
+    "seed:city-brief": "tsx scripts/seed-city-brief.ts",
     "parity:check": "tsx scripts/check-swift-parity.ts",
     "localization:check": "tsx scripts/check-localization.ts"
   },

--- a/packages/ai/src/__fixtures__/city-brief-deepseek-events.json
+++ b/packages/ai/src/__fixtures__/city-brief-deepseek-events.json
@@ -1,0 +1,64 @@
+{
+  "events": [
+    {
+      "name": "塔銮周边夜市",
+      "category": "market",
+      "when_label": "本周每晚",
+      "starts_at": null,
+      "ends_at": "2026-07-12T15:00:00Z",
+      "solo_score": 8.0,
+      "solo_note": "小吃摊多，独自吃走都自在",
+      "seen_label": "官方 · 7月",
+      "limited_label": "本周每晚",
+      "source_url": "https://www.tourismlaos.org/events/that-luang-night-market"
+    },
+    {
+      "name": "那伽火球节前导市集",
+      "category": "market",
+      "when_label": "本周五 傍晚",
+      "starts_at": "2026-07-10T10:00:00Z",
+      "ends_at": "2026-07-10T14:00:00Z",
+      "solo_score": 12.5,
+      "solo_note": "一个人逛正好，傍晚人最舒服",
+      "seen_label": "官方 · 7月",
+      "limited_label": "仅本周五",
+      "source_url": "https://www.tourismlaos.org/events/naga-fireball-market"
+    },
+    {
+      "name": "湄公河岸步道段整修封闭",
+      "category": "notice",
+      "when_label": "本周",
+      "starts_at": null,
+      "ends_at": "2026-07-12T16:59:00Z",
+      "solo_score": 5.0,
+      "solo_note": "傍晚散步改走 Chao Anouvong 公园一侧",
+      "seen_label": "官方 · 7月",
+      "limited_label": "本周封闭",
+      "source_url": "https://www.tourismlaos.org/notices/mekong-riverside-maintenance"
+    },
+    {
+      "name": "神秘河边酒吧一生一次派对",
+      "category": "music",
+      "when_label": "本周六",
+      "starts_at": "2026-07-11T13:00:00Z",
+      "ends_at": "2026-07-11T18:00:00Z",
+      "solo_score": 7.0,
+      "solo_note": "一生一次的绝对必去派对",
+      "seen_label": "博客",
+      "limited_label": "仅一晚",
+      "source_url": "https://www.tourismlaos.org/events/naga-fireball-market"
+    },
+    {
+      "name": "查无来源的幽灵集市",
+      "category": "market",
+      "when_label": "本周日",
+      "starts_at": null,
+      "ends_at": "2026-07-12T12:00:00Z",
+      "solo_score": 6.5,
+      "solo_note": "来源不在候选清单里",
+      "seen_label": "未知",
+      "limited_label": null,
+      "source_url": "https://random-travel-blog.example.com/ghost-market"
+    }
+  ]
+}

--- a/packages/ai/src/__fixtures__/city-brief-tavily-events.json
+++ b/packages/ai/src/__fixtures__/city-brief-tavily-events.json
@@ -1,0 +1,23 @@
+{
+  "query": "Vientiane events festivals things to do this week",
+  "results": [
+    {
+      "title": "That Luang Night Market — nightly food stalls",
+      "url": "https://www.tourismlaos.org/events/that-luang-night-market",
+      "content": "The night market around Pha That Luang runs every evening this week with food stalls and local crafts. Busiest just after sunset; quiet and easy to browse alone.",
+      "score": 0.91
+    },
+    {
+      "title": "Naga fireball pre-festival market this Friday",
+      "url": "https://www.tourismlaos.org/events/naga-fireball-market",
+      "content": "A pre-festival market ahead of the Naga fireball celebration takes place this Friday evening along the riverfront. Stalls open around 17:00 and wind down by 21:00 local time.",
+      "score": 0.88
+    },
+    {
+      "title": "Mekong riverside walkway maintenance closure",
+      "url": "https://www.tourismlaos.org/notices/mekong-riverside-maintenance",
+      "content": "A section of the Mekong riverside walkway is closed this week for maintenance. Pedestrians should use the Chao Anouvong park side instead.",
+      "score": 0.79
+    }
+  ]
+}

--- a/packages/ai/src/__tests__/city-brief-core.test.ts
+++ b/packages/ai/src/__tests__/city-brief-core.test.ts
@@ -1,0 +1,354 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+import {
+  tavilyQueries,
+  buildEventsPrompt,
+  buildKitPrompt,
+  parseModelJSON,
+  validateEvents,
+  validateKit,
+  eventId,
+  slugify,
+  normalizeName,
+  isAllowlistedKitHost,
+  type CityContext,
+  type Candidate,
+  type DateWindow,
+} from "../../../../infra/supabase/functions/_shared/city-brief-core";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const fixturesDir = join(__dirname, "..", "__fixtures__");
+
+function loadFixture<T>(name: string): T {
+  return JSON.parse(readFileSync(join(fixturesDir, name), "utf-8")) as T;
+}
+
+const tavilyEvents = loadFixture<{
+  results: Array<{ title: string; url: string; content: string; score: number }>;
+}>("city-brief-tavily-events.json");
+
+const deepseekEventsReply = loadFixture<Record<string, unknown>>("city-brief-deepseek-events.json");
+
+const VTE: CityContext = {
+  cityCode: "vte",
+  nameEn: "Vientiane",
+  nameZh: "万象",
+  timezone: "Asia/Vientiane",
+};
+
+// Anchor "now" to the seed week (Mon 2026-07-06) so fixture dates land inside
+// the [now-1d, now+21d] acceptance window deterministically.
+const NOW = new Date("2026-07-06T00:00:00Z");
+
+function windowFrom(now: Date): DateWindow {
+  return {
+    now,
+    earliest: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    latest: new Date(now.getTime() + 21 * 24 * 60 * 60 * 1000),
+  };
+}
+
+function candidatesFromTavily(): Candidate[] {
+  return tavilyEvents.results.map((r) => ({
+    sourceId: "tavily",
+    title: r.title,
+    rawText: r.content.slice(0, 1200),
+    url: r.url,
+    fetchedAt: NOW.toISOString(),
+  }));
+}
+
+/** Non-undefined first element (tsc `noUncheckedIndexedAccess`-friendly). */
+function first<T>(arr: T[]): T {
+  const v = arr[0];
+  if (v === undefined) throw new Error("expected a non-empty array");
+  return v;
+}
+
+// ─── tavilyQueries ───────────────────────────────────────────────────────────
+
+describe("tavilyQueries", () => {
+  it("builds 3 event queries incl. a news-topic notice query", () => {
+    const qs = tavilyQueries(VTE, "events", windowFrom(NOW));
+    expect(qs).toHaveLength(3);
+    expect(qs.every((q) => q.query.includes("Vientiane"))).toBe(true);
+    const news = qs.filter((q) => q.topic === "news");
+    expect(news).toHaveLength(1);
+    expect(first(news).days).toBeGreaterThan(0);
+  });
+
+  it("builds 4 kit queries, one per section", () => {
+    const qs = tavilyQueries(VTE, "kit", windowFrom(NOW));
+    expect(qs).toHaveLength(4);
+    expect(new Set(qs.map((q) => q.section))).toEqual(new Set(["net", "money", "visa", "safety"]));
+  });
+});
+
+// ─── prompts ─────────────────────────────────────────────────────────────────
+
+describe("prompt builders", () => {
+  it("events prompt lists every candidate URL for the whitelist", () => {
+    const cands = candidatesFromTavily();
+    const prompt = buildEventsPrompt(VTE, cands);
+    for (const c of cands) expect(prompt).toContain(c.url);
+    expect(prompt).toContain("zh-Hans");
+    expect(prompt).toContain("refuse");
+  });
+
+  it("kit prompt states link_url is never changed by the model", () => {
+    const prompt = buildKitPrompt(
+      VTE,
+      [{ section: "net", name: "eSIM", body: "buy eSIM", lensLine: null }],
+      candidatesFromTavily(),
+    );
+    expect(prompt.toLowerCase()).toContain("never change link_url".toLowerCase());
+    expect(prompt).toContain("confirm");
+    expect(prompt).toContain("omit");
+  });
+});
+
+// ─── parseModelJSON ──────────────────────────────────────────────────────────
+
+describe("parseModelJSON", () => {
+  it("strips markdown fences", () => {
+    const parsed = parseModelJSON('```json\n{"a":1}\n```');
+    expect(parsed).toEqual({ a: 1 });
+  });
+
+  it("takes first-brace to last-brace on surrounding prose", () => {
+    const parsed = parseModelJSON('Sure! Here you go: {"ok":true} — hope that helps');
+    expect(parsed).toEqual({ ok: true });
+  });
+
+  it("returns null on invalid JSON and on arrays", () => {
+    expect(parseModelJSON("not json")).toBeNull();
+    expect(parseModelJSON("[1,2,3]")).toBeNull();
+  });
+});
+
+// ─── slug / id / normalize ───────────────────────────────────────────────────
+
+describe("deterministic ids", () => {
+  it("eventId is stable and matches evt_{city}_{slug}_{yyyymmdd}", () => {
+    const id = eventId("VTE", "That Luang Night Market", "2026-07-12T15:00:00Z");
+    expect(id).toBe("evt_vte_that_luang_night_market_20260712");
+    // deterministic
+    expect(eventId("vte", "That Luang Night Market", "2026-07-12T15:00:00Z")).toBe(id);
+  });
+
+  it("slugify falls back to a stable hash for all-CJK names (no empty slug)", () => {
+    const s = slugify("塔銮周边夜市");
+    expect(s.length).toBeGreaterThan(0);
+    expect(slugify("塔銮周边夜市")).toBe(s); // stable
+    // two different CJK names must not collide to the same fallback
+    expect(slugify("塔銮周边夜市")).not.toBe(slugify("湄公河岸步道段整修封闭"));
+  });
+
+  it("normalizeName collapses punctuation/space for ±2-day dedup", () => {
+    expect(normalizeName("That Luang · Night Market")).toBe(normalizeName("thatluangnightmarket"));
+  });
+});
+
+// ─── isAllowlistedKitHost ────────────────────────────────────────────────────
+
+describe("isAllowlistedKitHost", () => {
+  it("accepts airalo/wise/geosure, *.gov and *.la", () => {
+    expect(isAllowlistedKitHost("https://www.airalo.com/laos-esim")).toBe(true);
+    expect(isAllowlistedKitHost("https://wise.com/x")).toBe(true);
+    expect(isAllowlistedKitHost("https://geosureglobal.com")).toBe(true);
+    expect(isAllowlistedKitHost("https://laoevisa.gov.la")).toBe(true);
+    expect(isAllowlistedKitHost("https://embassy.gov")).toBe(true);
+  });
+
+  it("rejects arbitrary blogs", () => {
+    expect(isAllowlistedKitHost("https://random-travel-blog.example.com/x")).toBe(false);
+    expect(isAllowlistedKitHost("not-a-url")).toBe(false);
+  });
+});
+
+// ─── validateEvents (the core quality gate) ──────────────────────────────────
+
+describe("validateEvents", () => {
+  const candidateURLs = tavilyEvents.results.map((r) => r.url);
+  const CAND0 = first(candidateURLs);
+
+  it("parses the canned DeepSeek reply and rejects hype + off-whitelist URLs", () => {
+    const parsed = parseModelJSON(JSON.stringify(deepseekEventsReply));
+    expect(parsed).not.toBeNull();
+    const { accepted, rejected } = validateEvents(parsed!["events"], candidateURLs, NOW);
+
+    const names = accepted.map((a) => a.name);
+    // three clean rows survive
+    expect(names).toContain("塔銮周边夜市");
+    expect(names).toContain("那伽火球节前导市集");
+    expect(names).toContain("湄公河岸步道段整修封闭");
+
+    // superlative row and off-whitelist row are rejected
+    expect(names).not.toContain("神秘河边酒吧一生一次派对");
+    expect(names).not.toContain("查无来源的幽灵集市");
+
+    const reasons = rejected.map((r) => r.reason);
+    expect(reasons.some((r) => /superlative/.test(r))).toBe(true);
+    expect(reasons.some((r) => /whitelist/.test(r))).toBe(true);
+  });
+
+  it("clamps solo_score into [0,10]", () => {
+    const parsed = parseModelJSON(JSON.stringify(deepseekEventsReply));
+    const { accepted } = validateEvents(parsed!["events"], candidateURLs, NOW);
+    const naga = accepted.find((a) => a.name === "那伽火球节前导市集");
+    expect(naga?.soloScore).toBe(10); // 12.5 clamped
+  });
+
+  it("forces solo_score = null for notices", () => {
+    const parsed = parseModelJSON(JSON.stringify(deepseekEventsReply));
+    const { accepted } = validateEvents(parsed!["events"], candidateURLs, NOW);
+    const notice = accepted.find((a) => a.category === "notice");
+    expect(notice?.soloScore).toBeNull();
+  });
+
+  it("rejects events whose ends_at is outside [now-1d, now+21d]", () => {
+    const items = [
+      {
+        name: "过期事件",
+        category: "market",
+        when_label: "上周",
+        ends_at: "2026-06-01T00:00:00Z",
+        solo_score: 7,
+        source_url: CAND0,
+      },
+      {
+        name: "太远的事件",
+        category: "market",
+        when_label: "下个月",
+        ends_at: "2026-09-01T00:00:00Z",
+        solo_score: 7,
+        source_url: CAND0,
+      },
+    ];
+    const { accepted, rejected } = validateEvents(items, candidateURLs, NOW);
+    expect(accepted).toHaveLength(0);
+    expect(rejected.every((r) => /outside/.test(r.reason))).toBe(true);
+  });
+
+  it("rejects ends_at before starts_at", () => {
+    const items = [
+      {
+        name: "时间倒挂",
+        category: "market",
+        when_label: "本周",
+        starts_at: "2026-07-10T10:00:00Z",
+        ends_at: "2026-07-10T08:00:00Z",
+        solo_score: 7,
+        source_url: CAND0,
+      },
+    ];
+    const { accepted, rejected } = validateEvents(items, candidateURLs, NOW);
+    expect(accepted).toHaveLength(0);
+    expect(first(rejected).reason).toMatch(/before starts_at/);
+  });
+
+  it("dedups same normalized name within ±2 days", () => {
+    const items = [
+      {
+        name: "夜市",
+        category: "market",
+        when_label: "周五",
+        ends_at: "2026-07-10T14:00:00Z",
+        solo_score: 8,
+        source_url: CAND0,
+      },
+      {
+        name: "夜 市",
+        category: "market",
+        when_label: "周六",
+        ends_at: "2026-07-11T14:00:00Z",
+        solo_score: 8,
+        source_url: CAND0,
+      },
+    ];
+    const { accepted, rejected } = validateEvents(items, candidateURLs, NOW);
+    expect(accepted).toHaveLength(1);
+    expect(rejected.some((r) => /duplicate/.test(r.reason))).toBe(true);
+  });
+
+  it("truncates over-long solo_note to 60 chars", () => {
+    const long = "很".repeat(80);
+    const items = [
+      {
+        name: "长备注事件",
+        category: "market",
+        when_label: "本周",
+        ends_at: "2026-07-10T14:00:00Z",
+        solo_score: 8,
+        solo_note: long,
+        source_url: CAND0,
+      },
+    ];
+    const { accepted } = validateEvents(items, candidateURLs, NOW);
+    expect(first(accepted).soloNote?.length).toBe(60);
+  });
+});
+
+// ─── validateKit ─────────────────────────────────────────────────────────────
+
+describe("validateKit", () => {
+  const candidateURLs = [
+    "https://www.airalo.com/laos-esim",
+    "https://random-travel-blog.example.com/x",
+  ];
+
+  it("passes confirm/omit through and accepts a clean update", () => {
+    const items = [
+      { section: "net", action: "confirm" },
+      { section: "money", action: "omit" },
+      {
+        section: "visa",
+        action: "update",
+        name: "落地签 30 天",
+        body: "多数国籍落地签 30 天。",
+        lens_line: "记好入境日",
+        health: "green",
+        sources: [{ type: "official", url: "https://www.airalo.com/laos-esim" }],
+      },
+    ];
+    const { decisions, rejected } = validateKit(items, candidateURLs);
+    expect(decisions).toHaveLength(3);
+    expect(rejected).toHaveLength(0);
+    const visa = decisions.find((d) => d.section === "visa");
+    expect(visa?.action).toBe("update");
+  });
+
+  it("rejects an update with superlative language", () => {
+    const items = [
+      {
+        section: "safety",
+        action: "update",
+        name: "绝对安全",
+        body: "这里必去，绝对最棒。",
+        health: "green",
+        sources: [],
+      },
+    ];
+    const { decisions, rejected } = validateKit(items, candidateURLs);
+    expect(decisions).toHaveLength(0);
+    expect(first(rejected).reason).toMatch(/superlative/);
+  });
+
+  it("rejects an update whose source url is off the allowlist", () => {
+    const items = [
+      {
+        section: "net",
+        action: "update",
+        name: "eSIM",
+        body: "买 eSIM。",
+        health: "green",
+        sources: [{ type: "blog", url: "https://random-travel-blog.example.com/x" }],
+      },
+    ];
+    const { decisions, rejected } = validateKit(items, candidateURLs);
+    expect(decisions).toHaveLength(0);
+    expect(first(rejected).reason).toMatch(/allowlist|whitelist/);
+  });
+});

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -2,8 +2,12 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
     "declaration": true
   },
+  // `rootDir` is intentionally omitted: city-brief-core.test.ts imports the
+  // shared pure core from ../../infra/supabase/functions/_shared (single source
+  // of truth lives there, deployed to Deno), which sits outside src/. This
+  // package is consumed as source (main → src/index.ts) and never emitted to
+  // dist, so relaxing rootDir has no build-output impact.
   "include": ["src/**/*"]
 }

--- a/scripts/seed-city-brief.ts
+++ b/scripts/seed-city-brief.ts
@@ -1,0 +1,283 @@
+/**
+ * seed-city-brief.ts
+ *
+ * Loads the curated city-brief seed (seeds/vte-city-brief.json) into Supabase
+ * via the service-role key (bypasses RLS). Upserts three tables:
+ *   - sc_cities   (by city_code)
+ *   - city_kits   (by (city_code, section))
+ *   - city_events (by deterministic id)
+ *
+ * Idempotent: re-running upserts the same rows. `last_verified_at` is preserved
+ * on existing rows via a pre-fetch — the seed value is used only when INSERTing a
+ * new row, so a human re-verification timestamp already in the DB is never
+ * clobbered by the seed's baseline date.
+ *
+ * Event IDs are derived the same way the compile-city-brief Edge Function does
+ * (evt_{city}_{slug≤32}_{yyyymmdd}), so a seeded event and a later model-refreshed
+ * event with the same name/date collapse onto one row instead of duplicating.
+ *
+ * Run:  pnpm tsx scripts/seed-city-brief.ts
+ * Env:  SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY read from process.env
+ *       (export them, or run under `tsx --env-file=.env`, mirroring seed-load.ts).
+ */
+
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { createClient } from "@supabase/supabase-js";
+import { eventId } from "../infra/supabase/functions/_shared/city-brief-core";
+
+// ─── Env ─────────────────────────────────────────────────────────────────────
+
+function requireEnv(key: string): string {
+  const v = process.env[key];
+  if (!v) throw new Error(`Missing required env var: ${key}`);
+  return v;
+}
+
+function getEnv(key: string, fallback: string): string {
+  return process.env[key] ?? fallback;
+}
+
+// ─── Seed shape ──────────────────────────────────────────────────────────────
+
+interface SeedCity {
+  city_code: string;
+  name_local: string;
+  name_zh: string;
+  name_en: string;
+  country_code: string;
+  lat: number;
+  lon: number;
+  timezone: string;
+  brief_enabled: boolean;
+}
+
+interface SeedKit {
+  section: "net" | "money" | "visa" | "safety";
+  name: string;
+  body: string;
+  lens_line?: string | null;
+  health?: "green" | "yellow" | "red" | "gray";
+  last_verified_at?: string | null;
+  link_url?: string | null;
+  link_label?: string | null;
+  action?: unknown;
+  sources?: unknown;
+  model_name?: string | null;
+  // `seen_label` in the seed is documentation only; there is no such column on
+  // city_kits — kit provenance lives in `sources`. It is ignored on load.
+  seen_label?: string | null;
+}
+
+interface SeedEvent {
+  name: string;
+  category: string;
+  when_label: string;
+  starts_at?: string | null;
+  ends_at: string;
+  solo_score?: number | null;
+  solo_note?: string | null;
+  health?: "green" | "yellow" | "red" | "gray";
+  seen_label?: string | null;
+  lat?: number | null;
+  lng?: number | null;
+  limited_label?: string | null;
+  source_url: string;
+  verified_at?: string | null;
+  model_name?: string | null;
+}
+
+interface Seed {
+  city: SeedCity;
+  kits: SeedKit[];
+  events: SeedEvent[];
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+function validateSeed(seed: unknown): asserts seed is Seed {
+  if (typeof seed !== "object" || seed === null) {
+    throw new Error("seed must be an object");
+  }
+  const s = seed as Record<string, unknown>;
+
+  const city = s["city"] as Record<string, unknown> | undefined;
+  if (!city || typeof city["city_code"] !== "string" || city["city_code"].trim() === "") {
+    throw new Error("seed.city.city_code must be a non-empty string");
+  }
+  if (city["city_code"] !== (city["city_code"] as string).toLowerCase()) {
+    throw new Error(`seed.city.city_code must be lowercase, got "${String(city["city_code"])}"`);
+  }
+  for (const field of ["name_local", "name_zh", "name_en", "country_code", "timezone"]) {
+    if (typeof city[field] !== "string" || (city[field] as string).trim() === "") {
+      throw new Error(`seed.city.${field} must be a non-empty string`);
+    }
+  }
+  if (typeof city["lat"] !== "number" || typeof city["lon"] !== "number") {
+    throw new Error("seed.city.lat / seed.city.lon must be numbers");
+  }
+
+  if (!Array.isArray(s["kits"])) throw new Error("seed.kits must be an array");
+  const sections = new Set<string>();
+  for (const [i, k] of (s["kits"] as Record<string, unknown>[]).entries()) {
+    const section = k["section"];
+    if (typeof section !== "string" || !["net", "money", "visa", "safety"].includes(section)) {
+      throw new Error(`seed.kits[${i}].section must be net|money|visa|safety`);
+    }
+    if (sections.has(section)) throw new Error(`seed.kits: duplicate section "${section}"`);
+    sections.add(section);
+    if (typeof k["name"] !== "string" || typeof k["body"] !== "string") {
+      throw new Error(`seed.kits[${i}] must have string name + body`);
+    }
+  }
+
+  if (!Array.isArray(s["events"])) throw new Error("seed.events must be an array");
+  const validCategories = ["culture", "wellness", "market", "music", "sports", "food", "notice"];
+  for (const [i, e] of (s["events"] as Record<string, unknown>[]).entries()) {
+    if (typeof e["name"] !== "string" || e["name"].trim() === "") {
+      throw new Error(`seed.events[${i}].name must be a non-empty string`);
+    }
+    if (typeof e["category"] !== "string" || !validCategories.includes(e["category"])) {
+      throw new Error(`seed.events[${i}].category invalid: ${String(e["category"])}`);
+    }
+    if (typeof e["ends_at"] !== "string" || Number.isNaN(Date.parse(e["ends_at"]))) {
+      throw new Error(`seed.events[${i}].ends_at must be a parseable ISO timestamp`);
+    }
+    if (typeof e["source_url"] !== "string" || e["source_url"].trim() === "") {
+      throw new Error(`seed.events[${i}].source_url must be a non-empty string`);
+    }
+    const score = e["solo_score"];
+    if (score != null && (typeof score !== "number" || score < 0 || score > 10)) {
+      throw new Error(`seed.events[${i}].solo_score must be null or in [0,10]`);
+    }
+  }
+}
+
+// ─── Row mappers ─────────────────────────────────────────────────────────────
+
+function kitToRow(cityCode: string, k: SeedKit, existingLastVerifiedAt: string | null) {
+  return {
+    city_code: cityCode,
+    section: k.section,
+    name: k.name,
+    body: k.body,
+    lens_line: k.lens_line ?? null,
+    health: k.health ?? "gray",
+    // Preserve a human re-verification timestamp already on the row.
+    last_verified_at: existingLastVerifiedAt ?? k.last_verified_at ?? null,
+    link_url: k.link_url ?? null,
+    link_label: k.link_label ?? null,
+    action: k.action ?? null,
+    sources: k.sources ?? [],
+    model_name: k.model_name ?? null,
+  };
+}
+
+function eventToRow(cityCode: string, e: SeedEvent, existingVerifiedAt: string | null) {
+  const anchor = e.starts_at ?? e.ends_at;
+  return {
+    id: eventId(cityCode, e.name, anchor),
+    city_code: cityCode,
+    name: e.name,
+    category: e.category,
+    when_label: e.when_label,
+    starts_at: e.starts_at ?? null,
+    ends_at: e.ends_at,
+    solo_score: e.solo_score ?? null,
+    solo_note: e.solo_note ?? null,
+    health: e.health ?? "gray",
+    seen_label: e.seen_label ?? null,
+    lat: e.lat ?? null,
+    lng: e.lng ?? null,
+    limited_label: e.limited_label ?? null,
+    source_url: e.source_url,
+    verified_at: existingVerifiedAt ?? e.verified_at ?? null,
+    model_name: e.model_name ?? null,
+    status: "active",
+  };
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const seedPath = resolve(getEnv("SEED_FILE", "./seeds/vte-city-brief.json"));
+  const supabaseUrl = requireEnv("SUPABASE_URL");
+  const serviceRoleKey = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
+
+  const raw = await readFile(seedPath, "utf-8");
+  const seed = JSON.parse(raw) as unknown;
+  validateSeed(seed);
+
+  const client = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+
+  const cityCode = seed.city.city_code;
+  console.log(`seed-city-brief: loading ${cityCode} from ${seedPath}`);
+
+  // 1. Upsert the city row.
+  const { error: cityErr } = await client.from("sc_cities").upsert(
+    {
+      city_code: cityCode,
+      name_local: seed.city.name_local,
+      name_zh: seed.city.name_zh,
+      name_en: seed.city.name_en,
+      country_code: seed.city.country_code,
+      lat: seed.city.lat,
+      lon: seed.city.lon,
+      timezone: seed.city.timezone,
+      brief_enabled: seed.city.brief_enabled,
+    },
+    { onConflict: "city_code" },
+  );
+  if (cityErr) throw new Error(`sc_cities upsert failed: ${cityErr.message}`);
+  console.log(`  [OK] sc_cities: ${cityCode}`);
+
+  // 2. Upsert kits, preserving last_verified_at on existing rows.
+  const { data: existingKits, error: kitFetchErr } = await client
+    .from("city_kits")
+    .select("section, last_verified_at")
+    .eq("city_code", cityCode);
+  if (kitFetchErr) throw new Error(`city_kits pre-fetch failed: ${kitFetchErr.message}`);
+  const kitLastVerified = new Map<string, string | null>();
+  for (const row of existingKits ?? []) {
+    kitLastVerified.set(row.section as string, (row.last_verified_at as string | null) ?? null);
+  }
+  const kitRows = seed.kits.map((k) => kitToRow(cityCode, k, kitLastVerified.get(k.section) ?? null));
+  const { error: kitErr, count: kitCount } = await client
+    .from("city_kits")
+    .upsert(kitRows, { onConflict: "city_code,section", ignoreDuplicates: false })
+    .select("section");
+  if (kitErr) throw new Error(`city_kits upsert failed: ${kitErr.message}`);
+  console.log(`  [OK] city_kits: ${kitCount ?? kitRows.length} row(s)`);
+
+  // 3. Upsert events, preserving verified_at on existing rows.
+  const eventIds = seed.events.map((e) => eventId(cityCode, e.name, e.starts_at ?? e.ends_at));
+  const { data: existingEvents, error: evFetchErr } = await client
+    .from("city_events")
+    .select("id, verified_at")
+    .in("id", eventIds);
+  if (evFetchErr) throw new Error(`city_events pre-fetch failed: ${evFetchErr.message}`);
+  const evVerified = new Map<string, string | null>();
+  for (const row of existingEvents ?? []) {
+    evVerified.set(row.id as string, (row.verified_at as string | null) ?? null);
+  }
+  const finalEventRows = seed.events.map((e) =>
+    eventToRow(cityCode, e, evVerified.get(eventId(cityCode, e.name, e.starts_at ?? e.ends_at)) ?? null),
+  );
+  const { error: evErr, count: evCount } = await client
+    .from("city_events")
+    .upsert(finalEventRows, { onConflict: "id", ignoreDuplicates: false })
+    .select("id");
+  if (evErr) throw new Error(`city_events upsert failed: ${evErr.message}`);
+  console.log(`  [OK] city_events: ${evCount ?? finalEventRows.length} row(s)`);
+
+  console.log(
+    `\nseed-city-brief complete — city: 1, kits: ${kitRows.length}, events: ${finalEventRows.length}`,
+  );
+}
+
+main().catch((err) => {
+  console.error("seed-city-brief error:", (err as Error).message);
+  process.exit(1);
+});

--- a/seeds/vte-city-brief.json
+++ b/seeds/vte-city-brief.json
@@ -1,0 +1,143 @@
+{
+  "city": {
+    "city_code": "vte",
+    "name_local": "ວຽງຈັນ",
+    "name_zh": "万象",
+    "name_en": "Vientiane",
+    "country_code": "LA",
+    "lat": 17.9757,
+    "lon": 102.6331,
+    "timezone": "Asia/Vientiane",
+    "brief_enabled": true
+  },
+  "kits": [
+    {
+      "section": "net",
+      "name": "Airalo 老挝 eSIM · 或 Unitel 门店",
+      "body": "落地即用 Airalo 老挝 eSIM（₭ 计价），或到市区 Unitel 门店办本地卡。机场覆盖良好，市区 4G 稳定。",
+      "lens_line": "机场到市区先用 eSIM，别机场柜台换卡",
+      "health": "green",
+      "last_verified_at": "2026-07-05T00:00:00Z",
+      "link_url": "https://www.airalo.com/laos-esim",
+      "link_label": "打开 Airalo",
+      "action": null,
+      "sources": [
+        { "type": "official", "url": "https://www.airalo.com/laos-esim", "attribution": "Airalo 官方" }
+      ],
+      "model_name": null,
+      "seen_label": "人工策展 · 7月5日"
+    },
+    {
+      "section": "money",
+      "name": "Wise 汇率最优 · ATM 手续费高",
+      "body": "Wise 汇率通常最优；本地 ATM 每笔手续费较高，建议一次多取。多数咖啡馆只收现金。",
+      "lens_line": "多数咖啡馆只收现金；BCEL One 本地扫码",
+      "health": "yellow",
+      "last_verified_at": "2026-07-05T00:00:00Z",
+      "link_url": "https://wise.com",
+      "link_label": "打开 Wise",
+      "action": null,
+      "sources": [
+        { "type": "official", "url": "https://wise.com/currency-converter/lak-rate", "attribution": "Wise 汇率" }
+      ],
+      "model_name": null,
+      "seen_label": "人工策展 · 7月5日"
+    },
+    {
+      "section": "visa",
+      "name": "落地签 30 天",
+      "body": "多数国籍可落地签停留 30 天，也可申请电子签。入境记录你的入境日，183 天税务线本地自算。",
+      "lens_line": "记好入境日，长住盯紧 183 天税务线",
+      "health": "green",
+      "last_verified_at": "2026-07-05T00:00:00Z",
+      "link_url": "https://laoevisa.gov.la",
+      "link_label": "老挝电子签",
+      "action": {
+        "type": "visa_reminder",
+        "visa_days": 30,
+        "tax_line_days": 183
+      },
+      "sources": [
+        { "type": "official", "url": "https://laoevisa.gov.la", "attribution": "老挝电子签官方" }
+      ],
+      "model_name": null,
+      "seen_label": "人工策展 · 7月5日"
+    },
+    {
+      "section": "safety",
+      "name": "市中心 / 湄公河岸独自较稳",
+      "body": "市中心与湄公河岸白天独自活动较稳；夜间避开偏僻河堤。急救号码离线可用。",
+      "lens_line": "🆘 191 警察 · 1195 旅游警察 · 夜间避开偏僻河堤",
+      "health": "green",
+      "last_verified_at": "2026-07-05T00:00:00Z",
+      "link_url": "https://geosureglobal.com",
+      "link_label": "GeoSure 安全评分",
+      "action": {
+        "type": "emergency_numbers",
+        "numbers": [
+          { "label": "警察", "number": "191" },
+          { "label": "旅游警察", "number": "1195" }
+        ]
+      },
+      "sources": [
+        { "type": "official", "url": "https://geosureglobal.com", "attribution": "GeoSure" },
+        { "type": "official", "url": "https://www.tourismlaos.org", "attribution": "老挝旅游局" }
+      ],
+      "model_name": null,
+      "seen_label": "人工策展 · 7月5日"
+    }
+  ],
+  "events": [
+    {
+      "name": "那伽火球节前导市集",
+      "category": "market",
+      "when_label": "本周五 傍晚",
+      "starts_at": "2026-07-10T10:00:00Z",
+      "ends_at": "2026-07-10T14:00:00Z",
+      "solo_score": 8.5,
+      "solo_note": "一个人逛正好，傍晚人最舒服",
+      "health": "green",
+      "seen_label": "人工策展 · 7月5日",
+      "lat": 17.9560,
+      "lng": 102.6130,
+      "limited_label": "仅本周五",
+      "source_url": "https://www.tourismlaos.org/events/naga-fireball-market",
+      "verified_at": "2026-07-05T00:00:00Z",
+      "model_name": null
+    },
+    {
+      "name": "塔銮周边夜市",
+      "category": "market",
+      "when_label": "本周每晚",
+      "starts_at": null,
+      "ends_at": "2026-07-12T15:00:00Z",
+      "solo_score": 8.0,
+      "solo_note": "小吃摊多，独自吃走都自在",
+      "health": "green",
+      "seen_label": "人工策展 · 7月5日",
+      "lat": 17.9700,
+      "lng": 102.6480,
+      "limited_label": "本周每晚",
+      "source_url": "https://www.tourismlaos.org/events/that-luang-night-market",
+      "verified_at": "2026-07-05T00:00:00Z",
+      "model_name": null
+    },
+    {
+      "name": "湄公河岸步道段整修封闭",
+      "category": "notice",
+      "when_label": "本周",
+      "starts_at": null,
+      "ends_at": "2026-07-12T16:59:00Z",
+      "solo_score": null,
+      "solo_note": "傍晚散步改走 Chao Anouvong 公园一侧",
+      "health": "yellow",
+      "seen_label": "人工策展 · 7月5日",
+      "lat": 17.9615,
+      "lng": 102.6075,
+      "limited_label": "本周封闭",
+      "source_url": "https://www.tourismlaos.org/notices/mekong-riverside-maintenance",
+      "verified_at": "2026-07-05T00:00:00Z",
+      "model_name": null
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

Solo City OS v2 的服务端内容管线:agent 用**真实 web 搜索**为每座城编译落地包与在地事件,写入公读表供 iOS 消费(配套 PR feat/city-os-kit-live)。

- **Schema `0013_city_brief.sql`**:`sc_cities`(城市注册表)/ `city_kits`(PK (city_code,section),lens_line 独行透镜 + health + last_verified_at + sources jsonb)/ `city_events`(确定性 id `evt_{city}_{slug}_{yyyymmdd}`,**source_url NOT NULL** 反幻觉不变量,ends_at 驱动过期)/ `city_brief_runs`(冷却+成本记账)。RLS 与 synthesized_experiences 同款:前三表公读、无写策略(service-role 边界);runs 不公读。0010 式条件 pg_cron 每小时过期清扫
- **Edge Function `compile-city-brief`**:鉴权 = service-role Bearer 或 x-cron-secret(**不开放用户触发**,内容城市级共享);冷却 events 72h / kit 240h;管线 = Tavily(≤4 查,候选≤18 条)→ DeepSeek(json_object,重试 1)→ 质量门 → upsert(事件永不删除,过期靠 status;kit confirm/update/omit 三态,模型永不改 link_url,45 天未核验自动降黄)
- **质量门**(`_shared/city-brief-core.ts`,零依赖纯 TS,Deno 部署 + Node 可测):source_url 必须∈候选 URL 白名单(模型不能造 URL)、最高级词黑名单(必去/绝对/must-see)、solo_score clamp、ends_at ∈ [now−1d, now+21d]、kit 深链域名白名单、±2 天同名去重;solo 评分 rubric = 安全感/单人自在/氛围/无需交谈,notice 类 solo_score=null
- **万象种子** `seeds/vte-city-brief.json` + 幂等 loader(保留 last_verified_at),seen_label 诚实标注「人工策展」、model_name=null
- **调度** `.github/workflows/city-brief-refresh.yml`:events 周一/周四、kit 周一(万象时区 05:00),workflow_dispatch 手动带 force

## 测试
- `pnpm --filter @solo-compass/ai test`:**74/74 绿**(新增 city-brief-core 套件 22 条:白名单拒绝/最高级拒绝/clamp/窗口/去重/CJK slug 回退/kit 三态),独立复跑确认
- `pnpm typecheck`:10/10 包绿
- RLS 冒烟:test_rls.ts 扩展(匿名可读 kits/events、写被拒、runs 不可读)

## 部署待办(需要人工)
1. `supabase secrets set TAVILY_API_KEY=tvly-…`(https://app.tavily.com 免费 1000 次/月)与 `CITY_BRIEF_CRON_SECRET=$(openssl rand -hex 32)`
2. GitHub repo secrets:`SUPABASE_PROJECT_REF`、`CITY_BRIEF_CRON_SECRET`
3. `supabase db push` + `supabase functions deploy compile-city-brief` + `pnpm tsx scripts/seed-city-brief.ts`
4. 首跑:workflow_dispatch 带 `force:true` 对 vte 实跑一轮,核验写入事件的 source_url

## 关联
PRD: tasks/prd-solo-city-os-v2.md §5.2-5.3 · iOS 消费端见 #591

https://claude.ai/code/session_017ora9WsVEikxfdz3Wh8HBz