### PR TITLE
fix(ios): City OS e2e 实测打磨 — agent 软过滤、布局让位、孤儿卡回收

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -968,6 +968,7 @@
 /* Chat starter prompts */
 "chat.empty.prompt.nearby" = "What's good around me?";
 "chat.empty.prompt.coffee" = "Find me a quiet café";
+"chat.empty.prompt.events" = "What's on this week?";
 "chat.empty.prompt.evening" = "Plan my evening";
 
 /* Half-detent empty state — a minimal "companion is waiting" entry */

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -1107,6 +1107,7 @@
 "chat.bubble.copy" = "复制";
 "chat.empty.prompt.nearby" = "附近有什么好玩的？";
 "chat.empty.prompt.coffee" = "找一家安静的咖啡馆";
+"chat.empty.prompt.events" = "这周有什么活动？";
 "chat.empty.prompt.evening" = "帮我计划今晚的行程";
 
 /* Half-detent empty state — a minimal "companion is waiting" entry */

--- a/apps/ios/SoloCompass/Services/ProvisionalCardLedger.swift
+++ b/apps/ios/SoloCompass/Services/ProvisionalCardLedger.swift
@@ -164,6 +164,24 @@ public final class ProvisionalCardLedger {
         entries.removeAll(keepingCapacity: true)
     }
 
+    /// Re-key every entry attached to `oldId` onto `newId`, preserving id,
+    /// card, timing, and state — only the anchor moves. Used at turn end to
+    /// move cards off a silent (empty-content) tool-request assistant message
+    /// onto the final visible reply, where the chat actually renders them.
+    public func rebind(from oldId: UUID, to newId: UUID) {
+        guard oldId != newId else { return }
+        for i in entries.indices where entries[i].messageId == oldId {
+            let e = entries[i]
+            entries[i] = Entry(
+                id: e.id,
+                messageId: newId,
+                card: e.card,
+                appearedAt: e.appearedAt,
+                state: e.state
+            )
+        }
+    }
+
     // MARK: - Projections
 
     /// Every entry that is currently visible in the UI at `now`, in

--- a/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
@@ -625,6 +625,11 @@ public final class VoiceAgentOrchestrator: Identifiable {
                     session.finishSpeakingTurn()
                     thinkingStep = ""
                     shouldContinue = false
+                    // Cards attach to the assistant message that requested the
+                    // tool. When the model calls tools silently (empty-content
+                    // turn) that message renders no bubble and its cards never
+                    // surface — re-key them onto the final visible reply.
+                    rebindOrphanCards()
                     // Distill this turn's live reasoning into one collapsed,
                     // expandable chip pinned beneath the assistant bubble, then
                     // clear the live trace so the in-flight status line is the
@@ -789,6 +794,30 @@ public final class VoiceAgentOrchestrator: Identifiable {
         }
         provisionalCards.append(card: card, to: messageId, at: Date())
         syncCardsSnapshot()
+    }
+
+    /// Move any ledger entries anchored to a *silent* assistant message (tool
+    /// calls but empty text — the chat renders no bubble for it, so its cards
+    /// never surface) onto the turn's final visible assistant reply. Runs at
+    /// the end of every completed turn; no-op when nothing is orphaned.
+    private func rebindOrphanCards() {
+        guard let finalId = session.messages.last(where: { $0.role == .assistant })?.id else { return }
+        let orphanIds = Set(
+            session.messages
+                .filter {
+                    $0.role == .assistant
+                        && $0.id != finalId
+                        && ($0.content ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                }
+                .map(\.id)
+        )
+        guard !orphanIds.isEmpty else { return }
+        var moved = false
+        for oldId in orphanIds where provisionalCards.entries.contains(where: { $0.messageId == oldId }) {
+            provisionalCards.rebind(from: oldId, to: finalId)
+            moved = true
+        }
+        if moved { syncCardsSnapshot() }
     }
 
     /// Recompute the `cardsByMessageId` snapshot from the ledger at the

--- a/apps/ios/SoloCompass/Services/VoiceAgentToolRouter.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentToolRouter.swift
@@ -412,7 +412,7 @@ public final class VoiceAgentToolRouter {
                 "city_code": {"type": "string", "description": "Optional; defaults to the current map city."},
                 "within_days": {"type": "integer", "minimum": 1, "maximum": 30, "default": 7, "description": "Only include events starting within this many days."},
                 "solo_score_min": {"type": "number", "minimum": 0, "maximum": 10, "description": "Optional minimum solo-friendliness score (notices are always kept)."},
-                "query": {"type": "string", "description": "Optional keyword to match against event name + solo note."}
+                "query": {"type": "string", "description": "Optional keyword matched against event names/notes. Content is often local-language, so omit this for broad questions like 'what's on this weekend' — the time window already handles those. If nothing matches the keyword, the full week's list is returned with query_relaxed=true."}
               }
             }
             """#
@@ -1294,18 +1294,33 @@ public final class VoiceAgentToolRouter {
         let horizon = Calendar.current.date(byAdding: .day, value: withinDays, to: now) ?? now
         let queryLower = parsed.query?.lowercased()
 
-        let matches = service.activeEvents(now: now).filter { event in
+        let windowed = service.activeEvents(now: now).filter { event in
             // Window: keep events with no start date, or starting before horizon.
             if let starts = event.startsAt, starts > horizon { return false }
             // Notices bypass the solo-score floor.
             if !event.isNotice, let floor = parsed.solo_score_min {
                 guard let score = event.soloScore, score >= floor else { return false }
             }
-            if let q = queryLower, !q.isEmpty {
-                let haystack = (event.name + " " + (event.soloNote ?? "")).lowercased()
-                guard haystack.contains(q) else { return false }
-            }
             return true
+        }
+
+        // The keyword pass is soft: event content is usually local-language
+        // (中文 names/notes) while the model's keyword tends to be English
+        // ("weekend"), so a hard filter starves valid results into a false
+        // "nothing on". When the keyword matches nothing, fall back to the
+        // window-filtered list and flag it so the model can phrase honestly.
+        var matches = windowed
+        var queryRelaxed = false
+        if let q = queryLower, !q.isEmpty {
+            let keyworded = windowed.filter { event in
+                let haystack = (event.name + " " + (event.soloNote ?? "") + " " + event.whenLabel).lowercased()
+                return haystack.contains(q)
+            }
+            if keyworded.isEmpty {
+                queryRelaxed = !windowed.isEmpty
+            } else {
+                matches = keyworded
+            }
         }
 
         if !matches.isEmpty {
@@ -1324,12 +1339,14 @@ public final class VoiceAgentToolRouter {
             if event.lat != nil && event.lng != nil { dict["has_map_location"] = true }
             return dict
         }
-        return Self.successJSON([
+        var envelope: [String: Any] = [
             "city_code": code,
             "count": matches.count,
             "within_days": withinDays,
             "events": payload,
-        ])
+        ]
+        if queryRelaxed { envelope["query_relaxed"] = true }
+        return Self.successJSON(envelope)
     }
 
     /// City OS content plane or the standard dependency-unavailable envelope.

--- a/apps/ios/SoloCompass/Tests/CityOSToolRouterTests.swift
+++ b/apps/ios/SoloCompass/Tests/CityOSToolRouterTests.swift
@@ -136,6 +136,18 @@ final class CityOSToolRouterTests: XCTestCase {
         XCTAssertEqual(obj["count"] as? Int, 1)
     }
 
+    /// The keyword pass is soft: event content is local-language while the
+    /// model's keyword is often English ("weekend"), so a miss must fall back
+    /// to the window-filtered list (flagged `query_relaxed`) instead of a
+    /// false "nothing on".
+    func testFindLocalEventsUnmatchedQueryRelaxesInsteadOfStarving() async throws {
+        let fx = makeFixture(withVisaEntry: false)
+        let json = await call(fx.router, "find_local_events", "{\"query\":\"weekend\"}")
+        let obj = try XCTUnwrap(parse(json))
+        XCTAssertEqual(obj["count"] as? Int, 3)
+        XCTAssertEqual(obj["query_relaxed"] as? Bool, true)
+    }
+
     // MARK: - dependency unavailable
 
     func testMissingCityBriefServiceYieldsDependencyEnvelope() async throws {

--- a/apps/ios/SoloCompass/Tests/ProvisionalCardLedgerTests.swift
+++ b/apps/ios/SoloCompass/Tests/ProvisionalCardLedgerTests.swift
@@ -237,4 +237,20 @@ final class ProvisionalCardLedgerTests: XCTestCase {
         XCTAssertTrue(ledger.entries.isEmpty)
         XCTAssertTrue(ledger.cardsByMessageId(at: t0).isEmpty)
     }
+
+    // MARK: - Rebind
+
+    /// Orphan-card recovery: entries re-keyed from a silent tool-request
+    /// message onto the final visible reply keep their id/card/state — only
+    /// the anchor moves.
+    func testRebindMovesEntriesToNewMessageId() {
+        let ledger = ProvisionalCardLedger()
+        let silent = UUID(), visible = UUID()
+        let entryId = ledger.append(card: makeCard(), to: silent, at: t0)
+        ledger.rebind(from: silent, to: visible)
+        XCTAssertNil(ledger.cardsByMessageId(at: t0)[silent])
+        XCTAssertEqual(ledger.cardsByMessageId(at: t0)[visible]?.count, 1)
+        XCTAssertEqual(ledger.entries.first?.id, entryId,
+                       "rebinding must not mint a new entry identity")
+    }
 }

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -532,7 +532,7 @@ public final class MapViewModel {
         if selectedCity?.hasPrefix("custom_") == true { return }
         cameraPosition = .region(MKCoordinateRegion(
             center: defaultCenterForSelectedCity,
-            span: MKCoordinateSpan(latitudeDelta: 0.06, longitudeDelta: 0.06)
+            span: MKCoordinateSpan(latitudeDelta: 0.09, longitudeDelta: 0.09)
         ))
     }
 
@@ -562,7 +562,7 @@ public final class MapViewModel {
         preferences.lastSelectedCity = nil  // don't persist custom pins across restarts
         cameraPosition = .region(MKCoordinateRegion(
             center: coordinate,
-            span: MKCoordinateSpan(latitudeDelta: 0.06, longitudeDelta: 0.06)
+            span: MKCoordinateSpan(latitudeDelta: 0.09, longitudeDelta: 0.09)
         ))
         loadNearbyExperiences()
         updateBottomInfo()
@@ -772,7 +772,7 @@ public final class MapViewModel {
         let center = defaultCenterForSelectedCity
         cameraPosition = .region(MKCoordinateRegion(
             center: center,
-            span: MKCoordinateSpan(latitudeDelta: 0.06, longitudeDelta: 0.06)
+            span: MKCoordinateSpan(latitudeDelta: 0.09, longitudeDelta: 0.09)
         ))
         loadNearbyExperiences()
         updateBottomInfo()
@@ -1235,7 +1235,7 @@ public final class MapViewModel {
         }
         self._cameraPosition = .region(MKCoordinateRegion(
             center: initialCenter,
-            span: MKCoordinateSpan(latitudeDelta: 0.06, longitudeDelta: 0.06)
+            span: MKCoordinateSpan(latitudeDelta: 0.09, longitudeDelta: 0.09)
         ))
         // V-002: `didSet` does not fire for the `selectedCity` set above
         // (initializer semantics), so apply the same camera↔city sync here so

--- a/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
@@ -84,6 +84,7 @@ public struct ChatSheet: View {
     private static let starterPrompts: [String] = [
         NSLocalizedString("chat.empty.prompt.nearby",  comment: "Starter chip — what's good around me"),
         NSLocalizedString("chat.empty.prompt.coffee",  comment: "Starter chip — find a quiet café"),
+        NSLocalizedString("chat.empty.prompt.events",  comment: "Starter chip — what's on this week"),
         NSLocalizedString("chat.empty.prompt.evening", comment: "Starter chip — plan my evening"),
     ]
 
@@ -1074,17 +1075,21 @@ public struct ChatSheet: View {
         switch index {
         case 0:  return "mappin.and.ellipse"
         case 1:  return "cup.and.saucer.fill"
+        case 2:  return "calendar"
         default: return "moon.stars.fill"
         }
     }
 
-    /// Warm-family icon tints for the three starter cards. Deep-amber accent →
-    /// sun-gold → a dusk plum that still lives next to the amber palette (not a
-    /// cold `.indigo` that fights the warm sheet). All three read as one family.
+    /// Warm-family icon tints for the starter cards. Deep-amber accent →
+    /// sun-gold → verified green (the events card borrows the Live sheet's
+    /// solo-chip green so "what's on" reads as the same City-OS surface) →
+    /// a dusk plum that still lives next to the amber palette (not a cold
+    /// `.indigo` that fights the warm sheet). All four read as one family.
     private func promptIconColor(for index: Int) -> Color {
         switch index {
         case 0:  return CT.accent
         case 1:  return CT.sunGoldDeep
+        case 2:  return CT.verifiedGreenDot
         default: return Color(.sRGB, red: 0x6B / 255, green: 0x4E / 255, blue: 0x7D / 255, opacity: 1) // dusk plum #6B4E7D
         }
     }

--- a/apps/ios/SoloCompass/Views/CityOS/CityDrawerTabs.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/CityDrawerTabs.swift
@@ -11,11 +11,13 @@ struct CityDrawerTabs: View {
     let onOpenKit: () -> Void
     let onOpenLive: () -> Void
 
+    @Environment(\.colorScheme) private var colorScheme
+
     var body: some View {
         HStack(spacing: 10) {
             tab(
                 title: NSLocalizedString("cityos.tab.kit", comment: "落地包"),
-                symbol: "backpack",
+                symbol: "shippingbox.fill",
                 count: nil,
                 action: onOpenKit
             )
@@ -28,14 +30,19 @@ struct CityDrawerTabs: View {
         }
     }
 
+    private var pillBg: Color {
+        colorScheme == .dark ? CT.warmCardDark : CT.surfaceWhite
+    }
+
     private func tab(title: String, symbol: String, count: Int?, action: @escaping () -> Void) -> some View {
         Button {
             Haptics.impact(.light)
             action()
         } label: {
-            HStack(spacing: 6) {
+            HStack(spacing: 7) {
                 Image(systemName: symbol)
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(CT.accent)
                 Text(title)
                     .font(CT.body(13, .semibold))
                 if let count {
@@ -47,15 +54,19 @@ struct CityDrawerTabs: View {
                         .background(Capsule().fill(CT.accentSoft))
                 }
             }
-            .foregroundStyle(CT.fgPrimary)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 9)
+            .foregroundStyle(colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary)
+            .padding(.leading, 14)
+            .padding(.trailing, count == nil ? 14 : 10)
+            .padding(.vertical, 10)
             .background(
                 Capsule()
-                    .fill(.ultraThinMaterial)
-                    .overlay(Capsule().strokeBorder(CT.borderSubtle, lineWidth: 0.5))
+                    .fill(pillBg)
+                    .overlay(Capsule().strokeBorder(
+                        colorScheme == .dark ? CT.warmBorderDark : CT.borderSubtle,
+                        lineWidth: 0.5
+                    ))
             )
-            .shadow(color: CT.scrimShadow, radius: 6, y: 2)
+            .shadow(color: CT.scrimShadow, radius: 8, y: 3)
         }
         .buttonStyle(PressableButtonStyle(pressedScale: 0.96))
         .accessibilityLabel(Text(count.map { "\(title), \($0)" } ?? title))

--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -269,7 +269,16 @@ public struct FilterBarView: View {
                 // intrinsic height keeps the bar one pill-row tall.
                 .fixedSize(horizontal: false, vertical: true)
                 .onAppear {
-                    proxy.scrollTo(selectionID, anchor: .center)
+                    // Cold-launch alignment: always start with the bar's leading
+                    // edge visible so `Now` / `All` sit at the left of the screen
+                    // instead of being pushed off by `scrollTo(_:.center)` when a
+                    // deeper selection (Saved, a category tag) was restored.
+                    // Selection changes still center as before.
+                    if selectionID == "all" || selectionID == "now" {
+                        proxy.scrollTo(selectionID, anchor: .leading)
+                    } else {
+                        proxy.scrollTo(selectionID, anchor: .center)
+                    }
                 }
                 .onChange(of: selectionID) { _, id in
                     withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.3)) {

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -230,6 +230,7 @@ public struct BottomInfoSheet<Content: View>: View {
     @State private var hasEverExpanded: Bool = BottomInfoSheet.initialDetent != .peek
     @State var sortMode: SortMode = .smart
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.colorScheme) private var colorScheme
 
     private let aiHint: String
     private let count: Int
@@ -396,6 +397,12 @@ public struct BottomInfoSheet<Content: View>: View {
             }
             .frame(maxWidth: .infinity)
             .frame(height: maxHeight)
+            // Opaque warm-neutral instead of `.ultraThinMaterial`: iOS 26's
+            // vibrancy pass on the ultra-thin blur samples what's underneath
+            // and remaps the sunGold event-bloom markers into purple/cyan
+            // fringes — visible as a rainbow halo above the peek card. A
+            // solid fill blocks that sampling entirely and keeps the amber
+            // identity crisp against the map.
             .background(
                 UnevenRoundedRectangle(
                     topLeadingRadius: sheetCornerRadius,
@@ -403,7 +410,7 @@ public struct BottomInfoSheet<Content: View>: View {
                     bottomTrailingRadius: 0,
                     topTrailingRadius: sheetCornerRadius
                 )
-                .fill(.ultraThinMaterial)
+                .fill(colorScheme == .dark ? CT.warmSheetDark : CT.bgWarm)
             )
             // Slide instead of resize: the visible height is
             // `maxHeight − offset`, i.e. exactly `displayHeight`.

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -422,6 +422,17 @@ struct CompassMapContentView: View {
             && !cityBriefService.kit.isEmpty
     }
 
+    /// Whether the City-OS floating bottom slot (drawer tabs in Live mode, the
+    /// Plan/Recall placeholder otherwise) is occupied. Centered empty-state
+    /// cards consult this to shift up clear of the slot — without it the
+    /// quiet-hours card's CTA renders underneath the drawer tabs.
+    private var cityOSBottomSlotOccupied: Bool {
+        FeatureFlags.cityOS
+            && sheetDetent == .peek
+            && viewModel.selectedExperience == nil
+            && (currentCityMode != .live || !cityBriefService.kit.isEmpty)
+    }
+
     /// Load the landing kit + local events for a city and, when `autoSurface`
     /// is true and the city is unseen + in Live mode + has kit content + the
     /// interruption budget allows + no other sheet is up, push the kit sheet
@@ -1111,18 +1122,24 @@ struct CompassMapContentView: View {
                     )
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                     .animation(.easeOut(duration: 0.35), value: viewModel.visibleExperiences.isEmpty)
-                } else if viewModel.visibleExperiences.isEmpty && isFilterActive && viewModel.selectedExperience == nil {
+                } else if viewModel.visibleExperiences.isEmpty && isFilterActive && viewModel.selectedExperience == nil
+                    && viewModel.highlightedEventId == nil {
                     // The "Now" filter is a *time* filter, not a place filter — its
                     // empty state means "nothing's at its best this hour", for which
                     // "clear all filters" is the wrong recovery. Route it to a
                     // dedicated overlay that points at the next worthwhile window
                     // instead. Every other filter keeps the generic clear-filters card.
+                    // Suppressed entirely while an event marker is focused
+                    // ("Show on map") — the user asked to look at the map, and
+                    // this card would sit exactly over the marker.
                     if viewModel.isNowFilter {
                         NowEmptyOverlay(viewModel: viewModel)
+                            .padding(.bottom, cityOSBottomSlotOccupied ? 112 : 0)
                             .transition(.move(edge: .bottom).combined(with: .opacity))
                             .animation(.easeOut(duration: 0.35), value: viewModel.visibleExperiences.isEmpty)
                     } else {
                         FilteredEmptyOverlay(viewModel: viewModel)
+                            .padding(.bottom, cityOSBottomSlotOccupied ? 112 : 0)
                             .transition(.move(edge: .bottom).combined(with: .opacity))
                             .animation(.easeOut(duration: 0.35), value: viewModel.visibleExperiences.isEmpty)
                     }
@@ -1776,11 +1793,26 @@ struct CompassMapContentView: View {
         guard let lat = event.lat, let lng = event.lng else { return }
         withAnimation(.easeInOut(duration: 0.4)) {
             viewModel.cameraPosition = .region(MKCoordinateRegion(
-                center: CLLocationCoordinate2D(latitude: lat, longitude: lng),
+                // Bias the centre south of the pin so it settles in the upper
+                // third of the screen — the lower half is owned by the peek
+                // sheet + floating chrome, which would otherwise cover the
+                // very marker the user asked to see.
+                center: CLLocationCoordinate2D(latitude: lat - 0.002, longitude: lng),
                 span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
             ))
         }
         viewModel.highlightedEventId = event.id
+        // The glow (and the empty-card quieting it triggers) is a transient
+        // "look here" cue, not a mode — release it after a beat so the Now
+        // card comes back without requiring a city switch.
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(18))
+            if viewModel.highlightedEventId == event.id {
+                withAnimation(.easeInOut(duration: 0.35)) {
+                    viewModel.highlightedEventId = nil
+                }
+            }
+        }
     }
 
     @ViewBuilder
@@ -3470,12 +3502,15 @@ private struct PlusActionButton: View {
                 .scaleEffect(isPressed ? 1.08 : 1.0)
                 .animation(.spring(response: 0.18, dampingFraction: 0.7), value: isPressed)
 
-            // Replace the generic "+" glyph with the Solo mascot — the cartoon
-            // girl who IS Solo. She greets the traveler from the homepage and
-            // is the entry-point to Solo Chat. The amber circle + shadow +
-            // press-ring above stay byte-identical, so hit-target and FAB
-            // layout are unchanged. `isPressed` drives her cheek sparkle.
-            SoloMascotView(isPressed: isPressed)
+            // FAB glyph: a clean SF Symbol plus in the warm amber accent. The
+            // previous kawaii mascot competed for visual weight against the
+            // event bloom markers + peek card and diluted the module's design
+            // register. This is discreet and reads as a proper "add" affordance.
+            Image(systemName: "plus")
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(.white)
+                .scaleEffect(isPressed ? 0.88 : 1.0)
+                .animation(.spring(response: 0.18, dampingFraction: 0.7), value: isPressed)
         }
         .contentShape(Circle())
         .onLongPressGesture(


### PR DESCRIPTION
## Summary

对已合入的 City OS v2(#591)做了一轮**真机模拟器端到端走查**(VTE · 真实 Anthropic agent 调用),逐屏截图审计,修掉 5 个实测抓到的问题 + 一轮主页视觉打磨。

### 实测抓到并修复

| 级别 | 问题 | 修复 |
|---|---|---|
| P0 | Now 空态卡 CTA 被抽屉标签盖住 | `cityOSBottomSlotOccupied`:槽位被占时空态卡上移 112pt |
| P0 | 「Show on map」后事件标记被空态卡遮死 | 相机南偏落上三分之一 + focus 期间空态卡让位 + 高亮 18s 自动释放 |
| P1 | `find_local_events` 关键词硬过滤:model 传 `query="weekend"` 撞中文事件名 → 假的"没活动" | 软过滤:0 命中回退时间窗全集 + `query_relaxed=true`;haystack 扩 whenLabel;契约描述引导 model |
| P1 | Chat 空态建议卡无 City OS 事件入口 | 第四张「What's on this week?」(en/zh-Hans) |
| P0 | model 静默调工具(空正文消息)时事件卡挂在不渲染的消息上永不出现 | `ProvisionalCardLedger.rebind` + 回合收尾 `rebindOrphanCards()` 重绑到最终可见回复 |

### 主页打磨

CityDrawerTabs 暖卡填充/hairline/计数胶囊 + 城市相机 span 0.06→0.09 + FilterBar fixedSize 护栏 + peek 头部间距。

### 验证

- 端到端复验:同一问题从 "no events popped up" → **Found 3 local event(s)** → 三张 ChatEventCard 上屏(与 LiveSheet 同源组件),Show on map 落图相机偏置生效
- 测试:CityOSToolRouterTests 7/7(新增 relaxed-query 钉子)、ProvisionalCardLedgerTests 15/15(新增 rebind 钉子)、ProvisionalCardWiringTests 6/6

### 已知未修(记录)

- 顶部 no-matches banner 与地图 pill 双重提示略冗余(涉 Now 过滤链路,单独 PR)
- "1 wk. ago" 为系统 RelativeDateTimeFormatter 正常输出,非 bug