### PR TITLE
feat(ios): city-os kit + live events + color token unification

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 
 /* Confidence */
 "confidence.signals" = "signals";
+"confidence.aiEstimate" = "AI estimate · unverified";
 "confidence.aiScrape" = "AI scrape age";
 "confidence.gps" = "GPS hits (30d)";
 "confidence.reports" = "User reports (30d)";
@@ -301,7 +302,7 @@
 "moderation.reason.fakeProfile" = "Fake profile";
 "moderation.reason.other" = "Other";
 "me.profile.name" = "Solo Traveler";
-"me.profile.subtitle" = "Your compass, your journey";
+"me.profile.subtitle" = "Confidence in every solo moment";
 "me.friends.incoming" = "Friend Requests";
 "me.friends.list" = "Friends";
 "me.friends.empty" = "No friends yet";
@@ -313,9 +314,9 @@
 "me.stats.saved" = "Saved";
 "me.stats.explored" = "Explored";
 "me.profile.progress.a11y" = "%d of %d saved places explored";
-"me.empty.title" = "Your journey starts here";
-"me.empty.subtitle" = "Explore the map, save your favorite spots, and track which ones you've visited.";
-"me.empty.cta" = "Back to the map";
+"me.empty.title" = "Your solo map awaits";
+"me.empty.subtitle" = "Save places that feel right for one, then see how your confidence grows.";
+"me.empty.cta" = "Explore the map";
 
 /* Map empty / loading */
 "map.empty.title" = "Quiet patch of map.";
@@ -752,7 +753,7 @@
 "exploreMode.cancelled.kept" = "Kept %d places · Explore stopped";
 "exploreMode.cancelled.dismiss" = "OK";
 "explore.error.nothingFound" = "No public places found nearby. Try moving the map.";
-"location.error.banner" = "Can't find your location — showing a default area. Check Location permissions in Settings.";
+"location.error.banner" = "Can't find your location — showing a default area.";
 "location.banner.openSettings" = "Open Settings";
 "explore.skeleton.oneLiner" = "A real spot pulled from OpenStreetMap.";
 "explore.skeleton.oneLiner.amap" = "A real spot pulled from AutoNavi (Amap).";
@@ -1494,7 +1495,7 @@
 "settings.companion.requests.empty" = "No recruitment requests yet.";
 "settings.companion.conversations" = "Joined group chats";
 "settings.companion.conversations.empty" = "You haven't joined any group chats yet.";
-"settings.companion.discover.routes" = "发现招募路线";
+"settings.companion.discover.routes" = "Discover recruiting routes";
 
 /* US-018 — BottomInfoSheet peek toolbar */
 "ai.now.hint" = "Good spots for right now";
@@ -1511,7 +1512,7 @@
 "sheet.handle" = "Sheet handle, swipe up or down to adjust";
 
 /* US-019 — BottomInfoSheet nearby section */
-"sheet.nearby.section.title" = "附近";
+"sheet.nearby.section.title" = "NEARBY";
 "sheet.nearby.smartPick.a11y" = "AI recommended";
 "sheet.nearby.openNow" = "Open now";
 "sheet.nearby.openNow.a11y" = "Open now";
@@ -1553,36 +1554,36 @@
 "sort.subtitle.now" = "Good right now";
 
 /* US-022 — VerifiedBadge */
-"verified.title.verified" = "已验证路线";
-"verified.title.watching" = "社群观察中";
-"verified.subtitle" = "与 %d 位旅人走过";
-"verified.short.verified" = "已验证";
-"verified.short.watching" = "观察中";
-"verified.inline" = "%1$@ · %2$d 人走过";
+"verified.title.verified" = "Verified route";
+"verified.title.watching" = "Community watching";
+"verified.subtitle" = "Walked by %d travelers";
+"verified.short.verified" = "Verified";
+"verified.short.watching" = "Watching";
+"verified.inline" = "%1$@ · walked by %2$d";
 
 /* US-023 — StopsList */
 "stops.start" = "Start";
 
 /* US-025 — RouteCard / RoutesSection */
-"sheet.routes.section.title" = "路线";
-"route.card.verified" = "已验证";
-"route.card.tag" = "路线 · %1$d 站 · %2$@";
-"route.card.now" = "此刻";
+"sheet.routes.section.title" = "ROUTES";
+"route.card.verified" = "Verified";
+"route.card.tag" = "Route · %1$d stops · %2$@";
+"route.card.now" = "Now";
 
 /* US-024 — RouteDetailView */
-"route.detail.save" = "保存到我的行程";
-"route.detail.favorite" = "加入收藏";
-"route.detail.bestNow.yes" = "此刻最佳";
-"route.detail.bestNow.no" = "非此刻";
-"route.detail.aiInsight.title" = "AI 洞察";
-"route.detail.aiInsight.locked" = "订阅 Pro 解锁路线分析 · 结合当前天气、人流、季节";
-"route.detail.aiInsight.unlock" = "解锁 →";
-"route.detail.tags.title" = "路线标签";
-"route.detail.start" = "开始路线";
-"route.detail.cta.requestJoin" = "申请加入";
-"route.detail.cta.review" = "审批 %d 个申请";
-"route.detail.cta.waiting" = "等待主理人确认";
-"route.detail.cta.groupChat" = "进入群聊";
+"route.detail.save" = "Save to my itinerary";
+"route.detail.favorite" = "Add to favorites";
+"route.detail.bestNow.yes" = "Best right now";
+"route.detail.bestNow.no" = "Not now";
+"route.detail.aiInsight.title" = "AI Insight";
+"route.detail.aiInsight.locked" = "Subscribe to Pro for route analysis · weather, crowds, seasons";
+"route.detail.aiInsight.unlock" = "Unlock →";
+"route.detail.tags.title" = "Route tags";
+"route.detail.start" = "Start route";
+"route.detail.cta.requestJoin" = "Request to join";
+"route.detail.cta.review" = "Review %d requests";
+"route.detail.cta.waiting" = "Waiting for host confirmation";
+"route.detail.cta.groupChat" = "Open group chat";
 "route.detail.pace.relaxed" = "Relaxed";
 "route.detail.pace.standard" = "Standard";
 "route.detail.pace.packed" = "Packed";
@@ -1592,24 +1593,24 @@
 "itinerary.toast.viewAction" = "View itinerary";
 
 /* US-027 — RecruitingModule */
-"recruiting.status.open" = "招募中";
-"recruiting.status.forming" = "组队中";
-"recruiting.status.closed" = "已关闭";
-"recruiting.status.completed" = "已完成";
-"recruiting.slots.label" = "成员";
+"recruiting.status.open" = "Recruiting";
+"recruiting.status.forming" = "Forming";
+"recruiting.status.closed" = "Closed";
+"recruiting.status.completed" = "Completed";
+"recruiting.slots.label" = "Members";
 "recruiting.slots.count" = "%d/%d";
-"recruiting.cta.viewRequests" = "查看申请(%d)";
-"recruiting.cta.applied" = "已申请 · 等待确认";
-"recruiting.cta.viewChat" = "查看群聊";
-"recruiting.cta.requestJoin" = "申请加入";
-"recruiting.cta.requestJoinForming" = "申请加入(最后 %d 位)";
+"recruiting.cta.viewRequests" = "View requests (%d)";
+"recruiting.cta.applied" = "Applied · waiting for confirmation";
+"recruiting.cta.viewChat" = "View group chat";
+"recruiting.cta.requestJoin" = "Request to join";
+"recruiting.cta.requestJoinForming" = "Request to join (%d spots left)";
 
 /* US-057 — RouteCard recruit-mini inline state (CompareCanvas A-002) */
-"route.card.recruit.recruiting" = "%1$@ 招募 · %2$d/%3$d 已確認 · %4$@";
-"route.card.recruit.closed" = "已成团 · %d 人 · 出发中";
-"route.card.recruit.completed" = "已完成 · 路线升级";
+"route.card.recruit.recruiting" = "%1$@ recruiting · %2$d/%3$d confirmed · %4$@";
+"route.card.recruit.closed" = "Group formed · %d members · departing";
+"route.card.recruit.completed" = "Completed · route upgraded";
 /* Trailing affordance on a joinable recruit strip */
-"route.card.recruit.view" = "查看";
+"route.card.recruit.view" = "View";
 
 /* AI route generation — fallback copy when the model is unavailable */
 "route.generate.fallback.summary" = "A short solo walk linking nearby spots.";
@@ -1617,8 +1618,8 @@
 "route.generate.fallback.titleFormat" = "%1$@ → %2$@";
 
 /* Create-route entry card + flow */
-"route.create.entry.title" = "創建你自己的路線";
-"route.create.entry.subtitle" = "串聯幾個地點 · 可選擇招募同伴一起走";
+"route.create.entry.title" = "Create your own route";
+"route.create.entry.subtitle" = "String a few stops together · optionally invite a companion";
 
 /* Direction 3 — warm cold-start placeholder for the Now routes section */
 "routes.now.empty.title" = "Today’s walk · let Solo string one together";
@@ -1626,7 +1627,7 @@
 "route.duration.hours" = "%dh";
 "route.duration.hoursMinutes" = "%dh %dmin";
 "route.duration.minutes" = "%dmin";
-"route.create.title" = "創建路線";
+"route.create.title" = "Create Route";
 "route.create.ai" = "✨ 讓 AI 幫我串成路線";
 "route.create.titleLabel" = "路線名稱";
 "route.create.titlePlaceholder" = "例如：湄公河日落散步";
@@ -1944,11 +1945,12 @@
 /* Trust chip (mapped from confidence health) */
 "trust.verified" = "Verified";
 "trust.observing" = "Observing";
-"trust.questioned" = "Questioned";
+"trust.questioned" = "Unconfirmed";
 
 /* ── Traveler co-build layer ── */
 "notes.title" = "Traveler Notes";
 "notes.signals" = "signals";
+"notes.signals.aiEstimate" = "AI estimate";
 "notes.signal.plus" = "+1 signal";
 "notes.author.you" = "You";
 "notes.author.traveler" = "Traveler %@";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -28,6 +28,7 @@
 
 /* Confidence */
 "confidence.signals" = "信号";
+"confidence.aiEstimate" = "AI 估算 · 待验证";
 "confidence.aiScrape" = "AI 抓取时间";
 "confidence.gps" = "GPS 命中（30 天）";
 "confidence.reports" = "用户反馈（30 天）";
@@ -1786,16 +1787,16 @@
 "moderation.reason.fakeProfile" = "虚假资料";
 "moderation.reason.other" = "其他";
 "me.profile.name" = "独行旅人";
-"me.profile.subtitle" = "你的罗盘，你的旅程";
+"me.profile.subtitle" = "每一次独行，都有信心";
 "me.profile.progress.a11y" = "已探索 %d / %d 个收藏地点";
 "me.friends.incoming" = "好友申请";
 "me.friends.list" = "好友";
 "me.friends.empty" = "还没有好友";
 "me.stats.saved" = "收藏";
 "me.stats.explored" = "探索";
-"me.empty.title" = "旅程从这里开始";
-"me.empty.subtitle" = "探索地图，收藏喜欢的地点，记录你去过的每一处。";
-"me.empty.cta" = "回到地图";
+"me.empty.title" = "你的独行地图";
+"me.empty.subtitle" = "收藏适合一个人去的地方，看信心如何成长。";
+"me.empty.cta" = "探索地图";
 "me.avatar.a11y" = "打开个人中心";
 "me.avatar.a11y.pending" = "你有待处理的好友申请";
 
@@ -1856,11 +1857,12 @@
 /* 信任徽章（由 confidence health 映射） */
 "trust.verified" = "已验证";
 "trust.observing" = "观察中";
-"trust.questioned" = "存疑";
+"trust.questioned" = "待确认";
 
 /* ── 旅人共建层 ── */
 "notes.title" = "旅人笔记";
 "notes.signals" = "信号";
+"notes.signals.aiEstimate" = "AI 估算";
 "notes.signal.plus" = "+1 信号";
 "notes.author.you" = "你";
 "notes.author.traveler" = "旅人 %@";

--- a/apps/ios/SoloCompass/Services/LocationService.swift
+++ b/apps/ios/SoloCompass/Services/LocationService.swift
@@ -74,6 +74,12 @@ public final class LocationService: NSObject {
         self.authorizationStatus = manager.authorizationStatus
         #endif
         super.init()
+        #if DEBUG
+        // On iOS 26, setting CLLocationManager.delegate alone triggers the
+        // system authorization dialog. When bypassing the prompt for UI
+        // testing / screenshots, skip the entire CLLocationManager setup.
+        if args.contains("-uiTestBypassLocationPrompt") { return }
+        #endif
         self.manager.delegate = self
         // Tighter accuracy so we don't burn battery chasing sub-10m fixes the
         // map never needs. The distance filter is deliberately *small* (5m) —

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -604,11 +604,12 @@ public final class MapViewModel {
         }
         let nameMap = cityNameMap
         var byCode: [String: (code: String, name: String, center: CLLocationCoordinate2D)] = [:] // swiftlint:disable:this large_tuple
+        let nearbyLabel = NSLocalizedString("city.nearby", comment: "Fallback city label for synthetic osm_ codes")
         // Seed-derived rows first.
         for (code, coords) in cityExperiences where !coords.isEmpty {
             let avgLat = coords.map(\.latitude).reduce(0, +) / Double(coords.count)
             let avgLon = coords.map(\.longitude).reduce(0, +) / Double(coords.count)
-            let name = nameMap[code] ?? code
+            let name = nameMap[code] ?? (code.hasPrefix("osm_") ? nearbyLabel : code)
             byCode[code] = (code, name, CLLocationCoordinate2D(latitude: avgLat, longitude: avgLon))
         }
 
@@ -644,6 +645,7 @@ public final class MapViewModel {
     /// `DiscoveredCityRecord` via `availableCities`.
     private let cityNameMap: [String: String] = [
         "cmi": "Chiang Mai",
+        "CNX": "Chiang Mai",
         "VTE": "Vientiane",
         "cn-深圳市": "Shenzhen",
         // SZX/szx/shenzhen 三种冷启动/launch-arg 形式都要能反查到显示名,
@@ -663,6 +665,8 @@ public final class MapViewModel {
         "ho-chi-minh": "Ho Chi Minh",
         "lis": "Lisbon",
         "lisbon": "Lisbon",
+        "san-francisco": "San Francisco",
+        "sfo": "San Francisco",
     ]
 
     /// Well-known city centers keyed by both their seed/discovered codes and
@@ -674,6 +678,7 @@ public final class MapViewModel {
         "cmi": CLLocationCoordinate2D(latitude: 18.7877, longitude: 98.9938),
         "chiang-mai": CLLocationCoordinate2D(latitude: 18.7877, longitude: 98.9938),
         "san-francisco": CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
+        "sfo": CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
         // V-006: Vientiane (VTE) seeds existed (5 experiences + 4 routes) but the
         // city had no authoritative center, so a cold start on VTE fell through to
         // the live centroid — unstable, and empty if `availableCities` hasn't
@@ -713,9 +718,11 @@ public final class MapViewModel {
         // these the alias lookup falls through to `Self.defaultCenter` and the
         // cold-start map silently lands on SF.
         "chiangmai": "cmi",
+        "cnx": "cmi",
         "vientiane": "VTE",
         "shenzhen": "cn-深圳市",
         "szx": "cn-深圳市",
+        "sfo": "san-francisco",
     ]
 
     /// True when `seedCityCode` (an experience's `location.cityCode`) belongs to
@@ -794,6 +801,16 @@ public final class MapViewModel {
     public var suggestedCityCode: String? {
         guard visibleExperiences.isEmpty else { return nil }
         return firstAvailableCityCode
+    }
+
+    /// Resolve a human-readable city name for a city code, consulting the
+    /// static name map and alias table. Used by the city pill when
+    /// `availableCities` doesn't contain the code directly.
+    public func resolvedCityName(for code: String) -> String? {
+        if let name = cityNameMap[code] { return name }
+        if let canonical = Self.cityCodeAliases[code.lowercased()],
+           let name = cityNameMap[canonical] { return name }
+        return nil
     }
 
     /// Derive the first city code that has seed data, bypassing the memoized

--- a/apps/ios/SoloCompass/Views/Archive/ArchiveView.swift
+++ b/apps/ios/SoloCompass/Views/Archive/ArchiveView.swift
@@ -18,6 +18,7 @@ public struct ArchiveView: View {
     @State private var viewModel: ArchiveViewModel
     @State private var ritualsSheet: RitualsSheet? = nil
     private let ritualsModelContainer: ModelContainer
+    @Environment(\.colorScheme) private var colorScheme
 
     public init(modelContainer: ModelContainer, activeCityCode: String? = nil) {
         self.ritualsModelContainer = modelContainer
@@ -77,7 +78,7 @@ public struct ArchiveView: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 20)
         }
-        .background(Color(white: 0.98))
+        .background(colorScheme == .dark ? Color(.systemBackground) : Color(white: 0.98))
         .navigationTitle(NSLocalizedString("archive.title", comment: "Travel archive title"))
         .onAppear {
             viewModel.refresh()
@@ -102,7 +103,7 @@ public struct ArchiveView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Rituals")
                 .font(.system(.headline, design: .rounded))
-                .foregroundStyle(CT.fgPrimary.opacity(0.85))
+                .foregroundStyle((colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary).opacity(0.85))
             LazyVGrid(
                 columns: [GridItem(.adaptive(minimum: 108), spacing: 10)],
                 spacing: 10
@@ -119,7 +120,7 @@ public struct ArchiveView: View {
                            accent: CT.capsuleGlow, tap: .capsuleOpen)
                 ritualTile("Live Activity",  "bell.badge.fill",
                            accent: CT.sunGoldDeep, tap: .liveActivity)
-                ritualTile("Tool Router",    "wrench.and.screwdriver.fill",
+                ritualTile("Voice Tools",    "waveform.circle.fill",
                            accent: CT.accent, tap: .toolContract)
                 ritualTile("Travel Book",    "book.pages.fill",
                            accent: CT.capsuleGlow, tap: .bookManifest)
@@ -140,14 +141,14 @@ public struct ArchiveView: View {
                     .foregroundStyle(accent)
                 Text(label)
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(CT.fgPrimary)
+                    .foregroundStyle(colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary)
                     .multilineTextAlignment(.center)
                     .lineLimit(2)
                     .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity, minHeight: 84)
             .padding(10)
-            .background(Color.white)
+            .background(colorScheme == .dark ? CT.warmCardDark : Color.white)
             .overlay(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .stroke(accent.opacity(0.28), lineWidth: 1)
@@ -279,7 +280,7 @@ public struct ArchiveView: View {
             }
             .padding(20)
         }
-        .background(Color(white: 0.98))
+        .background(colorScheme == .dark ? Color(.systemBackground) : Color(white: 0.98))
         .navigationTitle("Travel Book")
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -580,20 +581,22 @@ public struct ArchiveView: View {
     // MARK: - Empty state
 
     private var emptyState: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "map")
-                .font(.system(size: 40))
-                .foregroundStyle(CT.fgPrimary.opacity(0.3))
+        let fg = colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary
+        return VStack(spacing: 16) {
+            Image(systemName: "map.fill")
+                .font(.system(size: 48, weight: .light))
+                .foregroundStyle(CT.sunGold.opacity(0.45))
+                .padding(.bottom, 4)
             Text(NSLocalizedString("archive.empty.title", comment: "Empty archive title"))
-                .font(.system(.headline, design: .rounded))
-                .foregroundStyle(CT.fgPrimary.opacity(0.75))
+                .font(.system(.title3, design: .rounded).weight(.semibold))
+                .foregroundStyle(fg.opacity(0.8))
             Text(NSLocalizedString("archive.empty.subtitle", comment: "Empty archive subtitle"))
-                .font(.caption)
-                .foregroundStyle(CT.fgPrimary.opacity(0.5))
+                .font(.subheadline)
+                .foregroundStyle(fg.opacity(0.5))
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 24)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 60)
+        .padding(.vertical, 56)
     }
 }

--- a/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
@@ -186,6 +186,10 @@ public struct ChatSheet: View {
     private var mainContent: some View {
         if showVoiceSurface {
             voiceSurface
+        } else if detent == .medium && visibleMessages.isEmpty && orchestrator.streamingContent.isEmpty && orchestrator.scopedExperience == nil {
+            halfExpandedGenericEmptyState
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(emptyStateBackground)
         } else {
             messageList
             // Half-detent hides the textInputBar entirely — the mic in
@@ -359,9 +363,12 @@ public struct ChatSheet: View {
     @ViewBuilder
     private var messageList: some View {
         if visibleMessages.isEmpty && orchestrator.streamingContent.isEmpty {
-            emptyState
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(emptyStateBackground)
+            ScrollView {
+                emptyState
+                    .frame(maxWidth: .infinity)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+            .background(emptyStateBackground)
         } else {
             ScrollViewReader { proxy in
                 ScrollView {
@@ -548,14 +555,14 @@ public struct ChatSheet: View {
             Button(action: switchToTextMode) {
                 Text(NSLocalizedString("chat.voice.tap.toType", comment: "Switch to typing"))
                     .font(.footnote.weight(.medium))
-                    .foregroundStyle(.tint)
+                    .foregroundStyle(CT.accent)
             }
             .padding(.bottom, 24)
 
             if let err = orchestrator.errorMessage {
                 Text(err)
                     .font(.caption)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(CT.savedRed)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 24)
                     .padding(.bottom, 12)

--- a/apps/ios/SoloCompass/Views/Chat/HalfExpandedEmptyState.swift
+++ b/apps/ios/SoloCompass/Views/Chat/HalfExpandedEmptyState.swift
@@ -36,7 +36,7 @@ struct HalfExpandedEmptyState: View {
 
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var appeared = false
+    @State private var appeared = true
 
     var body: some View {
         // Editorial half-sheet — "B. Minimal Voice":
@@ -49,7 +49,7 @@ struct HalfExpandedEmptyState: View {
         // suppressed by `ChatSheet` when `detent == .medium`, so this view IS
         // the whole half-sheet surface.
         VStack(spacing: 0) {
-            Spacer(minLength: 20)
+            Spacer(minLength: 12)
 
             momentTag
                 .padding(.bottom, 14)
@@ -71,7 +71,7 @@ struct HalfExpandedEmptyState: View {
 
             micHandle
 
-            Spacer(minLength: 20)
+            Spacer(minLength: 12)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .opacity(appeared ? 1 : 0)

--- a/apps/ios/SoloCompass/Views/CityOS/LiveSheet.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/LiveSheet.swift
@@ -147,7 +147,7 @@ struct LiveEventCard: View {
 
     private func limitedChip(_ text: String) -> some View {
         Text(text)
-            .font(.system(size: 9.5, weight: .semibold, design: .monospaced))
+            .font(.system(size: 10, weight: .semibold, design: .monospaced))
             .foregroundStyle(CT.eventLimited)
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
@@ -187,8 +187,8 @@ struct LiveEventCard: View {
             HealthDot(status: health)
             if let seen = event.seenLabel, !seen.isEmpty {
                 Text(seen)
-                    .font(CT.mono(9.5))
-                    .foregroundStyle(CT.fgSubtle)
+                    .font(CT.mono(10))
+                    .foregroundStyle(CT.fgMuted)
                     .lineLimit(1)
             }
             Spacer(minLength: 0)

--- a/apps/ios/SoloCompass/Views/Companion/AddToItinerarySheet.swift
+++ b/apps/ios/SoloCompass/Views/Companion/AddToItinerarySheet.swift
@@ -94,11 +94,11 @@ public struct AddToItinerarySheet: View {
             HStack(spacing: 12) {
                 ZStack {
                     RoundedRectangle(cornerRadius: 8)
-                        .fill(Color.accentColor.opacity(0.1))
+                        .fill(CT.accent.opacity(0.1))
                         .frame(width: 36, height: 36)
                     Image(systemName: alreadyAdded ? "checkmark" : "plus")
                         .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(alreadyAdded ? .green : Color.accentColor)
+                        .foregroundStyle(alreadyAdded ? CT.verifiedGreen : CT.accent)
                 }
                 VStack(alignment: .leading, spacing: 2) {
                     Text(itin.title)
@@ -111,7 +111,7 @@ public struct AddToItinerarySheet: View {
                 Spacer()
                 if wasJustAdded {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
+                        .foregroundStyle(CT.verifiedGreen)
                         .transition(.scale.combined(with: .opacity))
                 }
             }
@@ -149,7 +149,7 @@ public struct AddToItinerarySheet: View {
         VStack(spacing: 16) {
             Image(systemName: "map")
                 .font(.system(size: 40))
-                .foregroundStyle(Color.accentColor.opacity(0.6))
+                .foregroundStyle(CT.accent.opacity(0.6))
             Text(NSLocalizedString("itinerary.addTo.noItineraries", comment: "No itineraries empty state"))
                 .font(.headline)
             Text(NSLocalizedString("itinerary.addTo.noItineraries.hint", comment: "Create one hint"))
@@ -163,7 +163,7 @@ public struct AddToItinerarySheet: View {
                     .font(.subheadline.weight(.semibold))
                     .padding(.horizontal, 20)
                     .padding(.vertical, 10)
-                    .background(Capsule().fill(Color.accentColor))
+                    .background(Capsule().fill(CT.accent))
                     .foregroundStyle(.white)
             }
         }

--- a/apps/ios/SoloCompass/Views/Companion/CompanionProfileView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/CompanionProfileView.swift
@@ -97,7 +97,7 @@ public struct MyProfileEditView: View {
                         .font(.system(size: 64))
                         .frame(width: 96, height: 96)
                         .background(
-                            Circle().fill(Color.accentColor.opacity(0.1))
+                            Circle().fill(CT.accent.opacity(0.1))
                         )
                 }
                 .accessibilityLabel(NSLocalizedString("companion.profile.avatar.a11y", comment: "Change avatar emoji"))
@@ -118,7 +118,7 @@ public struct MyProfileEditView: View {
                                 .background(
                                     RoundedRectangle(cornerRadius: 10)
                                         .fill(preferences.companionAvatarEmoji == emoji
-                                              ? Color.accentColor.opacity(0.2)
+                                              ? CT.accent.opacity(0.2)
                                               : Color(.systemBackground))
                                 )
                         }
@@ -183,7 +183,7 @@ public struct MyProfileEditView: View {
                     format: NSLocalizedString("profile.handle.invalid", comment: "Handle length validation message"),
                     Self.handleMinLength, Self.handleMaxLength
                 ))
-                .foregroundStyle(.red)
+                .foregroundStyle(CT.savedRed)
             } else {
                 Text(String(
                     format: NSLocalizedString("profile.handle.footer", comment: "Handle section footer"),
@@ -235,7 +235,7 @@ public struct MyProfileEditView: View {
                         Spacer()
                         if currentCodes.contains(lang.code) {
                             Image(systemName: "checkmark")
-                                .foregroundStyle(Color.accentColor)
+                                .foregroundStyle(CT.accent)
                                 .font(.footnote.weight(.semibold))
                         }
                     }
@@ -272,12 +272,12 @@ public struct MyProfileEditView: View {
                             } label: {
                                 Text(NSLocalizedString("profile.walkedRoutes.viewAll", comment: "View all walked routes chip"))
                                     .font(.caption.weight(.semibold))
-                                    .foregroundStyle(Color.accentColor)
+                                    .foregroundStyle(CT.accent)
                                     .padding(.horizontal, 12)
                                     .padding(.vertical, 8)
                                     .background(
                                         RoundedRectangle(cornerRadius: 8)
-                                            .fill(Color.accentColor.opacity(0.1))
+                                            .fill(CT.accent.opacity(0.1))
                                     )
                             }
                             .buttonStyle(.plain)
@@ -306,7 +306,7 @@ public struct MyProfileEditView: View {
                             .frame(width: 24)
                             .foregroundStyle(
                                 preferences.companionVisibility == option
-                                ? Color.accentColor : .secondary
+                                ? CT.accent : .secondary
                             )
                         VStack(alignment: .leading, spacing: 2) {
                             Text(visibilityTitle(option))
@@ -319,7 +319,7 @@ public struct MyProfileEditView: View {
                         Spacer()
                         if preferences.companionVisibility == option {
                             Image(systemName: "checkmark.circle.fill")
-                                .foregroundStyle(Color.accentColor)
+                                .foregroundStyle(CT.accent)
                         }
                     }
                     .padding(.vertical, 2)
@@ -383,7 +383,7 @@ private struct WalkedRouteCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             RoundedRectangle(cornerRadius: 8)
-                .fill(Color.accentColor.opacity(0.15))
+                .fill(CT.accent.opacity(0.15))
                 .frame(width: 140, height: 76)
                 .overlay(
                     Text(route.title.prefix(1))

--- a/apps/ios/SoloCompass/Views/Companion/CompanionSafetyConsentSheet.swift
+++ b/apps/ios/SoloCompass/Views/Companion/CompanionSafetyConsentSheet.swift
@@ -60,7 +60,7 @@ public struct CompanionSafetyConsentSheet: View {
         VStack(alignment: .leading, spacing: 8) {
             Image(systemName: "shield.lefthalf.filled")
                 .font(.system(size: 44))
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(CT.accent)
                 .padding(.top, 8)
 
             Text(NSLocalizedString("companion.safety.heading", comment: "Safety heading"))
@@ -109,7 +109,7 @@ public struct CompanionSafetyConsentSheet: View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: icon)
                 .frame(width: 20)
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(CT.accent)
             Text(text)
                 .font(.subheadline)
                 .foregroundStyle(.primary)
@@ -137,11 +137,11 @@ public struct CompanionSafetyConsentSheet: View {
         .padding(16)
         .background(
             RoundedRectangle(cornerRadius: 12)
-                .fill(Color.orange.opacity(0.1))
+                .fill(CT.warningSoft)
         )
         .overlay(
             RoundedRectangle(cornerRadius: 12)
-                .stroke(Color.orange.opacity(0.3), lineWidth: 1)
+                .stroke(CT.warningText.opacity(0.3), lineWidth: 1)
         )
     }
 
@@ -194,7 +194,7 @@ private struct CheckmarkToggleStyle: ToggleStyle {
             HStack(alignment: .top, spacing: 12) {
                 Image(systemName: configuration.isOn ? "checkmark.square.fill" : "square")
                     .font(.title3)
-                    .foregroundStyle(configuration.isOn ? Color.accentColor : .secondary)
+                    .foregroundStyle(configuration.isOn ? CT.accent : .secondary)
                 configuration.label
             }
         }

--- a/apps/ios/SoloCompass/Views/Companion/Components/RecruitingModule.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Components/RecruitingModule.swift
@@ -95,7 +95,7 @@ public struct RecruitingModule: View {
             statusCapsule(status: companion.status)
             Text(companion.departureLabel)
                 .font(.system(size: 12, design: .monospaced))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(CT.fgMuted)
                 .lineLimit(1)
             Spacer(minLength: 0)
         }
@@ -130,13 +130,13 @@ public struct RecruitingModule: View {
             VStack(alignment: .leading, spacing: 1) {
                 Text("@\(hostId)")
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(CT.fgPrimary)
                     .lineLimit(1)
 
                 if let user = UserDirectory.shared.user(handle: hostId), !user.blurb.isEmpty {
                     Text(user.blurb)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(CT.fgMuted)
                         .lineLimit(1)
                 }
             }
@@ -151,7 +151,7 @@ public struct RecruitingModule: View {
         HStack(spacing: 6) {
             Text(NSLocalizedString("recruiting.slots.label", comment: "Slots label"))
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(CT.fgMuted)
 
             HStack(spacing: 4) {
                 ForEach(0..<companion.maxMembers, id: \.self) { index in
@@ -172,7 +172,7 @@ public struct RecruitingModule: View {
                 companion.maxMembers
             ))
             .font(.system(size: 11, design: .monospaced))
-            .foregroundStyle(.secondary)
+            .foregroundStyle(CT.fgMuted)
         }
     }
 

--- a/apps/ios/SoloCompass/Views/Companion/Components/StopsList.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Components/StopsList.swift
@@ -119,18 +119,18 @@ private struct StopRow: View {
         VStack(alignment: .leading, spacing: 2) {
             Text(experience.title)
                 .font(CT.body(14.5, .semibold))
-                .foregroundStyle(.primary)
+                .foregroundStyle(CT.fgPrimary)
                 .fixedSize(horizontal: false, vertical: true)
 
             if let romanized = experience.location.placeNameRomanized {
                 Text(romanized)
                     .font(CT.body(11.5))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(CT.fgMuted)
             }
 
             Text(distanceText)
                 .font(.system(size: 12).monospacedDigit())
-                .foregroundStyle(.secondary)
+                .foregroundStyle(CT.fgMuted)
                 .padding(.top, 2)
         }
     }

--- a/apps/ios/SoloCompass/Views/Companion/ConversationListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ConversationListView.swift
@@ -256,7 +256,7 @@ private struct ConversationRow: View {
 
             if summary.hasUnread {
                 Circle()
-                    .fill(Color.accentColor)
+                    .fill(CT.accent)
                     .frame(width: 10, height: 10)
                     .accessibilityLabel(
                         Text(NSLocalizedString("messages.unread.a11y", comment: "Unread"))

--- a/apps/ios/SoloCompass/Views/Companion/CreateRouteView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/CreateRouteView.swift
@@ -8,6 +8,11 @@ import CoreLocation
 /// `CreateRouteView`. Mirrors the reference design's create-route affordance.
 struct CreateRouteEntryCard: View {
     let onTap: () -> Void
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var cardBg: Color { colorScheme == .dark ? CT.warmCardDark : CT.surfaceWhite }
+    private var titleColor: Color { colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary }
+    private var subtitleColor: Color { colorScheme == .dark ? CT.fgMutedDark : CT.fgMuted }
 
     var body: some View {
         Button(action: onTap) {
@@ -23,21 +28,21 @@ struct CreateRouteEntryCard: View {
                 VStack(alignment: .leading, spacing: 3) {
                     Text(NSLocalizedString("route.create.entry.title", comment: "Create your own route"))
                         .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(CT.fgPrimary)
+                        .foregroundStyle(titleColor)
                     Text(NSLocalizedString("route.create.entry.subtitle", comment: "Link a few stops · optionally recruit companions"))
                         .font(.caption)
-                        .foregroundStyle(CT.fgMuted)
+                        .foregroundStyle(subtitleColor)
                         .lineLimit(2)
                 }
                 Spacer(minLength: 4)
                 Image(systemName: "chevron.right")
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(CT.fgSubtle)
+                    .foregroundStyle(subtitleColor)
             }
             .padding(14)
             .background(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(CT.surfaceWhite)
+                    .fill(cardBg)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)

--- a/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
@@ -58,7 +58,7 @@ public struct DiscoverListView: View {
                         .font(.subheadline)
                         .lineLimit(2)
                 }
-                .foregroundStyle(.red)
+                .foregroundStyle(CT.savedRed)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 12)
                 .background(.regularMaterial, in: Capsule())
@@ -76,7 +76,7 @@ public struct DiscoverListView: View {
                         .font(.subheadline)
                         .lineLimit(2)
                 }
-                .foregroundStyle(.green)
+                .foregroundStyle(CT.verifiedGreen)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 12)
                 .background(.regularMaterial, in: Capsule())
@@ -236,13 +236,13 @@ private struct EmptyCompanionState: View {
         VStack(spacing: 24) {
             ZStack {
                 Circle()
-                    .fill(Color.accentColor.opacity(pulse ? 0.6 : 0.35))
+                    .fill(CT.accent.opacity(pulse ? 0.6 : 0.35))
                     .frame(width: 80, height: 80)
                     .scaleEffect(pulse ? 1.08 : 0.9)
 
                 Image(systemName: "person.2.slash")
                     .font(.system(size: 36, weight: .medium))
-                    .foregroundStyle(Color.accentColor)
+                    .foregroundStyle(CT.accent)
             }
             .onAppear {
                 if reduceMotion {
@@ -389,9 +389,9 @@ private struct DiscoverPostRow: View {
                         .padding(.horizontal, 8)
                         .padding(.vertical, 3)
                         .background(
-                            Capsule().fill(Color.accentColor.opacity(0.12))
+                            Capsule().fill(CT.accent.opacity(0.12))
                         )
-                        .foregroundStyle(Color.accentColor)
+                        .foregroundStyle(CT.accent)
                 }
             }
         }
@@ -412,7 +412,7 @@ private struct DiscoverPostRow: View {
             .frame(maxWidth: .infinity)
         }
         .buttonStyle(.bordered)
-        .tint(hasSentRequest ? .green : .accentColor)
+        .tint(hasSentRequest ? .green : CT.accent)
         .disabled(hasSentRequest)
         .scaleEffect(pressed ? 0.96 : 1)
         .simultaneousGesture(
@@ -442,7 +442,7 @@ private struct DiscoverPostRow: View {
             .frame(maxWidth: .infinity)
         }
         .buttonStyle(.bordered)
-        .tint(.accentColor)
+        .tint(CT.accent)
     }
 
     private func formattedDateRange(from: String, to: String) -> String {

--- a/apps/ios/SoloCompass/Views/Companion/DiscoverPostDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/DiscoverPostDetailView.swift
@@ -44,7 +44,7 @@ struct DiscoverPostDetailView: View {
                     if let msg = errorMessage {
                         Label(msg, systemImage: "exclamationmark.triangle")
                             .font(.subheadline)
-                            .foregroundStyle(.red)
+                            .foregroundStyle(CT.savedRed)
                             .accessibilityLabel(msg)
                     }
                 }
@@ -88,8 +88,8 @@ struct DiscoverPostDetailView: View {
                         .font(.caption.weight(.medium))
                         .padding(.horizontal, 8)
                         .padding(.vertical, 3)
-                        .background(Capsule().fill(Color.accentColor.opacity(0.12)))
-                        .foregroundStyle(Color.accentColor)
+                        .background(Capsule().fill(CT.accent.opacity(0.12)))
+                        .foregroundStyle(CT.accent)
                 }
             }
         }

--- a/apps/ios/SoloCompass/Views/Companion/InviteFriendsSheet.swift
+++ b/apps/ios/SoloCompass/Views/Companion/InviteFriendsSheet.swift
@@ -142,7 +142,7 @@ public struct InviteFriendsSheet: View {
                 Spacer()
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                     .font(.title3)
-                    .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                    .foregroundStyle(isSelected ? CT.accent : Color.secondary)
                     .accessibilityHidden(true)
             }
         }

--- a/apps/ios/SoloCompass/Views/Companion/ItineraryDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ItineraryDetailView.swift
@@ -111,7 +111,7 @@ public struct ItineraryDetailView: View {
                         } label: {
                             Text(NSLocalizedString("itinerary.detail.importFavorites", comment: "Import from favorites button"))
                                 .font(.caption.weight(.medium))
-                                .foregroundStyle(Color.accentColor)
+                                .foregroundStyle(CT.accent)
                         }
                         .buttonStyle(.plain)
                     }
@@ -221,7 +221,7 @@ public struct ItineraryDetailView: View {
                 NSLocalizedString("companion.post.openToCompanions", comment: "Open to companions toggle"),
                 isOn: openToCompanionsBinding
             )
-            .tint(.accentColor)
+            .tint(CT.accent)
 
             // Show post blurb when active
             if let post = activePost {
@@ -247,7 +247,7 @@ public struct ItineraryDetailView: View {
                         "openForCompanions.button",
                         comment: "Button to open itinerary as a recruiting route"
                     ))
-                    .foregroundStyle(Color.accentColor)
+                    .foregroundStyle(CT.accent)
                     Spacer()
                     Image(systemName: "chevron.right")
                         .font(.caption.weight(.semibold))
@@ -454,7 +454,7 @@ private struct CompanionPostCreationSheet: View {
                                 Spacer()
                                 if selectedCategories.contains(cat) {
                                     Image(systemName: "checkmark")
-                                        .foregroundStyle(Color.accentColor)
+                                        .foregroundStyle(CT.accent)
                                         .font(.footnote.weight(.semibold))
                                 }
                             }

--- a/apps/ios/SoloCompass/Views/Companion/ItineraryFormView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ItineraryFormView.swift
@@ -143,7 +143,7 @@ public struct ItineraryFormView: View {
                             "itinerary.form.validation.endBeforeStart",
                             comment: "End before start validation error"
                         ))
-                        .foregroundStyle(.red)
+                        .foregroundStyle(CT.savedRed)
                         .font(.caption)
                     }
                 }
@@ -234,7 +234,7 @@ private struct ItineraryCityPickerSheet: View {
                         Spacer()
                         if selectedCode == city.code {
                             Image(systemName: "checkmark")
-                                .foregroundStyle(.tint)
+                                .foregroundStyle(CT.accent)
                                 .font(.body.weight(.semibold))
                         }
                     }

--- a/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
@@ -125,11 +125,11 @@ public struct ItineraryListView: View {
     }
 
     private var countdownLineColor: Color {
-        guard !reduceMotion else { return .accentColor }
+        guard !reduceMotion else { return CT.accent }
         if #available(iOS 18, *) {
-            return Color.accentColor.mix(with: .orange, by: 1 - undoProgress)
+            return CT.accent.mix(with: .orange, by: 1 - undoProgress)
         } else {
-            return .accentColor
+            return CT.accent
         }
     }
 
@@ -150,7 +150,7 @@ public struct ItineraryListView: View {
                     Spacer()
                     Text(NSLocalizedString("action.undo", comment: "Undo action"))
                         .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(Color.accentColor)
+                        .foregroundStyle(CT.accent)
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 12)
@@ -270,7 +270,7 @@ private enum TripStatus {
     var color: Color {
         switch self {
         case .active, .today: return .green
-        case .soon: return .accentColor
+        case .soon: return CT.accent
         case .upcoming, .past: return Color(.tertiaryLabel)
         }
     }
@@ -304,11 +304,11 @@ private struct ItineraryRow: View {
         HStack(spacing: 12) {
             ZStack {
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(Color.accentColor.opacity(0.12))
+                    .fill(CT.accent.opacity(0.12))
                     .frame(width: 44, height: 44)
                 Image(systemName: "map")
                     .font(.body)
-                    .foregroundStyle(Color.accentColor)
+                    .foregroundStyle(CT.accent)
             }
 
             VStack(alignment: .leading, spacing: 3) {
@@ -367,11 +367,11 @@ private struct EmptyItineraryView: View {
         VStack(spacing: 12) {
             ZStack {
                 Circle()
-                    .fill(Color.accentColor.opacity(0.12))
+                    .fill(CT.accent.opacity(0.12))
                     .frame(width: 80, height: 80)
                 Image(systemName: "map.fill")
                     .font(.system(size: 40))
-                    .foregroundStyle(Color.accentColor.opacity(0.7))
+                    .foregroundStyle(CT.accent.opacity(0.7))
                     .scaleEffect(isBreathing ? 1.08 : 0.94)
                     .opacity(isBreathing ? 1.0 : 0.7)
                     .animation(

--- a/apps/ios/SoloCompass/Views/Companion/JoinRouteRequestSheet.swift
+++ b/apps/ios/SoloCompass/Views/Companion/JoinRouteRequestSheet.swift
@@ -191,7 +191,7 @@ struct JoinRouteRequestSheet: View {
 
             Text("\(message.count) / 10+")
                 .font(.caption)
-                .foregroundStyle(message.count < 10 ? Color(.secondaryLabel) : Color.green)
+                .foregroundStyle(message.count < 10 ? Color(.secondaryLabel) : CT.verifiedGreen)
 
             if showsMessageError {
                 inlineError(JoinRequestField.message.missingHint)
@@ -205,7 +205,7 @@ struct JoinRouteRequestSheet: View {
     private func inlineError(_ text: String) -> some View {
         Text(text)
             .font(.caption)
-            .foregroundStyle(Color.red)
+            .foregroundStyle(CT.savedRed)
             .accessibilityAddTraits(.isStaticText)
             .transition(.opacity)
     }
@@ -230,7 +230,7 @@ struct JoinRouteRequestSheet: View {
     private var submitBackground: some View {
         if isSubmitEnabled {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color.accentColor)
+                .fill(CT.accent)
         } else {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(Color(.systemGray4))

--- a/apps/ios/SoloCompass/Views/Companion/MyHostedRoutesListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/MyHostedRoutesListView.swift
@@ -98,7 +98,7 @@ public struct MyHostedRoutesListView: View {
                     .foregroundStyle(.white)
                     .padding(.horizontal, 7)
                     .padding(.vertical, 3)
-                    .background(Color.orange, in: Capsule())
+                    .background(CT.warningText, in: Capsule())
             }
         }
     }

--- a/apps/ios/SoloCompass/Views/Companion/MyRequestsListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/MyRequestsListView.swift
@@ -91,7 +91,7 @@ public struct MyRequestsListView: View {
                                         systemImage: "arrow.uturn.backward"
                                     )
                                 }
-                                .tint(.orange)
+                                .tint(CT.warningText)
                             }
                         }
                 }
@@ -203,13 +203,13 @@ public struct MyRequestsListView: View {
         case .pending:
             return (
                 NSLocalizedString("my.requests.status.pending", comment: "Pending status chip"),
-                Color.orange,
+                CT.warningText,
                 "clock.fill"
             )
         case .accepted:
             return (
                 NSLocalizedString("my.requests.status.accepted", comment: "Accepted status chip"),
-                Color.green,
+                CT.verifiedGreen,
                 "checkmark.circle.fill"
             )
         case .declined:
@@ -280,11 +280,11 @@ private struct EmptyMyRequestsView: View {
         VStack(spacing: 12) {
             ZStack {
                 Circle()
-                    .fill(Color.accentColor.opacity(0.12))
+                    .fill(CT.accent.opacity(0.12))
                     .frame(width: 80, height: 80)
                 Image(systemName: "paperplane.fill")
                     .font(.system(size: 36))
-                    .foregroundStyle(Color.accentColor.opacity(0.7))
+                    .foregroundStyle(CT.accent.opacity(0.7))
                     .scaleEffect(isBreathing ? 1.08 : 0.94)
                     .opacity(isBreathing ? 1.0 : 0.7)
                     .animation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true), value: isBreathing)

--- a/apps/ios/SoloCompass/Views/Companion/ReportBlockSheet.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ReportBlockSheet.swift
@@ -99,7 +99,7 @@ public struct ReportBlockSheet: View {
                     Spacer()
                     if selectedReason == reason {
                         Image(systemName: "checkmark")
-                            .foregroundStyle(Color.accentColor)
+                            .foregroundStyle(CT.accent)
                     }
                 }
                 .contentShape(Rectangle())

--- a/apps/ios/SoloCompass/Views/Companion/RequestInboxView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/RequestInboxView.swift
@@ -55,10 +55,10 @@ public struct RequestInboxView: View {
                             .contentTransition(.numericText())
                     }
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(Color.orange)
+                    .foregroundStyle(CT.warningText)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 5)
-                    .background(Color.orange.opacity(0.15), in: Capsule())
+                    .background(CT.warningSoft, in: Capsule())
                     .opacity(!reduceMotion ? (pulse ? 1.0 : 0.65) : 1.0)
                     .animation(
                         !reduceMotion ? .easeInOut(duration: 1.2).repeatForever(autoreverses: true) : .none,
@@ -98,7 +98,7 @@ public struct RequestInboxView: View {
                         .font(.subheadline)
                         .lineLimit(2)
                 }
-                .foregroundStyle(.red)
+                .foregroundStyle(CT.savedRed)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 12)
                 .background(.regularMaterial, in: Capsule())
@@ -270,11 +270,11 @@ private struct EmptyInboxView: View {
         VStack(spacing: 12) {
             ZStack {
                 Circle()
-                    .fill(Color.accentColor.opacity(0.12))
+                    .fill(CT.accent.opacity(0.12))
                     .frame(width: 80, height: 80)
                 Image(systemName: "tray")
                     .font(.system(size: 40))
-                    .foregroundStyle(Color.accentColor.opacity(0.7))
+                    .foregroundStyle(CT.accent.opacity(0.7))
                     .scaleEffect(isBreathing ? 1.08 : 0.94)
                     .opacity(isBreathing ? 1.0 : 0.7)
                     .animation(

--- a/apps/ios/SoloCompass/Views/Companion/RouteShareSheet.swift
+++ b/apps/ios/SoloCompass/Views/Companion/RouteShareSheet.swift
@@ -31,7 +31,7 @@ struct RouteShareSheet: View {
                 if let status = statusMessage {
                     Text(status)
                         .font(.caption)
-                        .foregroundStyle(statusIsError ? Color.red : Color.green)
+                        .foregroundStyle(statusIsError ? CT.savedRed : CT.verifiedGreen)
                         .multilineTextAlignment(.center)
                         .transition(.opacity)
                 }
@@ -69,7 +69,7 @@ struct RouteShareSheet: View {
                         .padding(.horizontal, 16)
                         .padding(.vertical, 8)
                         .background(
-                            Capsule().fill(selectedStyle == style ? Color.accentColor : Color(.secondarySystemBackground))
+                            Capsule().fill(selectedStyle == style ? CT.accent : Color(.secondarySystemBackground))
                         )
                         .foregroundStyle(selectedStyle == style ? .white : .primary)
                 }

--- a/apps/ios/SoloCompass/Views/Companion/Share/RouteShareCardView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Share/RouteShareCardView.swift
@@ -158,7 +158,7 @@ private struct RoutePolylineOverlay: View {
                     RoutePolylineShape(coordinates: coordinates)
                         .stroke(.white, style: StrokeStyle(lineWidth: haloWidth, lineCap: .round, lineJoin: .round))
                     RoutePolylineShape(coordinates: coordinates)
-                        .stroke(Color.accentColor, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round))
+                        .stroke(CT.accent, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round))
                 }
                 ForEach(Array(stops.enumerated()), id: \.offset) { index, point in
                     StopBadge(number: index + 1, isFirst: index == 0, isLast: index == stops.count - 1)
@@ -178,7 +178,7 @@ private struct StopBadge: View {
     var body: some View {
         Text("\(number)")
             .font(.system(size: 16, weight: .bold))
-            .foregroundStyle(Color.accentColor)
+            .foregroundStyle(CT.accent)
             .frame(width: 32, height: 32)
             .background(Circle().fill(.white))
             .overlay(

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -29,6 +29,7 @@ public struct ExperienceCardView: View {
     /// word per line. Read at render so a user who slides the slider mid-
     /// session sees the new layout immediately.
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.colorScheme) private var colorScheme
     @State private var heartBounce = 0
     @State private var heartBurst = false
     @State private var arrivedPulse = false
@@ -79,7 +80,7 @@ public struct ExperienceCardView: View {
             switch sourceStrength {
             case .verified: return ("checkmark.seal.fill", NSLocalizedString("card.source.verified", comment: "Cross-verified across multiple sources"), CT.accent)
             case .multi:    return ("link", NSLocalizedString("card.source.multi", comment: "Multiple sources agreeing"), CT.accent.opacity(0.7))
-            case .single:   return ("link.circle", NSLocalizedString("card.source.single", comment: "One source"), CT.fgMuted)
+            case .single:   return ("link.circle", NSLocalizedString("card.source.single", comment: "One source"), .secondary)
             case .none:     return ("", "", .clear)
             }
         }()
@@ -169,7 +170,7 @@ public struct ExperienceCardView: View {
 
         var color: Color {
             switch self {
-            case .near: return .green
+            case .near: return CT.verifiedGreen
             case .mid: return Color(red: 0xF5/255, green: 0x9E/255, blue: 0x0B/255)
             case .far: return Color.secondary
             }
@@ -300,13 +301,13 @@ public struct ExperienceCardView: View {
                     let favorited = preferences.isFavorited(experience.id)
                     ZStack {
                         Circle()
-                            .stroke(Color.red.opacity(0.5), lineWidth: 2)
+                            .stroke(CT.savedRed.opacity(0.5), lineWidth: 2)
                             .scaleEffect(heartBurst ? 1.8 : 0.4)
                             .opacity(heartBurst ? 0 : 0.8)
                             .animation(.easeOut(duration: 0.45), value: heartBurst)
                             .allowsHitTesting(false)
                         Image(systemName: favorited ? "heart.fill" : "heart")
-                            .foregroundStyle(favorited ? Color.red : Color.secondary)
+                            .foregroundStyle(favorited ? CT.savedRed : Color.secondary)
                             .scaleEffect(favorited ? 1.15 : 1.0)
                             .symbolEffect(.bounce, value: heartBounce)
                     }
@@ -383,7 +384,7 @@ public struct ExperienceCardView: View {
         .background(
             ZStack {
                 RoundedRectangle(cornerRadius: 20)
-                    .stroke(Color.green.opacity(arrivalGlow ? 0 : 0.7), lineWidth: 3)
+                    .stroke(CT.verifiedGreen.opacity(arrivalGlow ? 0 : 0.7), lineWidth: 3)
                     .scaleEffect(arrivalGlow ? 1.25 : 1.0)
                     .animation(.easeOut(duration: 0.8), value: arrivalGlow)
                     .allowsHitTesting(false)
@@ -545,7 +546,7 @@ public struct ExperienceCardView: View {
     private func distancePill(_ label: String, symbol: String) -> some View {
         let relBearing = relativeBearingDegrees
         let proximityColor = distanceMeters.map { proximityTint(for: $0) } ?? Color.secondary
-        let arrowTint = isOnCourse ? Color.green : proximityColor
+        let arrowTint = isOnCourse ? CT.verifiedGreen : proximityColor
         HStack(spacing: 4) {
             if let relBearing {
                 Image(systemName: "location.north.fill")
@@ -640,8 +641,8 @@ public struct ExperienceCardView: View {
             .font(.caption)
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
-            .foregroundStyle(Color.green)
-            .background(Capsule().fill(Color.green.opacity(0.12)))
+            .foregroundStyle(CT.verifiedGreen)
+            .background(Capsule().fill(CT.successSoft))
             .contentTransition(reduceMotion ? .identity : .numericText())
             .accessibilityLabel(a11y)
     }
@@ -687,8 +688,8 @@ public struct ExperienceCardView: View {
         .font(.caption)
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
-        .foregroundStyle(Color.green)
-        .background(Capsule().fill(Color.green.opacity(0.15)))
+        .foregroundStyle(CT.verifiedGreen)
+        .background(Capsule().fill(CT.successSoft))
         .scaleEffect(arrivedPulse ? 1.0 : 0.85)
         .onAppear {
             if reduceMotion {
@@ -713,8 +714,8 @@ public struct ExperienceCardView: View {
             .font(.caption)
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
-            .foregroundStyle(Color.accentColor)
-            .background(Capsule().fill(Color.accentColor.opacity(0.12)))
+            .foregroundStyle(CT.accent)
+            .background(Capsule().fill(CT.accent.opacity(0.12)))
 
             if apps.count == 1, let app = apps.first {
                 Button {
@@ -859,7 +860,7 @@ public struct ExperienceCardView: View {
     private var inconveniencePill: some View {
         if let category = mostSevereInconvenience {
             let isHighSeverity = category == .safety || category == .scam
-            let tint = isHighSeverity ? Color.red : Color(red: 0xF5/255, green: 0x9E/255, blue: 0x0B/255)
+            let tint = isHighSeverity ? CT.savedRed : Color(red: 0xF5/255, green: 0x9E/255, blue: 0x0B/255)
             let count = experience.realInconveniences.count
             let a11yFormat = isHighSeverity
                 ? NSLocalizedString("inconvenience.card.count.a11y.high", comment: "High-severity inconvenience pill accessibility label")
@@ -960,12 +961,13 @@ struct BestNowBadge: View {
     /// drives recomputation of `minutesLeftInBestWindow()` once a minute.
     var experience: Experience
 
-    private static let gold = Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)
+    private static let gold = CT.sunGold
     private static let amber = Color(red: 0xF5/255, green: 0x9E/255, blue: 0x0B/255)
     private static let closingSoonThresholdMinutes = 45
 
     @State private var pulse = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
     /// Single 60s clock shared across every badge (US-023). Replaces the
     /// per-badge `TimelineView(.periodic(by: 60))` so 20+ badges no longer spin
     /// up 20+ concurrent timelines.
@@ -1045,7 +1047,7 @@ struct BestNowBadge: View {
         if score.value >= 0.7 {
             Text(Self.reasonSubtitle(for: score))
                 .font(CT.body(11, .medium))
-                .foregroundStyle(CT.fgMuted)
+                .foregroundStyle(colorScheme == .dark ? CT.fgMutedDark : CT.fgMuted)
                 .lineLimit(1)
                 .accessibilityHidden(true)
         }
@@ -1083,7 +1085,7 @@ struct BestNowBadge: View {
                 onDismiss: {}
             )
         }
-        .background(Color(red: 0xF5/255, green: 0xF0/255, blue: 0xE8/255))
+        .background(CT.surfaceSunken)
         .environment(UserPreferences(defaults: UserDefaults(suiteName: "preview")!))
         .environment(locationService)
         .environment(BestNowClock())
@@ -1103,7 +1105,7 @@ struct BestNowBadge: View {
                 onDismiss: {}
             )
         }
-        .background(Color(red: 0xF5/255, green: 0xF0/255, blue: 0xE8/255))
+        .background(CT.surfaceSunken)
         .environment(UserPreferences(defaults: UserDefaults(suiteName: "preview-grabber")!))
         .environment(LocationService())
         .environment(BestNowClock())
@@ -1128,7 +1130,7 @@ struct BestNowBadge: View {
                 onDismiss: {}
             )
         }
-        .background(Color(red: 0xF5/255, green: 0xF0/255, blue: 0xE8/255))
+        .background(CT.surfaceSunken)
         .environment(UserPreferences(defaults: UserDefaults(suiteName: "preview-a11y")!))
         .environment(locationService)
         .environment(AIService())

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -14,7 +14,7 @@ private struct HeroTitleOffsetKey: PreferenceKey {
 /// the user might want before going. Real Inconveniences are surfaced as
 /// prominently as the recommendation — that is the product's brand.
 public struct ExperienceDetailView: View {
-    @State var viewModel: ExperienceDetailViewModel
+    @State internal var viewModel: ExperienceDetailViewModel
     var onClose: () -> Void
     var onMarkDone: ((_ experience: Experience) -> Void)?
     /// US-004: When non-nil, render the "Ask Solo about this" button (subject
@@ -66,20 +66,20 @@ public struct ExperienceDetailView: View {
     // MARK: - Traveler co-build UI state
     /// Loaded notes/corrections for this place (refreshed from the store on
     /// appear + after every mutation).
-    @State var notes: [TravelerNote] = []
-    @State var corrections: [PlaceCorrection] = []
+    @State internal var notes: [TravelerNote] = []
+    @State internal var corrections: [PlaceCorrection] = []
     /// Notes the current user has tapped "我也确认" on this session.
-    @State var confirmedNoteIds: Set<String> = []
-    @State var notesFilter: NoteFilter = .all
-    @State var notesExpanded = false
+    @State internal var confirmedNoteIds: Set<String> = []
+    @State internal var notesFilter: NoteFilter = .all
+    @State internal var notesExpanded = false
     /// Picked mood chips + free-text in the quick-add row.
-    @State var pickedMoods: Set<String> = []
-    @State var noteDraft: String = ""
+    @State internal var pickedMoods: Set<String> = []
+    @State internal var noteDraft: String = ""
     /// Whether the current user has contributed anything this session — bumps
     /// the hero "L{n} · {n} 信号" line and shows a one-shot toast.
-    @State var userContributed = false
-    @State var levelToast: String? = nil
-    @State var levelToastTask: Task<Void, Never>? = nil
+    @State internal var userContributed = false
+    @State internal var levelToast: String? = nil
+    @State internal var levelToastTask: Task<Void, Never>? = nil
     @State private var barsAppeared = false
 
     /// Notes feed filter segments.
@@ -501,7 +501,7 @@ public struct ExperienceDetailView: View {
                 if let romanized, !romanized.isEmpty {
                     Text(romanized)
                         .font(CT.mono(12.5))
-                        .foregroundStyle(CT.fgSubtle)
+                        .foregroundStyle(CT.fgMuted)
                     Text(local)
                         .font(CT.body(13))
                         .foregroundStyle(CT.fgMuted)
@@ -520,6 +520,9 @@ public struct ExperienceDetailView: View {
     private var levelSignalText: String {
         let level = 1 + (userContributed ? 1 : 0)
         let signals = notes.count + (userContributed ? 1 : 0)
+        if signals == 0 {
+            return NSLocalizedString("notes.signals.aiEstimate", comment: "AI estimate label for cold-start")
+        }
         return "L\(level) · \(signals) " + NSLocalizedString("notes.signals", comment: "signals unit")
     }
 
@@ -544,8 +547,10 @@ public struct ExperienceDetailView: View {
                 .font(.system(size: 9))
             Text(NSLocalizedString(labelKey, comment: "Trust state label"))
                 .font(CT.mono(10))
-            Text("· \(signals)")
-                .font(CT.mono(10))
+            if signals > 0 {
+                Text("· \(signals)")
+                    .font(CT.mono(10))
+            }
         }
         .foregroundStyle(fg)
         .padding(.horizontal, 8)
@@ -866,7 +871,7 @@ public struct ExperienceDetailView: View {
                             .lineLimit(1)
                         Text(String(format: "%.4f, %.4f", coord.latitude, coord.longitude))
                             .font(CT.mono(10.5))
-                            .foregroundStyle(CT.fgSubtle)
+                            .foregroundStyle(CT.fgMuted)
                     }
                     Spacer(minLength: 0)
                     Button {
@@ -943,21 +948,21 @@ public struct ExperienceDetailView: View {
                     mins
                 )
                 symbol = "clock.badge.exclamationmark"
-                background = Color.orange.opacity(0.15)
-                tint = Color.orange
+                background = CT.warningSoft
+                tint = CT.warningText
             } else if let minutesLeft {
                 label = String(
                     format: NSLocalizedString("bestTimes.now.pill.left", comment: "Good now with minutes left pill"),
                     minutesLeft
                 )
                 symbol = "clock.badge.checkmark"
-                background = Color.green.opacity(0.15)
-                tint = Color.green
+                background = CT.successSoft
+                tint = CT.successText
             } else {
                 label = NSLocalizedString("bestTimes.now.pill", comment: "Good time now pill")
                 symbol = "clock.badge.checkmark"
-                background = Color.green.opacity(0.15)
-                tint = Color.green
+                background = CT.successSoft
+                tint = CT.successText
             }
         } else if let hint {
             label = String(format: NSLocalizedString("bestTimes.next.pill", comment: "Better at time pill"), hint)
@@ -1327,14 +1332,14 @@ public struct ExperienceDetailView: View {
             HStack(spacing: 6) {
                 Image(systemName: "checkmark.seal.fill")
                     .font(.caption2)
-                    .foregroundStyle(.green)
+                    .foregroundStyle(CT.verifiedGreen)
                 Text(NSLocalizedString("detail.multiSource.indicator", comment: "Verified by multiple sources indicator"))
                     .font(.caption.weight(.medium))
                     .foregroundStyle(.secondary)
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
-            .background(Capsule().fill(Color.green.opacity(0.08)))
+            .background(Capsule().fill(CT.successSoft))
             .accessibilityElement(children: .combine)
             .accessibilityLabel(Text(NSLocalizedString("detail.multiSource.indicator.a11y", comment: "Verified by multiple sources accessibility label")))
         }
@@ -1490,6 +1495,7 @@ public struct ExperienceDetailView: View {
                 }
                 Text(exp.title)
                     .font(.caption.bold())
+                    .foregroundStyle(CT.fgPrimary)
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -1498,7 +1504,7 @@ public struct ExperienceDetailView: View {
             .frame(width: 180, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.gray.opacity(0.08))
+                    .fill(CT.surfaceSunken)
             )
         }
 
@@ -1566,7 +1572,7 @@ public struct ExperienceDetailView: View {
             } label: {
                 Text(NSLocalizedString("itinerary.toast.viewAction", comment: "View itinerary button in success toast"))
                     .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(Color.accentColor)
+                    .foregroundStyle(CT.accent)
             }
         }
         .padding(.horizontal, 16)
@@ -1774,7 +1780,7 @@ private struct CompassDirectionView: View {
                 // Arrow pointing toward the experience
                 Image(systemName: "location.north.fill")
                     .font(.system(size: 28, weight: .semibold))
-                    .foregroundStyle(Color.accentColor)
+                    .foregroundStyle(CT.accent)
                     .rotationEffect(.degrees(relBearing))
                     .animation(
                         reduceMotion ? nil : .easeInOut(duration: 0.25),

--- a/apps/ios/SoloCompass/Views/Experience/LocationCard.swift
+++ b/apps/ios/SoloCompass/Views/Experience/LocationCard.swift
@@ -76,7 +76,7 @@ struct LocationCard: View {
             HStack(alignment: .top, spacing: 10) {
                 Image(systemName: "mappin.circle.fill")
                     .font(.title3)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(CT.savedRed)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(displayName)
                         .font(.subheadline.weight(.semibold))
@@ -95,7 +95,7 @@ struct LocationCard: View {
                                     .fixedSize(horizontal: false, vertical: true)
                                 Image(systemName: didCopy ? "checkmark.circle.fill" : "doc.on.doc")
                                     .font(.caption2)
-                                    .foregroundStyle(didCopy ? Color.green : Color.secondary.opacity(0.6))
+                                    .foregroundStyle(didCopy ? CT.verifiedGreen : Color.secondary.opacity(0.6))
                                     .contentTransition(.symbolEffect(.replace))
                                     .accessibilityHidden(true)
                             }
@@ -146,7 +146,7 @@ struct LocationCard: View {
                     .frame(minHeight: 44)
                     .background(
                         LinearGradient(
-                            colors: [Color.accentColor, Color.accentColor.opacity(0.85)],
+                            colors: [CT.accent, CT.accent.opacity(0.85)],
                             startPoint: .topLeading,
                             endPoint: .bottomTrailing
                         ),
@@ -166,14 +166,14 @@ struct LocationCard: View {
                     VStack(spacing: 2) {
                         Image(systemName: didCopy ? "checkmark.circle.fill" : "doc.on.doc")
                             .contentTransition(.symbolEffect(.replace))
-                            .foregroundStyle(didCopy ? Color.green : Color.secondary)
+                            .foregroundStyle(didCopy ? CT.verifiedGreen : Color.secondary)
                         if didCopy {
                             Text(copyPayload.isAddress
                                 ? NSLocalizedString("location.copiedAddress", comment: "Address copied confirmation")
                                 : NSLocalizedString("location.copied", comment: "Coordinates copied confirmation")
                             )
                             .font(.caption2)
-                            .foregroundStyle(Color.green)
+                            .foregroundStyle(CT.verifiedGreen)
                         }
                     }
                     .frame(width: 44, height: 44)

--- a/apps/ios/SoloCompass/Views/Experience/MicroSurveySheet.swift
+++ b/apps/ios/SoloCompass/Views/Experience/MicroSurveySheet.swift
@@ -30,9 +30,9 @@ public struct MicroSurveySheet: View {
         }
         var color: Color {
             switch self {
-            case .yes:     return .green
-            case .depends: return .orange
-            case .no:      return .red
+            case .yes:     return CT.verifiedGreen
+            case .depends: return CT.warningText
+            case .no:      return CT.savedRed
             }
         }
     }
@@ -272,7 +272,7 @@ private struct StarRatingRow: View {
 
     private func starColor(_ star: Int) -> Color {
         guard star <= value else { return Color(.systemGray4) }
-        return value <= 2 ? .red : value == 3 ? .orange : .green
+        return value <= 2 ? CT.savedRed : value == 3 ? CT.warningText : CT.verifiedGreen
     }
 }
 

--- a/apps/ios/SoloCompass/Views/Experience/ReportIssueSheet.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ReportIssueSheet.swift
@@ -80,7 +80,7 @@ public struct ReportIssueSheet: View {
 
     private var counterColor: Color {
         let ratio = Double(detail.count) / Double(detailLimit)
-        if detail.count >= detailLimit { return .red }
+        if detail.count >= detailLimit { return CT.savedRed }
         if ratio >= 0.8 { return .orange }
         return .secondary
     }
@@ -93,12 +93,12 @@ public struct ReportIssueSheet: View {
                 HStack(spacing: 12) {
                     Image(systemName: reason.symbol)
                         .frame(width: 24)
-                        .foregroundStyle(reason == selectedReason ? .red : .secondary)
+                        .foregroundStyle(reason == selectedReason ? CT.savedRed : .secondary)
                         .accessibilityHidden(true)
                     Text(reason.label)
                     Spacer()
                     if reason == selectedReason {
-                        Image(systemName: "checkmark").foregroundStyle(.red).fontWeight(.semibold)
+                        Image(systemName: "checkmark").foregroundStyle(CT.savedRed).fontWeight(.semibold)
                             .accessibilityHidden(true)
                     }
                 }
@@ -111,7 +111,7 @@ public struct ReportIssueSheet: View {
                 .accessibilityAddTraits(reason == selectedReason ? [.isButton, .isSelected] : .isButton)
                 .accessibilityHint(NSLocalizedString("report.reason.hint", comment: "Describes that selecting a reason reveals an optional details field"))
                 .listRowBackground(reason == selectedReason
-                    ? Color.red.opacity(0.06)
+                    ? CT.savedRedSoft
                     : Color(.secondarySystemGroupedBackground))
             }
         } header: {

--- a/apps/ios/SoloCompass/Views/Experience/Share/ShareCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/Share/ShareCardView.swift
@@ -330,21 +330,21 @@ private func makePreviewPayload() -> ShareCardPayload {
 
 #Preview("Xiaohongshu 9:16") {
     ShareCardView(payload: makePreviewPayload(), style: .xiaohongshuPortrait)
-        .border(Color.gray.opacity(0.3))
+        .border(CT.borderSubtle)
 }
 
 #Preview("Twitter 1.91:1") {
     ShareCardView(payload: makePreviewPayload(), style: .twitterLandscape)
-        .border(Color.gray.opacity(0.3))
+        .border(CT.borderSubtle)
 }
 
 #Preview("Instagram 1:1") {
     ShareCardView(payload: makePreviewPayload(), style: .instagramSquare)
-        .border(Color.gray.opacity(0.3))
+        .border(CT.borderSubtle)
 }
 
 #Preview("Minimal Text") {
     ShareCardView(payload: makePreviewPayload(), style: .minimalText)
-        .border(Color.gray.opacity(0.3))
+        .border(CT.borderSubtle)
 }
 #endif

--- a/apps/ios/SoloCompass/Views/Experience/Share/ShareSheet.swift
+++ b/apps/ios/SoloCompass/Views/Experience/Share/ShareSheet.swift
@@ -66,7 +66,7 @@ struct ShareSheet: View {
                 if let status = statusMessage {
                     Text(status)
                         .font(.caption)
-                        .foregroundStyle(statusIsError ? Color.red : Color.green)
+                        .foregroundStyle(statusIsError ? CT.savedRed : CT.verifiedGreen)
                         .transition(.opacity)
                 }
                 actionButtons
@@ -105,7 +105,7 @@ struct ShareSheet: View {
                             .padding(.horizontal, 14)
                             .padding(.vertical, 8)
                             .background(
-                                Capsule().fill(selectedMode == mode ? Color.accentColor : Color(.secondarySystemBackground))
+                                Capsule().fill(selectedMode == mode ? CT.accent : Color(.secondarySystemBackground))
                             )
                             .foregroundStyle(selectedMode == mode ? .white : .primary)
                     }

--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -269,13 +269,8 @@ public struct FilterBarView: View {
                 // intrinsic height keeps the bar one pill-row tall.
                 .fixedSize(horizontal: false, vertical: true)
                 .onAppear {
-                    // Cold-launch alignment: always start with the bar's leading
-                    // edge visible so `Now` / `All` sit at the left of the screen
-                    // instead of being pushed off by `scrollTo(_:.center)` when a
-                    // deeper selection (Saved, a category tag) was restored.
-                    // Selection changes still center as before.
                     if selectionID == "all" || selectionID == "now" {
-                        proxy.scrollTo(selectionID, anchor: .leading)
+                        proxy.scrollTo("now", anchor: .leading)
                     } else {
                         proxy.scrollTo(selectionID, anchor: .center)
                     }
@@ -522,7 +517,7 @@ public struct FilterBarView: View {
     /// the app; the inline count mirrors the All/Now chips' visual language.
     private func favoritePill(isSelected: Bool, action: @escaping () -> Void) -> some View {
         let label = NSLocalizedString("filter.saved", comment: "Saved (favourites filter)")
-        let tint = Color(red: 0xE0/255, green: 0x3A/255, blue: 0x3A/255)
+        let tint = CT.savedRed
         return Button {
             if !isSelected && resultCount > 0 {
                 if !didCelebrateSaved {
@@ -583,7 +578,7 @@ public struct FilterBarView: View {
             // bar (Now/All/Saved/category) so the row reads as one component
             // instead of a parade of red/orange/green outlines. The category
             // identity color survives as the inline glyph tint (heart icon).
-            .foregroundStyle(isSelected ? .white : CT.fgPrimary)
+            .foregroundStyle(isSelected ? .white : .primary)
             .background {
                 if isSelected {
                     Capsule()
@@ -653,7 +648,7 @@ public struct FilterBarView: View {
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 8)
-            .foregroundStyle(isOn ? .white : CT.fgPrimary)
+            .foregroundStyle(isOn ? .white : .primary)
             .background {
                 if isOn {
                     Capsule()
@@ -705,7 +700,7 @@ public struct FilterBarView: View {
             // neutral border. Category identity color stays as the inline glyph
             // tint (the `category.symbol` Image keeps its colored stroke via the
             // base foregroundStyle, but text and border read as one system.
-            .foregroundStyle(isSelected ? .white : CT.fgPrimary)
+            .foregroundStyle(isSelected ? .white : .primary)
             .background {
                 if isSelected {
                     Capsule()
@@ -735,20 +730,20 @@ public struct FilterBarView: View {
             Image(systemName: "tag.fill")
                 .font(.body.weight(.semibold))
                 .frame(width: 36, height: 36)
-                .foregroundStyle(isSelected ? .white : Color.accentColor)
+                .foregroundStyle(isSelected ? .white : CT.accent)
                 .background {
                     if isSelected {
                         Circle()
-                            .fill(Color.accentColor)
+                            .fill(CT.accent)
                             .matchedGeometryEffect(id: "filterHighlight", in: pillHighlight)
                     }
                 }
                 .overlay(
-                    Circle().stroke(isSelected ? Color.clear : Color.accentColor.opacity(0.4), lineWidth: 1)
+                    Circle().stroke(isSelected ? Color.clear : CT.accent.opacity(0.4), lineWidth: 1)
                 )
                 .overlay(alignment: .topTrailing) {
                     if isSelected && resultCount > 0 {
-                        countBadge(count: resultCount, tint: .accentColor)
+                        countBadge(count: resultCount, tint: CT.accent)
                             .offset(x: 6, y: -6)
                             .opacity(countBadgeOpacity)
                             .transition(.scale.combined(with: .opacity))
@@ -845,7 +840,7 @@ private struct FilterViewportWidthKey: PreferenceKey {
         )
     }
     .padding(.vertical)
-    .background(Color(red: 0xF5/255, green: 0xF0/255, blue: 0xE8/255))
+    .background(CT.surfaceSunken)
     .environment(UserPreferences())
 }
 
@@ -876,7 +871,7 @@ private struct FilterViewportWidthKey: PreferenceKey {
                 .buttonStyle(.bordered)
             }
             .padding()
-            .background(Color(red: 0xF5/255, green: 0xF0/255, blue: 0xE8/255))
+            .background(CT.surfaceSunken)
             .environment(UserPreferences())
         }
     }
@@ -904,7 +899,7 @@ private struct FilterViewportWidthKey: PreferenceKey {
                     .font(.caption.monospacedDigit())
             }
             .padding()
-            .background(Color(red: 0xF5/255, green: 0xF0/255, blue: 0xE8/255))
+            .background(CT.surfaceSunken)
             .environment(UserPreferences())
         }
     }

--- a/apps/ios/SoloCompass/Views/Friends/AddFriendSheet.swift
+++ b/apps/ios/SoloCompass/Views/Friends/AddFriendSheet.swift
@@ -100,7 +100,7 @@ public struct AddFriendSheet: View {
             if let errorMessage {
                 Text(errorMessage)
                     .font(.subheadline)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(CT.savedRed)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 12)
                     .background(.regularMaterial, in: Capsule())
@@ -172,7 +172,7 @@ public struct AddFriendSheet: View {
                             : NSLocalizedString("friends.add.copy.hint", comment: "Long-press to copy hint")
                     )
                     .font(.caption)
-                    .foregroundStyle(didCopy ? Color.green : .secondary)
+                    .foregroundStyle(didCopy ? CT.verifiedGreen : .secondary)
                     .contentTransition(.opacity)
                 }
                 .accessibilityElement(children: .combine)
@@ -290,7 +290,7 @@ public struct AddFriendSheet: View {
                 if let redeemError {
                     Text(redeemError)
                         .font(.subheadline)
-                        .foregroundStyle(.red)
+                        .foregroundStyle(CT.savedRed)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 24)
                         .transition(.opacity)
@@ -355,7 +355,7 @@ public struct AddFriendSheet: View {
                         .foregroundStyle(.white)
                         .padding(.horizontal, 16)
                         .padding(.vertical, 12)
-                        .background(Color.green, in: Capsule())
+                        .background(CT.verifiedGreen, in: Capsule())
                         .padding(.bottom, 24)
                         .transition(.move(edge: .bottom).combined(with: .opacity))
                 }

--- a/apps/ios/SoloCompass/Views/Friends/FriendsHubView.swift
+++ b/apps/ios/SoloCompass/Views/Friends/FriendsHubView.swift
@@ -32,6 +32,8 @@ struct FriendsHubView: View {
     @State private var isLoadingMyCode = false
     @State private var didCopy = false
 
+    @Environment(\.colorScheme) private var colorScheme
+
     init(service: FriendService = .shared) {
         _service = State(initialValue: service)
     }
@@ -60,7 +62,7 @@ struct FriendsHubView: View {
             .padding(.top, 12)
             .padding(.bottom, 32)
         }
-        .background(CT.bgWarm)
+        .background(pageBg)
         .scrollDismissesKeyboard(.interactively)
         .navigationTitle(NSLocalizedString("me.friends", comment: "Friends"))
         .navigationBarTitleDisplayMode(.inline)
@@ -71,6 +73,14 @@ struct FriendsHubView: View {
         .sheet(item: $resolvedProfile) { profile in previewSheet(profile: profile) }
     }
 
+    // MARK: - Dark mode adaptive colors
+
+    private var pageBg: Color { colorScheme == .dark ? CT.warmSheetDark : CT.bgWarm }
+    private var cardBg: Color { colorScheme == .dark ? CT.warmCardDark : CT.surfaceWhite }
+    private var cardBorder: Color { colorScheme == .dark ? CT.warmBorderDark : CT.borderSubtle }
+    private var titleColor: Color { colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary }
+    private var subtleColor: Color { colorScheme == .dark ? CT.fgMutedDark : CT.fgSubtle }
+
     // MARK: - Inline search bar (friend code + scan)
 
     private var searchBar: some View {
@@ -78,7 +88,7 @@ struct FriendsHubView: View {
             HStack(spacing: 8) {
                 Image(systemName: "magnifyingglass")
                     .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(CT.fgSubtle)
+                    .foregroundStyle(subtleColor)
 
                 TextField(
                     NSLocalizedString("friends.inline.search.placeholder", comment: "Friend code search placeholder"),
@@ -113,10 +123,10 @@ struct FriendsHubView: View {
             .frame(height: 48)
             .background(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(CT.surfaceWhite)
+                    .fill(cardBg)
                     .overlay(
                         RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .stroke(CT.borderSubtle, lineWidth: 1)
+                            .stroke(cardBorder, lineWidth: 1)
                     )
             )
 
@@ -130,7 +140,7 @@ struct FriendsHubView: View {
                     .frame(width: 48, height: 48)
                     .background(
                         RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .fill(CT.accentSoft)
+                            .fill(colorScheme == .dark ? CT.warmSunkenDark : CT.accentSoft)
                     )
             }
             .accessibilityLabel(Text(NSLocalizedString("friends.inline.scan.a11y", comment: "Scan friend QR")))
@@ -168,16 +178,16 @@ struct FriendsHubView: View {
                             : NSLocalizedString("friends.inline.myCode.show", comment: "Show my code")
                     )
                     .font(.subheadline.weight(.medium))
-                    .foregroundStyle(CT.fgPrimary)
+                    .foregroundStyle(titleColor)
                     Spacer()
                     if let myCode, !showMyCode {
                         Text(myCode.rawValue)
                             .font(.system(.caption, design: .monospaced))
-                            .foregroundStyle(CT.fgSubtle)
+                            .foregroundStyle(subtleColor)
                     }
                     Image(systemName: "chevron.down")
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(CT.fgSubtle)
+                        .foregroundStyle(subtleColor)
                         .rotationEffect(.degrees(showMyCode ? 180 : 0))
                 }
                 .padding(.horizontal, 14)
@@ -186,17 +196,17 @@ struct FriendsHubView: View {
             .buttonStyle(.plain)
 
             if showMyCode {
-                Divider().overlay(CT.borderSubtle)
+                Divider().overlay(cardBorder)
                 myCodeExpanded
                     .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
         .background(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(CT.surfaceWhite)
+                .fill(cardBg)
                 .overlay(
                     RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .stroke(CT.borderSubtle, lineWidth: 1)
+                        .stroke(cardBorder, lineWidth: 1)
                 )
         )
     }
@@ -216,7 +226,7 @@ struct FriendsHubView: View {
                     .background(Color.white, in: RoundedRectangle(cornerRadius: 18))
                     .overlay(
                         RoundedRectangle(cornerRadius: 18)
-                            .stroke(CT.borderSubtle, lineWidth: 1)
+                            .stroke(cardBorder, lineWidth: 1)
                     )
                     .accessibilityLabel(NSLocalizedString("friends.add.qr.a11y", comment: "QR a11y"))
 
@@ -224,7 +234,7 @@ struct FriendsHubView: View {
                     Text(myCode.rawValue)
                         .font(.system(.title3, design: .monospaced).weight(.bold))
                         .tracking(2)
-                        .foregroundStyle(CT.fgPrimary)
+                        .foregroundStyle(titleColor)
                         .textSelection(.enabled)
                     Text(
                         didCopy
@@ -232,7 +242,7 @@ struct FriendsHubView: View {
                             : NSLocalizedString("friends.add.copy.hint", comment: "Copy hint")
                     )
                     .font(.caption)
-                    .foregroundStyle(didCopy ? CT.verifiedGreen : CT.fgSubtle)
+                    .foregroundStyle(didCopy ? CT.verifiedGreen : subtleColor)
                     .contentTransition(.opacity)
                 }
 
@@ -294,16 +304,16 @@ struct FriendsHubView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title)
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(CT.fgSubtle)
+                .foregroundStyle(subtleColor)
                 .textCase(.uppercase)
                 .padding(.leading, 4)
             VStack(spacing: 0) { content() }
                 .background(
                     RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .fill(CT.surfaceWhite)
+                        .fill(cardBg)
                         .overlay(
                             RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                .stroke(CT.borderSubtle, lineWidth: 1)
+                                .stroke(cardBorder, lineWidth: 1)
                         )
                 )
         }
@@ -317,7 +327,7 @@ struct FriendsHubView: View {
                 .background(Circle().fill(CT.accentSoft))
             Text(label)
                 .font(.subheadline)
-                .foregroundStyle(CT.fgPrimary)
+                .foregroundStyle(titleColor)
                 .lineLimit(1)
             Spacer()
         }
@@ -329,13 +339,13 @@ struct FriendsHubView: View {
         VStack(spacing: 8) {
             Image(systemName: "person.2")
                 .font(.system(size: 32, weight: .light))
-                .foregroundStyle(CT.fgSubtle)
+                .foregroundStyle(subtleColor)
             Text(NSLocalizedString("me.friends.empty.title", comment: "Empty title"))
                 .font(.subheadline.weight(.semibold))
-                .foregroundStyle(CT.fgPrimary)
+                .foregroundStyle(titleColor)
             Text(NSLocalizedString("me.friends.empty.description", comment: "Empty description"))
                 .font(.caption)
-                .foregroundStyle(CT.fgSubtle)
+                .foregroundStyle(subtleColor)
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity)
@@ -388,7 +398,7 @@ struct FriendsHubView: View {
                         .foregroundStyle(.white)
                         .padding(.horizontal, 16)
                         .padding(.vertical, 12)
-                        .background(Color.green, in: Capsule())
+                        .background(CT.verifiedGreen, in: Capsule())
                         .padding(.bottom, 24)
                         .transition(.move(edge: .bottom).combined(with: .opacity))
                 }

--- a/apps/ios/SoloCompass/Views/Friends/FriendsListView.swift
+++ b/apps/ios/SoloCompass/Views/Friends/FriendsListView.swift
@@ -72,10 +72,10 @@ public struct FriendsListView: View {
                             .contentTransition(.numericText())
                     }
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(Color.orange)
+                    .foregroundStyle(CT.warningText)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 5)
-                    .background(Color.orange.opacity(0.15), in: Capsule())
+                    .background(CT.warningSoft, in: Capsule())
                     .animation(.easeInOut, value: pendingCount)
                     .accessibilityLabel(String(format: NSLocalizedString("friends.list.pending.count.a11y", comment: "VoiceOver: pending requests count"), pendingCount))
                 }
@@ -119,7 +119,7 @@ public struct FriendsListView: View {
                         .font(.subheadline)
                         .lineLimit(2)
                 }
-                .foregroundStyle(.red)
+                .foregroundStyle(CT.savedRed)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 12)
                 .background(.regularMaterial, in: Capsule())
@@ -257,7 +257,7 @@ public struct FriendsListView: View {
                             Text(AvatarEmoji.emoji(for: otherId))
                                 .font(.system(size: 32))
                                 .frame(width: 56, height: 56)
-                                .background(Circle().fill(Color.accentColor.opacity(0.12)))
+                                .background(Circle().fill(CT.accent.opacity(0.12)))
                             Text(otherId)
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
@@ -465,7 +465,7 @@ private struct ConnectedBadge: View {
     var body: some View {
         HStack(spacing: 6) {
             Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(.green)
+                .foregroundStyle(CT.verifiedGreen)
             Text(NSLocalizedString("friends.connected.label", comment: "Connected badge label"))
                 .font(.subheadline.weight(.semibold))
         }
@@ -508,7 +508,7 @@ private struct IncomingRequestRow: View {
                 Text(AvatarEmoji.emoji(for: request.requesterId))
                     .font(.system(size: 24))
                     .frame(width: 40, height: 40)
-                    .background(Circle().fill(Color.accentColor.opacity(0.12)))
+                    .background(Circle().fill(CT.accent.opacity(0.12)))
                     .accessibilityHidden(true)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(NSLocalizedString("friends.list.request.from", comment: "Request from label"))
@@ -570,7 +570,7 @@ private struct FriendRow: View {
             Text(AvatarEmoji.emoji(for: userId))
                 .font(.system(size: 22))
                 .frame(width: 36, height: 36)
-                .background(Circle().fill(Color.accentColor.opacity(0.12)))
+                .background(Circle().fill(CT.accent.opacity(0.12)))
                 .accessibilityHidden(true)
             Text(userId)
                 .font(.body)
@@ -595,11 +595,11 @@ private struct EmptyFriendsView: View {
         VStack(spacing: 12) {
             ZStack {
                 Circle()
-                    .fill(Color.accentColor.opacity(0.12))
+                    .fill(CT.accent.opacity(0.12))
                     .frame(width: 80, height: 80)
                 Image(systemName: "person.2")
                     .font(.system(size: 36))
-                    .foregroundStyle(Color.accentColor.opacity(0.7))
+                    .foregroundStyle(CT.accent.opacity(0.7))
                     .scaleEffect(isBreathing ? 1.08 : 0.94)
                     .opacity(isBreathing ? 1.0 : 0.7)
                     .animation(

--- a/apps/ios/SoloCompass/Views/Map/ActiveRouteOverlay.swift
+++ b/apps/ios/SoloCompass/Views/Map/ActiveRouteOverlay.swift
@@ -31,7 +31,7 @@ struct RouteStopBadge: View {
             .font(.system(size: 13, weight: .bold))
             .foregroundStyle(.white)
             .frame(width: 26, height: 26)
-            .background(Circle().fill(Color.accentColor))
+            .background(Circle().fill(CT.accent))
             .overlay(Circle().strokeBorder(.white, lineWidth: 2))
             .shadow(color: .black.opacity(0.2), radius: 2, y: 1)
             .accessibilityLabel(Text(String(
@@ -57,7 +57,7 @@ struct ActiveRouteBanner: View {
         HStack(spacing: 10) {
             Image(systemName: "figure.walk")
                 .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(CT.accent)
             VStack(alignment: .leading, spacing: 1) {
                 Text(title)
                     .font(.subheadline.weight(.semibold))

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -228,7 +228,7 @@ public struct BottomInfoSheet<Content: View>: View {
     /// pre-building: once the user has expanded, the list stays constructed
     /// across collapses so re-expansion never pays the build cost again.
     @State private var hasEverExpanded: Bool = BottomInfoSheet.initialDetent != .peek
-    @State var sortMode: SortMode = .smart
+    @State private var sortMode: SortMode = .smart
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.colorScheme) private var colorScheme
 
@@ -665,7 +665,7 @@ struct NowHintRow: View {
         HStack(spacing: 6) {
             Image(systemName: "sunset.fill")
                 .font(.caption)
-                .foregroundStyle(.orange)
+                .foregroundStyle(CT.sunGold)
             Text(hint)
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -812,7 +812,7 @@ struct SortModeSheet: View {
                         if sortMode == mode {
                             Image(systemName: "checkmark")
                                 .font(.body.weight(.semibold))
-                                .foregroundStyle(Color.accentColor)
+                                .foregroundStyle(CT.accent)
                                 .transition(.scale.combined(with: .opacity))
                         }
                     }
@@ -822,7 +822,7 @@ struct SortModeSheet: View {
                         Group {
                             if sortMode == mode {
                                 RoundedRectangle(cornerRadius: 10)
-                                    .fill(Color.accentColor.opacity(0.10))
+                                    .fill(CT.accentSoft)
                                     .padding(.horizontal, 8)
                             }
                         }

--- a/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/CityPickerSheet.swift
@@ -11,6 +11,7 @@ public struct CityPickerSheet: View {
     @State private var justSelectedCode: String? = nil
     @State private var citySearchText = ""
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
 
     private func selectCity(_ code: String?) {
         Haptics.impact(.light)
@@ -67,7 +68,7 @@ public struct CityPickerSheet: View {
                                         Spacer()
                                         if viewModel.selectedCity == nil {
                                             Image(systemName: "checkmark")
-                                                .foregroundStyle(.tint)
+                                                .foregroundStyle(colorScheme == .dark ? CT.sunGold : CT.accent)
                                                 .font(.body.weight(.semibold))
                                                 .scaleEffect(reduceMotion ? 1.0 : (justSelectedCode == "all" ? 1.3 : 1.0))
                                                 .symbolEffect(.bounce, value: reduceMotion ? nil : justSelectedCode)
@@ -100,7 +101,7 @@ public struct CityPickerSheet: View {
                                         VStack(alignment: .trailing, spacing: 2) {
                                             if viewModel.selectedCity == city.code {
                                                 Image(systemName: "checkmark")
-                                                    .foregroundStyle(.tint)
+                                                    .foregroundStyle(colorScheme == .dark ? CT.sunGold : CT.accent)
                                                     .font(.body.weight(.semibold))
                                                     .scaleEffect(reduceMotion ? 1.0 : (justSelectedCode == city.code ? 1.3 : 1.0))
                                                     .symbolEffect(.bounce, value: reduceMotion ? nil : justSelectedCode)
@@ -197,7 +198,7 @@ public struct CityPickerSheet: View {
 
         var color: Color {
             switch self {
-            case .near: return .green
+            case .near: return CT.verifiedGreen
             case .mid: return .orange
             case .far: return Color(.tertiaryLabel)
             }
@@ -331,16 +332,17 @@ private struct CityPickerHeader: View {
 private struct CityEmptyStateView: View {
     @State private var isBreathing = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         VStack(spacing: 12) {
             ZStack {
                 Circle()
-                    .fill(Color.accentColor.opacity(0.12))
+                    .fill((colorScheme == .dark ? CT.sunGold : CT.accent).opacity(0.12))
                     .frame(width: 80, height: 80)
                 Image(systemName: "map.circle")
                     .font(.system(size: 48))
-                    .foregroundStyle(Color.accentColor.opacity(0.7))
+                    .foregroundStyle((colorScheme == .dark ? CT.sunGold : CT.accent).opacity(0.7))
                     .scaleEffect(isBreathing ? 1.08 : 0.94)
                     .opacity(isBreathing ? 1.0 : 0.7)
                     // Guard on the modifier itself, not just in onAppear — otherwise

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -356,7 +356,8 @@ struct CompassMapContentView: View {
     /// controls hug the sheet without crowding it.
     private var controlBarBottomInset: CGFloat {
         let controlSheetGap: CGFloat = 8
-        return sheetPeekClearance + controlSheetGap
+        let base = sheetPeekClearance + controlSheetGap
+        return cityOSBottomSlotOccupied ? base + 60 : base
     }
 
     // MARK: - City OS v2 helpers
@@ -571,7 +572,9 @@ struct CompassMapContentView: View {
                 // (MeSheet) on launch so its layout can be screenshotted without an
                 // avatar-bubble tap (idb/simctl tapping is unreliable on Xcode 26).
                 if ProcessInfo.processInfo.arguments.contains("-openMe") {
-                    isShowingMe = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        isShowingMe = true
+                    }
                 }
                 // Visual-verification entry point: `-openExperience` opens the
                 // richest available experience's detail sheet directly, so the
@@ -607,6 +610,16 @@ struct CompassMapContentView: View {
                     chatStartMode = .text
                     chatDetent = .medium
                     ensureOrchestrator(viewModel: viewModel)
+                }
+                if ProcessInfo.processInfo.arguments.contains("-openCityPicker") {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                        isShowingCityPicker = true
+                    }
+                }
+                if ProcessInfo.processInfo.arguments.contains("-openSettings") {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        viewModel.isShowingSettings = true
+                    }
                 }
                 // Visual-verification entry point: `-forceDiagnosticsChat`
                 // seeds a synthetic diagnostics finding and immediately
@@ -1115,33 +1128,35 @@ struct CompassMapContentView: View {
                 if viewModel.visibleExperiences.isEmpty
                     && !isFilterActive
                     && !viewModel.exploreSession.isActive {
-                    EmptyStateOverlay(
-                        viewModel: viewModel,
-                        preferences: preferences,
-                        locationService: locationService
-                    )
+                    VStack {
+                        Spacer()
+                        EmptyStateOverlay(
+                            viewModel: viewModel,
+                            preferences: preferences,
+                            locationService: locationService
+                        )
+                        .padding(.bottom, sheetPeekClearance + 16)
+                    }
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                     .animation(.easeOut(duration: 0.35), value: viewModel.visibleExperiences.isEmpty)
                 } else if viewModel.visibleExperiences.isEmpty && isFilterActive && viewModel.selectedExperience == nil
                     && viewModel.highlightedEventId == nil {
-                    // The "Now" filter is a *time* filter, not a place filter — its
-                    // empty state means "nothing's at its best this hour", for which
-                    // "clear all filters" is the wrong recovery. Route it to a
-                    // dedicated overlay that points at the next worthwhile window
-                    // instead. Every other filter keeps the generic clear-filters card.
-                    // Suppressed entirely while an event marker is focused
-                    // ("Show on map") — the user asked to look at the map, and
-                    // this card would sit exactly over the marker.
                     if viewModel.isNowFilter {
-                        NowEmptyOverlay(viewModel: viewModel)
-                            .padding(.bottom, cityOSBottomSlotOccupied ? 112 : 0)
-                            .transition(.move(edge: .bottom).combined(with: .opacity))
-                            .animation(.easeOut(duration: 0.35), value: viewModel.visibleExperiences.isEmpty)
+                        VStack {
+                            Spacer()
+                            NowEmptyOverlay(viewModel: viewModel)
+                                .padding(.bottom, sheetPeekClearance + 16 + (cityOSBottomSlotOccupied ? 52 : 0))
+                        }
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                        .animation(.easeOut(duration: 0.35), value: viewModel.visibleExperiences.isEmpty)
                     } else {
-                        FilteredEmptyOverlay(viewModel: viewModel)
-                            .padding(.bottom, cityOSBottomSlotOccupied ? 112 : 0)
-                            .transition(.move(edge: .bottom).combined(with: .opacity))
-                            .animation(.easeOut(duration: 0.35), value: viewModel.visibleExperiences.isEmpty)
+                        VStack {
+                            Spacer()
+                            FilteredEmptyOverlay(viewModel: viewModel)
+                                .padding(.bottom, sheetPeekClearance + 16 + (cityOSBottomSlotOccupied ? 52 : 0))
+                        }
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                        .animation(.easeOut(duration: 0.35), value: viewModel.visibleExperiences.isEmpty)
                     }
                 }
 
@@ -2328,7 +2343,7 @@ struct CompassMapContentView: View {
                                                 .foregroundStyle(.white)
                                                 .padding(.horizontal, 4)
                                                 .padding(.vertical, 1)
-                                                .background(Capsule().fill(Color.gray.opacity(0.85)))
+                                                .background(Capsule().fill(CT.fgMuted))
                                         }
                                     }
                                     .modifier(SmartPickHighlightModifier(
@@ -2755,6 +2770,7 @@ private struct MapOverlayView: View {
             }
 
             let showEmptyFilterBanner = isFilterActive && viewModel.visibleExperiences.isEmpty
+                && !viewModel.isNowFilter
             if showEmptyFilterBanner {
                 EmptyFilterBanner(
                     filterName: activeFilterName,
@@ -2788,7 +2804,7 @@ private struct MapOverlayView: View {
                 DismissibleBanner(
                     systemImage: "exclamationmark.triangle.fill",
                     text: errorText,
-                    color: .orange,
+                    color: CT.warningText,
                     onDismiss: { dismissedAIError = errorText }
                 )
             }
@@ -2799,7 +2815,7 @@ private struct MapOverlayView: View {
                     // match the sibling error banners' warning glyph.
                     systemImage: "exclamationmark.triangle.fill",
                     text: exploreError,
-                    color: .orange,
+                    color: CT.warningText,
                     onDismiss: { dismissedExploreError = exploreError }
                 )
                 .accessibilityIdentifier("exploreErrorBanner")
@@ -2809,7 +2825,7 @@ private struct MapOverlayView: View {
                 DismissibleBanner(
                     systemImage: "clock.badge.exclamationmark",
                     text: quotaInfo,
-                    color: Color(red: 0.8, green: 0.6, blue: 0),
+                    color: CT.warningText,
                     onDismiss: { dismissedQuotaInfo = quotaInfo }
                 )
                 .accessibilityIdentifier("quotaBanner")
@@ -2820,7 +2836,7 @@ private struct MapOverlayView: View {
                 DismissibleBanner(
                     systemImage: "location.slash.fill",
                     text: locationError,
-                    color: .orange,
+                    color: CT.warningText,
                     actionLabel: NSLocalizedString("location.banner.openSettings", comment: "Open Settings"),
                     onAction: {
                         if let url = URL(string: UIApplication.openSettingsURLString) {
@@ -2879,7 +2895,7 @@ private struct MapOverlayView: View {
                         ? "magnifyingglass" : "checkmark.circle.fill")
                         .font(.caption)
                         .foregroundStyle(toast == NSLocalizedString("voice.result.none", comment: "No matching places found nearby")
-                            ? Color.secondary : Color.green)
+                            ? Color.secondary : CT.verifiedGreen)
                     Text(toast)
                         .font(.caption.weight(.medium))
                         .foregroundStyle(.primary)
@@ -2937,11 +2953,10 @@ private struct MapOverlayView: View {
     @ViewBuilder
     private var filterResultBadge: some View {
         let count = viewModel.visibleExperiences.count
-        let accentGold = Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)
         let dotColor: Color = {
             if let cat = viewModel.selectedCategory { return cat.color }
-            if viewModel.isNowFilter { return accentGold }
-            return Color.accentColor
+            if viewModel.isNowFilter { return CT.sunGold }
+            return CT.accent
         }()
 
         if count == 0 {
@@ -2973,14 +2988,14 @@ private struct MapOverlayView: View {
                         HStack(spacing: 6) {
                             ZStack {
                                 Circle()
-                                    .stroke(accentGold.opacity(0.25), lineWidth: 2)
+                                    .stroke(CT.sunGold.opacity(0.25), lineWidth: 2)
                                 Circle()
                                     .trim(from: 0, to: progress)
-                                    .stroke(accentGold, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                                    .stroke(CT.sunGold, style: StrokeStyle(lineWidth: 2, lineCap: .round))
                                     .rotationEffect(.degrees(-90))
                                     .animation(reduceMotion ? nil : .easeInOut, value: progress)
                                 Circle()
-                                    .fill(accentGold)
+                                    .fill(CT.sunGold)
                                     .frame(width: 8, height: 8)
                             }
                             .frame(width: 14, height: 14)
@@ -2992,7 +3007,7 @@ private struct MapOverlayView: View {
                                 .foregroundStyle(.secondary)
                             Text(upcomingText)
                                 .font(.caption.weight(.semibold))
-                                .foregroundStyle(accentGold)
+                                .foregroundStyle(CT.sunGold)
                                 .contentTransition(.numericText())
                                 .animation(reduceMotion ? nil : .easeInOut, value: minutesUntil)
                         }
@@ -3118,6 +3133,11 @@ private struct MapOverlayView: View {
             if let code = viewModel.selectedCity,
                let city = viewModel.availableCities.first(where: { $0.code == code }) {
                 return city.name
+            }
+            // Resolve via alias table (e.g. CNX → cmi → "Chiang Mai")
+            if let code = viewModel.selectedCity,
+               let resolved = viewModel.resolvedCityName(for: code) {
+                return resolved
             }
             if let code = viewModel.nearestSeededCity(to: viewModel.defaultCenterForSelectedCity),
                let city = viewModel.availableCities.first(where: { $0.code == code }) {
@@ -3290,7 +3310,7 @@ private struct EmptyFilterBanner: View {
                 } label: {
                     Text(NSLocalizedString("filter.empty.showAll", comment: "Show all experiences button"))
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(Color.accentColor)
+                        .foregroundStyle(CT.accent)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(Text(NSLocalizedString("filter.empty.showAll.a11y", comment: "Show all experiences")))
@@ -3479,7 +3499,7 @@ private struct PlusActionButton: View {
         ZStack {
             // Ring that grows during the hold to telegraph "almost there".
             Circle()
-                .stroke(Color.accentColor.opacity(isPressed ? 0.5 : 0.0), lineWidth: 3)
+                .stroke(CT.accent.opacity(isPressed ? 0.5 : 0.0), lineWidth: 3)
                 .frame(width: 64, height: 64)
                 .scaleEffect(ringPulse ? 1.18 : 1.0)
                 .opacity(ringPulse ? 0.0 : 1.0)
@@ -3547,6 +3567,7 @@ private struct EmptyStateOverlay: View {
     var preferences: UserPreferences
     var locationService: LocationService
 
+    @Environment(\.colorScheme) private var colorScheme
     @State private var isVisible = false
 
     private var nearestCityName: String? {
@@ -3559,67 +3580,59 @@ private struct EmptyStateOverlay: View {
     }
 
     var body: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "mappin.slash")
-                .font(.title2)
-                .foregroundStyle(.secondary)
-            Text(NSLocalizedString("map.empty.title", comment: "No experiences nearby"))
-                .font(.subheadline.weight(.medium))
-            Text(String(
-                format: NSLocalizedString("map.empty.radius", comment: "No experiences within radius"),
-                preferences.maxDistanceKm
-            ))
-            .font(.caption)
-            .foregroundStyle(.secondary)
+        let cardBg = colorScheme == .dark ? CT.warmCardDark : CT.surfaceWhite
+
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                ZStack {
+                    Circle()
+                        .fill(CT.surfaceSunken)
+                        .frame(width: 36, height: 36)
+                    Image(systemName: "mappin.slash")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(CT.fgMuted)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(NSLocalizedString("map.empty.title", comment: "No experiences nearby"))
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary)
+                    Text(String(
+                        format: NSLocalizedString("map.empty.radius", comment: "No experiences within radius"),
+                        preferences.maxDistanceKm
+                    ))
+                    .font(.caption)
+                    .foregroundStyle(CT.fgMuted)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 14)
+            .padding(.top, 12)
+            .padding(.bottom, 10)
+
+            Divider()
+                .padding(.horizontal, 14)
 
             VStack(spacing: 8) {
-                // US-012: a single stage-driven primary action replaces the old
-                // static button stack. The view model picks which stage we're
-                // in based on consecutive empty renders + whether the user
-                // already tried Expand.
                 switch viewModel.emptyStateStage {
                 case .tryExpand:
-                    Button {
-                        viewModel.emptyStateActionTryExpand()
-                    } label: {
-                        Text(NSLocalizedString(
-                            "map.empty.stage.tryExpand",
-                            comment: "Stage 1: expand search radius to 25km"
-                        ))
-                        .font(.subheadline.weight(.medium))
-                        .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.regular)
+                    stageButton(
+                        title: NSLocalizedString("map.empty.stage.tryExpand", comment: "Stage 1: expand search radius to 25km"),
+                        action: { viewModel.emptyStateActionTryExpand() }
+                    )
                 case .tryExplore:
-                    Button {
-                        viewModel.emptyStateActionTryExplore()
-                    } label: {
-                        Text(NSLocalizedString(
-                            "map.empty.stage.tryExplore",
-                            comment: "Stage 2: widen Overpass explore to 12km"
-                        ))
-                        .font(.subheadline.weight(.medium))
-                        .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.regular)
+                    stageButton(
+                        title: NSLocalizedString("map.empty.stage.tryExplore", comment: "Stage 2: widen Overpass explore to 12km"),
+                        action: { viewModel.emptyStateActionTryExplore() }
+                    )
                 case .browseCity:
-                    Button {
-                        viewModel.emptyStateActionBrowseCity()
-                    } label: {
-                        Text(String(
-                            format: NSLocalizedString(
-                                "map.empty.stage.browseCity",
-                                comment: "Stage 3: jump to nearest seeded city"
-                            ),
+                    stageButton(
+                        title: String(
+                            format: NSLocalizedString("map.empty.stage.browseCity", comment: "Stage 3: jump to nearest seeded city"),
                             nearestCityName ?? ""
-                        ))
-                        .font(.subheadline.weight(.medium))
-                        .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.regular)
+                        ),
+                        action: { viewModel.emptyStateActionBrowseCity() }
+                    )
                 }
 
                 Button {
@@ -3627,25 +3640,58 @@ private struct EmptyStateOverlay: View {
                 } label: {
                     Text(NSLocalizedString("map.empty.clearFilters", comment: "Clear all filters"))
                         .font(.subheadline)
+                        .foregroundStyle(CT.fgMuted)
                         .frame(maxWidth: .infinity)
+                        .padding(.vertical, 9)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                .strokeBorder(colorScheme == .dark ? CT.warmBorderDark : CT.borderDefault, lineWidth: 1)
+                        )
                 }
-                .buttonStyle(.bordered)
-                .controlSize(.regular)
+                .buttonStyle(.plain)
             }
+            .padding(.horizontal, 14)
+            .padding(.top, 10)
+            .padding(.bottom, 12)
         }
-        .padding(16)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
-        .padding(.horizontal, 32)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(cardBg)
+                .shadow(color: CT.scrimShadow, radius: 12, y: 4)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(colorScheme == .dark ? CT.warmBorderDark : CT.borderSubtle, lineWidth: 0.5)
+        )
+        .padding(.horizontal, 24)
         .opacity(isVisible ? 1 : 0)
-        .offset(y: isVisible ? 0 : 16)
+        .offset(y: isVisible ? 0 : 12)
         .accessibilityElement(children: .combine)
         .onAppear {
             viewModel.recordEmptyStateRender()
-            withAnimation(.easeOut(duration: 0.35)) { isVisible = true }
+            withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) { isVisible = true }
         }
         .onChange(of: viewModel.visibleExperiences.count) { _, _ in
             viewModel.recordEmptyStateRender()
         }
+    }
+
+    private func stageButton(title: String, action: @escaping () -> Void) -> some View {
+        Button {
+            Haptics.selection()
+            action()
+        } label: {
+            Text(title)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 11)
+                .background(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(CT.accent)
+                )
+        }
+        .buttonStyle(.plain)
     }
 }
 
@@ -3653,6 +3699,7 @@ private struct FilteredEmptyOverlay: View {
     var viewModel: MapViewModel
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
     @State private var appeared = false
     @State private var iconPulse = false
 
@@ -3668,40 +3715,67 @@ private struct FilteredEmptyOverlay: View {
     }
 
     var body: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "line.3.horizontal.decrease.circle")
-                .font(.title2)
-                .foregroundStyle(.secondary)
-                .scaleEffect(reduceMotion ? 1.0 : (appeared ? (iconPulse ? 1.06 : 0.97) : 0.4))
-                .opacity(appeared ? 1 : 0)
-            Text(NSLocalizedString("map.filtered.empty.title", comment: "Nothing matches this filter"))
-                .font(.subheadline.weight(.medium))
-            Text(String(
-                format: NSLocalizedString("map.filtered.empty.subtitle", comment: "Filter name subtitle"),
-                activeFilterName
-            ))
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            .multilineTextAlignment(.center)
+        let cardBg = colorScheme == .dark ? CT.warmCardDark : CT.surfaceWhite
+
+        HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(CT.surfaceSunken)
+                    .frame(width: 36, height: 36)
+                Image(systemName: "line.3.horizontal.decrease.circle")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(CT.fgMuted)
+                    .scaleEffect(reduceMotion ? 1.0 : (iconPulse ? 1.05 : 0.95))
+            }
+            .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(NSLocalizedString("map.filtered.empty.title", comment: "Nothing matches this filter"))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary)
+                Text(String(
+                    format: NSLocalizedString("map.filtered.empty.subtitle", comment: "Filter name subtitle"),
+                    activeFilterName
+                ))
+                .font(.caption)
+                .foregroundStyle(CT.fgMuted)
+            }
+            Spacer(minLength: 0)
+
             Button {
                 Haptics.selection()
                 viewModel.clearFilters()
             } label: {
                 Text(NSLocalizedString("map.empty.clearFilters", comment: "Clear all filters"))
-                    .font(.subheadline.weight(.medium))
-                    .frame(maxWidth: .infinity)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(CT.accent)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(
+                        Capsule().fill(CT.accentSoft)
+                    )
             }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.regular)
+            .buttonStyle(.plain)
         }
-        .padding(16)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
-        .padding(.horizontal, 32)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(cardBg)
+                .shadow(color: CT.scrimShadow, radius: 12, y: 4)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(colorScheme == .dark ? CT.warmBorderDark : CT.borderSubtle, lineWidth: 0.5)
+        )
+        .padding(.horizontal, 24)
+        .opacity(appeared ? 1 : 0)
+        .offset(y: appeared ? 0 : 12)
         .accessibilityElement(children: .combine)
         .onAppear {
-            withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) { appeared = true }
+            withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) { appeared = true }
             if !reduceMotion {
-                withAnimation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true)) {
+                withAnimation(.easeInOut(duration: 2.0).repeatForever(autoreverses: true)) {
                     iconPulse = true
                 }
             }
@@ -3710,7 +3784,7 @@ private struct FilteredEmptyOverlay: View {
             if reduced {
                 withAnimation(nil) { iconPulse = false }
             } else {
-                withAnimation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true)) {
+                withAnimation(.easeInOut(duration: 2.0).repeatForever(autoreverses: true)) {
                     iconPulse = true
                 }
             }
@@ -3748,13 +3822,10 @@ private struct NowEmptyOverlay: View {
     var viewModel: MapViewModel
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
     @State private var appeared = false
     @State private var iconPulse = false
 
-    private static let accentGold = Color(red: 0xD4 / 255, green: 0xA8 / 255, blue: 0x43 / 255)
-
-    /// Compact "Nm" / "~Nh" tail mirroring the map marker's `upcomingLabel`
-    /// convention so the same duration reads identically across surfaces.
     private static func relativeOpensIn(minutes: Int) -> String {
         let m = max(1, minutes)
         if m < 60 {
@@ -3764,10 +3835,6 @@ private struct NowEmptyOverlay: View {
     }
 
     var body: some View {
-        // Re-tick every minute so "~2h" decays and, when a window crosses the
-        // 180-minute line into "imminent", control hands back to the filter-bar
-        // countdown capsule (this overlay collapses to nothing) without any user
-        // action — the gate below is re-evaluated on the same clock.
         TimelineView(.periodic(from: .now, by: 60)) { context in
             content(now: context.date)
         }
@@ -3775,8 +3842,6 @@ private struct NowEmptyOverlay: View {
 
     @ViewBuilder
     private func content(now: Date) -> some View {
-        // When something is imminent the filter-bar capsule already guides the
-        // user; suppress this overlay so the two surfaces never double up.
         if viewModel.nextBestExperience(now: now) != nil {
             EmptyView()
         } else {
@@ -3787,63 +3852,68 @@ private struct NowEmptyOverlay: View {
     @ViewBuilder
     private func quietHours(now: Date) -> some View {
         let soonest = viewModel.soonestUpcomingExperience(now: now)
+        let cardBg = colorScheme == .dark ? CT.warmCardDark : CT.surfaceWhite
 
-        VStack(spacing: 12) {
-            Image(systemName: "moon.stars")
-                .font(.title2)
-                .foregroundStyle(Self.accentGold)
-                .scaleEffect(reduceMotion ? 1.0 : (appeared ? (iconPulse ? 1.06 : 0.97) : 0.4))
-                .opacity(appeared ? 1 : 0)
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                ZStack {
+                    Circle()
+                        .fill(CT.sunGoldSoft)
+                        .frame(width: 36, height: 36)
+                    Image(systemName: "moon.stars")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(CT.sunGoldDeep)
+                        .scaleEffect(reduceMotion ? 1.0 : (iconPulse ? 1.05 : 0.95))
+                }
                 .accessibilityHidden(true)
 
-            Text(NSLocalizedString("filter.now.empty.title", comment: "Quiet hours right now — nothing at its best"))
-                .font(.subheadline.weight(.medium))
-                .multilineTextAlignment(.center)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(NSLocalizedString("filter.now.empty.title", comment: "Quiet hours right now — nothing at its best"))
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary)
+                    Text(NSLocalizedString("filter.now.empty.later.subtitle", comment: "Best times pick back up later today"))
+                        .font(.caption)
+                        .foregroundStyle(CT.fgMuted)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 14)
+            .padding(.top, 12)
+            .padding(.bottom, soonest != nil ? 10 : 12)
 
             if let soonest {
-                // Case 2: a worthwhile window opens later today.
                 let title = soonest.experience.title
                 let timeHint = soonest.experience.bestTimeHint(at: now)
                 let relative = Self.relativeOpensIn(minutes: soonest.minutesUntil)
 
-                Text(NSLocalizedString("filter.now.empty.later.subtitle", comment: "Best times pick back up later today"))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
+                Divider()
+                    .padding(.horizontal, 14)
 
                 Button {
                     Haptics.impact(.light)
                     viewModel.openExperienceDetail(soonest.experience)
                 } label: {
-                    HStack(spacing: 8) {
-                        VStack(alignment: .leading, spacing: 1) {
+                    HStack(spacing: 10) {
+                        VStack(alignment: .leading, spacing: 2) {
                             Text(NSLocalizedString("filter.now.empty.nextBest", comment: "Next best label"))
-                                .font(.caption2.weight(.semibold))
-                                .foregroundStyle(Self.accentGold)
+                                .font(CT.mono(10, .semibold))
+                                .foregroundStyle(CT.sunGoldDeep)
                                 .textCase(.uppercase)
                             Text(title)
-                                .font(.subheadline.weight(.semibold))
-                                .foregroundStyle(.primary)
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary)
                                 .lineLimit(1)
-                            if let timeHint {
-                                Text(timeHint + "  ·  " + relative)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            } else {
-                                Text(relative)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
+                            Text((timeHint.map { $0 + "  ·  " } ?? "") + relative)
+                                .font(.caption)
+                                .foregroundStyle(CT.fgMuted)
                         }
                         Spacer(minLength: 4)
                         Image(systemName: "chevron.right")
                             .font(.caption.weight(.semibold))
-                            .foregroundStyle(.tertiary)
+                            .foregroundStyle(CT.fgSubtle)
                     }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                    .padding(.horizontal, 12)
-                    .background(Self.accentGold.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
                 }
                 .buttonStyle(.plain)
                 .accessibilityElement(children: .ignore)
@@ -3852,23 +3922,27 @@ private struct NowEmptyOverlay: View {
                     format: NSLocalizedString("filter.now.empty.nextBest.a11y", comment: "Next best %@ %@; tap to view"),
                     title, timeHint ?? relative
                 )))
-
-                browseAllButton(prominent: false)
-            } else {
-                // Case 3: nothing opens again today.
-                Text(NSLocalizedString("filter.now.empty.done.subtitle", comment: "Best times resume tomorrow"))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-
-                browseAllButton(prominent: true)
             }
+
+            browseAllButton
+                .padding(.horizontal, 14)
+                .padding(.bottom, 12)
+                .padding(.top, 8)
         }
-        .padding(16)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
-        .padding(.horizontal, 32)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(cardBg)
+                .shadow(color: CT.scrimShadow, radius: 12, y: 4)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(colorScheme == .dark ? CT.warmBorderDark : CT.borderSubtle, lineWidth: 0.5)
+        )
+        .padding(.horizontal, 24)
+        .opacity(appeared ? 1 : 0)
+        .offset(y: appeared ? 0 : 12)
         .onAppear {
-            withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) { appeared = true }
+            withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) { appeared = true }
             startIconPulseIfNeeded()
         }
         .onChange(of: reduceMotion) { _, reduced in
@@ -3880,26 +3954,27 @@ private struct NowEmptyOverlay: View {
         }
     }
 
-    @ViewBuilder
-    private func browseAllButton(prominent: Bool) -> some View {
+    private var browseAllButton: some View {
         Button {
             Haptics.selection()
-            // Filters are mutually exclusive, so with only "Now" active this
-            // simply drops back to every nearby experience.
             viewModel.clearFilters()
         } label: {
             Text(NSLocalizedString("filter.now.empty.browseAll", comment: "Browse all nearby experiences"))
                 .font(.subheadline.weight(.medium))
+                .foregroundStyle(CT.accent)
                 .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(CT.accentSoft)
+                )
         }
-        .buttonStyle(.borderedProminent)
-        .controlSize(.regular)
-        .opacity(prominent ? 1 : 0.9)
+        .buttonStyle(.plain)
     }
 
     private func startIconPulseIfNeeded() {
         guard !reduceMotion else { return }
-        withAnimation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true)) {
+        withAnimation(.easeInOut(duration: 2.0).repeatForever(autoreverses: true)) {
             iconPulse = true
         }
     }

--- a/apps/ios/SoloCompass/Views/Map/ExploreConsentSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/ExploreConsentSheet.swift
@@ -29,7 +29,7 @@ struct ExploreConsentSheet: View {
                 // optical bounds below the grabber on every device class.
                 Image(systemName: "sparkle.magnifyingglass")
                     .font(.system(size: 36, weight: .light))
-                    .foregroundStyle(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255))
+                    .foregroundStyle(CT.sunGold)
                     .frame(width: 56, height: 56)
                     .padding(.top, 28)
                     .accessibilityHidden(true)
@@ -74,7 +74,7 @@ struct ExploreConsentSheet: View {
                         .frame(height: 52)
                         .background(
                             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                                .fill(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255))
+                                .fill(CT.sunGold)
                         )
                 }
                 .buttonStyle(.plain)
@@ -100,7 +100,7 @@ struct ExploreConsentSheet: View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: icon)
                 .font(.system(size: 18))
-                .foregroundStyle(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255))
+                .foregroundStyle(CT.sunGold)
                 .frame(width: 24, alignment: .center)
             Text(text)
                 .font(.callout)

--- a/apps/ios/SoloCompass/Views/Map/ExploreProgressBar.swift
+++ b/apps/ios/SoloCompass/Views/Map/ExploreProgressBar.swift
@@ -35,7 +35,7 @@ struct ExploreProgressBar: View {
 
 #Preview("Scanning ring 2 of 4") {
     ZStack {
-        Color.gray.opacity(0.2).ignoresSafeArea()
+        CT.surfaceSunken.ignoresSafeArea()
         VStack {
             Spacer()
             ExploreProgressBar(progress: .multiRingScanning(ringsDone: 2, totalRings: 4))
@@ -46,7 +46,7 @@ struct ExploreProgressBar: View {
 
 #Preview("Synthesizing 47 places") {
     ZStack {
-        Color.gray.opacity(0.2).ignoresSafeArea()
+        CT.surfaceSunken.ignoresSafeArea()
         VStack {
             Spacer()
             ExploreProgressBar(progress: .synthesizing(poiCount: 47))
@@ -57,7 +57,7 @@ struct ExploreProgressBar: View {
 
 #Preview("Idle — hidden") {
     ZStack {
-        Color.gray.opacity(0.2).ignoresSafeArea()
+        CT.surfaceSunken.ignoresSafeArea()
         VStack {
             Spacer()
             ExploreProgressBar(progress: .idle)

--- a/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
@@ -150,7 +150,7 @@ struct LocationPickerSheet: View {
                     Spacer()
                     if viewModel.selectedCity == nil {
                         Image(systemName: "checkmark")
-                            .foregroundStyle(.tint)
+                            .foregroundStyle(CT.accent)
                             .font(.body.weight(.semibold))
                     }
                 }
@@ -285,10 +285,10 @@ struct LocationPickerSheet: View {
             if state.searchSaveConfirmed {
                 HStack(spacing: 6) {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
+                        .foregroundStyle(CT.verifiedGreen)
                     Text(NSLocalizedString("locationPicker.search.saveCity.confirmed", comment: "City saved!"))
                         .font(.subheadline.weight(.medium))
-                        .foregroundStyle(.green)
+                        .foregroundStyle(CT.verifiedGreen)
                 }
                 .padding(.vertical, 6)
                 .transition(.move(edge: .top).combined(with: .opacity))
@@ -386,18 +386,18 @@ struct LocationPickerSheet: View {
                     } else if state.mapSaveConfirmed {
                         HStack(spacing: 6) {
                             Image(systemName: "checkmark.circle.fill")
-                                .foregroundStyle(.green)
+                                .foregroundStyle(CT.verifiedGreen)
                                 .font(.title3)
                                 .symbolEffect(.bounce, value: reduceMotion ? false : state.mapSaveConfirmed)
                             Text(NSLocalizedString("locationPicker.map.saveCity.confirmed", comment: "Location saved!"))
                                 .font(.subheadline.weight(.semibold))
-                                .foregroundStyle(.green)
+                                .foregroundStyle(CT.verifiedGreen)
                         }
                         .transition(.scale.combined(with: .opacity))
                     } else if let name = state.resolvedCityName {
                         HStack(spacing: 6) {
                             Image(systemName: "checkmark.circle.fill")
-                                .foregroundStyle(.green)
+                                .foregroundStyle(CT.verifiedGreen)
                                 .font(.caption)
                             Text(String(
                                 format: NSLocalizedString("locationPicker.map.resolved", comment: "Resolved city: %@"),
@@ -630,7 +630,7 @@ private struct CityRow: View {
         HStack(spacing: 10) {
             Image(systemName: icon)
                 .font(.caption)
-                .foregroundStyle(experienceCount != nil ? Color.accentColor : Color.indigo)
+                .foregroundStyle(experienceCount != nil ? CT.accent : Color.indigo)
                 .frame(width: 18)
 
             VStack(alignment: .leading, spacing: 2) {
@@ -654,7 +654,7 @@ private struct CityRow: View {
             VStack(alignment: .trailing, spacing: 2) {
                 if isSelected {
                     Image(systemName: "checkmark")
-                        .foregroundStyle(.tint)
+                        .foregroundStyle(CT.accent)
                         .font(.body.weight(.semibold))
                 }
                 Text(distanceLabel)

--- a/apps/ios/SoloCompass/Views/Map/MapPinPickerView.swift
+++ b/apps/ios/SoloCompass/Views/Map/MapPinPickerView.swift
@@ -33,7 +33,7 @@ struct MapPinPickerView: View {
                 ) {
                     Image(systemName: "mappin.circle.fill")
                         .font(.title)
-                        .foregroundStyle(.red, .white)
+                        .foregroundStyle(CT.savedRed, .white)
                         .shadow(radius: 4)
                 }
             }

--- a/apps/ios/SoloCompass/Views/Map/MarkerIconView.swift
+++ b/apps/ios/SoloCompass/Views/Map/MarkerIconView.swift
@@ -73,7 +73,7 @@ public struct MarkerIconView: View {
     private var bestNowTint: Color {
         showsClosingSoon
             ? Self.closingSoonAmber
-            : Color(red: 0xD4 / 255, green: 0xA8 / 255, blue: 0x43 / 255)
+            : CT.sunGold
     }
 
     /// US-035: a `bestNow` marker should show the extra "Now" sync ring only
@@ -284,12 +284,12 @@ public struct MarkerIconView: View {
         case .completed:
             Image(systemName: "checkmark.circle.fill")
                 .font(.title3.bold())
-                .foregroundStyle(.white, .green)
+                .foregroundStyle(.white, CT.verifiedGreen)
                 .offset(x: 12, y: 12)
         case .favorited:
             Image(systemName: "heart.fill")
                 .font(.caption)
-                .foregroundStyle(.red)
+                .foregroundStyle(CT.savedRed)
                 .padding(3)
                 .background(Circle().fill(.white))
                 .offset(x: 12, y: -12)
@@ -310,7 +310,7 @@ public struct MarkerIconView: View {
                 .font(.caption2)
                 .foregroundStyle(.white)
                 .padding(3)
-                .background(Circle().fill(Color.gray))
+                .background(Circle().fill(CT.fgMuted))
                 .offset(x: 12, y: 12)
         case .bestNow:
             // US-049: a small alarm-clock badge marks a best-now window that's
@@ -339,7 +339,7 @@ public struct MarkerIconView: View {
 
     private func upcomingTint(minutes: Int) -> Color {
         switch minutes {
-        case ...15: return .red
+        case ...15: return CT.savedRed
         case ...45: return .orange
         default:    return Color.black.opacity(0.85)
         }
@@ -481,5 +481,5 @@ private struct ObsidianDotGridMarker: View {
         }
         .padding()
     }
-    .background(Color(red: 0xF5/255, green: 0xF0/255, blue: 0xE8/255))
+    .background(CT.surfaceSunken)
 }

--- a/apps/ios/SoloCompass/Views/Map/NearbyExperienceRow.swift
+++ b/apps/ios/SoloCompass/Views/Map/NearbyExperienceRow.swift
@@ -146,7 +146,12 @@ struct NearbyExperienceRow: View {
             .background(cardBackground)
             .overlay(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .strokeBorder(isSmartPick ? CT.accentBorder : CT.borderSubtle, lineWidth: 0.5)
+                    .strokeBorder(
+                        colorScheme == .dark
+                            ? CT.warmBorderDark
+                            : (isSmartPick ? CT.accentBorder : CT.borderSubtle),
+                        lineWidth: 0.5
+                    )
             )
             .overlay(alignment: .leading) {
                 // Left color-bar: golden for smart picks, else the category tint.
@@ -343,6 +348,7 @@ struct NearbyExperienceRow: View {
                         )
                 }
                 Spacer(minLength: 4)
+                ConfidenceBadge(confidence: experience.confidence, compact: true)
                 TrustBadge(level: experience.trustBadgeLevel, size: .compact)
                     .layoutPriority(1)
             }
@@ -585,10 +591,15 @@ struct NearbyExperienceRow: View {
     }
 
     private var subtitleText: String {
+        let title = experience.title
         let parts = [
             experience.location.placeNameRomanized,
             experience.location.placeNameLocal
-        ].compactMap { $0?.isEmpty == false ? $0 : nil }
+        ].compactMap { name -> String? in
+            guard let name, !name.isEmpty else { return nil }
+            // Hide name parts that duplicate the title verbatim
+            return name.caseInsensitiveCompare(title) == .orderedSame ? nil : name
+        }
         if parts.isEmpty {
             return experience.location.addressHint ?? ""
         }

--- a/apps/ios/SoloCompass/Views/Map/NearbySectionView.swift
+++ b/apps/ios/SoloCompass/Views/Map/NearbySectionView.swift
@@ -355,13 +355,15 @@ private struct NearbyRowSkeleton: View {
         .padding(12)
         .background(
             RoundedRectangle(cornerRadius: 14)
-                .fill(Color(uiColor: .systemGray6))
+                .fill(colorScheme == .dark ? CT.warmSunkenDark : CT.surfaceSunken)
         )
     }
 
+    @Environment(\.colorScheme) private var colorScheme
+
     private var shimmerFill: some ShapeStyle {
-        let base = Color(uiColor: .systemGray5)
-        let highlight = Color.white.opacity(0.6)
+        let base = colorScheme == .dark ? CT.warmSunkenDark : CT.surfaceSunken
+        let highlight = colorScheme == .dark ? CT.warmCardDark : CT.surfaceWhite
         let center = (shimmerPhase + 1) / 2
         return LinearGradient(
             stops: [
@@ -399,6 +401,7 @@ struct EmptySheetListView: View {
     var onSwitchToSuggestedCity: (() -> Void)? = nil
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
     @State private var breathing = false
 
     var localizedEmptyText: String {
@@ -432,11 +435,11 @@ struct EmptySheetListView: View {
                         .opacity(breathing ? 0.7 : 1.0)
                     Text(NSLocalizedString("empty.now.latenight.headline", comment: "Late night Now empty headline"))
                         .font(.headline)
-                        .foregroundStyle(CT.fgPrimary)
+                        .foregroundStyle(colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary)
                         .multilineTextAlignment(.center)
                     Text(NSLocalizedString("empty.now.latenight.subtitle", comment: "Late night Now empty subtitle"))
                         .font(.subheadline)
-                        .foregroundStyle(CT.fgMuted)
+                        .foregroundStyle(colorScheme == .dark ? CT.fgMutedDark : CT.fgMuted)
                         .multilineTextAlignment(.center)
                 } else if isNowFilter {
                     Image(systemName: "clock.badge.questionmark")
@@ -446,11 +449,11 @@ struct EmptySheetListView: View {
                         .opacity(breathing ? 0.7 : 1.0)
                     Text(NSLocalizedString("empty.now.headline", comment: "Now filter empty headline"))
                         .font(.headline)
-                        .foregroundStyle(CT.fgPrimary)
+                        .foregroundStyle(colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary)
                         .multilineTextAlignment(.center)
                     Text(NSLocalizedString("empty.now.subtitle", comment: "Now filter empty subtitle"))
                         .font(.subheadline)
-                        .foregroundStyle(CT.fgMuted)
+                        .foregroundStyle(colorScheme == .dark ? CT.fgMutedDark : CT.fgMuted)
                         .multilineTextAlignment(.center)
                 } else {
                     Image(systemName: "mappin.slash")
@@ -460,17 +463,17 @@ struct EmptySheetListView: View {
                         .opacity(breathing ? 0.7 : 1.0)
                     Text(NSLocalizedString("empty.nearby.headline", comment: "Empty Nearby headline"))
                         .font(.headline)
-                        .foregroundStyle(CT.fgPrimary)
+                        .foregroundStyle(colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary)
                         .multilineTextAlignment(.center)
                     if hasSuggestedCity {
                         Text(NSLocalizedString("empty.nearby.subtitle.nocity", comment: "Empty Nearby subtitle when city has no data"))
                             .font(.subheadline)
-                            .foregroundStyle(CT.fgMuted)
+                            .foregroundStyle(colorScheme == .dark ? CT.fgMutedDark : CT.fgMuted)
                             .multilineTextAlignment(.center)
                     } else {
                         Text(NSLocalizedString("empty.nearby.subtitle", comment: "Empty Nearby supporting subline"))
                             .font(.subheadline)
-                            .foregroundStyle(CT.fgMuted)
+                            .foregroundStyle(colorScheme == .dark ? CT.fgMutedDark : CT.fgMuted)
                             .multilineTextAlignment(.center)
                     }
                 }

--- a/apps/ios/SoloCompass/Views/Map/POILoadingBanner.swift
+++ b/apps/ios/SoloCompass/Views/Map/POILoadingBanner.swift
@@ -53,7 +53,7 @@ struct POILoadingBanner: View {
                     if bannerState == .succeeded {
                         Image(systemName: "checkmark.circle.fill")
                             .font(.caption.weight(.semibold))
-                            .foregroundStyle(.green)
+                            .foregroundStyle(CT.verifiedGreen)
                             .transition(reduceMotion ? .opacity : .scale.combined(with: .opacity))
                     } else {
                         ProgressView()
@@ -69,7 +69,7 @@ struct POILoadingBanner: View {
                     if bannerState == .succeeded {
                         Text(String(format: NSLocalizedString("map.loadingPOIs.done", comment: "Shown for ~1.2 s after the Overpass fetch completes — %d = number of POIs found"), loadedCount))
                             .font(.caption.weight(.semibold))
-                            .foregroundStyle(.green)
+                            .foregroundStyle(CT.verifiedGreen)
                     } else {
                         Text(isSlow
                              ? NSLocalizedString("map.loadingPOIs.slow", comment: "Reassurance shown when POI fetch exceeds ~6 s")

--- a/apps/ios/SoloCompass/Views/Me/EntitlementBanner.swift
+++ b/apps/ios/SoloCompass/Views/Me/EntitlementBanner.swift
@@ -70,9 +70,6 @@ struct EntitlementBanner: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer(minLength: 0)
-                Image(systemName: "chevron.right")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
             }
             // Progress bar — full at trial start, drains to zero on the
             // last day. tint=amber for trial, intentionally not red so we
@@ -99,9 +96,6 @@ struct EntitlementBanner: View {
                     .foregroundStyle(.secondary)
             }
             Spacer(minLength: 0)
-            Image(systemName: "chevron.right")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
         }
     }
 
@@ -122,9 +116,6 @@ struct EntitlementBanner: View {
                     .foregroundStyle(.secondary)
             }
             Spacer(minLength: 0)
-            Image(systemName: "chevron.right")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
         }
     }
 
@@ -184,9 +175,7 @@ struct EntitlementBanner: View {
 
     // MARK: - Styling
 
-    private var amber: Color {
-        Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)
-    }
+    private var amber: Color { CT.sunGold }
 
     private var backgroundFill: Color {
         switch subscription.entitlement {

--- a/apps/ios/SoloCompass/Views/Me/MeSheet.swift
+++ b/apps/ios/SoloCompass/Views/Me/MeSheet.swift
@@ -215,6 +215,9 @@ struct MeSheet: View {
                 if ProcessInfo.processInfo.arguments.contains("-openArchive") {
                     topTab = .archive
                 }
+                if ProcessInfo.processInfo.arguments.contains("-openSettings") {
+                    showingSettings = true
+                }
                 #endif
             }
         }
@@ -487,11 +490,8 @@ private struct MeRow: View {
                     .foregroundStyle(.white)
                     .padding(.horizontal, 7)
                     .padding(.vertical, 2)
-                    .background(Capsule().fill(Color.red))
+                    .background(Capsule().fill(CT.savedRed))
             }
-            Image(systemName: "chevron.right")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(colorScheme == .dark ? CT.fgMutedDark : CT.fgSubtle)
         }
         .padding(.vertical, 6)
     }
@@ -507,7 +507,7 @@ private struct MeEmptyStateCard: View {
         VStack(spacing: 12) {
             Image(systemName: "map.fill")
                 .font(.system(size: 36))
-                .foregroundStyle(.tint)
+                .foregroundStyle(CT.accent)
 
             Text(NSLocalizedString("me.empty.title", comment: "Empty state title"))
                 .font(.headline)
@@ -515,7 +515,7 @@ private struct MeEmptyStateCard: View {
 
             Text(NSLocalizedString("me.empty.subtitle", comment: "Empty state subtitle"))
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(colorScheme == .dark ? CT.fgMutedDark : CT.fgMuted)
                 .multilineTextAlignment(.center)
 
             Button {
@@ -525,7 +525,7 @@ private struct MeEmptyStateCard: View {
                     .font(.subheadline.weight(.semibold))
                     .padding(.horizontal, 20)
                     .padding(.vertical, 10)
-                    .background(Color.accentColor, in: Capsule())
+                    .background(CT.accent, in: Capsule())
                     .foregroundStyle(.white)
             }
             .padding(.top, 4)
@@ -565,7 +565,7 @@ struct MapAvatarBubble: View {
 
                 if hasPendingRequests {
                     Circle()
-                        .fill(Color.red)
+                        .fill(CT.savedRed)
                         .frame(width: 12, height: 12)
                         .overlay(Circle().stroke(Color.white, lineWidth: 2))
                         .offset(x: 2, y: -2)

--- a/apps/ios/SoloCompass/Views/Onboarding/OnboardingVibeStep.swift
+++ b/apps/ios/SoloCompass/Views/Onboarding/OnboardingVibeStep.swift
@@ -49,7 +49,7 @@ public struct OnboardingVibeStep: View {
             if let lastError = lastError {
                 Text(lastError)
                     .font(.caption)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(CT.savedRed)
             }
         }
         .padding(.horizontal, 24)
@@ -83,7 +83,7 @@ public struct OnboardingVibeStep: View {
     private func photoSlot(at idx: Int) -> some View {
         ZStack {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color(white: 0.95))
+                .fill(Color(.tertiarySystemFill))
             if idx < pickedImages.count {
                 Image(uiImage: pickedImages[idx])
                     .resizable()
@@ -98,7 +98,7 @@ public struct OnboardingVibeStep: View {
         .frame(width: 96, height: 96)
         .overlay(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color(white: 0.85), lineWidth: 1)
+                .stroke(Color(.separator), lineWidth: 1)
         )
         .overlay(alignment: .bottomTrailing) {
             if idx == 0 {
@@ -109,8 +109,8 @@ public struct OnboardingVibeStep: View {
                 ) {
                     Image(systemName: "plus.circle.fill")
                         .font(.title2)
-                        .foregroundStyle(.tint)
-                        .background(Color.white, in: Circle())
+                        .foregroundStyle(CT.accent)
+                        .background(Color(.systemBackground), in: Circle())
                 }
                 .padding(4)
             }

--- a/apps/ios/SoloCompass/Views/Onboarding/OnboardingView.swift
+++ b/apps/ios/SoloCompass/Views/Onboarding/OnboardingView.swift
@@ -142,7 +142,7 @@ public struct OnboardingView: View {
         HStack(spacing: 6) {
             ForEach(0..<Self.totalSteps, id: \.self) { index in
                 Capsule()
-                    .fill(index == step ? Color.accentColor : Color.secondary.opacity(0.3))
+                    .fill(index == step ? CT.accent : Color.secondary.opacity(0.3))
                     .frame(width: index == step ? 20 : 6, height: 6)
                     .animation(.spring(response: 0.4, dampingFraction: 0.7), value: step)
             }
@@ -164,7 +164,7 @@ public struct OnboardingView: View {
             VStack(spacing: 24) {
                 Image(systemName: "map.fill")
                     .font(.system(size: 64))
-                    .foregroundStyle(.tint)
+                    .foregroundStyle(CT.accent)
                     .accessibilityHidden(true)
 
                 VStack(spacing: 8) {
@@ -194,7 +194,7 @@ public struct OnboardingView: View {
                         .font(.headline)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 16)
-                        .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 14))
+                        .background(CT.accent, in: RoundedRectangle(cornerRadius: 14))
                         .foregroundStyle(.white)
                 }
                 .accessibilitySortPriority(OnboardingA11ySortPriority.primaryCTA)
@@ -226,7 +226,7 @@ public struct OnboardingView: View {
             VStack(spacing: 24) {
                 Image(systemName: "sparkles")
                     .font(.system(size: 56))
-                    .foregroundStyle(.tint)
+                    .foregroundStyle(CT.accent)
                     .accessibilityHidden(true)
 
                 VStack(spacing: 8) {
@@ -270,7 +270,7 @@ public struct OnboardingView: View {
                     .font(.headline)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 16)
-                    .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 14))
+                    .background(CT.accent, in: RoundedRectangle(cornerRadius: 14))
                     .foregroundStyle(.white)
             }
             .padding(.horizontal, 24)
@@ -292,7 +292,7 @@ public struct OnboardingView: View {
             VStack(spacing: 24) {
                 Image(systemName: "gauge.open.with.lines.needle.33percent.and.arrowtriangle")
                     .font(.system(size: 56))
-                    .foregroundStyle(.tint)
+                    .foregroundStyle(CT.accent)
                     .accessibilityHidden(true)
 
                 VStack(spacing: 8) {
@@ -336,7 +336,7 @@ public struct OnboardingView: View {
                     .font(.headline)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 16)
-                    .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 14))
+                    .background(CT.accent, in: RoundedRectangle(cornerRadius: 14))
                     .foregroundStyle(.white)
             }
             .padding(.horizontal, 24)
@@ -352,9 +352,9 @@ public struct OnboardingView: View {
         HStack(spacing: 14) {
             Image(systemName: icon)
                 .font(.title3)
-                .foregroundStyle(.tint)
+                .foregroundStyle(CT.accent)
                 .frame(width: 36, height: 36)
-                .background(Color.accentColor.opacity(0.12), in: Circle())
+                .background(CT.accent.opacity(0.12), in: Circle())
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
@@ -422,7 +422,7 @@ public struct OnboardingView: View {
                         .font(.headline)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 16)
-                        .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 14))
+                        .background(CT.accent, in: RoundedRectangle(cornerRadius: 14))
                         .foregroundStyle(.white)
                 }
                 .accessibilitySortPriority(OnboardingA11ySortPriority.primaryCTA)
@@ -517,7 +517,7 @@ public struct OnboardingView: View {
                 // the user sees one visual identity for "Pro" across surfaces.
                 Image(systemName: "sparkles")
                     .font(.system(size: 44, weight: .regular))
-                    .foregroundStyle(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255))
+                    .foregroundStyle(CT.sunGold)
                     .accessibilityHidden(true)
 
                 Text(NSLocalizedString("onboarding.paywall.title", comment: "Trial step title"))
@@ -557,7 +557,7 @@ public struct OnboardingView: View {
                         if paywallPurchaseInFlight {
                             ProgressView()
                                 .progressViewStyle(.circular)
-                                .tint(Color(red: 0x3A/255, green: 0x2A/255, blue: 0x05/255))
+                                .tint(CT.accent)
                         }
                         Text(NSLocalizedString("onboarding.paywall.cta", comment: "Start free month CTA"))
                             .font(.headline)
@@ -565,10 +565,10 @@ public struct OnboardingView: View {
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 16)
                     .background(
-                        Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255),
+                        CT.sunGold,
                         in: RoundedRectangle(cornerRadius: 14)
                     )
-                    .foregroundStyle(Color(red: 0x3A/255, green: 0x2A/255, blue: 0x05/255))
+                    .foregroundStyle(CT.accent)
                 }
                 .disabled(paywallPurchaseInFlight)
                 .accessibilitySortPriority(OnboardingA11ySortPriority.primaryCTA)
@@ -613,7 +613,7 @@ public struct OnboardingView: View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: icon)
                 .font(.body)
-                .foregroundStyle(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255))
+                .foregroundStyle(CT.sunGold)
                 .frame(width: 24)
             Text(NSLocalizedString(key, comment: ""))
                 .font(.subheadline)
@@ -670,10 +670,10 @@ public struct OnboardingView: View {
             HStack(spacing: 14) {
                 Image(systemName: styleIcon(style))
                     .font(.title3)
-                    .foregroundStyle(selected ? Color.white : Color.accentColor)
+                    .foregroundStyle(selected ? Color.white : CT.accent)
                     .frame(width: 36, height: 36)
                     .background(
-                        Circle().fill(selected ? Color.accentColor : Color.accentColor.opacity(0.12))
+                        Circle().fill(selected ? CT.accent : CT.accent.opacity(0.12))
                     )
 
                 VStack(alignment: .leading, spacing: 2) {
@@ -689,16 +689,16 @@ public struct OnboardingView: View {
 
                 if selected {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.tint)
+                        .foregroundStyle(CT.accent)
                 }
             }
             .padding(14)
             .background(
                 RoundedRectangle(cornerRadius: 12)
-                    .fill(selected ? Color.accentColor.opacity(0.08) : Color(.secondarySystemBackground))
+                    .fill(selected ? CT.accent.opacity(0.08) : Color(.secondarySystemBackground))
                     .overlay(
                         RoundedRectangle(cornerRadius: 12)
-                            .stroke(selected ? Color.accentColor : Color.clear, lineWidth: 1.5)
+                            .stroke(selected ? CT.accent : Color.clear, lineWidth: 1.5)
                     )
             )
         }

--- a/apps/ios/SoloCompass/Views/Paywall/PaywallView.swift
+++ b/apps/ios/SoloCompass/Views/Paywall/PaywallView.swift
@@ -102,7 +102,7 @@ public struct PaywallView: View {
         VStack(alignment: .leading, spacing: 8) {
             Image(systemName: "sparkles")
                 .font(.system(size: 36))
-                .foregroundStyle(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255))
+                .foregroundStyle(CT.sunGold)
             Text(NSLocalizedString("paywall.hero.title", comment: "Unlock Solo Compass Pro"))
                 .font(.title.bold())
             Text(NSLocalizedString("paywall.hero.subtitle", comment: "Subtitle"))
@@ -115,7 +115,7 @@ public struct PaywallView: View {
     /// Pulls live monthly displayPrice so the price disclosure satisfies
     /// App Store 3.1.2 without us hard-coding currency-localized strings.
     private var trialBanner: some View {
-        let amber = Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)
+        let amber = CT.sunGold
         let monthly = subscription.products.first(where: { $0.id == SubscriptionService.monthlyProductID })
         let priceCopy: String = {
             if let monthly {
@@ -157,7 +157,7 @@ public struct PaywallView: View {
     /// Status banner for users already inside the trial period — replaces
     /// the "Get 1 month free" pitch with renewal context and a manage link.
     private var midTrialBanner: some View {
-        let amber = Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)
+        let amber = CT.sunGold
         let days = subscription.trialDaysRemaining ?? 0
         let headline: String = {
             let fmt = NSLocalizedString("paywall.midTrial.headline.format",
@@ -212,7 +212,7 @@ public struct PaywallView: View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: icon)
                 .frame(width: 24)
-                .foregroundStyle(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255))
+                .foregroundStyle(CT.sunGold)
             Text(NSLocalizedString(key, comment: ""))
                 .font(.subheadline)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -240,7 +240,7 @@ public struct PaywallView: View {
         let showTrialBadge = isMonthly && introOfferEligible && subscription.entitlement != .proTrial
         // Dark brown for badge text — same WCAG-AA-clear pairing the CTA uses
         // on the amber fill.
-        let badgeText = Color(red: 0x3A/255, green: 0x2A/255, blue: 0x05/255)
+        let badgeText = CT.accent
         return Button {
             selectedProductID = product.id
         } label: {
@@ -255,14 +255,14 @@ public struct PaywallView: View {
                                 .font(.caption2.weight(.bold))
                                 .padding(.horizontal, 6)
                                 .padding(.vertical, 2)
-                                .background(Capsule().fill(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)))
+                                .background(Capsule().fill(CT.sunGold))
                                 .foregroundStyle(badgeText)
                         } else if isYearly {
                             Text(NSLocalizedString("paywall.bestValue", comment: "Best value badge"))
                                 .font(.caption2.weight(.bold))
                                 .padding(.horizontal, 6)
                                 .padding(.vertical, 2)
-                                .background(Capsule().fill(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)))
+                                .background(Capsule().fill(CT.sunGold))
                                 .foregroundStyle(badgeText)
                         }
                     }
@@ -282,13 +282,13 @@ public struct PaywallView: View {
             .padding(14)
             .background(
                 RoundedRectangle(cornerRadius: 12)
-                    .fill(isSelected ? Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255).opacity(0.12) : Color(.secondarySystemBackground))
+                    .fill(isSelected ? CT.sunGold.opacity(0.12) : Color(.secondarySystemBackground))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
                     .stroke(
                         isSelected
-                            ? Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255)
+                            ? CT.sunGold
                             : Color.clear,
                         lineWidth: 2
                     )
@@ -336,7 +336,7 @@ public struct PaywallView: View {
         // White text on the gold fill (#D4A843) only reaches ~2.2:1 contrast,
         // below WCAG AA (4.5:1). Use a dark brown that's harmonious with the
         // gold and clears AA comfortably (~6.4:1) for low-vision legibility.
-        let ctaText = Color(red: 0x3A/255, green: 0x2A/255, blue: 0x05/255)
+        let ctaText = CT.accent
         return Button {
             Task { await runPurchase() }
         } label: {
@@ -350,7 +350,7 @@ public struct PaywallView: View {
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 14)
-            .background(Color(red: 0xD4/255, green: 0xA8/255, blue: 0x43/255))
+            .background(CT.sunGold)
             .foregroundStyle(ctaText)
             .clipShape(RoundedRectangle(cornerRadius: 12))
         }

--- a/apps/ios/SoloCompass/Views/Shared/BottomInfoBar.swift
+++ b/apps/ios/SoloCompass/Views/Shared/BottomInfoBar.swift
@@ -80,7 +80,7 @@ public struct BottomInfoBar: View {
             nearbySoloCount: 12
         )
     }
-    .background(Color(red: 0xF5/255, green: 0xF0/255, blue: 0xE8/255))
+    .background(CT.surfaceSunken)
 }
 
 #Preview("No nearby solos") {
@@ -91,5 +91,5 @@ public struct BottomInfoBar: View {
             nearbySoloCount: 0
         )
     }
-    .background(Color(red: 0xF5/255, green: 0xF0/255, blue: 0xE8/255))
+    .background(CT.surfaceSunken)
 }

--- a/apps/ios/SoloCompass/Views/Shared/ChatStateModifier.swift
+++ b/apps/ios/SoloCompass/Views/Shared/ChatStateModifier.swift
@@ -48,7 +48,7 @@ private struct ListeningModifier: ViewModifier {
         content
             .overlay(
                 RoundedRectangle(cornerRadius: 16)
-                    .stroke(Color.accentColor, lineWidth: 2)
+                    .stroke(CT.accent, lineWidth: 2)
                     .scaleEffect(pulse)
                     .opacity(reduceMotion ? 1 : 2 - pulse)
             )
@@ -66,7 +66,7 @@ private struct ProcessingModifier: ViewModifier {
         content
             .overlay(
                 RoundedRectangle(cornerRadius: 16)
-                    .stroke(Color.accentColor.opacity(0.5), lineWidth: 1.5)
+                    .stroke(CT.accent.opacity(0.5), lineWidth: 1.5)
             )
             .overlay(alignment: .topTrailing) {
                 ProgressView()
@@ -83,7 +83,7 @@ private struct RespondingModifier: ViewModifier {
         content
             .overlay(
                 RoundedRectangle(cornerRadius: 16)
-                    .stroke(Color.green.opacity(0.5), lineWidth: 1.5)
+                    .stroke(CT.verifiedGreen.opacity(0.5), lineWidth: 1.5)
             )
     }
 }
@@ -95,7 +95,7 @@ private struct ErrorModifier: ViewModifier {
         content
             .overlay(
                 RoundedRectangle(cornerRadius: 16)
-                    .stroke(Color.red, lineWidth: 2)
+                    .stroke(CT.savedRed, lineWidth: 2)
             )
     }
 }
@@ -105,9 +105,9 @@ private struct UnconfiguredModifier: ViewModifier {
         content
             .overlay(
                 RoundedRectangle(cornerRadius: 16)
-                    .stroke(Color.orange.opacity(0.6), lineWidth: 1.5)
+                    .stroke(CT.warningText.opacity(0.6), lineWidth: 1.5)
             )
-            .tint(.orange)
+            .tint(CT.warningText)
     }
 }
 

--- a/apps/ios/SoloCompass/Views/Shared/CompareTokens.swift
+++ b/apps/ios/SoloCompass/Views/Shared/CompareTokens.swift
@@ -86,6 +86,10 @@ public enum CT {
     /// (0x5D3000) to avoid competing with the primary accent CTA.
     public static let blindboxAmber  = rgb(0x8A, 0x4A, 0x14)
 
+    // Saved/favourite warm red — used on the Saved filter pill and heart icons.
+    public static let savedRed      = rgb(0xE0, 0x3A, 0x3A)
+    public static let savedRedSoft  = Color(.sRGB, red: 0xE0 / 255, green: 0x3A / 255, blue: 0x3A / 255, opacity: 0.12)
+
     // Heatmap scale — Solo-Score dimension bars (styles.css .sc-solo-card .dim .fill).
     // hi=deep amber accent · mid=sun-gold · lo=pale amber · empty=track. An amber
     // ramp replaces red/green so the breakdown stays in the warm system.

--- a/apps/ios/SoloCompass/Views/Shared/ConfidenceBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/ConfidenceBadge.swift
@@ -52,12 +52,15 @@ public struct ConfidenceBadge: View {
                     }
                 }
                 if !compact {
-                    // Show the human-readable health label (Verified / Fading /
-                    // …) instead of the opaque internal "L2" level code, which
-                    // means nothing to a traveler.
-                    Text("\(confidence.health.localizedDescription) · \(confidence.signals.totalCount) \(NSLocalizedString("confidence.signals", comment: "signals"))")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
+                    if confidence.signals.totalCount == 0 {
+                        Text(NSLocalizedString("confidence.aiEstimate", comment: "AI estimate for zero-signal cold start"))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("\(confidence.health.localizedDescription) · \(confidence.signals.totalCount) \(NSLocalizedString("confidence.signals", comment: "signals"))")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
             .contentShape(Rectangle())

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -50,7 +50,7 @@ public struct FavoritesListView: View {
 
         var color: Color {
             switch self {
-            case .near: return .green
+            case .near: return CT.verifiedGreen
             case .mid: return .orange
             case .far: return Color(.tertiaryLabel)
             }
@@ -177,10 +177,10 @@ public struct FavoritesListView: View {
             Text(String(format: NSLocalizedString("favorites.nearby.walkBudget", comment: "Walk budget chip: ~Xm on foot"), mins))
         }
         .font(.caption2)
-        .foregroundStyle(Color.green)
+        .foregroundStyle(CT.verifiedGreen)
         .padding(.horizontal, 10)
         .padding(.vertical, 5)
-        .background(Color.green.opacity(0.12), in: Capsule())
+        .background(CT.successSoft, in: Capsule())
         .animation(.easeInOut, value: nearbyWalkMinutesTotal)
         .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
     }
@@ -321,7 +321,7 @@ public struct FavoritesListView: View {
                                                 .padding(.vertical, showRemainingOnly ? 4 : 0)
                                                 .background(
                                                     showRemainingOnly
-                                                        ? Color.green.opacity(0.12)
+                                                        ? CT.successSoft
                                                         : Color.clear,
                                                     in: Capsule()
                                                 )
@@ -347,16 +347,16 @@ public struct FavoritesListView: View {
                                     } label: {
                                         HStack(spacing: 4) {
                                             Circle()
-                                                .fill(Color.green)
+                                                .fill(CT.verifiedGreen)
                                                 .frame(width: 7, height: 7)
                                                 .accessibilityHidden(true)
                                             Text(String(format: NSLocalizedString("favorites.nearby.count", comment: "N nearby chip"), nearbyCount))
                                                 .font(.caption2)
-                                                .foregroundStyle(Color.green)
+                                                .foregroundStyle(CT.verifiedGreen)
                                         }
                                         .padding(.horizontal, 10)
                                         .padding(.vertical, 5)
-                                        .background(Color.green.opacity(0.12), in: Capsule())
+                                        .background(CT.successSoft, in: Capsule())
                                     }
                                     .buttonStyle(.plain)
                                     .accessibilityLabel(String(format: NSLocalizedString("favorites.nearby.count.a11y", comment: "N nearby chip accessibility label"), nearbyCount))
@@ -397,10 +397,10 @@ public struct FavoritesListView: View {
                                                 Text(NSLocalizedString("favorites.nearby.go", comment: "Go button: launch directions to nearest favorite"))
                                             }
                                             .font(.caption2)
-                                            .foregroundStyle(Color.green)
+                                            .foregroundStyle(CT.verifiedGreen)
                                             .padding(.horizontal, 10)
                                             .padding(.vertical, 5)
-                                            .background(Color.green.opacity(0.12), in: Capsule())
+                                            .background(CT.successSoft, in: Capsule())
                                         }
                                         .buttonStyle(.plain)
                                         .accessibilityLabel(String(format: NSLocalizedString("favorites.nearby.go.a11y", comment: "Directions to nearest favorite accessibility label"), nearest.title))
@@ -577,21 +577,21 @@ private struct FavoritesJourneyHeader: View {
             let pillContent = HStack(spacing: 4) {
                 Image(systemName: "clock.badge.checkmark")
                     .font(.caption2)
-                    .foregroundStyle(Color.green)
+                    .foregroundStyle(CT.verifiedGreen)
                     .accessibilityHidden(true)
                 Text(label)
                     .font(.caption2)
-                    .foregroundStyle(Color.green)
+                    .foregroundStyle(CT.verifiedGreen)
                 if onTapGoodNow != nil {
                     Image(systemName: "chevron.right.circle.fill")
                         .font(.caption2)
-                        .foregroundStyle(Color.green)
+                        .foregroundStyle(CT.verifiedGreen)
                         .accessibilityHidden(true)
                 }
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
-            .background(Color.green.opacity(0.12), in: Capsule())
+            .background(CT.successSoft, in: Capsule())
             .transition(reduceMotion ? .opacity : .scale(scale: 0.9).combined(with: .opacity))
 
             if let onTap = onTapGoodNow {
@@ -618,17 +618,17 @@ private struct FavoritesJourneyHeader: View {
             let nudgeContent = HStack(spacing: 4) {
                 Text(label)
                     .font(.caption2)
-                    .foregroundStyle(Color.green)
+                    .foregroundStyle(CT.verifiedGreen)
                 if onTapNearby != nil {
                     Image(systemName: "chevron.right.circle.fill")
                         .font(.caption2)
-                        .foregroundStyle(Color.green)
+                        .foregroundStyle(CT.verifiedGreen)
                         .accessibilityHidden(true)
                 }
             }
             .padding(.horizontal, onTapNearby != nil ? 8 : 0)
             .padding(.vertical, onTapNearby != nil ? 4 : 0)
-            .background(onTapNearby != nil ? Color.green.opacity(0.12) : Color.clear, in: Capsule())
+            .background(onTapNearby != nil ? CT.successSoft : Color.clear, in: Capsule())
             .transition(reduceMotion ? .opacity : .scale(scale: 0.9).combined(with: .opacity))
 
             if let onTap = onTapNearby {
@@ -821,14 +821,14 @@ private struct JourneyProgressBar: View {
         GeometryReader { geo in
             ZStack(alignment: .leading) {
                 Capsule()
-                    .fill(Color.green.opacity(0.15))
+                    .fill(CT.successSoft)
                     .frame(height: 4)
                 if total >= 2 {
                     Capsule()
                         .fill(
                             isPastHalfway
-                                ? Color.green
-                                : Color.green.opacity(0.25)
+                                ? CT.verifiedGreen
+                                : CT.verifiedGreen.opacity(0.25)
                         )
                         .frame(width: 2, height: 8)
                         .offset(x: geo.size.width * 0.5 - 1)
@@ -839,11 +839,11 @@ private struct JourneyProgressBar: View {
                         .accessibilityHidden(true)
                 }
                 Capsule()
-                    .fill(isAllDone ? Color.green : Color.green.opacity(0.75))
+                    .fill(isAllDone ? CT.verifiedGreen : CT.verifiedGreen.opacity(0.75))
                     .frame(width: geo.size.width * animatedFraction, height: 4)
                     .scaleEffect(x: 1, y: fillScaleY, anchor: .center)
                     .shadow(
-                        color: isAllDone ? Color.green.opacity(0.4) : Color.clear,
+                        color: isAllDone ? CT.verifiedGreen.opacity(0.4) : Color.clear,
                         radius: 3
                     )
                     .overlay(alignment: .leading) {
@@ -866,7 +866,7 @@ private struct JourneyProgressBar: View {
                     .clipShape(Capsule())
                 if glowOpacity > 0 {
                     Capsule()
-                        .fill(Color.green.opacity(glowOpacity))
+                        .fill(CT.verifiedGreen.opacity(glowOpacity))
                         .frame(width: geo.size.width * animatedFraction, height: 4)
                         .blur(radius: 3)
                         .allowsHitTesting(false)
@@ -960,20 +960,20 @@ private struct CompletionRing: View {
         ZStack {
             HeartBurstView(trigger: celebrationBurst)
             Circle()
-                .stroke(Color.green.opacity(0.15), lineWidth: 2.5)
+                .stroke(CT.successSoft, lineWidth: 2.5)
             Circle()
                 .trim(from: 0, to: animatedFraction)
-                .stroke(Color.green, style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
+                .stroke(CT.verifiedGreen, style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
                 .rotationEffect(.degrees(-90))
             if isAllDone {
                 Image(systemName: "checkmark.circle.fill")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(Color.green)
+                    .foregroundStyle(CT.verifiedGreen)
                     .scaleEffect(bloomScale)
             } else {
                 Text(pctLabel)
                     .font(.system(size: 7, weight: .semibold).monospacedDigit())
-                    .foregroundStyle(Color.green)
+                    .foregroundStyle(CT.verifiedGreen)
                     .contentTransition(.numericText())
                     .animation(reduceMotion ? nil : .easeInOut, value: done)
             }
@@ -1143,7 +1143,7 @@ private struct AllRemainingDoneView: View {
         VStack(spacing: 12) {
             Image(systemName: "checkmark.seal.fill")
                 .font(.system(size: 48))
-                .foregroundStyle(Color.green)
+                .foregroundStyle(CT.verifiedGreen)
                 .accessibilityHidden(true)
             Text(NSLocalizedString("favorites.remaining.allDone.title", comment: "All remaining favorites done title"))
                 .font(.headline)
@@ -1289,7 +1289,7 @@ private extension FavoritesListView {
                     Spacer()
                     Text(NSLocalizedString("action.undo", comment: "Undo action"))
                         .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(Color.accentColor)
+                        .foregroundStyle(CT.accent)
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 12)
@@ -1358,11 +1358,11 @@ private extension FavoritesListView {
     }
 
     private var countdownLineColor: Color {
-        guard !reduceMotion else { return .accentColor }
+        guard !reduceMotion else { return CT.accent }
         if #available(iOS 18, *) {
-            return Color.accentColor.mix(with: .orange, by: 1 - undoProgress)
+            return CT.accent.mix(with: .orange, by: 1 - undoProgress)
         } else {
-            return .accentColor
+            return CT.accent
         }
     }
 
@@ -1408,7 +1408,7 @@ private extension FavoritesListView {
                     if isDone {
                         Image(systemName: "checkmark.circle.fill")
                             .font(.system(size: 16, weight: .semibold))
-                            .foregroundStyle(Color.green)
+                            .foregroundStyle(CT.verifiedGreen)
                             .background(Circle().fill(Color.white).padding(2))
                             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
                             .accessibilityHidden(true)
@@ -1447,10 +1447,10 @@ private extension FavoritesListView {
                                 Text(String(format: NSLocalizedString("favorites.row.closingSoon", comment: "Closing soon pill in favorites row"), mins))
                             }
                             .font(.caption2)
-                            .foregroundStyle(Color.orange)
+                            .foregroundStyle(CT.warningText)
                             .padding(.horizontal, 10)
                             .padding(.vertical, 5)
-                            .background(Color.orange.opacity(0.12), in: Capsule())
+                            .background(CT.warningSoft, in: Capsule())
                             .padding(.top, 2)
                             .transition(reduceMotion ? .opacity : .scale(scale: 0.85).combined(with: .opacity))
                             .accessibilityHidden(true)
@@ -1601,7 +1601,7 @@ private extension FavoritesListView {
                     systemImage: isDone ? "arrow.uturn.backward" : "checkmark.circle"
                 )
             }
-            .tint(.green)
+            .tint(CT.verifiedGreen)
         }
         .modifier(DirectionsSwipeModifier(exp: exp))
         .accessibilityAction(named: Text(isDone
@@ -1667,7 +1667,7 @@ private struct RowCompletionFlourish: View {
                     LinearGradient(
                         stops: [
                             .init(color: .clear, location: 0),
-                            .init(color: Color.green.opacity(0.18), location: 0.5),
+                            .init(color: CT.verifiedGreen.opacity(0.18), location: 0.5),
                             .init(color: .clear, location: 1),
                         ],
                         startPoint: .leading,
@@ -1681,7 +1681,7 @@ private struct RowCompletionFlourish: View {
                     // Bloom checkmark centred over the 44-pt icon circle (leading inset ~22pt)
                     Image(systemName: "checkmark.circle.fill")
                         .font(.system(size: 22, weight: .semibold))
-                        .foregroundStyle(Color.green)
+                        .foregroundStyle(CT.verifiedGreen)
                         .scaleEffect(bloomScale)
                         .frame(width: 44, height: 44)
                         .offset(x: 0, y: 0)
@@ -1747,7 +1747,7 @@ private struct DirectionsSwipeModifier: ViewModifier {
                         systemImage: "arrow.triangle.turn.up.right.diamond.fill"
                     )
                 }
-                .tint(.accentColor)
+                .tint(CT.accent)
             }
         } else {
             content

--- a/apps/ios/SoloCompass/Views/Shared/HeartBurstView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/HeartBurstView.swift
@@ -163,7 +163,7 @@ public struct HeartBurstView: View {
                             Text("#\(t)")
                                 .font(.caption2)
                                 .padding(4)
-                                .background(Capsule().fill(Color.red.opacity(0.15)))
+                                .background(Capsule().fill(CT.savedRedSoft))
                         }
                     }
                 }

--- a/apps/ios/SoloCompass/Views/Shared/OfflineBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/OfflineBanner.swift
@@ -122,9 +122,9 @@ struct OfflineBanner: View {
 
     private var bannerColor: Color {
         switch bannerState {
-        case .offline: return retryFailed ? .red : .orange
-        case .retrying: return .orange
-        case .recovered: return .green
+        case .offline: return retryFailed ? CT.savedRed : CT.warningText
+        case .retrying: return CT.warningText
+        case .recovered: return CT.verifiedGreen
         }
     }
 
@@ -137,7 +137,7 @@ struct OfflineBanner: View {
                     if isRetrying {
                         ProgressView()
                             .controlSize(.mini)
-                            .tint(Color.orange)
+                            .tint(CT.warningText)
                     } else if bannerState == .recovered {
                         Image(systemName: "checkmark.circle.fill")
                             .font(.caption.weight(.semibold))

--- a/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
@@ -102,7 +102,7 @@ public struct PendingCheckInBanner: View {
                         }
                         .padding(.horizontal, 12)
                         .padding(.vertical, 6)
-                        .background(Capsule().fill(confirmed ? Color.green : (isExpiringSoon ? Color.orange : Color.blue)))
+                        .background(Capsule().fill(confirmed ? CT.verifiedGreen : (isExpiringSoon ? CT.warningText : Color.accentColor)))
                         .foregroundStyle(.white)
                         .scaleEffect(reduceMotion ? 1.0 : (confirmed ? 1.0 : (pulse ? 1.04 : 1.0)))
                         .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.6), value: confirmed)
@@ -134,7 +134,7 @@ public struct PendingCheckInBanner: View {
             if !reduceMotion {
                 GeometryReader { geo in
                     Capsule()
-                        .fill(isInteracting ? Color.gray : (isExpiringSoon ? Color.orange : Color.blue))
+                        .fill(isInteracting ? CT.fgMuted : (isExpiringSoon ? CT.warningText : Color.accentColor))
                         .frame(width: geo.size.width * countdownProgress, height: 2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .opacity(isInteracting ? 0.4 : 1.0)

--- a/apps/ios/SoloCompass/Views/Shared/PressableButtonStyle.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PressableButtonStyle.swift
@@ -40,7 +40,7 @@ public struct PressableButtonStyle: ButtonStyle {
             .buttonStyle(PressableButtonStyle())
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
-            .background(Capsule().fill(Color.accentColor.opacity(0.15)))
+            .background(Capsule().fill(CT.accent.opacity(0.15)))
 
         Button("No Haptic") {}
             .buttonStyle(PressableButtonStyle(haptic: false))

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreBadge.swift
@@ -284,7 +284,7 @@ private struct SoloScorePopoverContent: View {
                 HStack(spacing: 4) {
                     Image(systemName: "star.fill")
                         .font(.caption2)
-                        .foregroundStyle(.green)
+                        .foregroundStyle(CT.verifiedGreen)
                         .accessibilityHidden(true)
                     Text(String(format: NSLocalizedString("solo.strongest", comment: ""), strongestLabel))
                         .font(.caption2)
@@ -298,7 +298,7 @@ private struct SoloScorePopoverContent: View {
                 HStack(spacing: 4) {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(.caption2)
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(CT.warningText)
                         .accessibilityHidden(true)
                     Text(String(format: NSLocalizedString("solo.weakest", comment: ""), weakestLabel))
                         .font(.caption2)
@@ -312,16 +312,16 @@ private struct SoloScorePopoverContent: View {
                 HStack(spacing: 6) {
                     Image(systemName: "shield.lefthalf.filled.slash")
                         .font(.caption2)
-                        .foregroundStyle(Color(red: 0.85, green: 0.38, blue: 0.1))
+                        .foregroundStyle(CT.warningText)
                         .accessibilityHidden(true)
                     Text(NSLocalizedString("solo.safety.caution", comment: ""))
                         .font(.caption2.weight(.medium))
-                        .foregroundStyle(Color(red: 0.65, green: 0.3, blue: 0.05))
+                        .foregroundStyle(CT.warningText)
                 }
                 .padding(.horizontal, 8)
                 .padding(.vertical, 5)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color.orange.opacity(0.14), in: Capsule())
+                .background(CT.warningSoft, in: Capsule())
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel(Text(NSLocalizedString("solo.safety.caution.a11y", comment: "")))
                 .scaleEffect(appeared && !reduceMotion ? 1 : (reduceMotion ? 1 : 0.92))
@@ -347,10 +347,10 @@ private struct SoloScorePopoverContent: View {
                 HStack(spacing: 6) {
                     Image(systemName: "person.2.fill")
                         .font(.caption2)
-                        .foregroundStyle(isEarlyEstimate ? Color.orange.opacity(0.9) : .secondary)
+                        .foregroundStyle(isEarlyEstimate ? CT.warningText : .secondary)
                     Text(String(format: NSLocalizedString("solo.basedOn", comment: "Based on N solo travelers"), score.basedOnCount))
                         .font(.caption)
-                        .foregroundStyle(isEarlyEstimate ? Color.orange.opacity(0.9) : .secondary)
+                        .foregroundStyle(isEarlyEstimate ? CT.warningText : .secondary)
                     if isEarlyEstimate {
                         HStack(spacing: 3) {
                             Image(systemName: "hourglass")
@@ -359,10 +359,10 @@ private struct SoloScorePopoverContent: View {
                             Text(NSLocalizedString("solo.earlyEstimate", comment: "Early estimate"))
                                 .font(.caption2.weight(.medium))
                         }
-                        .foregroundStyle(Color.orange.opacity(0.9))
+                        .foregroundStyle(CT.warningText)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
-                        .background(Color.orange.opacity(0.12), in: Capsule())
+                        .background(CT.warningSoft, in: Capsule())
                         .scaleEffect(appeared && !reduceMotion ? 1 : (reduceMotion ? 1 : 0.85))
                         .opacity(appeared ? 1 : 0)
                     }
@@ -404,7 +404,7 @@ private struct SoloScorePopoverContent: View {
 
     private func dimensionRow(label: String, desc: String, value: Double, index: Int, isWeakest: Bool, isStrongest: Bool = false) -> some View {
         let clamped = max(0, min(10, value))
-        let barColor: Color = isWeakest ? .orange.opacity(0.8) : isStrongest ? .green.opacity(0.8) : score.scoreColor.opacity(0.8)
+        let barColor: Color = isWeakest ? CT.warningText.opacity(0.8) : isStrongest ? CT.verifiedGreen.opacity(0.8) : score.scoreColor.opacity(0.8)
         let isExpanded = expandedIndex == index
         return Button {
             withAnimation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.8)) {
@@ -417,12 +417,12 @@ private struct SoloScorePopoverContent: View {
                     if isWeakest {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .font(.system(size: 9))
-                            .foregroundStyle(.orange)
+                            .foregroundStyle(CT.warningText)
                             .accessibilityHidden(true)
                     } else if isStrongest {
                         Image(systemName: "star.fill")
                             .font(.system(size: 9))
-                            .foregroundStyle(.green)
+                            .foregroundStyle(CT.verifiedGreen)
                             .accessibilityHidden(true)
                     }
                     Text(label)

--- a/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SoloScoreRadarChart.swift
@@ -61,8 +61,8 @@ public struct SoloScoreRadarChart: View {
     }
 
     // Amber accent matching the app's accentGold
-    private static let amberAccent = Color(red: 0xD4 / 255, green: 0xA8 / 255, blue: 0x43 / 255)
-    private static let greenAccent = Color.green
+    private static let amberAccent = CT.sunGold
+    private static let greenAccent = CT.verifiedGreen
 
     public init(score: SoloScore) {
         self.score = score
@@ -435,7 +435,7 @@ public struct SoloScoreRadarChart: View {
                         .accessibilityHidden(true)
                     GeometryReader { geo in
                         ZStack(alignment: .leading) {
-                            Capsule().fill(Color.gray.opacity(0.15))
+                            Capsule().fill(CT.surfaceSunken)
                                 .accessibilityHidden(true)
                             Capsule()
                                 .fill(score.scoreColor)

--- a/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
+++ b/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
@@ -42,7 +42,7 @@ public struct VoiceButton: View {
         ZStack {
             if isRecording {
                 Circle()
-                    .stroke(Color.red.opacity(0.5), lineWidth: 4)
+                    .stroke(CT.savedRed.opacity(0.5), lineWidth: 4)
                     .frame(width: 72, height: 72)
                     .scaleEffect(reduceMotion ? 1.0 : (pulse ? 1.2 : 0.95))
                     .opacity(reduceMotion ? 0.7 : (pulse ? 0.0 : 0.8))
@@ -56,7 +56,7 @@ public struct VoiceButton: View {
                 Circle()
                     .trim(from: 0, to: progress)
                     .stroke(
-                        nearEnd ? Color.orange : Color.red.opacity(0.6),
+                        nearEnd ? CT.warningText : CT.savedRed.opacity(0.6),
                         style: StrokeStyle(lineWidth: 3, lineCap: .round)
                     )
                     .frame(width: 64, height: 64)
@@ -72,7 +72,7 @@ public struct VoiceButton: View {
             }
 
             Circle()
-                .fill(isRecording ? Color.red : Color.black.opacity(0.85))
+                .fill(isRecording ? CT.savedRed : Color.black.opacity(0.85))
                 .frame(width: 56, height: 56)
                 .shadow(radius: isRecording ? 10 : 4)
 
@@ -127,7 +127,7 @@ public struct VoiceButton: View {
                     if let hint = emptyHint {
                         Text(hint)
                             .font(.caption)
-                            .foregroundStyle(AnyShapeStyle(Color.orange))
+                            .foregroundStyle(AnyShapeStyle(CT.warningText))
                             .padding(.horizontal, 10)
                             .padding(.vertical, 6)
                             .background(.thinMaterial, in: Capsule())
@@ -137,12 +137,12 @@ public struct VoiceButton: View {
                     } else if let message = autoStopMessage {
                         Text(message)
                             .font(.caption.monospacedDigit())
-                            .foregroundStyle(AnyShapeStyle(Color.orange))
+                            .foregroundStyle(AnyShapeStyle(CT.warningText))
                             .accessibilityHidden(true)
                     } else if inCountdown {
                         Text(String(format: NSLocalizedString("voice.recording.secondsLeft", comment: "%ds left countdown"), secondsRemaining))
                             .font(.caption.monospacedDigit())
-                            .foregroundStyle(AnyShapeStyle(Color.orange))
+                            .foregroundStyle(AnyShapeStyle(CT.warningText))
                             .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: secondsRemaining)
                             .accessibilityHidden(true)
                     } else {


### PR DESCRIPTION
## Summary

- **City Brief core**: models, compliance math, interruption budget, cache service
- **City OS surfaces**: kit sheet, live events, banner, event markers on map
- **Agent tools**: `get_city_kit`, `find_local_events`, 今日城市签 (daily city stamp)
- **Home polish**: drawer tab styling, wider city camera
- **E2E audit fixes**: soft event query (English keywords × Chinese content starvation), layout clearance, orphan chat card rebind
- **Color token unification**: migrate 68 files from hardcoded `Color.green/.red/.orange/.accentColor` to CT semantic tokens (`verifiedGreen`, `savedRed`, `warningText`, `accent`, `sunGold`); add `savedRed`/`savedRedSoft` tokens
- **Empty-state layout fix**: overlays now properly anchored above sheet peek with `sheetPeekClearance`
- **Dark mode**: adaptive colors for FriendsHubView
- **Testing launch args**: `-openCityPicker`, `-openSettings`, `-uiTestBypassLocationPrompt` for visual verification

## Test plan

- [ ] Build succeeds on iPhone 17 Pro simulator (iOS latest)
- [ ] City OS drawer opens with kit/live tabs, events render on map
- [ ] Agent tools (`get_city_kit`, `find_local_events`) respond correctly in chat
- [ ] Color tokens render consistently in light and dark mode
- [ ] Empty-state overlays (Now/Filtered/Generic) sit above bottom sheet, not mid-screen
- [ ] Heart icons use warm red (`CT.savedRed`) across cards and favorites
- [ ] Warning banners use `CT.warningText` consistently
- [ ] Filter pills use `.primary` text in unselected state (no CT.fgPrimary override)
- [ ] FriendsHubView renders correctly in dark mode
- [ ] Launch arg `-openCityPicker` opens city picker after 0.8s delay
- [ ] Launch arg `-uiTestBypassLocationPrompt` suppresses location dialog