### PR TITLE
feat(ios): City OS kit + live events surfaces & home polish

### DIFF
--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -3522,15 +3522,18 @@ private struct PlusActionButton: View {
                 .scaleEffect(isPressed ? 1.08 : 1.0)
                 .animation(.spring(response: 0.18, dampingFraction: 0.7), value: isPressed)
 
-            // FAB glyph: a clean SF Symbol plus in the warm amber accent. The
-            // previous kawaii mascot competed for visual weight against the
-            // event bloom markers + peek card and diluted the module's design
-            // register. This is discreet and reads as a proper "add" affordance.
-            Image(systemName: "plus")
-                .font(.system(size: 22, weight: .semibold))
-                .foregroundStyle(.white)
-                .scaleEffect(isPressed ? 0.88 : 1.0)
-                .animation(.spring(response: 0.18, dampingFraction: 0.7), value: isPressed)
+            // FAB glyph: the Solo mascot — the cartoon girl who IS Solo. She
+            // greets the traveler and is the entry-point to Solo Chat, giving
+            // the FAB brand identity + warmth that a bare "+" lacks. Scaled
+            // down slightly + a touch of transparency so she reads as a
+            // friendly companion without out-shouting the event bloom markers
+            // + peek card the way the full-weight mascot once did. The amber
+            // circle + shadow + press-ring above stay byte-identical, so
+            // hit-target and FAB layout are unchanged. `isPressed` drives her
+            // cheek sparkle.
+            SoloMascotView(isPressed: isPressed)
+                .scaleEffect(0.88)
+                .opacity(0.95)
         }
         .contentShape(Circle())
         .onLongPressGesture(

--- a/apps/ios/SoloCompass/Views/Map/NearbyExperienceRow.swift
+++ b/apps/ios/SoloCompass/Views/Map/NearbyExperienceRow.swift
@@ -348,7 +348,13 @@ struct NearbyExperienceRow: View {
                         )
                 }
                 Spacer(minLength: 4)
-                ConfidenceBadge(confidence: experience.confidence, compact: true)
+                // Provenance signal for the row is carried solely by TrustBadge
+                // (it has a legible text label — OSM / 高德 / verified). The
+                // former compact ConfidenceBadge rendered here as a lone,
+                // label-less grey dot + tiny health glyph that read as a broken
+                // "⊗" placeholder and duplicated TrustBadge's trust role. Its
+                // full signal breakdown still lives in the detail sheet, so the
+                // compact row loses nothing legible by dropping it.
                 TrustBadge(level: experience.trustBadgeLevel, size: .compact)
                     .layoutPriority(1)
             }
@@ -740,5 +746,48 @@ struct NearbyExperienceRow: View {
             )
         }
         return Self.distanceFormatter.string(from: Measurement(value: meters, unit: UnitLength.meters))
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Nearby row — nearby / open now") {
+    if let exp = ExperienceService.hardcodedSeed.first {
+        return AnyView(
+            NearbyExperienceRow(
+                experience: exp,
+                isSmartPick: true,
+                distanceMeters: 120,
+                isOpenNow: true,
+                bestNowChipState: BestNowChipState(isClosingSoon: false, minutesLeft: nil),
+                onTap: {}
+            )
+            .padding()
+            .background(CT.surfaceSunken)
+            .environment(LocationService())
+            .environment(UserPreferences(defaults: UserDefaults(suiteName: "preview-nearby-row")!))
+        )
+    } else {
+        return AnyView(Text("No seed data"))
+    }
+}
+
+#Preview("Nearby row — far / plain") {
+    if let exp = ExperienceService.hardcodedSeed.first {
+        return AnyView(
+            NearbyExperienceRow(
+                experience: exp,
+                isSmartPick: false,
+                distanceMeters: 4200,
+                isOpenNow: false,
+                onTap: {}
+            )
+            .padding()
+            .background(CT.surfaceSunken)
+            .environment(LocationService())
+            .environment(UserPreferences(defaults: UserDefaults(suiteName: "preview-nearby-row-far")!))
+        )
+    } else {
+        return AnyView(Text("No seed data"))
     }
 }


### PR DESCRIPTION
## Summary

City OS 相关的一系列 iOS 界面落地与打磨，从 kit sheet / live events 表面到主页视觉统一，再到本轮的 FAB 吉祥物与 nearby row 徽章清理。

## Changes

- **City OS surfaces** — kit sheet、live events、banner、event markers 落地，新增 agent 工具 `get_city_kit` / `find_local_events` / 今日城市签。
- **Home polish** — drawer tab 样式、更宽的 city camera。
- **e2e audit fixes** — 软化 event query（英文泛词×中文内容不再饿死结果）、布局 clearance、修复静默工具调用产生的孤儿 chat 卡。
- **Color tokens** — 统一色彩 token、修空态布局、补齐深色模式支持。
- **FAB & nearby row (本轮)** — FAB 换回 `SoloMascotView` 承载 Solo 品牌形象（缩放 0.88 + 0.95 透明度，命中区/布局字节级不变）；移除 NearbyExperienceRow 里无标签、渲染成破损 "⊗" 占位符且与 TrustBadge 职责重复的 compact ConfidenceBadge；补两个 SwiftUI preview。

## Test plan

- [ ] iOS 冷启动主页视觉核对（FAB 吉祥物、nearby row 徽章）
- [ ] City kit sheet / live events 交互
- [ ] 深色模式检查

🤖 Generated with [Claude Code](https://claude.com/claude-code)