### PR TITLE
feat(ios): City OS v3 — real Plan/Recall modes, verify loop, lifecycle pill

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		2C15829741157EA5A2EC8A5C /* AddFriendButtonRenderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB51F8355673EA0628510F0 /* AddFriendButtonRenderTest.swift */; };
 		2C5A15DE0FCF30A3BCF1EB20 /* RouteItineraryBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8670B08F2AB2779C31E0870 /* RouteItineraryBridgeTests.swift */; };
 		2D379EAE0BCD339DB670EB5C /* CompanionPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431DC31A80132F719AFEE471 /* CompanionPost.swift */; };
+		2E48BDB5332F76C0F9A6CD3F /* VerifySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D3D546D951B0C1DDE95610 /* VerifySheet.swift */; };
 		2EC741296992D9D0A4F3077D /* RouteCardNowReasonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D31F422914779D9228B0278 /* RouteCardNowReasonTests.swift */; };
 		2ED16C7027DB2250262F5D3F /* ProactiveNudgeSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5780606CA08F571BF04ACE /* ProactiveNudgeSchedulerTests.swift */; };
 		2F00F874A1B50C113AC8CA55 /* ChatRedesignVisualTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB511F86191D72DBCBCB5A01 /* ChatRedesignVisualTest.swift */; };
@@ -896,6 +897,7 @@
 		86AEAFC3C13D4A82B3C55154 /* ExperienceRepositoryExportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceRepositoryExportTests.swift; sourceTree = "<group>"; };
 		87002BB6D344B384A3FDFBFD /* LanguageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageService.swift; sourceTree = "<group>"; };
 		873ACB737A9B43254C17B238 /* CityPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityPickerSheet.swift; sourceTree = "<group>"; };
+		87D3D546D951B0C1DDE95610 /* VerifySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifySheet.swift; sourceTree = "<group>"; };
 		884AFD2A4ADF051FA9643166 /* RouteItineraryBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteItineraryBridge.swift; sourceTree = "<group>"; };
 		884C97C686E2AFC3C534381A /* TasteUpdateServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasteUpdateServiceTests.swift; sourceTree = "<group>"; };
 		88553B5578C07FA890183A0D /* BottomInfoSheetHandleHitTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomInfoSheetHandleHitTargetTests.swift; sourceTree = "<group>"; };
@@ -2074,6 +2076,7 @@
 				294D570FD35987EDF2DA50FB /* KitSheet.swift */,
 				4ABE29FC4F9EBBBF8C3C61C4 /* LiveSheet.swift */,
 				112AE9791A5032033EEDC882 /* ModePlaceholderCards.swift */,
+				87D3D546D951B0C1DDE95610 /* VerifySheet.swift */,
 			);
 			path = CityOS;
 			sourceTree = "<group>";
@@ -2825,6 +2828,7 @@
 				2ADAE5305CE2984A5F4EF36C /* UserLocationMarker.swift in Sources */,
 				C2C0AF72D709EDC17C6ED874 /* UserPreferences.swift in Sources */,
 				321C062B9C6CA3558BC88C91 /* VerifiedBadge.swift in Sources */,
+				2E48BDB5332F76C0F9A6CD3F /* VerifySheet.swift in Sources */,
 				F001C2FCA4105020BC221A3D /* VisitRecord.swift in Sources */,
 				A068F103E60F3CD258FA4EE0 /* VisitTrackingService.swift in Sources */,
 				BB0BC19A9BE687E947C48034 /* VoiceAgentOrchestrator.swift in Sources */,

--- a/apps/ios/SoloCompass/Models/CityBrief.swift
+++ b/apps/ios/SoloCompass/Models/CityBrief.swift
@@ -16,6 +16,50 @@ public enum CityMode: String, Codable, Sendable, CaseIterable {
     case recall
 }
 
+/// Lifecycle stage within a stay: 抵达 → 立足 → 生活 → 离开 (PRD §4.1). Inferred
+/// purely from days stayed (the visa entry date the traveler already gave the
+/// kit) — it only drives presentation (city-pill stage dots, shelf ordering)
+/// and never gates content.
+public enum CityStage: String, Codable, Sendable, CaseIterable {
+    case land
+    case settle
+    case live
+    case leave
+
+    /// Stage from mode + 1-based days stayed (`ComplianceMath.daysStayed`).
+    /// Recall is always `leave`; Plan has no stage (the stay hasn't started);
+    /// Live maps day 1 → land, days 2–3 → settle, day 4+ → live. A Live city
+    /// with no entry date set rests at `live` — the steady-state default.
+    public static func inferred(mode: CityMode, daysStayed: Int?) -> CityStage? {
+        switch mode {
+        case .recall: return .leave
+        case .plan: return nil
+        case .live:
+            guard let daysStayed, daysStayed >= 1 else { return .live }
+            switch daysStayed {
+            case 1: return .land
+            case 2...3: return .settle
+            default: return .live
+            }
+        }
+    }
+
+    /// Position along the land → settle → live → leave rail, for stage dots.
+    public var index: Int {
+        Self.allCases.firstIndex(of: self) ?? 0
+    }
+
+    /// Localized short label ("抵达" / "立足" / "生活" / "回顾").
+    public var localizedLabel: String {
+        switch self {
+        case .land:   return NSLocalizedString("cityos.stage.land", comment: "抵达")
+        case .settle: return NSLocalizedString("cityos.stage.settle", comment: "立足")
+        case .live:   return NSLocalizedString("cityos.stage.live", comment: "生活")
+        case .leave:  return NSLocalizedString("cityos.stage.leave", comment: "回顾")
+        }
+    }
+}
+
 /// A structured action attached to a landing-kit row, interpreted by the
 /// client (e.g. schedule a visa-expiry reminder, render tappable emergency
 /// numbers). Mirrors the `action` jsonb column of `city_kits`.

--- a/apps/ios/SoloCompass/Models/UserPreferences.swift
+++ b/apps/ios/SoloCompass/Models/UserPreferences.swift
@@ -96,6 +96,12 @@ public final class UserPreferences {
         var kitSeenCities: Set<String> = []
         var cityModesRaw: [String: String] = [:]
 
+        // City OS v3: per-city pre-trip checklist ticks (Plan mode) keyed by
+        // lowercase city code → done kit-item kinds; and the set of experience
+        // ids the traveler has personally verified (Recall 印证).
+        var kitTodosDoneRaw: [String: [String]] = [:]
+        var verifiedExperiences: Set<String> = []
+
         // swiftlint:disable:next nesting
         enum CodingKeys: String, CodingKey {
             case preferredCategories, dislikedCategories, soloTravelStyle, maxDistanceKm
@@ -114,6 +120,7 @@ public final class UserPreferences {
             case companionModuleStrengthRaw
             case visaEntryDate, visaLengthDays, visaReminderEnabled
             case kitSeenCities, cityModesRaw
+            case kitTodosDoneRaw, verifiedExperiences
         }
 
         init() {}
@@ -161,7 +168,9 @@ public final class UserPreferences {
             visaLengthDays: Int? = nil,
             visaReminderEnabled: Bool = false,
             kitSeenCities: Set<String> = [],
-            cityModesRaw: [String: String] = [:]
+            cityModesRaw: [String: String] = [:],
+            kitTodosDoneRaw: [String: [String]] = [:],
+            verifiedExperiences: Set<String> = []
         ) {
             self.preferredCategories = preferredCategories
             self.dislikedCategories = dislikedCategories
@@ -206,6 +215,8 @@ public final class UserPreferences {
             self.visaReminderEnabled = visaReminderEnabled
             self.kitSeenCities = kitSeenCities
             self.cityModesRaw = cityModesRaw
+            self.kitTodosDoneRaw = kitTodosDoneRaw
+            self.verifiedExperiences = verifiedExperiences
         }
 
         init(from decoder: Decoder) throws {
@@ -254,6 +265,8 @@ public final class UserPreferences {
             self.visaReminderEnabled = try container.decodeIfPresent(Bool.self, forKey: .visaReminderEnabled) ?? false
             self.kitSeenCities = try container.decodeIfPresent(Set<String>.self, forKey: .kitSeenCities) ?? []
             self.cityModesRaw = try container.decodeIfPresent([String: String].self, forKey: .cityModesRaw) ?? [:]
+            self.kitTodosDoneRaw = try container.decodeIfPresent([String: [String]].self, forKey: .kitTodosDoneRaw) ?? [:]
+            self.verifiedExperiences = try container.decodeIfPresent(Set<String>.self, forKey: .verifiedExperiences) ?? []
         }
     }
 
@@ -390,6 +403,13 @@ public final class UserPreferences {
     /// Per-city mode (`CityMode.rawValue`) keyed by lowercase city code.
     /// Read/written through `CityOSStore`; default is `live`.
     public var cityModesRaw: [String: String] { didSet { persist() } }
+    /// City OS v3 · Plan mode's pre-trip checklist: lowercase city code →
+    /// ticked kit-item kinds (`CityKitItem.Kind.rawValue`). Read/written
+    /// through `CityOSStore`.
+    public var kitTodosDoneRaw: [String: [String]] { didSet { persist() } }
+    /// City OS v3 · Recall 印证: experience ids the traveler has personally
+    /// verified. Local-only; feeds the Recall contribution loop.
+    public var verifiedExperiences: Set<String> { didSet { persist() } }
 
     /// Typed access to the selected AI provider. Reads/writes `aiProviderRaw`.
     public var aiProvider: AIProvider {
@@ -452,6 +472,8 @@ public final class UserPreferences {
         self.visaReminderEnabled = snapshot.visaReminderEnabled
         self.kitSeenCities = snapshot.kitSeenCities
         self.cityModesRaw = snapshot.cityModesRaw
+        self.kitTodosDoneRaw = snapshot.kitTodosDoneRaw
+        self.verifiedExperiences = snapshot.verifiedExperiences
 
         // One-time migration: bump the historical 5 km default to the new 8 km
         // cold-start default for users who never touched the distance slider.
@@ -523,7 +545,9 @@ public final class UserPreferences {
             visaLengthDays: visaLengthDays,
             visaReminderEnabled: visaReminderEnabled,
             kitSeenCities: kitSeenCities,
-            cityModesRaw: cityModesRaw
+            cityModesRaw: cityModesRaw,
+            kitTodosDoneRaw: kitTodosDoneRaw,
+            verifiedExperiences: verifiedExperiences
         )
         do {
             let data = try JSONEncoder.iso8601Encoder.encode(snapshot)

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -2235,11 +2235,53 @@
 "cityos.mode.live.tag" = "Here now";
 "cityos.mode.plan.tag" = "Plan";
 "cityos.mode.plan.title" = "%@ · Planning";
-"cityos.mode.plan.body" = "Pre-trip checklist, visa timing, and what to line up before you land — coming soon.";
+"cityos.mode.plan.body" = "Line these up before you go — the moment you land, you can just start living.";
 "cityos.mode.plan.cta" = "See the landing kit";
+"cityos.mode.plan.cta.checklist" = "Open pre-trip checklist";
+"cityos.mode.plan.progress" = "%1$d/%2$d ready";
 "cityos.mode.recall.tag" = "Recall";
 "cityos.mode.recall.title" = "%@ · Looking back";
-"cityos.mode.recall.body" = "Your walks, moments, and what this city was like for you — coming soon.";
+"cityos.mode.recall.body" = "Places you complete here will show up for a quick verify — your 30 seconds backs the next solo traveler.";
+"cityos.mode.recall.pending.body" = "You visited %1$d places and %2$d still await your verify — their freshness is decaying. Your 30 seconds is the next solo traveler's confidence.";
+"cityos.mode.recall.alldone.body" = "You visited %d places, all verified. This city is more honest for the next solo traveler because of you.";
+"cityos.mode.recall.verify.cta" = "Verify “%@”";
+"cityos.mode.recall.verify.cta.generic" = "Verify a place you visited";
+
+/* City OS v3: lifecycle stage + city pill */
+"cityos.stage.land" = "Landing";
+"cityos.stage.settle" = "Settling";
+"cityos.stage.live" = "Living";
+"cityos.stage.leave" = "Looking back";
+"cityos.pill.plan" = "Not yet · Plan";
+"cityos.pill.recall" = "Left · Recall";
+"cityos.pill.live" = "Day %1$d · %2$@";
+
+/* City OS v3: pre-trip checklist (Plan mode kit) */
+"cityos.kit.title.plan" = "Pre-trip checklist";
+"cityos.kit.todo.done.a11y" = "Ready, tap to untick";
+"cityos.kit.todo.pending.a11y" = "Mark as ready";
+
+/* City OS v3: verify sheet (Recall 印证) */
+"cityos.verify.title" = "30 seconds for the next solo traveler";
+"cityos.verify.subtitle" = "%@ — three taps, and your verify feeds straight into this place's confidence.";
+"cityos.verify.q.exists" = "Is it still there, still open?";
+"cityos.verify.q.exists.yes" = "Still there ✓";
+"cityos.verify.q.exists.no" = "Changed / closed";
+"cityos.verify.q.solo" = "Comfortable going alone?";
+"cityos.verify.q.solo.yes" = "Very comfortable";
+"cityos.verify.q.solo.no" = "A bit awkward";
+"cityos.verify.q.crowd" = "How crowded was it?";
+"cityos.verify.q.crowd.few" = "Quiet";
+"cityos.verify.q.crowd.many" = "Pretty packed";
+"cityos.verify.submit" = "Submit verify";
+"cityos.verify.toast" = "Verified · this place's confidence +1, thank you";
+"cityos.verify.note.prefix" = "Verified: ";
+"cityos.verify.note.exists" = "still open";
+"cityos.verify.note.changed" = "changed / closed";
+"cityos.verify.note.solo" = "comfortable solo";
+"cityos.verify.note.awkward" = "a bit awkward solo";
+"cityos.verify.note.few" = "quiet";
+"cityos.verify.note.crowded" = "crowded";
 
 /* City OS v2: today's city omen (今日城市签) */
 "cityos.omen.line" = "Today's city omen · %@";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -2245,11 +2245,53 @@
 "cityos.mode.live.tag" = "在此城";
 "cityos.mode.plan.tag" = "计划";
 "cityos.mode.plan.title" = "%@ · 计划中";
-"cityos.mode.plan.body" = "行前清单、签证时点、落地前该安排好的事 —— 即将上线。";
+"cityos.mode.plan.body" = "出发前备好这几件事，落地那一刻就能直接开始生活。";
 "cityos.mode.plan.cta" = "先看落地包";
+"cityos.mode.plan.cta.checklist" = "查看行前清单";
+"cityos.mode.plan.progress" = "行前 %1$d/%2$d 已备";
 "cityos.mode.recall.tag" = "回顾";
 "cityos.mode.recall.title" = "%@ · 回顾";
-"cityos.mode.recall.body" = "你走过的路、停留的瞬间、这座城市于你的样子 —— 即将上线。";
+"cityos.mode.recall.body" = "你在这座城完成过的点会出现在这里等你印证 —— 你的 30 秒，是下一个独行者的底气。";
+"cityos.mode.recall.pending.body" = "你去过 %1$d 个点，还有 %2$d 个没印证 —— 它们的健康度正在衰减。你的 30 秒，是下一个独行者的底气。";
+"cityos.mode.recall.alldone.body" = "你去过 %d 个点，全部已印证。这座城因为你，对下一个独行者更诚实了。";
+"cityos.mode.recall.verify.cta" = "印证「%@」";
+"cityos.mode.recall.verify.cta.generic" = "印证一个去过的点";
+
+/* City OS v3: 生命周期阶段 + 城市 pill */
+"cityos.stage.land" = "抵达";
+"cityos.stage.settle" = "立足";
+"cityos.stage.live" = "生活";
+"cityos.stage.leave" = "回顾";
+"cityos.pill.plan" = "未到 · 计划";
+"cityos.pill.recall" = "已离 · 回顾";
+"cityos.pill.live" = "第 %1$d 天 · %2$@";
+
+/* City OS v3: 行前清单（Plan 模式落地包） */
+"cityos.kit.title.plan" = "行前清单";
+"cityos.kit.todo.done.a11y" = "已备，点按取消";
+"cityos.kit.todo.pending.a11y" = "标记已备";
+
+/* City OS v3: 印证 sheet（Recall） */
+"cityos.verify.title" = "30 秒，帮下一个独行者";
+"cityos.verify.subtitle" = "%@ —— 三下点完，你的印证会直接进入这个点的信心分。";
+"cityos.verify.q.exists" = "它还在、还开着吗？";
+"cityos.verify.q.exists.yes" = "还在 ✓";
+"cityos.verify.q.exists.no" = "变了 / 关了";
+"cityos.verify.q.solo" = "一个人去，自在吗？";
+"cityos.verify.q.solo.yes" = "很自在";
+"cityos.verify.q.solo.no" = "有点尴尬";
+"cityos.verify.q.crowd" = "你去的时候人多吗？";
+"cityos.verify.q.crowd.few" = "人少";
+"cityos.verify.q.crowd.many" = "挺挤";
+"cityos.verify.submit" = "提交印证";
+"cityos.verify.toast" = "已印证 · 这个点的信心 +1，谢谢你";
+"cityos.verify.note.prefix" = "印证：";
+"cityos.verify.note.exists" = "还在营业";
+"cityos.verify.note.changed" = "已变动/关闭";
+"cityos.verify.note.solo" = "一个人很自在";
+"cityos.verify.note.awkward" = "一个人有点尴尬";
+"cityos.verify.note.few" = "人少";
+"cityos.verify.note.crowded" = "挺挤";
 
 /* City OS v2: 今日城市签 daily omen */
 "cityos.omen.line" = "今日城市签 · %@";

--- a/apps/ios/SoloCompass/Services/CityOSStore.swift
+++ b/apps/ios/SoloCompass/Services/CityOSStore.swift
@@ -56,4 +56,58 @@ public final class CityOSStore {
         seen.insert(Self.normalizedCityKey(cityCode))
         preferences.kitSeenCities = seen
     }
+
+    // MARK: - Plan mode · pre-trip checklist (City OS v3)
+
+    /// Whether a kit item is ticked on this city's pre-trip checklist.
+    public func isKitTodoDone(_ kind: CityKitItem.Kind, cityCode: String) -> Bool {
+        preferences.kitTodosDoneRaw[Self.normalizedCityKey(cityCode)]?
+            .contains(kind.rawValue) ?? false
+    }
+
+    /// Toggles a pre-trip checklist tick (persists via the preferences blob).
+    public func toggleKitTodo(_ kind: CityKitItem.Kind, cityCode: String) {
+        let key = Self.normalizedCityKey(cityCode)
+        var all = preferences.kitTodosDoneRaw
+        var done = Set(all[key] ?? [])
+        if done.contains(kind.rawValue) {
+            done.remove(kind.rawValue)
+        } else {
+            done.insert(kind.rawValue)
+        }
+        // Sorted for a stable blob — Set order would churn the persisted JSON.
+        all[key] = done.sorted()
+        preferences.kitTodosDoneRaw = all
+    }
+
+    /// How many of the given kit's items are ticked for this city. Counts only
+    /// kinds present in `kit`, so stale ticks from a changed kit don't inflate
+    /// the Plan card's progress.
+    public func kitTodoDoneCount(cityCode: String, kit: [CityKitItem]) -> Int {
+        kit.filter { isKitTodoDone($0.kind, cityCode: cityCode) }.count
+    }
+
+    // MARK: - Recall mode · 印证 (City OS v3)
+
+    /// Whether the traveler has personally verified this experience.
+    public func isVerified(_ experienceId: String) -> Bool {
+        preferences.verifiedExperiences.contains(experienceId)
+    }
+
+    /// Records a personal verification — the Recall contribution loop's write
+    /// path. Idempotent.
+    public func markVerified(_ experienceId: String) {
+        var verified = preferences.verifiedExperiences
+        verified.insert(experienceId)
+        preferences.verifiedExperiences = verified
+    }
+
+    // MARK: - Lifecycle stage (City OS v3)
+
+    /// The lifecycle stage for a city: mode + days stayed → land/settle/live/
+    /// leave (`CityStage.inferred`). Pass `ComplianceMath.daysStayed` for the
+    /// current city, nil when no entry date is set.
+    public func stage(for cityCode: String?, daysStayed: Int?) -> CityStage? {
+        CityStage.inferred(mode: mode(for: cityCode), daysStayed: daysStayed)
+    }
 }

--- a/apps/ios/SoloCompass/Tests/CityOSStoreTests.swift
+++ b/apps/ios/SoloCompass/Tests/CityOSStoreTests.swift
@@ -59,4 +59,78 @@ final class CityOSStoreTests: XCTestCase {
         XCTAssertTrue(store.hasSeenKit("vte"))
         XCTAssertFalse(store.hasSeenKit("cmi"), "别的城市不受影响")
     }
+
+    // MARK: - City OS v3 · pre-trip checklist (Plan mode)
+
+    func testKitTodoToggleRoundTripsAndPersists() {
+        let (store, _) = makeStore()
+        XCTAssertFalse(store.isKitTodoDone(.net, cityCode: "CMI"))
+        store.toggleKitTodo(.net, cityCode: "CMI")
+        XCTAssertTrue(store.isKitTodoDone(.net, cityCode: "cmi"), "城市码大小写互通")
+        // Persists across a fresh store over the same defaults.
+        let (reloaded, _) = makeStore()
+        XCTAssertTrue(reloaded.isKitTodoDone(.net, cityCode: "cmi"))
+        // Toggle back off.
+        reloaded.toggleKitTodo(.net, cityCode: "cmi")
+        XCTAssertFalse(reloaded.isKitTodoDone(.net, cityCode: "cmi"))
+    }
+
+    func testKitTodoDoneCountOnlyCountsKindsInKit() {
+        let (store, _) = makeStore()
+        store.toggleKitTodo(.net, cityCode: "cmi")
+        store.toggleKitTodo(.visa, cityCode: "cmi")
+        // Kit without the visa row: the stale visa tick must not inflate progress.
+        let kit = [makeKitItem(kind: .net), makeKitItem(kind: .money)]
+        XCTAssertEqual(store.kitTodoDoneCount(cityCode: "cmi", kit: kit), 1)
+    }
+
+    func testKitTodosAreScopedPerCity() {
+        let (store, _) = makeStore()
+        store.toggleKitTodo(.money, cityCode: "cmi")
+        XCTAssertFalse(store.isKitTodoDone(.money, cityCode: "vte"), "别的城市不受影响")
+    }
+
+    // MARK: - City OS v3 · Recall 印证
+
+    func testMarkVerifiedIsIdempotentAndPersists() {
+        let (store, prefs) = makeStore()
+        XCTAssertFalse(store.isVerified("x10kup"))
+        store.markVerified("x10kup")
+        store.markVerified("x10kup")
+        XCTAssertTrue(store.isVerified("x10kup"))
+        XCTAssertEqual(prefs.verifiedExperiences.count, 1)
+        let (reloaded, _) = makeStore()
+        XCTAssertTrue(reloaded.isVerified("x10kup"))
+    }
+
+    // MARK: - City OS v3 · lifecycle stage
+
+    func testStageInference() {
+        XCTAssertEqual(CityStage.inferred(mode: .live, daysStayed: 1), .land)
+        XCTAssertEqual(CityStage.inferred(mode: .live, daysStayed: 2), .settle)
+        XCTAssertEqual(CityStage.inferred(mode: .live, daysStayed: 3), .settle)
+        XCTAssertEqual(CityStage.inferred(mode: .live, daysStayed: 4), .live)
+        XCTAssertEqual(CityStage.inferred(mode: .live, daysStayed: nil), .live,
+                       "没有入境日的 Live 城市停在稳态,不装知道")
+        XCTAssertEqual(CityStage.inferred(mode: .live, daysStayed: 0), .live,
+                       "入境日在未来 → daysStayed 0 → 稳态")
+        XCTAssertEqual(CityStage.inferred(mode: .recall, daysStayed: 10), .leave)
+        XCTAssertNil(CityStage.inferred(mode: .plan, daysStayed: nil),
+                     "Plan 的停留还没开始,没有阶段")
+    }
+
+    func testStoreStageFollowsCityMode() {
+        let (store, _) = makeStore()
+        store.setMode(.recall, for: "lpq")
+        XCTAssertEqual(store.stage(for: "lpq", daysStayed: nil), .leave)
+        store.setMode(.plan, for: "cmi")
+        XCTAssertNil(store.stage(for: "cmi", daysStayed: nil))
+        XCTAssertEqual(store.stage(for: "vte", daysStayed: 1), .land)
+    }
+
+    // MARK: - Helpers
+
+    private func makeKitItem(kind: CityKitItem.Kind) -> CityKitItem {
+        CityKitItem(cityCode: "cmi", kind: kind, name: kind.rawValue, main: "main")
+    }
 }

--- a/apps/ios/SoloCompass/Views/CityOS/KitSheet.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/KitSheet.swift
@@ -15,6 +15,13 @@ struct KitSheet: View {
     /// When set (e.g. opened from the compliance banner), the visa row is
     /// highlighted and scrolled to on appear.
     var focusKind: CityKitItem.Kind?
+    /// City OS v3 · Plan mode turns the kit into a pre-trip checklist: the
+    /// title flips to 「行前清单」 and every row grows a tick circle. The tick
+    /// state lives in `CityOSStore` (per city); the closures keep this view
+    /// decoupled from the store.
+    var planMode: Bool = false
+    var isTodoDone: (CityKitItem.Kind) -> Bool = { _ in false }
+    var onToggleTodo: (CityKitItem.Kind) -> Void = { _ in }
     let onDismiss: () -> Void
 
     @Environment(\.colorScheme) private var colorScheme
@@ -39,6 +46,8 @@ struct KitSheet: View {
                                 preferences: preferences,
                                 complianceService: complianceService,
                                 isFocused: item.kind == focusKind,
+                                planTick: planMode ? isTodoDone(item.kind) : nil,
+                                onToggleTick: { onToggleTodo(item.kind) },
                                 onOpenLink: openLink
                             )
                             .id(item.kind)
@@ -54,7 +63,9 @@ struct KitSheet: View {
                     }
                 }
             }
-            .navigationTitle(NSLocalizedString("cityos.kit.title", comment: "落地包 sheet title"))
+            .navigationTitle(planMode
+                ? NSLocalizedString("cityos.kit.title.plan", comment: "行前清单 sheet title")
+                : NSLocalizedString("cityos.kit.title", comment: "落地包 sheet title"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
@@ -114,6 +125,9 @@ private struct KitRowCard: View {
     @Bindable var preferences: UserPreferences
     let complianceService: ComplianceService
     let isFocused: Bool
+    /// Non-nil in Plan mode: the row's pre-trip tick state (v3 行前清单).
+    var planTick: Bool?
+    var onToggleTick: () -> Void = {}
     let onOpenLink: (URL, String) -> Void
 
     @Environment(\.colorScheme) private var colorScheme
@@ -162,7 +176,39 @@ private struct KitRowCard: View {
                 .font(CT.display(15, .bold))
                 .foregroundStyle(primaryText)
             Spacer(minLength: 0)
+            if let planTick {
+                tickCircle(on: planTick)
+            }
         }
+    }
+
+    /// Plan-mode pre-trip tick: empty circle → verifiedGreen filled check.
+    private func tickCircle(on: Bool) -> some View {
+        Button {
+            Haptics.impact(.light)
+            onToggleTick()
+        } label: {
+            Image(systemName: "checkmark")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(on ? Color.white : Color.clear)
+                .frame(width: 26, height: 26)
+                .background(
+                    Circle().fill(on ? CT.verifiedGreen : Color.clear)
+                )
+                .overlay(
+                    Circle().strokeBorder(
+                        on ? CT.verifiedGreen : borderColor,
+                        lineWidth: 1.5
+                    )
+                )
+                .contentShape(Circle())
+        }
+        .buttonStyle(PressableButtonStyle(pressedScale: 0.92))
+        .animation(.spring(response: 0.25, dampingFraction: 0.8), value: on)
+        .accessibilityLabel(Text(on
+            ? NSLocalizedString("cityos.kit.todo.done.a11y", comment: "已备")
+            : NSLocalizedString("cityos.kit.todo.pending.a11y", comment: "标记已备")))
+        .accessibilityAddTraits(on ? [.isSelected] : [])
     }
 
     /// The existing hint idiom: sparkle prefix + accentSoft capsule + accent text.

--- a/apps/ios/SoloCompass/Views/CityOS/ModePlaceholderCards.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/ModePlaceholderCards.swift
@@ -1,12 +1,15 @@
 import SwiftUI
 
-/// City OS v2 · Plan / Recall mode placeholder cards (PRD §4.1). The product
-/// decision for v2 is: Live mode is fully built; Plan and Recall get honest
-/// placeholder cards so the mode switch is real and legible, but they don't
-/// pretend to have features that aren't there yet. Each teases what the mode
-/// will hold and offers the one thing that IS live — the landing kit.
+/// City OS v3 · Plan / Recall mode dock cards. v2 shipped these as honest
+/// placeholders; v3 makes them real: Plan carries the pre-trip checklist
+/// progress, Recall carries the visited/verified contribution loop —
+/// "从消费者变成贡献者" (design handoff v3/modules.jsx).
 struct PlanCard: View {
     let cityName: String
+    /// Pre-trip checklist progress (ticked / total kit items). Zero total
+    /// means the city has no kit yet — the progress row hides.
+    let doneCount: Int
+    let totalCount: Int
     let onOpenKit: () -> Void
 
     var body: some View {
@@ -18,15 +21,27 @@ struct PlanCard: View {
                 cityName
             ),
             bodyText: NSLocalizedString("cityos.mode.plan.body", comment: "Pre-trip checklist teaser"),
-            ctaText: NSLocalizedString("cityos.mode.plan.cta", comment: "先看落地包"),
+            ctaText: NSLocalizedString("cityos.mode.plan.cta.checklist", comment: "查看行前清单"),
+            ctaSymbol: "checklist",
             onCTA: onOpenKit
-        )
+        ) {
+            if totalCount > 0 {
+                PlanProgressRow(done: doneCount, total: totalCount)
+            }
+        }
     }
 }
 
-/// The Recall-mode placeholder — muted, retrospective register.
+/// The Recall-mode card: visited / pending-verify stats plus the 印证 CTA.
 struct RecallCard: View {
     let cityName: String
+    /// Experiences in this city the traveler completed (去过).
+    let visitedCount: Int
+    /// Visited experiences not yet personally verified.
+    let pendingCount: Int
+    /// Display name of the next pending experience, for the CTA label.
+    let nextPendingName: String?
+    let onVerifyNext: () -> Void
     let onOpenKit: () -> Void
 
     var body: some View {
@@ -37,23 +52,100 @@ struct RecallCard: View {
                 format: NSLocalizedString("cityos.mode.recall.title", comment: "%@ · 回顾"),
                 cityName
             ),
-            bodyText: NSLocalizedString("cityos.mode.recall.body", comment: "Looking-back teaser"),
-            ctaText: nil,
-            onCTA: onOpenKit
+            bodyText: bodyText,
+            ctaText: ctaText,
+            ctaSymbol: "eye",
+            onCTA: pendingCount > 0 ? onVerifyNext : onOpenKit
+        ) {
+            EmptyView()
+        }
+    }
+
+    private var bodyText: String {
+        if visitedCount == 0 {
+            return NSLocalizedString("cityos.mode.recall.body", comment: "Looking-back teaser")
+        }
+        if pendingCount > 0 {
+            return String(
+                format: NSLocalizedString(
+                    "cityos.mode.recall.pending.body",
+                    comment: "你去过 N 个点，还有 M 个没印证"
+                ),
+                visitedCount, pendingCount
+            )
+        }
+        return String(
+            format: NSLocalizedString(
+                "cityos.mode.recall.alldone.body",
+                comment: "你去过 N 个点，全部已印证"
+            ),
+            visitedCount
         )
+    }
+
+    private var ctaText: String? {
+        guard pendingCount > 0 else { return nil }
+        guard let nextPendingName else {
+            return NSLocalizedString("cityos.mode.recall.verify.cta.generic", comment: "印证一个去过的点")
+        }
+        return String(
+            format: NSLocalizedString("cityos.mode.recall.verify.cta", comment: "印证「%@」"),
+            nextPendingName
+        )
+    }
+}
+
+// MARK: - PlanProgressRow
+
+/// The pre-trip progress bar: modePlanBlue fill + mono "行前 N/M 已备" count —
+/// mono because the count is a self-computed, checkable number (PRD §2 公理二).
+private struct PlanProgressRow: View {
+    let done: Int
+    let total: Int
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: 8) {
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(trackFill)
+                    Capsule()
+                        .fill(CT.modePlanBlue)
+                        .frame(width: geo.size.width * CGFloat(done) / CGFloat(max(total, 1)))
+                        .animation(.easeInOut(duration: 0.3), value: done)
+                }
+            }
+            .frame(height: 5)
+            Text(String(
+                format: NSLocalizedString("cityos.mode.plan.progress", comment: "行前 %1$d/%2$d 已备"),
+                done, total
+            ))
+            .font(CT.mono(10.5, .medium))
+            .foregroundStyle(CT.fgMuted)
+            .contentTransition(.numericText())
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private var trackFill: Color {
+        colorScheme == .dark ? CT.warmSunkenDark : CT.surfaceSunken
     }
 }
 
 // MARK: - ModeCard
 
-/// Shared chrome for the mode placeholder cards.
-private struct ModeCard: View {
+/// Shared chrome for the mode dock cards. `extra` slots between the body copy
+/// and the CTA (the Plan progress row lives there).
+private struct ModeCard<Extra: View>: View {
     let tagText: String
     let tagColor: Color
     let title: String
     let bodyText: String
     let ctaText: String?
+    var ctaSymbol: String = "backpack"
     let onCTA: () -> Void
+    @ViewBuilder let extra: () -> Extra
 
     @Environment(\.colorScheme) private var colorScheme
 
@@ -68,23 +160,25 @@ private struct ModeCard: View {
                 .font(CT.body(13))
                 .foregroundStyle(CT.fgMuted)
                 .fixedSize(horizontal: false, vertical: true)
+            extra()
             if let ctaText {
                 Button {
                     Haptics.impact(.light)
                     onCTA()
                 } label: {
-                    HStack(spacing: 5) {
-                        Image(systemName: "backpack")
+                    HStack(spacing: 6) {
+                        Image(systemName: ctaSymbol)
                             .font(.system(size: 12, weight: .semibold))
                         Text(ctaText)
-                            .font(CT.body(13, .semibold))
+                            .font(CT.body(13.5, .semibold))
+                            .lineLimit(1)
                     }
-                    .foregroundStyle(CT.accent)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 7)
-                    .background(Capsule().fill(CT.accentSoft))
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+                    .background(Capsule().fill(CT.accent))
                 }
-                .buttonStyle(PressableButtonStyle(pressedScale: 0.96))
+                .buttonStyle(PressableButtonStyle(pressedScale: 0.97))
             }
         }
         .padding(16)

--- a/apps/ios/SoloCompass/Views/CityOS/VerifySheet.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/VerifySheet.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+/// City OS v3 · 离店一键印证 (design handoff v2/detail.jsx VerifySheet):
+/// three binary questions answerable in 30 seconds, feeding the Recall
+/// contribution loop. Submit stays disabled until all three are answered —
+/// a half-filled verification is worse than none.
+struct VerifySheet: View {
+    /// The traveler's three answers, index 0 = the first (positive) option.
+    struct Answers: Equatable {
+        var stillThere: Int?
+        var soloComfort: Int?
+        var crowd: Int?
+
+        var isComplete: Bool {
+            stillThere != nil && soloComfort != nil && crowd != nil
+        }
+    }
+
+    let placeName: String
+    let onSubmit: (Answers) -> Void
+    let onDismiss: () -> Void
+
+    @State private var answers = Answers()
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            question(
+                text: NSLocalizedString("cityos.verify.q.exists", comment: "它还在、还开着吗？"),
+                options: [
+                    NSLocalizedString("cityos.verify.q.exists.yes", comment: "还在 ✓"),
+                    NSLocalizedString("cityos.verify.q.exists.no", comment: "变了 / 关了"),
+                ],
+                selection: $answers.stillThere
+            )
+            question(
+                text: NSLocalizedString("cityos.verify.q.solo", comment: "一个人去，自在吗？"),
+                options: [
+                    NSLocalizedString("cityos.verify.q.solo.yes", comment: "很自在"),
+                    NSLocalizedString("cityos.verify.q.solo.no", comment: "有点尴尬"),
+                ],
+                selection: $answers.soloComfort
+            )
+            question(
+                text: NSLocalizedString("cityos.verify.q.crowd", comment: "你去的时候人多吗？"),
+                options: [
+                    NSLocalizedString("cityos.verify.q.crowd.few", comment: "人少"),
+                    NSLocalizedString("cityos.verify.q.crowd.many", comment: "挺挤"),
+                ],
+                selection: $answers.crowd
+            )
+            submitButton
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(sheetBackground.ignoresSafeArea())
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.visible)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(NSLocalizedString("cityos.verify.title", comment: "30 秒，帮下一个独行者"))
+                .font(CT.displayRounded(18, .bold))
+                .foregroundStyle(primaryText)
+            Text(String(
+                format: NSLocalizedString(
+                    "cityos.verify.subtitle",
+                    comment: "%@ —— 三下点完，你的印证会直接进入这个点的信心分"
+                ),
+                placeName
+            ))
+            .font(CT.body(12.5))
+            .foregroundStyle(CT.fgMuted)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func question(text: String, options: [String], selection: Binding<Int?>) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text(text)
+                .font(CT.body(13.5, .semibold))
+                .foregroundStyle(primaryText)
+            HStack(spacing: 8) {
+                ForEach(options.indices, id: \.self) { index in
+                    optionPill(
+                        label: options[index],
+                        isSelected: selection.wrappedValue == index
+                    ) {
+                        Haptics.impact(.light)
+                        selection.wrappedValue = index
+                    }
+                }
+            }
+        }
+    }
+
+    private func optionPill(label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(CT.body(13, .medium))
+                .foregroundStyle(isSelected ? CT.accent : CT.fgMuted)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 9)
+                .background(
+                    Capsule().fill(isSelected ? CT.accentSoft : optionFill)
+                )
+                .overlay(
+                    Capsule().strokeBorder(
+                        isSelected ? CT.accent : borderColor,
+                        lineWidth: isSelected ? 1.2 : 0.5
+                    )
+                )
+        }
+        .buttonStyle(PressableButtonStyle(pressedScale: 0.97))
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+
+    private var submitButton: some View {
+        Button {
+            Haptics.notify(.success)
+            onSubmit(answers)
+            onDismiss()
+        } label: {
+            Text(NSLocalizedString("cityos.verify.submit", comment: "提交印证"))
+                .font(CT.body(14.5, .semibold))
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(Capsule().fill(answers.isComplete ? CT.accent : CT.fgSubtle))
+        }
+        .buttonStyle(PressableButtonStyle(pressedScale: 0.98))
+        .disabled(!answers.isComplete)
+        .padding(.top, 4)
+        .animation(.easeInOut(duration: 0.2), value: answers.isComplete)
+    }
+
+    // MARK: - Colors
+
+    private var sheetBackground: Color { colorScheme == .dark ? CT.warmSheetDark : CT.surfaceSunken }
+    private var optionFill: Color { colorScheme == .dark ? CT.warmCardDark : CT.surfaceWhite }
+    private var borderColor: Color { colorScheme == .dark ? CT.warmBorderDark : CT.borderSubtle }
+    private var primaryText: Color { colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary }
+}

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -185,6 +185,10 @@ struct CompassMapContentView: View {
     /// the compliance banner). Cleared on dismiss.
     @State private var kitSheetFocus: CityKitItem.Kind? = nil
     @State private var isShowingLiveSheet: Bool = false
+    /// City OS v3 · Recall 印证 target — non-nil presents the VerifySheet.
+    @State private var verifyTarget: Experience?
+    /// Transient City-OS toast ("已印证 · 信心 +1") floating above the dock slot.
+    @State private var cityOSToast: String?
     /// Session-scoped dismissal of the compliance banner — it reappears next day
     /// (a fresh interruption-budget day), never again this session.
     @State private var complianceBannerDismissed: Bool = false
@@ -372,6 +376,95 @@ struct CompassMapContentView: View {
     /// The current city's mode (Live/Plan/Recall). Live is the default.
     private var currentCityMode: CityMode {
         cityOSStore.mode(for: viewModel.selectedCity)
+    }
+
+    /// City OS v3 · lifecycle stage for the city pill's rail dots. Days stayed
+    /// come from the visa entry date the traveler already gave the kit.
+    private var currentCityStage: CityStage? {
+        cityOSStore.stage(
+            for: viewModel.selectedCity,
+            daysStayed: complianceService.state()?.daysStayed
+        )
+    }
+
+    /// City OS v3 · the city pill's second line ("第 3 天 · 生活" / "未到 · 计划"
+    /// / "已离 · 回顾"). Nil keeps the pill single-line: Live with no entry date
+    /// has nothing honest to say, so it says nothing.
+    private var cityPillModeLine: String? {
+        guard FeatureFlags.cityOS, viewModel.selectedCity != nil else { return nil }
+        switch currentCityMode {
+        case .plan:
+            return NSLocalizedString("cityos.pill.plan", comment: "未到 · 计划")
+        case .recall:
+            return NSLocalizedString("cityos.pill.recall", comment: "已离 · 回顾")
+        case .live:
+            guard let days = complianceService.state()?.daysStayed, days >= 1,
+                  let stage = currentCityStage else { return nil }
+            return String(
+                format: NSLocalizedString("cityos.pill.live", comment: "第 %1$d 天 · %2$@"),
+                days, stage.localizedLabel
+            )
+        }
+    }
+
+    /// Stage-dot rail index for the pill (Live mode only; nil hides the rail).
+    private var cityPillStageIndex: Int? {
+        guard FeatureFlags.cityOS, currentCityMode == .live,
+              complianceService.state() != nil else { return nil }
+        return currentCityStage?.index
+    }
+
+    /// Recall mode · experiences in the current city the traveler completed
+    /// (去过). Source of truth is `preferences.completedExperiences`.
+    private var recallVisited: [Experience] {
+        guard let city = viewModel.selectedCity else { return [] }
+        let key = CityOSStore.normalizedCityKey(city)
+        return experienceService.allExperiences.filter {
+            CityOSStore.normalizedCityKey($0.location.cityCode) == key
+                && preferences.completedExperiences.contains($0.id)
+        }
+    }
+
+    /// Visited experiences the traveler hasn't personally verified yet — the
+    /// Recall card's contribution queue.
+    private var recallPending: [Experience] {
+        recallVisited.filter { !cityOSStore.isVerified($0.id) }
+    }
+
+    /// VerifySheet submit: record the verification (idempotent), feed the
+    /// answers into the co-build layer as a note authored by "你", and confirm
+    /// with a toast — the 消费者→贡献者 loop closing in one tap.
+    private func submitVerification(_ answers: VerifySheet.Answers, for experience: Experience) {
+        cityOSStore.markVerified(experience.id)
+        let parts = [
+            answers.stillThere == 0
+                ? NSLocalizedString("cityos.verify.note.exists", comment: "还在营业")
+                : NSLocalizedString("cityos.verify.note.changed", comment: "已变动/关闭"),
+            answers.soloComfort == 0
+                ? NSLocalizedString("cityos.verify.note.solo", comment: "一个人很自在")
+                : NSLocalizedString("cityos.verify.note.awkward", comment: "一个人有点尴尬"),
+            answers.crowd == 0
+                ? NSLocalizedString("cityos.verify.note.few", comment: "人少")
+                : NSLocalizedString("cityos.verify.note.crowded", comment: "挺挤"),
+        ]
+        let prefix = NSLocalizedString("cityos.verify.note.prefix", comment: "印证：")
+        TravelerNoteStore().addNote(
+            experienceId: experience.id,
+            text: prefix + parts.joined(separator: " · ")
+        )
+        showCityOSToast(NSLocalizedString(
+            "cityos.verify.toast",
+            comment: "已印证 · 这个点的信心 +1，谢谢你"
+        ))
+    }
+
+    /// Show the transient City-OS toast for ~2.4s.
+    private func showCityOSToast(_ text: String) {
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) { cityOSToast = text }
+        Task {
+            try? await Task.sleep(for: .seconds(2.4))
+            withAnimation(.easeInOut(duration: 0.3)) { cityOSToast = nil }
+        }
     }
 
     /// Display name for the current city (for the mode placeholder cards),
@@ -912,6 +1005,9 @@ struct CompassMapContentView: View {
                 // city so a stale marker glow / dismissed banner don't carry over.
                 viewModel.highlightedEventId = nil
                 complianceBannerDismissed = false
+                // City OS v3: 切城 = 切换整个聚合上下文 — active filters belong
+                // to the city they were set in, so they never carry over.
+                viewModel.clearFilters()
                 loadCityBrief(for: cityCode, autoSurface: true)
             }
             .onReceive(NotificationCenter.default.publisher(for: RouteStore.didChange)) { _ in
@@ -941,6 +1037,13 @@ struct CompassMapContentView: View {
             // sheets (see the L1180-ish stacked-sheets note).
             .sheet(isPresented: $isShowingKitSheet, onDismiss: { kitSheetFocus = nil }) { kitSheetContent }
             .sheet(isPresented: $isShowingLiveSheet) { liveSheetContent }
+            .sheet(item: $verifyTarget) { experience in
+                VerifySheet(
+                    placeName: experience.shortName,
+                    onSubmit: { answers in submitVerification(answers, for: experience) },
+                    onDismiss: { verifyTarget = nil }
+                )
+            }
             .sheet(isPresented: $isShowingFavorites) { favoritesSheetContent }
             // Bind the chat sheet to the orchestrator itself instead of a
             // separate Bool. With `.sheet(isPresented:)` the content closure
@@ -1055,6 +1158,8 @@ struct CompassMapContentView: View {
                 MapOverlayView(
                     viewModel: viewModel,
                     isAIProcessing: aiService.isProcessing,
+                    cityModeLine: cityPillModeLine,
+                    cityStageIndex: cityPillStageIndex,
                     isShowingCityPicker: $isShowingCityPicker,
                     dismissedAIError: $dismissedAIError,
                     dismissedExploreError: $dismissedExploreError,
@@ -1436,9 +1541,23 @@ struct CompassMapContentView: View {
                             Spacer()
                             Group {
                                 if currentCityMode == .plan {
-                                    PlanCard(cityName: currentCityDisplayName, onOpenKit: { isShowingKitSheet = true })
+                                    PlanCard(
+                                        cityName: currentCityDisplayName,
+                                        doneCount: viewModel.selectedCity.map {
+                                            cityOSStore.kitTodoDoneCount(cityCode: $0, kit: cityBriefService.kit)
+                                        } ?? 0,
+                                        totalCount: cityBriefService.kit.count,
+                                        onOpenKit: { isShowingKitSheet = true }
+                                    )
                                 } else {
-                                    RecallCard(cityName: currentCityDisplayName, onOpenKit: { isShowingKitSheet = true })
+                                    RecallCard(
+                                        cityName: currentCityDisplayName,
+                                        visitedCount: recallVisited.count,
+                                        pendingCount: recallPending.count,
+                                        nextPendingName: recallPending.first?.shortName,
+                                        onVerifyNext: { verifyTarget = recallPending.first },
+                                        onOpenKit: { isShowingKitSheet = true }
+                                    )
                                 }
                             }
                             .padding(.horizontal, 20)
@@ -1446,6 +1565,24 @@ struct CompassMapContentView: View {
                         }
                         .transition(.opacity)
                     }
+                }
+
+                // City OS v3 toast (印证 confirmation). Floats above the dock
+                // slot; purely informational, never intercepts touches.
+                if let cityOSToast {
+                    VStack {
+                        Spacer()
+                        Text(cityOSToast)
+                            .font(CT.body(13, .medium))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 10)
+                            .background(Capsule().fill(CT.accent))
+                            .padding(.bottom, drawerTabsBottomInset + 62)
+                    }
+                    .allowsHitTesting(false)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .accessibilityAddTraits(.updatesFrequently)
                 }
 
                 // Active-route banner: a pill naming the walk with an end button.
@@ -1786,6 +1923,15 @@ struct CompassMapContentView: View {
             preferences: preferences,
             complianceService: complianceService,
             focusKind: kitSheetFocus,
+            planMode: currentCityMode == .plan,
+            isTodoDone: { kind in
+                guard let city = viewModel.selectedCity else { return false }
+                return cityOSStore.isKitTodoDone(kind, cityCode: city)
+            },
+            onToggleTodo: { kind in
+                guard let city = viewModel.selectedCity else { return }
+                cityOSStore.toggleKitTodo(kind, cityCode: city)
+            },
             onDismiss: { isShowingKitSheet = false }
         )
     }
@@ -2669,6 +2815,10 @@ enum MapOverlayMetrics {
 private struct MapOverlayView: View {
     var viewModel: MapViewModel
     var isAIProcessing: Bool
+    /// City OS v3 · optional second pill line ("第 3 天 · 生活"). Nil = one line.
+    var cityModeLine: String?
+    /// City OS v3 · lifecycle rail position (0–3) for the stage dots; nil hides.
+    var cityStageIndex: Int?
     @Binding var isShowingCityPicker: Bool
     @Binding var dismissedAIError: String?
     @Binding var dismissedExploreError: String?
@@ -3149,15 +3299,36 @@ private struct MapOverlayView: View {
         Button {
             isShowingCityPicker = true
         } label: {
-            HStack(spacing: 4) {
-                Text(cityName)
-                    .font(.subheadline.weight(.medium))
-                Image(systemName: "chevron.down")
-                    .font(.caption.weight(.semibold))
+            VStack(alignment: .leading, spacing: 1) {
+                HStack(spacing: 4) {
+                    Text(cityName)
+                        .font(.subheadline.weight(.medium))
+                    Image(systemName: "chevron.down")
+                        .font(.caption.weight(.semibold))
+                }
+                .foregroundStyle(CT.accent)
+                // City OS v3 · lifecycle line: mode + day + stage dots. The
+                // pill stays one-line whenever there is nothing honest to add.
+                if let cityModeLine {
+                    HStack(spacing: 4) {
+                        Text(cityModeLine)
+                            .font(CT.mono(9, .medium))
+                            .foregroundStyle(CT.sunGoldDeep)
+                        if let cityStageIndex {
+                            HStack(spacing: 2.5) {
+                                ForEach(0..<4, id: \.self) { dot in
+                                    Circle()
+                                        .fill(dot <= cityStageIndex ? CT.sunGoldDeep : CT.borderSubtle)
+                                        .frame(width: 3.5, height: 3.5)
+                                }
+                            }
+                            .accessibilityHidden(true)
+                        }
+                    }
+                }
             }
-            .foregroundStyle(CT.accent)
             .padding(.horizontal, 12)
-            .padding(.vertical, 6)
+            .padding(.vertical, cityModeLine == nil ? 6 : 4)
             .background(CT.surfaceWhite.opacity(0.78), in: Capsule())
             .frame(
                 minWidth: MapOverlayMetrics.cityPillHitTarget,
@@ -3165,7 +3336,7 @@ private struct MapOverlayView: View {
             )
             .contentShape(Rectangle())
         }
-        .accessibilityLabel(Text(cityName))
+        .accessibilityLabel(Text(cityModeLine.map { "\(cityName), \($0)" } ?? cityName))
         .accessibilityHint(Text(NSLocalizedString("city.picker.title", comment: "City picker sheet title")))
     }
 


### PR DESCRIPTION
## Summary

Implements the **SoloCompass v3 design (Solo City OS)** from the claude.ai/design handoff: the two City-OS modes that shipped as honest placeholders in v2 (PR #592–595) become real features.

### Plan 模式 → 行前清单
- `KitSheet` plan variant: title flips to 「行前清单」, every kit row gets a tick circle (verifiedGreen on tick)
- Ticks persist **per city** via new `UserPreferences.kitTodosDoneRaw` blob field + `CityOSStore` semantics (`isKitTodoDone` / `toggleKitTodo` / `kitTodoDoneCount` — stale ticks from a changed kit never inflate progress)
- `PlanCard` shows real progress (modePlanBlue bar + mono 「行前 N/M 已备」) instead of "coming soon"

### Recall 模式 → 印证贡献闭环
- `RecallCard` reports 「你去过 N 个点，还有 M 个没印证」 from `completedExperiences`, with a verify CTA for the next pending place (all-done and zero-visited states covered)
- New `VerifySheet`: 30 秒三问（还在吗 / 一个人自在吗 / 人多吗），全答完才能提交
- Submit → `verifiedExperiences` 持久化（幂等）+ TravelerNote 落入旅人共建层 + toast 「已印证 · 信心 +1」

### 生命周期 (PRD §4.1 phase)
- New `CityStage` (land/settle/live/leave) inferred from mode + `ComplianceMath.daysStayed` — pure function, boundary-pinned by tests
- City pill second line: 「第 3 天 · 生活」+ 4-dot stage rail (Live) / 「未到 · 计划」 / 「已离 · 回顾」; stays one-line when there's nothing honest to say (no entry date)
- 切城 = 切换整个聚合上下文: switching city now clears active filters

## Verification
- `xcodebuild build` ✅ BUILD SUCCEEDED
- `CityOSStoreTests` (6 new) + `ComplianceBannerArbitrationTests` + `CityBriefHealthTests`: **35 tests, 0 failures** ✅
- `SFSymbolExistenceTests` 2/2 ✅ (new symbols: checklist / eye)
- `pnpm parity:check` all four parity gates ✅ (schema untouched — new state is prefs-blob only, local-first)
- en + zh-Hans strings added in lockstep (no raw-key regressions)