### PR TITLE
fix(ios): follow the GPS city on entry & locate tap, kill camera tug-of-war

### DIFF
--- a/apps/ios/SoloCompass/Tests/MapViewModelCityRegionSyncTests.swift
+++ b/apps/ios/SoloCompass/Tests/MapViewModelCityRegionSyncTests.swift
@@ -109,50 +109,39 @@ final class MapViewModelCityRegionSyncTests: XCTestCase {
         )
     }
 
-    // MARK: - V-007: a GPS fix must not override an explicit city pick
+    // MARK: - GPS city follow (cold start + locate button)
 
-    /// Regression (V-007): when the user has picked a preset city, the first GPS
-    /// fix at a far-away real location (e.g. picking a SF/China city while
-    /// physically in Laos) must NOT snap the camera back to the GPS location.
-    ///
-    /// Before the fix, `bindToLocation` skipped the camera recenter for a preset
-    /// city but still ran `autoExploreIfEmpty(at: gps)`, whose `exploreNearby`
-    /// tail called `selectCity(discoveredCity)` + `recenter(gps)` — silently
-    /// overriding the pick. The fix moves `autoExploreIfEmpty` inside the
-    /// "no city selected" branch so a preset city is left untouched.
-    func testGPSFixDoesNotOverridePresetCity() throws {
+    /// V-007 (narrowed to its actual scenario): a city picked explicitly *in
+    /// this session* — the user tapped it in the picker while GPS was still
+    /// warming up — must survive the first GPS fix. Picking a SF/China city
+    /// while physically in Laos must not snap the camera back to Laos.
+    func testExplicitSessionPickSurvivesFirstGPSFix() throws {
+        UserDefaults.standard.removeObject(forKey: "startCity")
         let locationService = LocationService()
         let prefs = UserPreferences(defaults: makeIsolatedDefaults())
-        prefs.lastSelectedCity = "san-francisco"
         let vm = MapViewModel(
             locationService: locationService,
             experienceService: ExperienceService(),
             aiService: AIService(),
             preferences: prefs
         )
-        XCTAssertEqual(vm.selectedCity, "san-francisco")
+        // The user picks San Francisco through the picker BEFORE any fix lands.
+        vm.selectCity("san-francisco")
         let sf = try XCTUnwrap(MapViewModel.knownCityCenters["san-francisco"])
 
         // Simulate the traveler being physically in Vientiane, Laos — ~12,000 km
         // from the picked San Francisco.
         let laos = CLLocationCoordinate2D(latitude: 17.9757, longitude: 102.6331)
         locationService.simulate(location: CLLocation(latitude: laos.latitude, longitude: laos.longitude))
-
-        // The first GPS fix fires bindToLocation (CompassMapView's onChange).
         vm.bindToLocation()
 
-        // Core regression assertion: a preset city must NOT trigger GPS-anchored
-        // auto-explore at all. (`exploreNearby`'s tail — selectCity + recenter —
-        // is async, so asserting on the count is the deterministic way to prove
-        // the override path is never entered; reverting the fix makes this fail.)
         XCTAssertEqual(
             vm.autoExploreInvocationCount, 0,
-            "A preset-city GPS fix must not run GPS-anchored auto-explore"
+            "An in-session pick's GPS fix must not run GPS-anchored auto-explore"
         )
-        // The pick must survive: city unchanged, camera still on SF.
         XCTAssertEqual(
             vm.selectedCity, "san-francisco",
-            "A GPS fix must not change an explicit preset-city pick"
+            "A GPS fix must not change an explicit in-session city pick"
         )
         let region = try XCTUnwrap(vm.cameraPosition.region)
         XCTAssertLessThan(
@@ -163,6 +152,186 @@ final class MapViewModelCityRegionSyncTests: XCTestCase {
             distanceKm(region.center, laos), 1000.0,
             "Camera must NOT be anywhere near the real GPS location"
         )
+    }
+
+    /// The new cold-start rule: a city merely *persisted from a previous
+    /// session* does NOT own the camera. Entering the app with the first GPS
+    /// fix in Vientiane must land the map on the fix and flip the selection
+    /// (the top-left pill) to Vientiane — where the traveler physically is.
+    func testColdStartFollowsGPSCityOverPersistedCity() throws {
+        UserDefaults.standard.removeObject(forKey: "startCity")
+        let locationService = LocationService()
+        let prefs = UserPreferences(defaults: makeIsolatedDefaults())
+        prefs.lastSelectedCity = "san-francisco"
+        let vm = MapViewModel(
+            locationService: locationService,
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: prefs
+        )
+        XCTAssertEqual(vm.selectedCity, "san-francisco")
+
+        let laos = CLLocationCoordinate2D(latitude: 17.9757, longitude: 102.6331)
+        locationService.simulate(location: CLLocation(latitude: laos.latitude, longitude: laos.longitude))
+        vm.bindToLocation()
+
+        let selected = try XCTUnwrap(vm.selectedCity, "Cold start must adopt the GPS city")
+        XCTAssertTrue(
+            MapViewModel.cityCodeMatches("VTE", selected: selected),
+            "Selection must flip to the GPS city (Vientiane), got \(selected)"
+        )
+        XCTAssertEqual(
+            prefs.lastSelectedCity, selected,
+            "The adopted GPS city must persist for the next cold start"
+        )
+        let region = try XCTUnwrap(vm.cameraPosition.region)
+        XCTAssertLessThan(
+            distanceKm(region.center, laos), 5.0,
+            "Camera must center on the GPS fix, not the persisted city"
+        )
+    }
+
+    /// The locate button (`recenterOnUser`) also adopts the GPS city: tapping
+    /// it after wandering to another city must move the camera to the fix AND
+    /// flip the pill/selection to the fix's city.
+    func testRecenterOnUserAdoptsGPSCity() throws {
+        UserDefaults.standard.removeObject(forKey: "startCity")
+        let locationService = LocationService()
+        let prefs = UserPreferences(defaults: makeIsolatedDefaults())
+        prefs.lastSelectedCity = "chiang-mai"
+        let vm = MapViewModel(
+            locationService: locationService,
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: prefs
+        )
+
+        let shenzhen = CLLocationCoordinate2D(latitude: 22.5431, longitude: 114.0579)
+        locationService.simulate(location: CLLocation(latitude: shenzhen.latitude, longitude: shenzhen.longitude))
+        vm.recenterOnUser()
+
+        let selected = try XCTUnwrap(vm.selectedCity, "Locate must adopt the GPS city")
+        let selectedCenter = try XCTUnwrap(
+            MapViewModel.knownCityCenters[selected],
+            "Adopted city must resolve in the catalog, got \(selected)"
+        )
+        XCTAssertLessThan(
+            distanceKm(selectedCenter, shenzhen), 5.0,
+            "Adopted city must be Shenzhen, got \(selected)"
+        )
+        let region = try XCTUnwrap(vm.cameraPosition.region)
+        XCTAssertLessThan(
+            distanceKm(region.center, shenzhen), 1.0,
+            "Camera must center on the GPS fix after tapping locate"
+        )
+    }
+
+    /// A fix far from every known city (Beijing) drops to pure GPS-follow:
+    /// selection cleared so the nearby query anchors on the fix, camera on the
+    /// fix, and auto-explore left to discover + name the city.
+    func testColdStartFarFromKnownCitiesDropsToGPSFollow() throws {
+        UserDefaults.standard.removeObject(forKey: "startCity")
+        let locationService = LocationService()
+        let prefs = UserPreferences(defaults: makeIsolatedDefaults())
+        prefs.lastSelectedCity = "chiang-mai"
+        let vm = MapViewModel(
+            locationService: locationService,
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: prefs
+        )
+
+        let beijing = CLLocationCoordinate2D(latitude: 39.9042, longitude: 116.4074)
+        locationService.simulate(location: CLLocation(latitude: beijing.latitude, longitude: beijing.longitude))
+        vm.bindToLocation()
+
+        XCTAssertNil(
+            vm.selectedCity,
+            "Far from every known city, the stale persisted selection must clear"
+        )
+        let region = try XCTUnwrap(vm.cameraPosition.region)
+        XCTAssertLessThan(
+            distanceKm(region.center, beijing), 5.0,
+            "Camera must still center on the GPS fix"
+        )
+        XCTAssertEqual(
+            vm.autoExploreInvocationCount, 1,
+            "GPS-follow must hand the fix to auto-explore to discover the city"
+        )
+    }
+
+    /// Foreground return with the process alive across a flight: the fix now
+    /// resolves to another city → re-follow. Same city → leave pan/zoom alone.
+    func testRefollowOnForegroundOnlyWhenCityChanged() throws {
+        UserDefaults.standard.removeObject(forKey: "startCity")
+        let locationService = LocationService()
+        let prefs = UserPreferences(defaults: makeIsolatedDefaults())
+        let vm = MapViewModel(
+            locationService: locationService,
+            experienceService: ExperienceService(),
+            aiService: AIService(),
+            preferences: prefs
+        )
+        // Cold start in Chiang Mai.
+        let chiangMai = CLLocationCoordinate2D(latitude: 18.7877, longitude: 98.9938)
+        locationService.simulate(location: CLLocation(latitude: chiangMai.latitude, longitude: chiangMai.longitude))
+        vm.bindToLocation()
+        let selectedAfterBind = try XCTUnwrap(vm.selectedCity)
+        XCTAssertTrue(MapViewModel.cityCodeMatches("cmi", selected: selectedAfterBind))
+
+        // Same-city foreground return: the user's pan must survive.
+        let panTarget = CLLocationCoordinate2D(latitude: 18.9, longitude: 99.1)
+        vm.cameraPosition = .region(MKCoordinateRegion(
+            center: panTarget,
+            span: MKCoordinateSpan(latitudeDelta: 0.02, longitudeDelta: 0.02)
+        ))
+        vm.refollowUserCityIfMoved()
+        let sameCityRegion = try XCTUnwrap(vm.cameraPosition.region)
+        XCTAssertLessThan(
+            distanceKm(sameCityRegion.center, panTarget), 1.0,
+            "Foreground return in the same city must not move the camera"
+        )
+
+        // Flight to Shenzhen, then foreground return: must re-follow.
+        let shenzhen = CLLocationCoordinate2D(latitude: 22.5431, longitude: 114.0579)
+        locationService.simulate(location: CLLocation(latitude: shenzhen.latitude, longitude: shenzhen.longitude))
+        vm.refollowUserCityIfMoved()
+        let movedRegion = try XCTUnwrap(vm.cameraPosition.region)
+        XCTAssertLessThan(
+            distanceKm(movedRegion.center, shenzhen), 1.0,
+            "Foreground return in a new city must recenter on the fix"
+        )
+        let selected = try XCTUnwrap(vm.selectedCity)
+        let selectedCenter = try XCTUnwrap(MapViewModel.knownCityCenters[selected])
+        XCTAssertLessThan(
+            distanceKm(selectedCenter, shenzhen), 5.0,
+            "Selection must flip to the new GPS city, got \(selected)"
+        )
+    }
+
+    /// `recenter(on:)` must pin the camera exactly on the requested coordinate.
+    /// Regression: the reload inside it used to run the pin auto-fit, which
+    /// immediately dragged the camera back toward the nearest experience
+    /// cluster — the user saw their location circle glide to screen center and
+    /// slide away again on every locate tap.
+    func testRecenterPinsCameraOnCoordinate() throws {
+        let vm = makeViewModel(startingCity: "chiang-mai")
+        // A wide settled span makes the Chiang Mai seed cluster "much tighter
+        // than the camera", which is exactly the condition that used to
+        // trigger the auto-fit yank.
+        vm.currentSpanLatitudeDelta = 1.0
+
+        // Recenter on a spot deliberately offset from the seed cluster.
+        let target = CLLocationCoordinate2D(latitude: 18.75, longitude: 99.05)
+        vm.recenter(on: target)
+
+        let region = try XCTUnwrap(vm.cameraPosition.region)
+        XCTAssertEqual(region.center.latitude, target.latitude, accuracy: 0.0001,
+                       "Camera must stay pinned on the recenter coordinate")
+        XCTAssertEqual(region.center.longitude, target.longitude, accuracy: 0.0001,
+                       "Camera must stay pinned on the recenter coordinate")
+        XCTAssertEqual(region.span.latitudeDelta, 0.04, accuracy: 0.0001,
+                       "Recenter must keep its own span, not the auto-fit's")
     }
 
     /// Complement to the above: with NO city selected (pure GPS-follow mode), the

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -381,58 +381,141 @@ public final class MapViewModel {
     /// subsequent user pan/zoom gestures.
     private var hasAutoCentered = false
 
-    /// Recenter the camera to the user's current location ONCE, on the first
-    /// non-nil GPS fix. Subsequent calls are no-ops so the user's manual
-    /// pan/zoom is preserved.
+    /// True once the user has explicitly chosen a city *in this session* —
+    /// via the city picker (`selectCity`), a custom pin
+    /// (`selectCustomLocation`), or the DEBUG `-startCity` launch argument
+    /// (e2e harnesses rely on the forced city holding the camera). Only an
+    /// explicit in-session pick survives the first GPS fix; a city merely
+    /// persisted from a previous session does NOT own the camera anymore —
+    /// entering the app should land the traveler where they physically are.
+    @ObservationIgnored private(set) var cityPickedExplicitlyThisSession = false
+
+    /// Align camera + city selection to the user's current location ONCE, on
+    /// the first non-nil GPS fix. Subsequent calls are no-ops so the user's
+    /// manual pan/zoom is preserved.
     public func bindToLocation() {
         guard !hasAutoCentered,
               let coordinate = locationService.currentLocation?.coordinate else { return }
         hasAutoCentered = true
-        // V-004 (C2): a *preset* city selection owns the camera — the cold-start
-        // city (persisted or `-startCity`) must not be yanked to the first GPS
-        // fix. In the simulator that fix defaults to San Francisco, so without
-        // this guard a `cmi` cold start shows the "Chiang Mai" header over a San
-        // Francisco map with an empty nearby list. The user can still pull to
-        // their real location via the explicit recenter button
-        // (`recenterOnUser`), which bypasses `hasAutoCentered`.
-        //
-        // Bugfix (V-007): when a preset city owns the camera we must ALSO skip
-        // `autoExploreIfEmpty`, not just the recenter. The auto-explore runs at
-        // the *GPS* coordinate, and on success `exploreNearby` ends with both
-        // `selectCity(discoveredCity)` and `recenter(gpsCoord)` — which silently
-        // overrode the user's explicit city pick (e.g. picking a China city
-        // while physically in Laos snapped the map + nearby list back to Laos).
-        // A user who picked a city wants that city; GPS-anchored auto-explore is
-        // only appropriate when we're actually following GPS (no city selected).
-        let cityOwnsCamera = (selectedCity.map { !$0.hasPrefix("custom_") }) ?? false
-        // Beta-P0-F (narrowed): the original guard rejected any fix outside a
-        // ~200 km radius of our 8 seeded cities, but that silently threw away
-        // legitimate GPS on real devices anywhere else (Guangzhou, Beijing,
-        // London, ...) and left the map stuck on the Chiang Mai default —
-        // exactly the "current location looks offset" report we're fixing.
-        // The original bug was specifically the Simulator defaulting to
-        // Apple's San Francisco fix (37.7749, -122.4194), so restrict the
-        // suppression to that case: only when we're in the simulator AND the
-        // fix is on top of that default do we hold the seed camera. Real
-        // devices are always trusted.
+        // Cold-start rule (supersedes V-004/V-007's "preset city owns the
+        // camera"): entering the app follows GPS — the camera centers on the
+        // fix and `selectedCity` (the top-left pill) adopts the city the
+        // traveler is physically in. A city persisted from a *previous*
+        // session is just a pre-GPS placeholder now, not a pick. What still
+        // holds the camera:
+        //   1. An explicit in-session pick (picker / custom pin / -startCity)
+        //      made before the first fix landed — V-007's actual scenario
+        //      (picking a China city while physically in Laos) stays fixed.
+        //   2. The Simulator's default San Francisco fix (Beta-P0-F,
+        //      narrowed) — otherwise every seeded-city cold start in the sim
+        //      snaps to SF.
         let looksLikeSimulatorDefault = Self.isSimulatorDefaultSanFrancisco(coordinate)
         let suppressGPS = looksLikeSimulatorDefault
-        if !cityOwnsCamera && !suppressGPS {
-            recenter(on: coordinate)
-            autoExploreIfEmpty(at: coordinate)
+        if !cityPickedExplicitlyThisSession && !suppressGPS {
+            followUserLocation(coordinate, runAutoExplore: true)
         }
         SentryService.capture(
             message: "map.coldStart.cameraResolution",
             level: .info,
             context: [
                 "selectedCity": selectedCity ?? "nil",
-                "cityOwnsCamera": cityOwnsCamera,
+                "explicitSessionPick": cityPickedExplicitlyThisSession,
                 "suppressGPS": suppressGPS,
                 "simulatorDefaultSF": looksLikeSimulatorDefault,
                 "lat": coordinate.latitude,
                 "lon": coordinate.longitude
             ]
         )
+    }
+
+    // MARK: - GPS city follow
+
+    /// How far (metres) a GPS fix may sit from a city's center and still adopt
+    /// that city as the selection. Beyond this the app drops to pure
+    /// GPS-follow (no city pill lock) and lets auto-explore discover the city.
+    static let cityFollowMaxDistanceMeters: CLLocationDistance = 75_000
+
+    /// Align the whole aggregation context to where the traveler physically
+    /// is: adopt the nearest known city (so the city pill and the nearby list
+    /// agree with the GPS fix) and center the camera on the fix itself — NOT
+    /// on the city's catalog center, so the map opens on the user's block.
+    public func followUserLocation(
+        _ coordinate: CLLocationCoordinate2D,
+        runAutoExplore: Bool = false
+    ) {
+        if let city = nearestKnownCity(to: coordinate) {
+            let alreadySelected = selectedCity.map { Self.cityCodeMatches(city, selected: $0) } ?? false
+            if !alreadySelected {
+                customCoordinates = nil
+                customLocationLabel = nil
+                selectedCity = city
+                preferences.lastSelectedCity = city
+                didAutoRecoverEmpty = false
+            }
+        } else if selectedCity != nil {
+            // Far from every known city: a stale selection would keep the
+            // nearby query anchored thousands of km away, so drop to pure
+            // GPS-follow and let auto-explore discover + name the city.
+            customCoordinates = nil
+            customLocationLabel = nil
+            selectedCity = nil
+            preferences.lastSelectedCity = nil
+        }
+        recenter(on: coordinate)
+        if runAutoExplore { autoExploreIfEmpty(at: coordinate) }
+    }
+
+    /// Foreground return ("entering the app" with the process still alive —
+    /// e.g. reopening after a flight): if the GPS fix now resolves to a
+    /// DIFFERENT city than the current selection, re-follow it. Same-city app
+    /// switches leave the user's pan/zoom untouched, and an explicit
+    /// in-session pick is never fought — the locate button remains the
+    /// manual override.
+    public func refollowUserCityIfMoved() {
+        guard hasAutoCentered,
+              !cityPickedExplicitlyThisSession,
+              let coordinate = locationService.currentLocation?.coordinate,
+              !Self.isSimulatorDefaultSanFrancisco(coordinate) else { return }
+        let stillInSelectedCity: Bool
+        if let resolved = nearestKnownCity(to: coordinate) {
+            stillInSelectedCity = selectedCity.map { Self.cityCodeMatches(resolved, selected: $0) } ?? false
+        } else if selectedCity != nil {
+            // No known city near the fix: the selection is stale only when
+            // the fix has left its follow radius.
+            let center = defaultCenterForSelectedCity
+            let dist = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+                .distance(from: CLLocation(latitude: center.latitude, longitude: center.longitude))
+            stillInSelectedCity = dist <= Self.cityFollowMaxDistanceMeters
+        } else {
+            stillInSelectedCity = true // already in pure GPS-follow
+        }
+        guard !stillInSelectedCity else { return }
+        followUserLocation(coordinate, runAutoExplore: true)
+    }
+
+    /// Nearest city (authoritative catalog + seed/discovered centroids) within
+    /// `cityFollowMaxDistanceMeters` of the coordinate, or nil when the fix is
+    /// beyond every known city. Ties prefer `availableCities` entries (they
+    /// carry real experiences) because they are scanned last with `<=`.
+    private func nearestKnownCity(to coordinate: CLLocationCoordinate2D) -> String? {
+        let here = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+        var bestCode: String?
+        var bestDistance = Self.cityFollowMaxDistanceMeters
+        for (code, center) in Self.knownCityCenters {
+            let dist = here.distance(from: CLLocation(latitude: center.latitude, longitude: center.longitude))
+            if dist <= bestDistance {
+                bestDistance = dist
+                bestCode = code
+            }
+        }
+        for city in availableCities where !city.code.hasPrefix("custom_") {
+            let dist = here.distance(from: CLLocation(latitude: city.center.latitude, longitude: city.center.longitude))
+            if dist <= bestDistance {
+                bestDistance = dist
+                bestCode = city.code
+            }
+        }
+        return bestCode
     }
 
     /// Returns true only for the iOS Simulator default location (Apple HQ /
@@ -461,13 +544,16 @@ public final class MapViewModel {
         locationService.currentLocation != nil
     }
 
-    /// Recenter the camera on the user's current location on demand (the custom
+    /// Recenter on the user's current location on demand (the custom
     /// "locate me" button). Unlike `bindToLocation` this ignores the
-    /// `hasAutoCentered` guard, so the user can re-center any time after panning
-    /// away. No-op when there is no GPS fix yet.
+    /// `hasAutoCentered` guard, so the user can re-center any time after
+    /// panning away. Beyond moving the camera it also adopts the GPS city as
+    /// the selection, so the top-left city pill and the nearby list follow
+    /// the tap — "locate me" means "put me back in MY city", not just "slide
+    /// the map". No-op when there is no GPS fix yet.
     public func recenterOnUser() {
         guard let coordinate = locationService.currentLocation?.coordinate else { return }
-        recenter(on: coordinate)
+        followUserLocation(coordinate)
     }
 
     #if DEBUG
@@ -556,6 +642,7 @@ public final class MapViewModel {
         label: String,
         cityCode: String
     ) {
+        cityPickedExplicitlyThisSession = true
         customCoordinates = coordinate
         customLocationLabel = label
         selectedCity = cityCode
@@ -766,8 +853,14 @@ public final class MapViewModel {
     }
 
     /// Selects a preset city, recenters the map, and reloads experiences.
-    /// Clears any active custom-coordinate pin.
-    public func selectCity(_ cityCode: String?) {
+    /// Clears any active custom-coordinate pin. `explicit` marks the jump as
+    /// a deliberate user pick (picker, empty-state redirect) that the first
+    /// GPS fix / foreground re-follow must not fight (V-007); explore's
+    /// programmatic discovery passes `false` so GPS city-follow stays armed.
+    public func selectCity(_ cityCode: String?, explicit: Bool = true) {
+        if explicit {
+            cityPickedExplicitlyThisSession = true
+        }
         customCoordinates = nil
         customLocationLabel = nil
         selectedCity = cityCode
@@ -1215,8 +1308,12 @@ public final class MapViewModel {
         // a seeded city without persisting through the picker. Release builds and
         // launches without the flag fall back to the persisted last-selected city.
         #if DEBUG
-        let resolvedStartCity = UserDefaults.standard.string(forKey: "startCity")
-            ?? preferences.lastSelectedCity
+        let forcedStartCity = UserDefaults.standard.string(forKey: "startCity")
+        let resolvedStartCity = forcedStartCity ?? preferences.lastSelectedCity
+        // A `-startCity` launch argument is an explicit pick: e2e harnesses
+        // and demo recipes depend on the forced city holding the camera, so
+        // the first GPS fix must not re-follow it to the fix's city.
+        self.cityPickedExplicitlyThisSession = forcedStartCity != nil
         #else
         let resolvedStartCity = preferences.lastSelectedCity
         #endif
@@ -1279,8 +1376,10 @@ public final class MapViewModel {
 
     /// Internal load that lets the cold-start auto-recovery widen the radius
     /// in-memory (without persisting the change to `preferences.maxDistanceKm`).
-    /// Pass `nil` for the normal preference-driven path.
-    private func loadNearbyExperiences(overrideRadiusKm: Double?) {
+    /// Pass `nil` for the normal preference-driven path. `fitCamera: false`
+    /// skips the pin auto-fit for callers that just pinned the camera on a
+    /// deliberate coordinate (see `recenter(on:)`).
+    private func loadNearbyExperiences(overrideRadiusKm: Double?, fitCamera: Bool = true) {
         // US-017: the experience set (and thus discovered cities) may have
         // changed since the last load — e.g. after an Explore added pins.
         // Drop the city cache so the next `availableCities` read recomputes.
@@ -1295,7 +1394,9 @@ public final class MapViewModel {
         aiSmartPickIds = []
         recomputeNowCount()
         updateBottomInfo()
-        fitCameraToPinsIfNeeded(nearby)
+        if fitCamera {
+            fitCameraToPinsIfNeeded(nearby)
+        }
         scheduleColdStartEmptyWatchdog()
     }
 
@@ -1749,7 +1850,11 @@ public final class MapViewModel {
                 span: MKCoordinateSpan(latitudeDelta: 0.04, longitudeDelta: 0.04)
             ))
         }
-        loadNearbyExperiences()
+        // The camera was just deliberately pinned on `coordinate`; the pin
+        // auto-fit inside the reload would immediately drag it back toward
+        // the nearest experience cluster — the user saw their location circle
+        // glide to screen center and then slide away again on every recenter.
+        loadNearbyExperiences(overrideRadiusKm: nil, fitCamera: false)
         updateBottomInfo()
     }
 
@@ -1798,7 +1903,10 @@ public final class MapViewModel {
                 span: MKCoordinateSpan(latitudeDelta: latDelta, longitudeDelta: lonDelta)
             ))
         }
-        loadNearbyExperiences()
+        // This method IS the deliberate camera fit — the reload's own pin
+        // auto-fit would re-fit against a stale settled span and tug the
+        // camera a second time.
+        loadNearbyExperiences(overrideRadiusKm: nil, fitCamera: false)
         updateBottomInfo()
     }
 
@@ -2618,7 +2726,7 @@ public final class MapViewModel {
                     || Self.cityCodeAliases[cityCode] == selectedCity
                     || Self.cityCodeAliases.first(where: { $0.value == selectedCity })?.key == cityCode
                 if !userOwnsCity || discoveredMatchesSelected {
-                    selectCity(cityCode)
+                    selectCity(cityCode, explicit: false)
                     // Rubric fix: fit the added cluster instead of snapping
                     // to a fixed 4 km span. Falls back to plain recenter if
                     // the batch is empty (added==0 branch handled above).
@@ -2931,7 +3039,7 @@ public final class MapViewModel {
             let added = experienceService.appendGenerated(generated)
             lastExploreAddedCount = added
             if added > 0 {
-                selectCity(cityCode)
+                selectCity(cityCode, explicit: false)
                 if let resolved {
                     lastExploreToast = String(
                         format: NSLocalizedString("explore.toast.addedNamed", comment: "Now exploring %@ · %d places added"),

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -154,6 +154,9 @@ struct CompassMapContentView: View {
     /// Honored by the preview-card pop animation on long-press: motion-sensitive
     /// users get an instant, spring-free selection instead of the scale+rise.
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Drives the foreground-return re-follow: reopening the app in a new
+    /// city (process still alive across a flight) re-aligns map + city pill.
+    @Environment(\.scenePhase) private var scenePhase
     /// US-049: the shared 60s clock. Reading `tick` inside `mapLayer` re-evaluates
     /// the marker layer every minute, so a best-now pin flips to its amber
     /// "closing soon" treatment live as its window crosses the 45-min threshold —
@@ -905,6 +908,14 @@ struct CompassMapContentView: View {
             }
             .onChange(of: locationService.currentLocation) { _, _ in
                 viewModel.bindToLocation()
+            }
+            // "Entering the app" isn't only a cold launch: when the process
+            // survives a trip to another city, returning to the foreground
+            // must re-align the map + city pill to where the traveler now is.
+            .onChange(of: scenePhase) { _, phase in
+                if phase == .active {
+                    viewModel.refollowUserCityIfMoved()
+                }
             }
             // P1.1 #112: keep the halo set in sync as new VisitRecords land
             // (the SwiftData @Query auto-refreshes; we re-publish to the vm).
@@ -3288,6 +3299,13 @@ private struct MapOverlayView: View {
             if let code = viewModel.selectedCity,
                let resolved = viewModel.resolvedCityName(for: code) {
                 return resolved
+            }
+            // Pure GPS-follow (no city selected but we do have a fix): say
+            // "Nearby" honestly instead of falling through to the nearest
+            // *seeded* city, which far from any seed resolves to the global
+            // default and puts a wrong city name over the user's real map.
+            if viewModel.selectedCity == nil, viewModel.hasUserLocation {
+                return NSLocalizedString("city.nearby", comment: "Fallback city label for synthetic osm_ codes")
             }
             if let code = viewModel.nearestSeededCity(to: viewModel.defaultCenterForSelectedCity),
                let city = viewModel.availableCities.first(where: { $0.code == code }) {


### PR DESCRIPTION
## 问题（用户反馈）

1. 进入 app / 点右上角定位按钮时，地图不跳到 GPS 所在城市，左上角 pill 显示的还是旧城市。
2. 定位总是偏离：定位圆圈先向屏幕中心滑过来，随即又滑出去，反复拉扯。

## 根因

**拉扯振荡**：`recenter(on:)` 把相机钉在 GPS 坐标后，紧接着的 `loadNearbyExperiences()` 内部 `fitCameraToPinsIfNeeded` 用过期的 settled span 把相机再次拽向最近的 pin 簇（且 nearby origin 还是旧城市中心）——一次定位点按 = 相机一进一出各动画一次。

**城市不跟随**：`bindToLocation` 的 V-004 规则让「持久化的 lastSelectedCity」持有相机，首个 GPS fix 被整体跳过；`recenterOnUser` 只挪相机、不改 `selectedCity`，pill 与 nearby 列表停在旧城市。

## 修复

- **冷启动跟随 GPS 城市**：持久化城市 ≠ 本会话显式选择。首个 fix 走 `followUserLocation`：75 km 内解析最近已知城市（catalog + seed/discovered）→ 切换 `selectedCity` + 持久化，相机居中在 fix 本身（不是城市目录中心）；75 km 外降级纯 GPS-follow（pill 显示「附近」），交给 auto-explore 发现并命名。
- **仍受保护的场景**：本会话显式选城（picker / 自定义 pin / DEBUG `-startCity`）与模拟器默认 SF fix —— V-007 的真实场景（GPS 未热前手选城市）不回归，e2e/演示配方保持确定性。
- **定位按钮**：`recenterOnUser` → `followUserLocation`，pill/列表随 tap 切到 GPS 城市。
- **回前台重跟随**：`refollowUserCityIfMoved()` 挂 scenePhase→.active，仅当 fix 解析出**不同城市**时才动相机（进程跨飞行存活的场景）；同城切 app 不打扰用户的 pan/zoom。
- **杀掉拉扯**：`recenter`/`zoomToFit` 的 reload 传 `fitCamera: false`，跳过 pin 自动 fit。
- **防误伤**：`selectCity(_:explicit:)` — exploreNearby 的程序化发现传 `explicit: false`，不会关闭本会话的重跟随。

## 验证

- `xcodebuild build` 绿。
- `MapViewModelCityRegionSyncTests` 12/12 全过，含 6 个新用例：持久化城市被 GPS 城市取代、显式会话选城免疫首个 fix、定位按钮切城、远离已知城市降级 GPS-follow、前台重跟随只在跨城触发、recenter 相机钉死在坐标上（振荡回归测试）。
- 相邻套件 O1FixesRegressionTests / ColdStartExperienceLoadTests / FilterNowMapSyncTest / VisitedMarkerStateTests 全绿。
- 基线既有红（与本 PR 无关，stash 验证过）：`testCityNameMapCoversAllSeedCodes`（共享 store 被 rubric fixture 城市污染）、`testToolRouterAllToolsAreWellFormedSchemas`（断言 allTools==10，实际已 20）等。