### PR TITLE
feat(ios): digital-nomad entry points + main-thread/gesture refactor

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		1DAB805A68DF18F2AC776160 /* OnboardingA11yOrderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D000D2E41CDD0DBF2B54C1 /* OnboardingA11yOrderTest.swift */; };
 		1DE607FCF1FFFAC7A8291375 /* BlindboxLaunchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25BADDFAE88472DEA796890 /* BlindboxLaunchView.swift */; };
 		1DF5877BF77C262224C1FD1B /* ArchiveSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD9439F2BA19FE7A56182B7 /* ArchiveSnapshotTests.swift */; };
+		1F6E1F9BF806F5C2D38EAE44 /* WorkFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A79F81F2C059CCF9C07BC4 /* WorkFilterTests.swift */; };
 		20423B565A01DBAAF1BD9A5C /* FriendshipStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213FE51765A7760838EC4FCE /* FriendshipStateMachine.swift */; };
 		214AF641496E8E50E3EC5FE4 /* MicroSurveySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA6E405C780A5A12A9FC1D6 /* MicroSurveySheet.swift */; };
 		216BA52386A50FF740EED857 /* CityBriefService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9052079680AA5EA57B014D93 /* CityBriefService.swift */; };
@@ -1111,6 +1112,7 @@
 		E71DE291BE5569E719413B74 /* SoloCompassApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassApp.swift; sourceTree = "<group>"; };
 		E75D6A32EAF01F792AFAE15E /* NowScore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowScore.swift; sourceTree = "<group>"; };
 		E79DAF94BA8A4DD5FF569EF3 /* RouteIsBestNowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteIsBestNowTests.swift; sourceTree = "<group>"; };
+		E7A79F81F2C059CCF9C07BC4 /* WorkFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkFilterTests.swift; sourceTree = "<group>"; };
 		E7E69F3EF6F0100CFA47DAFE /* AISynthesisCacheRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISynthesisCacheRecord.swift; sourceTree = "<group>"; };
 		E893D776B3D5A647320EDDB0 /* LocationSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchService.swift; sourceTree = "<group>"; };
 		E934CD39C814AF280C2483DF /* AIObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIObservability.swift; sourceTree = "<group>"; };
@@ -1524,6 +1526,7 @@
 				E536D4CFF44CF4CEFD1EFF4F /* WeatherCacheTTLTests.swift */,
 				C0F20A91F36C7CA4041BEEC9 /* WeatherServiceTests.swift */,
 				672C97E1FBA4FEF7EE87D59B /* WeatherSignalTests.swift */,
+				E7A79F81F2C059CCF9C07BC4 /* WorkFilterTests.swift */,
 				F9BD2D777F3A487C7C211E7E /* ZhHansPunctuationTest.swift */,
 				31C755D99D3C5CA318357B6C /* fixtures */,
 			);
@@ -2496,6 +2499,7 @@
 				85C233AB7998521788B2BB5F /* WeatherCacheTTLTests.swift in Sources */,
 				CD74E5E501088F7BECA74FBC /* WeatherServiceTests.swift in Sources */,
 				D51532D17022F9004544FFF3 /* WeatherSignalTests.swift in Sources */,
+				1F6E1F9BF806F5C2D38EAE44 /* WorkFilterTests.swift in Sources */,
 				24A47D8F35DD718BD74601F6 /* ZhHansPunctuationTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "filter.all" = "All";
 "filter.saved" = "Saved";
 "filter.saved.a11y" = "Saved, %d favourited experiences";
+"filter.work" = "Work-ready";
 "filter.solo.agent" = "Ask Solo";
 "filter.solo.agent.a11y" = "Ask Solo Agent for a nearby suggestion";
 "filter.taste.rank" = "My taste";
@@ -2200,6 +2201,9 @@
 
 /* City OS v2: landing kit (落地包) */
 "cityos.kit.title" = "Landing Kit";
+"cityos.kit.stage.land.prompt" = "Just landed — get a SIM and get online first.";
+"cityos.kit.stage.settle.prompt" = "Settling in — check your visa days left and lock down a base.";
+"cityos.kit.stage.live.prompt" = "Living here — mind the 183-day tax line and your renew-or-move call.";
 "cityos.kit.link.open" = "Open";
 "cityos.kit.link.open.a11y" = "Open %@";
 "cityos.kit.link.toast" = "Opened %@ · come back to continue";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "filter.all" = "全部";
 "filter.saved" = "收藏";
 "filter.saved.a11y" = "收藏，%d 个已收藏的体验";
+"filter.work" = "可办公";
 "filter.solo.agent" = "问 Solo";
 "filter.solo.agent.a11y" = "让 Solo 给一个附近的建议";
 "filter.taste.rank" = "我的菜";
@@ -2210,6 +2211,9 @@
 
 /* City OS v2: 落地包 landing kit */
 "cityos.kit.title" = "落地包";
+"cityos.kit.stage.land.prompt" = "刚落地 —— 先搞定 SIM 卡，联上网。";
+"cityos.kit.stage.settle.prompt" = "正在立足 —— 看看签证还剩几天，找个落脚的据点。";
+"cityos.kit.stage.live.prompt" = "在这生活 —— 留意 183 天税务线，想好续签还是启程。";
 "cityos.kit.link.open" = "打开";
 "cityos.kit.link.open.a11y" = "打开 %@";
 "cityos.kit.link.toast" = "已为你打开 %@ · 回来继续";

--- a/apps/ios/SoloCompass/Services/CityBriefService.swift
+++ b/apps/ios/SoloCompass/Services/CityBriefService.swift
@@ -128,8 +128,15 @@ public final class CityBriefService {
             return
         }
 
-        guard let freshKit = try? Self.decoder.decode([CityKitItem].self, from: kitData),
-              let freshEvents = try? Self.decoder.decode([CityEvent].self, from: eventsData) else {
+        // Decode off the main actor. `CityBriefService` is `@MainActor`, so a
+        // plain `Self.decoder.decode(...)` here ran on the main thread — and
+        // `refresh` fires on every city switch, a high-frequency interaction.
+        // Both result types are `Sendable` and `Self.decoder` is an immutable
+        // static, so the decode is safe to hop to a detached task.
+        async let kitDecode = Self.decode([CityKitItem].self, from: kitData)
+        async let eventsDecode = Self.decode([CityEvent].self, from: eventsData)
+        guard let freshKit = await kitDecode,
+              let freshEvents = await eventsDecode else {
             Self.logger.error("city-brief decode failed for \(code, privacy: .public) — keeping cache")
             return
         }
@@ -204,4 +211,16 @@ public final class CityBriefService {
         }
         return decoder
     }()
+
+    /// Decode `Data` into a `Sendable` array off the main actor using the shared
+    /// fractional-seconds-tolerant `decoder`. Returns nil on failure so callers
+    /// keep whatever the cache already published.
+    nonisolated static func decode<T: Decodable & Sendable>(
+        _ type: [T].Type,
+        from data: Data
+    ) async -> [T]? {
+        await Task.detached(priority: .userInitiated) {
+            try? decoder.decode(type, from: data)
+        }.value
+    }
 }

--- a/apps/ios/SoloCompass/Services/SyncService.swift
+++ b/apps/ios/SoloCompass/Services/SyncService.swift
@@ -285,7 +285,7 @@ public final class SyncService {
         _ table: String,
         context: ModelContext,
         deviceID: String,
-        merge: @escaping (Data, ModelContext, String) -> Void
+        merge: (Data, ModelContext, String) async -> Void
     ) async {
         let since = Self.lastPulledAt(for: table)
         var query = [URLQueryItem(name: "select", value: "*")]
@@ -298,90 +298,105 @@ public final class SyncService {
         let result = await supabaseClient.get(table: table, query: query)
         guard case .success(let data) = result, !data.isEmpty else { return }
 
-        merge(data, context, deviceID)
+        await merge(data, context, deviceID)
 
         // Advance the cursor to now so next pull only fetches deltas.
         Self.setLastPulledAt(Date(), for: table)
     }
 
-    // MARK: - LWW merge helpers
-
-    private func mergeCompletion(_ data: Data, _ context: ModelContext, _ myDeviceID: String) {
-        struct RemoteCompletion: Decodable {
-            let experience_id: String
-            let completed_at: String      // ISO8601
-            let updated_at: String        // ISO8601
-            let device_id: String?
-        }
-
-        let rows: [RemoteCompletion]
-        do {
-            rows = try JSONDecoder().decode([RemoteCompletion].self, from: data)
-        } catch {
-            reporter.capture(error, context: "SyncService.mergeCompletion", payload: "user_completions")
-            return
-        }
-        let formatter = ISO8601DateFormatter()
-
-        for row in rows {
-            guard let completedAt = formatter.date(from: row.completed_at),
-                  let updatedAt = formatter.date(from: row.updated_at) else { continue }
-
-            // Check if a local completion for this experience + completedAt exists.
-            let expId = row.experience_id
-            let completedAtRef = completedAt
-            let descriptor = FetchDescriptor<UserCompletionRecord>(
-                predicate: #Predicate {
-                    $0.experienceId == expId && $0.completedAt == completedAtRef
-                }
-            )
-            let existing = (try? context.fetch(descriptor)) ?? []
-
-            if existing.isEmpty {
-                // No local record — remote wins by default (LWW: remote is newer
-                // than lastPulledAt by definition of the query filter).
-                context.insert(
-                    UserCompletionRecord(experienceId: row.experience_id, completedAt: completedAt)
-                )
-            }
-            // If a local record already exists with the same (experienceId, completedAt)
-            // key, we keep the local row — it's already on-device and the data is
-            // identical (completions are immutable once written).
-            _ = updatedAt  // used for cursor advancement, not per-row LWW here
-            _ = myDeviceID
-        }
-        saveOrReport(context, op: "mergeCompletion")
+    /// Decode a `Decodable` array off the main actor. `SyncService` is
+    /// `@MainActor`, so a plain `JSONDecoder().decode(...)` in a merge helper ran
+    /// on the main thread; a large pull (hundreds of rows) then decoded on the
+    /// same thread that drives the UI, right as the app returned to foreground.
+    /// The decoded rows are value types (`Sendable`), so the decode has no
+    /// business touching the main actor — hop it to a detached task.
+    nonisolated static func decodeRows<T: Decodable & Sendable>(
+        _ type: [T].Type,
+        from data: Data
+    ) async -> [T]? {
+        await Task.detached(priority: .userInitiated) {
+            try? JSONDecoder().decode(type, from: data)
+        }.value
     }
 
-    private func mergeFavorite(_ data: Data, _ context: ModelContext, _ myDeviceID: String) {
-        struct RemoteFavorite: Decodable {
-            let experience_id: String
-            let favorited_at: String?     // nil means unfavorited (tombstone)
-            let updated_at: String        // ISO8601
-            let device_id: String?
-        }
+    // MARK: - LWW merge helpers
 
-        let rows: [RemoteFavorite]
-        do {
-            rows = try JSONDecoder().decode([RemoteFavorite].self, from: data)
-        } catch {
-            reporter.capture(error, context: "SyncService.mergeFavorite", payload: "user_favorites")
+    private func mergeCompletion(_ data: Data, _ context: ModelContext, _ myDeviceID: String) async {
+        guard let rows = await Self.decodeRows([RemoteCompletion].self, from: data) else {
+            reporter.capture(
+                SyncDecodeError.completions,
+                context: "SyncService.mergeCompletion",
+                payload: "user_completions"
+            )
             return
         }
         let formatter = ISO8601DateFormatter()
+
+        // Batch-fetch every local completion ONCE, key it by (experienceId,
+        // completedAt), and diff the remote rows against that set in memory.
+        // The previous code ran a `#Predicate` fetch per row — a SQLite round
+        // trip on the main thread for each of potentially hundreds of pulled
+        // rows. Completions are immutable once written, so "does this key
+        // already exist?" is the only question, and one fetch answers it for
+        // the whole batch.
+        let allLocal = (try? context.fetch(FetchDescriptor<UserCompletionRecord>())) ?? []
+        var seen = Set(allLocal.map { CompletionKey(experienceId: $0.experienceId, completedAt: $0.completedAt) })
+
+        var didInsert = false
+        for row in rows {
+            guard let completedAt = formatter.date(from: row.completed_at) else { continue }
+            let key = CompletionKey(experienceId: row.experience_id, completedAt: completedAt)
+            // De-dupe against both existing rows AND earlier rows in this same
+            // batch, so a remote payload with duplicates inserts at most once.
+            guard !seen.contains(key) else { continue }
+            seen.insert(key)
+            // No local record — remote wins by default (LWW: remote is newer
+            // than lastPulledAt by definition of the query filter).
+            context.insert(
+                UserCompletionRecord(experienceId: row.experience_id, completedAt: completedAt)
+            )
+            didInsert = true
+        }
+        _ = myDeviceID  // completions are immutable; no per-row LWW / device tiebreak.
+        if didInsert {
+            saveOrReport(context, op: "mergeCompletion")
+        }
+    }
+
+    /// Identity key for a completion row — completions are unique by
+    /// (experienceId, completedAt), so this is the natural de-dupe key.
+    private struct CompletionKey: Hashable {
+        let experienceId: String
+        let completedAt: Date
+    }
+
+    private func mergeFavorite(_ data: Data, _ context: ModelContext, _ myDeviceID: String) async {
+        guard let rows = await Self.decodeRows([RemoteFavorite].self, from: data) else {
+            reporter.capture(
+                SyncDecodeError.favorites,
+                context: "SyncService.mergeFavorite",
+                payload: "user_favorites"
+            )
+            return
+        }
+        let formatter = ISO8601DateFormatter()
+
+        // Batch-fetch every local favorite ONCE and index it by experienceId
+        // so the per-row LWW below is a dictionary lookup, not a `#Predicate`
+        // SQLite round trip per remote row (the old cost, on the main thread).
+        let allLocal = (try? context.fetch(FetchDescriptor<UserFavoriteRecord>())) ?? []
+        var localByExp = Dictionary(
+            allLocal.map { ($0.experienceId, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
 
         for row in rows {
             guard let updatedAt = formatter.date(from: row.updated_at) else { continue }
-            let expId = row.experience_id
-            let descriptor = FetchDescriptor<UserFavoriteRecord>(
-                predicate: #Predicate { $0.experienceId == expId }
-            )
-            let existing = (try? context.fetch(descriptor)) ?? []
 
             let remoteIsFavorited = row.favorited_at != nil
             let remoteDeviceID = row.device_id ?? ""
 
-            if let local = existing.first {
+            if let local = localByExp[row.experience_id] {
                 // LWW: compare updated_at. On tie, lex device_id decides.
                 let localUpdatedAt = local.favoritedAt  // best proxy for local write time
                 let remoteWins: Bool
@@ -400,14 +415,17 @@ public final class SyncService {
                         }
                     } else {
                         context.delete(local)
+                        localByExp[row.experience_id] = nil
                     }
                 }
             } else if remoteIsFavorited {
                 // No local record and remote says it's favorited — insert.
                 let favoritedAt = row.favorited_at.flatMap { formatter.date(from: $0) } ?? updatedAt
-                context.insert(
-                    UserFavoriteRecord(experienceId: row.experience_id, favoritedAt: favoritedAt)
-                )
+                let record = UserFavoriteRecord(experienceId: row.experience_id, favoritedAt: favoritedAt)
+                context.insert(record)
+                // Keep the index consistent so a later remote row for the same
+                // experience in this batch hits the LWW branch, not re-insert.
+                localByExp[row.experience_id] = record
             }
             // Remote says unfavorited and we have no local row — already in sync.
         }
@@ -416,42 +434,31 @@ public final class SyncService {
 
     // MARK: - Itinerary LWW merge (US-007)
 
-    private func mergeItinerary(_ data: Data, _ context: ModelContext, _ myDeviceID: String) {
-        struct RemoteItinerary: Decodable {
-            let id: String
-            let owner_id: String
-            let title: String
-            let city_code: String
-            let start_date: String
-            let end_date: String
-            let experience_ids: [String]
-            let note: String?
-            let open_to_companions: Bool
-            let is_deleted: Bool
-            let device_id: String?
-            let created_at: String
-            let updated_at: String
-        }
-
-        let rows: [RemoteItinerary]
-        do {
-            rows = try JSONDecoder().decode([RemoteItinerary].self, from: data)
-        } catch {
-            reporter.capture(error, context: "SyncService.mergeItinerary", payload: "itineraries")
+    private func mergeItinerary(_ data: Data, _ context: ModelContext, _ myDeviceID: String) async {
+        guard let rows = await Self.decodeRows([RemoteItinerary].self, from: data) else {
+            reporter.capture(
+                SyncDecodeError.itineraries,
+                context: "SyncService.mergeItinerary",
+                payload: "itineraries"
+            )
             return
         }
         let formatter = ISO8601DateFormatter()
 
+        // Batch-fetch every local itinerary ONCE, keyed by id, so the per-row
+        // LWW below is a dictionary lookup instead of a `#Predicate` SQLite
+        // round trip per remote row on the main thread.
+        let allLocal = (try? context.fetch(FetchDescriptor<ItineraryRecord>())) ?? []
+        var localById = Dictionary(
+            allLocal.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
         for row in rows {
             guard let remoteUpdatedAt = formatter.date(from: row.updated_at) else { continue }
-            let rowId = row.id
-            let descriptor = FetchDescriptor<ItineraryRecord>(
-                predicate: #Predicate { $0.id == rowId }
-            )
-            let existing = (try? context.fetch(descriptor)) ?? []
             let remoteDeviceID = row.device_id ?? ""
 
-            if let local = existing.first {
+            if let local = localById[row.id] {
                 // LWW: compare updated_at. On tie, lex device_id decides.
                 guard let localUpdatedAt = formatter.date(from: local.updatedAt) else { continue }
                 let remoteWins: Bool
@@ -466,6 +473,7 @@ public final class SyncService {
                 if remoteWins {
                     if row.is_deleted {
                         context.delete(local)
+                        localById[row.id] = nil
                     } else {
                         local.title = row.title
                         local.cityCode = row.city_code
@@ -481,7 +489,7 @@ public final class SyncService {
             } else if !row.is_deleted {
                 // No local record and remote is not a tombstone — insert.
                 let blob = encodeExperienceIDs(row.experience_ids) ?? Data()
-                context.insert(ItineraryRecord(
+                let record = ItineraryRecord(
                     id: row.id,
                     ownerId: row.owner_id,
                     title: row.title,
@@ -493,7 +501,9 @@ public final class SyncService {
                     openToCompanions: row.open_to_companions,
                     createdAt: row.created_at,
                     updatedAt: row.updated_at
-                ))
+                )
+                context.insert(record)
+                localById[row.id] = record
             }
         }
         saveOrReport(context, op: "mergeItinerary")
@@ -570,4 +580,46 @@ private struct AnyEncodable: Encodable {
     let value: any Encodable
     init(_ value: any Encodable) { self.value = value }
     func encode(to encoder: Encoder) throws { try value.encode(to: encoder) }
+}
+
+// MARK: - Remote row shapes (file-scope so they're Sendable across the
+// off-actor decode). Field names mirror the PostgREST snake_case columns.
+
+struct RemoteCompletion: Decodable, Sendable {
+    let experience_id: String
+    let completed_at: String      // ISO8601
+    let updated_at: String        // ISO8601
+    let device_id: String?
+}
+
+struct RemoteFavorite: Decodable, Sendable {
+    let experience_id: String
+    let favorited_at: String?     // nil means unfavorited (tombstone)
+    let updated_at: String        // ISO8601
+    let device_id: String?
+}
+
+struct RemoteItinerary: Decodable, Sendable {
+    let id: String
+    let owner_id: String
+    let title: String
+    let city_code: String
+    let start_date: String
+    let end_date: String
+    let experience_ids: [String]
+    let note: String?
+    let open_to_companions: Bool
+    let is_deleted: Bool
+    let device_id: String?
+    let created_at: String
+    let updated_at: String
+}
+
+/// The off-actor decode helper returns nil on failure (it can't carry the
+/// thrown error across the actor hop cheaply), so we report a typed marker
+/// instead — enough for Sentry to see *which* table's payload failed to decode.
+enum SyncDecodeError: Error {
+    case completions
+    case favorites
+    case itineraries
 }

--- a/apps/ios/SoloCompass/Services/VoiceService.swift
+++ b/apps/ios/SoloCompass/Services/VoiceService.swift
@@ -2,6 +2,7 @@ import Foundation
 import Speech
 import AVFoundation
 import Observation
+import os
 
 /// Native speech recognition. No third-party deps — uses SFSpeechRecognizer +
 /// AVAudioEngine. Streams partial transcripts via AsyncThrowingStream so the
@@ -97,7 +98,14 @@ public final class VoiceService {
         // `request` directly (SFSpeechAudioBufferRecognitionRequest.append is
         // thread-safe) instead of touching main-actor-isolated `self` state, and
         // hop to the main actor only to publish the amplitude.
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+        // Throttle the main-actor hop: at 1024-frame buffers the tap fires
+        // ~43×/sec, and each hop wrote `amplitude` (an @Observable) → a full
+        // SwiftUI waveform re-evaluation. That's 43 actor hops + 43 redraws per
+        // second for a bar chart the eye can't resolve past ~20fps. The gate
+        // hops only when the amplitude moved a visible amount OR ~50ms elapsed,
+        // roughly halving the hop/redraw rate while keeping the attack crisp.
+        let amplitudeGate = AmplitudeGate()
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, time in
             request.append(buffer)
             // Compute RMS amplitude for waveform rendering
             if let channelData = buffer.floatChannelData?[0] {
@@ -106,6 +114,7 @@ public final class VoiceService {
                 for i in 0..<frames { rms += channelData[i] * channelData[i] }
                 rms = sqrtf(rms / Float(max(frames, 1)))
                 let normalized = Double(min(rms * 8, 1.0))
+                guard amplitudeGate.shouldPublish(normalized, at: time.hostTime) else { return }
                 Task { @MainActor [weak self] in self?.amplitude = normalized }
             }
         }
@@ -166,5 +175,52 @@ public final class VoiceService {
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
         isListening = false
         amplitude = 0
+    }
+}
+
+/// Coalesces the ~43 amplitude samples/sec the audio tap produces down to the
+/// ~20/sec the waveform can actually show. Called from the real-time audio
+/// thread, so it must be `Sendable` and lock-guarded — it holds only two
+/// `Double`s behind an `os_unfair_lock`, cheap enough for a render-thread call.
+///
+/// Publish rule: emit when the amplitude moved ≥ `minDelta` (so a sudden
+/// syllable's attack is never swallowed) OR ≥ `minInterval` elapsed since the
+/// last emit (so a slow swell still animates). Everything else is dropped.
+final class AmplitudeGate: @unchecked Sendable {
+    private var lock = os_unfair_lock()
+    private var lastPublished: Double = -1
+    private var lastHostTime: UInt64 = 0
+
+    /// Minimum visible amplitude change (0–1) that forces an immediate publish.
+    private let minDelta: Double = 0.04
+    /// Minimum wall-clock gap between forced publishes, in seconds (~20fps).
+    private let minInterval: Double = 0.05
+
+    /// `hostTime` is the buffer's `AVAudioTime.hostTime` (mach absolute ticks).
+    func shouldPublish(_ amplitude: Double, at hostTime: UInt64) -> Bool {
+        os_unfair_lock_lock(&lock)
+        defer { os_unfair_lock_unlock(&lock) }
+
+        let elapsed = Self.seconds(from: lastHostTime, to: hostTime)
+        let movedEnough = abs(amplitude - lastPublished) >= minDelta
+        let waitedEnough = lastHostTime == 0 || elapsed >= minInterval
+        guard movedEnough || waitedEnough else { return false }
+
+        lastPublished = amplitude
+        lastHostTime = hostTime
+        return true
+    }
+
+    /// Convert a mach-tick delta to seconds using the host timebase.
+    private static let timebase: mach_timebase_info_data_t = {
+        var info = mach_timebase_info_data_t()
+        mach_timebase_info(&info)
+        return info
+    }()
+
+    private static func seconds(from start: UInt64, to end: UInt64) -> Double {
+        guard end > start, timebase.denom != 0 else { return .greatestFiniteMagnitude }
+        let nanos = Double(end - start) * Double(timebase.numer) / Double(timebase.denom)
+        return nanos / 1_000_000_000
     }
 }

--- a/apps/ios/SoloCompass/Tests/WorkFilterTests.swift
+++ b/apps/ios/SoloCompass/Tests/WorkFilterTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+import CoreLocation
+import SwiftData
+@testable import SoloCompass
+
+/// "可办公 / Work-ready" map filter (the laptop pill) — the digital-nomad entry
+/// point. `MapViewModel.isWorkFilter` keeps only places you can actually work
+/// from, and is mutually exclusive with the category / custom-tag / Now / Saved
+/// filters. The qualifying signal reuses the existing `.work` category and the
+/// wifi/power `CategoryHighlight`s the enrichment pipeline already emits — no
+/// new schema — so these tests pin both the pure predicate and the filter path.
+@MainActor
+final class WorkFilterTests: XCTestCase {
+
+    private func makeIsolatedDefaults() -> UserDefaults {
+        let suite = "work.filter.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    private func makeExperience(
+        id: String,
+        cityCode: String,
+        lon: Double,
+        lat: Double,
+        category: ExperienceCategory,
+        highlights: [CategoryHighlight] = []
+    ) -> Experience {
+        let now = Date()
+        return Experience(
+            id: id,
+            title: "Fixture \(id)",
+            oneLiner: "Fixture \(id)",
+            whyItMatters: "Work filter fixture",
+            category: category,
+            location: ExperienceLocation(coordinates: [lon, lat], cityCode: cityCode),
+            bestTimes: [],
+            durationMinutes: .init(min: 30, max: 60),
+            howTo: [],
+            realInconveniences: [],
+            soloScore: SoloScore(
+                overall: 5,
+                breakdown: .init(
+                    seatingFriendly: 7, soloPatronRatio: 7, staffPressure: 7,
+                    soloPortioning: 7, ambianceFit: 7, safety: 7
+                ),
+                basedOnCount: 1
+            ),
+            sources: [InformationSource(type: .user, attribution: "test", verifiedAt: now)],
+            confidence: Confidence(
+                level: 3,
+                lastVerifiedAt: now,
+                reason: "Test fixture",
+                signals: .init(aiScrapeAgeDays: 1, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)
+            ),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .active,
+            createdAt: now,
+            updatedAt: now,
+            categoryHighlights: highlights.isEmpty ? nil : highlights
+        )
+    }
+
+    private func makeViewModel(seed: [Experience]) -> MapViewModel {
+        let prefs = UserPreferences(defaults: makeIsolatedDefaults())
+        prefs.lastSelectedCity = "cmi"
+        let service = ExperienceService(seed: seed)
+        return MapViewModel(
+            locationService: LocationService(),
+            experienceService: service,
+            aiService: AIService(),
+            preferences: prefs
+        )
+    }
+
+    // MARK: - Pure predicate
+
+    func testWorkReadyTrueForWorkCategory() {
+        let coworking = makeExperience(id: "w", cityCode: "cmi", lon: 98.99, lat: 18.78, category: .work)
+        XCTAssertTrue(MapViewModel.isWorkReady(coworking),
+                      "explicit .work spots (coworking, libraries) are always work-ready")
+    }
+
+    func testWorkReadyTrueForCafeWithWifi() {
+        let cafe = makeExperience(
+            id: "c", cityCode: "cmi", lon: 98.99, lat: 18.78, category: .coffee,
+            highlights: [CategoryHighlight(kind: .wifi, label: "WiFi", value: "fast")]
+        )
+        XCTAssertTrue(MapViewModel.isWorkReady(cafe),
+                      "a café that advertises wifi is somewhere you can sit and work")
+    }
+
+    func testWorkReadyTrueForCafeWithPower() {
+        let cafe = makeExperience(
+            id: "c", cityCode: "cmi", lon: 98.99, lat: 18.78, category: .coffee,
+            highlights: [CategoryHighlight(kind: .power, label: "Outlets", value: "at seats")]
+        )
+        XCTAssertTrue(MapViewModel.isWorkReady(cafe),
+                      "power at seats is enough to qualify a café")
+    }
+
+    func testWorkReadyFalseForPlainCafe() {
+        let cafe = makeExperience(id: "c", cityCode: "cmi", lon: 98.99, lat: 18.78, category: .coffee)
+        XCTAssertFalse(MapViewModel.isWorkReady(cafe),
+                       "a café with no wifi/power signal is not work-ready — don't over-promise")
+    }
+
+    func testWorkReadyFalseForFood() {
+        // Even a restaurant that happens to carry a wifi highlight isn't a work spot.
+        let restaurant = makeExperience(
+            id: "f", cityCode: "cmi", lon: 98.99, lat: 18.78, category: .food,
+            highlights: [CategoryHighlight(kind: .wifi, label: "WiFi", value: "free")]
+        )
+        XCTAssertFalse(MapViewModel.isWorkReady(restaurant),
+                       "only .work and wifi/power cafés qualify — food stays out")
+    }
+
+    // MARK: - Filtering end to end
+
+    func testWorkFilterKeepsOnlyWorkReady() {
+        let seed = [
+            makeExperience(id: "coworking", cityCode: "cmi", lon: 98.9938, lat: 18.7877, category: .work),
+            makeExperience(id: "wifi_cafe", cityCode: "cmi", lon: 98.9940, lat: 18.7880, category: .coffee,
+                           highlights: [CategoryHighlight(kind: .wifi, label: "WiFi", value: "fast")]),
+            makeExperience(id: "plain_cafe", cityCode: "cmi", lon: 98.9942, lat: 18.7882, category: .coffee),
+            makeExperience(id: "restaurant", cityCode: "cmi", lon: 98.9944, lat: 18.7884, category: .food)
+        ]
+        let vm = makeViewModel(seed: seed)
+        XCTAssertFalse(vm.isWorkFilter, "starts inactive")
+
+        vm.selectWorkFilter()
+
+        XCTAssertTrue(vm.isWorkFilter, "filter active after selecting")
+        XCTAssertEqual(Set(vm.visibleExperiences.map(\.id)), ["coworking", "wifi_cafe"],
+                       "only the coworking spot and the wifi café survive")
+    }
+
+    func testWorkFilterTogglesOff() {
+        let seed = [
+            makeExperience(id: "coworking", cityCode: "cmi", lon: 98.9938, lat: 18.7877, category: .work),
+            makeExperience(id: "restaurant", cityCode: "cmi", lon: 98.9944, lat: 18.7884, category: .food)
+        ]
+        let vm = makeViewModel(seed: seed)
+        let baseline = vm.visibleExperiences.count
+
+        vm.selectWorkFilter()
+        XCTAssertTrue(vm.isWorkFilter)
+
+        vm.selectWorkFilter()
+        XCTAssertFalse(vm.isWorkFilter, "re-tap toggles the filter off")
+        XCTAssertEqual(vm.visibleExperiences.count, baseline,
+                       "clearing restores the full nearby list")
+    }
+
+    // MARK: - Mutual exclusivity
+
+    func testSelectingWorkClearsOtherFilters() {
+        let seed = [makeExperience(id: "coworking", cityCode: "cmi", lon: 98.9938, lat: 18.7877, category: .work)]
+        let vm = makeViewModel(seed: seed)
+        vm.selectNowFilter()
+        vm.selectFavoriteFilter()   // saved now active
+
+        vm.selectWorkFilter()
+
+        XCTAssertTrue(vm.isWorkFilter)
+        XCTAssertNil(vm.selectedCategory, "category cleared when Work activates")
+        XCTAssertFalse(vm.isNowFilter, "Now cleared when Work activates")
+        XCTAssertFalse(vm.isFavoriteFilter, "Saved cleared when Work activates")
+    }
+
+    func testSelectingOtherFilterClearsWork() {
+        let seed = [makeExperience(id: "coworking", cityCode: "cmi", lon: 98.9938, lat: 18.7877, category: .work)]
+        let vm = makeViewModel(seed: seed)
+
+        vm.selectWorkFilter()
+        XCTAssertTrue(vm.isWorkFilter)
+        vm.selectNowFilter()
+        XCTAssertFalse(vm.isWorkFilter, "Now clears the Work filter")
+
+        vm.selectWorkFilter()
+        XCTAssertTrue(vm.isWorkFilter)
+        vm.selectCategory(.food)
+        XCTAssertFalse(vm.isWorkFilter, "category clears the Work filter")
+
+        vm.selectWorkFilter()
+        XCTAssertTrue(vm.isWorkFilter)
+        vm.clearFilters()
+        XCTAssertFalse(vm.isWorkFilter, "clearFilters clears the Work filter")
+    }
+}

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -1166,6 +1166,16 @@ public final class MapViewModel {
     /// (`preferences.favoritedExperiences`); this is the map filter entry point.
     public var isFavoriteFilter: Bool = false
 
+    /// True when the "可办公 / Work-ready" filter is active — keeps only places a
+    /// digital nomad can actually work from. Mutually exclusive with the other
+    /// filter modes. A place qualifies when it's an explicit `.work` category
+    /// spot OR a café that already advertises a wifi/power highlight — reusing
+    /// the `CategoryHighlight` signals the enrichment pipeline already emits, so
+    /// no new schema is needed. This is the map entry point nomads were missing:
+    /// "where can I get things done right now" instead of hunting the `.work`
+    /// pill buried in the horizontal category strip.
+    public var isWorkFilter: Bool = false
+
     // MARK: - Location error surfacing (US-026)
 
     /// Tracks the most recent `LocationService.lastError` we already reported to
@@ -1555,6 +1565,9 @@ public final class MapViewModel {
             let favorites = preferences.favoritedExperiences
             nearby = nearby.filter { favorites.contains($0.id) }
         }
+        if isWorkFilter {
+            nearby = nearby.filter { Self.isWorkReady($0) }
+        }
         if !preferences.dislikedCategories.isEmpty {
             let disliked = Set(preferences.dislikedCategories)
             nearby = nearby.filter { !disliked.contains($0.category) }
@@ -1577,6 +1590,18 @@ public final class MapViewModel {
         }
         #endif
         return nearby
+    }
+
+    /// Whether an experience is somewhere a digital nomad can actually work.
+    /// True for explicit `.work` spots (coworking, libraries) and for cafés that
+    /// already advertise a wifi *or* power `CategoryHighlight` — the two signals
+    /// the enrichment pipeline emits for "can I sit here with a laptop". Kept
+    /// `static` and pure so it's cheap in the `applyFilters` hot loop and unit
+    /// testable without a live view model.
+    static func isWorkReady(_ experience: Experience) -> Bool {
+        if experience.category == .work { return true }
+        guard experience.category == .coffee else { return false }
+        return experience.highlights.contains { $0.kind == .wifi || $0.kind == .power }
     }
 
     #if DEBUG
@@ -1608,6 +1633,7 @@ public final class MapViewModel {
         selectedCustomTag = nil
         isNowFilter = false
         isFavoriteFilter = false
+        isWorkFilter = false
         loadNearbyExperiences()
         updateBottomInfo()
         // US-011: empty category inside a seeded city → debounced auto-Explore.
@@ -1621,6 +1647,7 @@ public final class MapViewModel {
         selectedCategory = nil
         selectedCustomTag = nil
         isFavoriteFilter = false
+        isWorkFilter = false
         loadNearbyExperiences()
         updateBottomInfo()
     }
@@ -1637,6 +1664,24 @@ public final class MapViewModel {
             selectedCategory = nil
             selectedCustomTag = nil
             isNowFilter = false
+            isWorkFilter = false
+        }
+        loadNearbyExperiences()
+        updateBottomInfo()
+    }
+
+    /// Toggle the "可办公 / Work-ready" filter. Tapping again clears it (back to
+    /// All), matching the other pills. Activating it clears every other filter so
+    /// the filter modes stay mutually exclusive.
+    public func selectWorkFilter() {
+        if isWorkFilter {
+            isWorkFilter = false
+        } else {
+            isWorkFilter = true
+            selectedCategory = nil
+            selectedCustomTag = nil
+            isNowFilter = false
+            isFavoriteFilter = false
         }
         loadNearbyExperiences()
         updateBottomInfo()
@@ -1648,6 +1693,7 @@ public final class MapViewModel {
         selectedCustomTag = nil
         isNowFilter = false
         isFavoriteFilter = false
+        isWorkFilter = false
         loadNearbyExperiences()
         updateBottomInfo()
     }

--- a/apps/ios/SoloCompass/Views/Chat/AttachmentInputBar.swift
+++ b/apps/ios/SoloCompass/Views/Chat/AttachmentInputBar.swift
@@ -118,7 +118,7 @@ struct AttachmentInputBar: View {
             allowedContentTypes: [.item],
             allowsMultipleSelection: true
         ) { result in
-            ingest(fileResult: result)
+            Task { await ingest(fileResult: result) }
         }
     }
 
@@ -199,22 +199,24 @@ struct AttachmentInputBar: View {
     // MARK: - Attachment ingestion
 
     /// Decode picked photo-library items into image drafts.
+    ///
+    /// A full-resolution `UIImage(data:)` decode of a modern phone photo (often
+    /// 10–50 MB) can block for tens to hundreds of ms. Running it on the main
+    /// actor froze the picker's dismiss animation the instant you tapped "add".
+    /// We now decode + pre-render off the main actor and only hop back to append
+    /// the finished, immutable draft — the UI stays live while the bytes land.
     private func ingest(photoItems: [PhotosPickerItem]) async {
         var picked: [LocalAttachment] = []
         for item in photoItems {
             guard let data = try? await item.loadTransferable(type: Data.self) else { continue }
-            let image = UIImage(data: data)
             let ext = item.supportedContentTypes.first?.preferredFilenameExtension ?? "jpg"
             let mime = item.supportedContentTypes.first?.preferredMIMEType ?? "image/jpeg"
-            picked.append(
-                LocalAttachment(
-                    kind: .image,
-                    fileName: "image-\(UUID().uuidString.prefix(8)).\(ext)",
-                    mimeType: mime,
-                    data: data,
-                    image: image
-                )
+            let draft = await ChatAttachmentDecoder.imageDraft(
+                data: data,
+                fileName: "image-\(UUID().uuidString.prefix(8)).\(ext)",
+                mimeType: mime
             )
+            picked.append(draft)
         }
         if !picked.isEmpty {
             attachments.append(contentsOf: picked)
@@ -237,25 +239,19 @@ struct AttachmentInputBar: View {
     }
 
     /// Read security-scoped files chosen via the document picker into drafts.
-    private func ingest(fileResult: Result<[URL], Error>) {
+    ///
+    /// `Data(contentsOf:)` and image decode both block, and picked files can be
+    /// large (a PDF, a video). Read + decode each off the main actor and hop
+    /// back only to append; the picker dismiss stays smooth. The security scope
+    /// must be opened/closed on the same actor that reads, so the whole
+    /// per-URL read runs inside one detached task.
+    private func ingest(fileResult: Result<[URL], Error>) async {
         guard case let .success(urls) = fileResult else { return }
         var picked: [LocalAttachment] = []
         for url in urls {
-            let scoped = url.startAccessingSecurityScopedResource()
-            defer { if scoped { url.stopAccessingSecurityScopedResource() } }
-            guard let data = try? Data(contentsOf: url) else { continue }
-            let type = UTType(filenameExtension: url.pathExtension)
-            let isImage = type?.conforms(to: .image) ?? false
-            let mime = type?.preferredMIMEType ?? "application/octet-stream"
-            picked.append(
-                LocalAttachment(
-                    kind: isImage ? .image : .file,
-                    fileName: url.lastPathComponent,
-                    mimeType: mime,
-                    data: data,
-                    image: isImage ? UIImage(data: data) : nil
-                )
-            )
+            if let draft = await ChatAttachmentDecoder.fileDraft(url) {
+                picked.append(draft)
+            }
         }
         if !picked.isEmpty {
             attachments.append(contentsOf: picked)
@@ -291,8 +287,8 @@ struct AttachmentInputBar: View {
 
 /// Small helper so the previews can mutate `draftText` like the real parent.
 private struct StatefulAttachmentBarPreview: View {
-    @State var text: String
-    @State var attachments: [LocalAttachment]
+    @State private var text: String
+    @State private var attachments: [LocalAttachment]
 
     init(initial: String, attachments: [LocalAttachment] = []) {
         self._text = State(initialValue: initial)

--- a/apps/ios/SoloCompass/Views/Chat/ChatInputBar.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatInputBar.swift
@@ -194,7 +194,7 @@ public struct ChatInputBar: View {
             allowedContentTypes: [.item],
             allowsMultipleSelection: true
         ) { result in
-            ingest(fileResult: result)
+            Task { await ingest(fileResult: result) }
         }
     }
 
@@ -548,23 +548,21 @@ public struct ChatInputBar: View {
 
     // MARK: - Attachment ingestion
 
-    /// Decode picked photo-library items into image drafts.
+    /// Decode picked photo-library items into image drafts. Full-resolution
+    /// photo decode (10–50 MB) blocks for tens–hundreds of ms; run it off the
+    /// main actor so the picker dismiss stays smooth, then hop back to append.
     private func ingest(photoItems: [PhotosPickerItem]) async {
         var picked: [LocalAttachment] = []
         for item in photoItems {
             guard let data = try? await item.loadTransferable(type: Data.self) else { continue }
-            let image = UIImage(data: data)
             let ext = (item.supportedContentTypes.first?.preferredFilenameExtension) ?? "jpg"
             let mime = item.supportedContentTypes.first?.preferredMIMEType ?? "image/jpeg"
-            picked.append(
-                LocalAttachment(
-                    kind: .image,
-                    fileName: "image-\(UUID().uuidString.prefix(8)).\(ext)",
-                    mimeType: mime,
-                    data: data,
-                    image: image
-                )
+            let draft = await ChatAttachmentDecoder.imageDraft(
+                data: data,
+                fileName: "image-\(UUID().uuidString.prefix(8)).\(ext)",
+                mimeType: mime
             )
+            picked.append(draft)
         }
         if !picked.isEmpty {
             attachments.append(contentsOf: picked)
@@ -587,29 +585,63 @@ public struct ChatInputBar: View {
     }
 
     /// Read security-scoped files chosen via the document picker into drafts.
-    private func ingest(fileResult: Result<[URL], Error>) {
+    /// Reads + decodes each file off the main actor (files can be large PDFs /
+    /// videos) so the picker dismiss stays smooth; hops back only to append.
+    private func ingest(fileResult: Result<[URL], Error>) async {
         guard case let .success(urls) = fileResult else { return }
         var picked: [LocalAttachment] = []
         for url in urls {
-            let scoped = url.startAccessingSecurityScopedResource()
-            defer { if scoped { url.stopAccessingSecurityScopedResource() } }
-            guard let data = try? Data(contentsOf: url) else { continue }
-            let type = UTType(filenameExtension: url.pathExtension)
-            let isImage = type?.conforms(to: .image) ?? false
-            let mime = type?.preferredMIMEType ?? "application/octet-stream"
-            picked.append(
-                LocalAttachment(
-                    kind: isImage ? .image : .file,
-                    fileName: url.lastPathComponent,
-                    mimeType: mime,
-                    data: data,
-                    image: isImage ? UIImage(data: data) : nil
-                )
-            )
+            if let draft = await ChatAttachmentDecoder.fileDraft(url) {
+                picked.append(draft)
+            }
         }
         if !picked.isEmpty {
             attachments.append(contentsOf: picked)
         }
+    }
+}
+
+/// Shared off-main-actor decoders for chat attachment drafts. Both the Voice
+/// Agent composer (`ChatInputBar`) and the companion composer (`AttachmentInputBar`)
+/// pick photos/files; decoding a full-resolution image or reading a large file
+/// blocks, so every path funnels through here to keep it off the main actor.
+enum ChatAttachmentDecoder {
+    /// Decode image bytes into a preview-ready draft off the main actor.
+    /// `preparingForDisplay()` forces the decode now instead of lazily on the
+    /// render thread at first draw.
+    static func imageDraft(data: Data, fileName: String, mimeType: String) async -> LocalAttachment {
+        let prepared: UIImage? = await Task.detached(priority: .userInitiated) {
+            guard let raw = UIImage(data: data) else { return nil }
+            return raw.preparingForDisplay() ?? raw
+        }.value
+        return LocalAttachment(
+            kind: .image,
+            fileName: fileName,
+            mimeType: mimeType,
+            data: data,
+            image: prepared
+        )
+    }
+
+    /// Read one picked file off the main actor: opens its security scope, reads
+    /// the bytes, and (for images) decodes a preview. Returns nil on read failure.
+    static func fileDraft(_ url: URL) async -> LocalAttachment? {
+        await Task.detached(priority: .userInitiated) {
+            let scoped = url.startAccessingSecurityScopedResource()
+            defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+            guard let data = try? Data(contentsOf: url) else { return nil }
+            let type = UTType(filenameExtension: url.pathExtension)
+            let isImage = type?.conforms(to: .image) ?? false
+            let mime = type?.preferredMIMEType ?? "application/octet-stream"
+            let image = isImage ? UIImage(data: data)?.preparingForDisplay() : nil
+            return LocalAttachment(
+                kind: isImage ? .image : .file,
+                fileName: url.lastPathComponent,
+                mimeType: mime,
+                data: data,
+                image: image
+            )
+        }.value
     }
 }
 
@@ -733,8 +765,8 @@ private struct ChatCameraPicker: UIViewControllerRepresentable {
 
 /// Small helper so the previews can mutate `draftText` like the real parent.
 private struct StatefulPreviewWrapper: View {
-    @State var text: String
-    @State var attachments: [LocalAttachment]
+    @State private var text: String
+    @State private var attachments: [LocalAttachment]
     let micState: ChatInputBar.MicState
     let error: String?
     let placeContextName: String?

--- a/apps/ios/SoloCompass/Views/CityOS/KitSheet.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/KitSheet.swift
@@ -22,6 +22,13 @@ struct KitSheet: View {
     var planMode: Bool = false
     var isTodoDone: (CityKitItem.Kind) -> Bool = { _ in false }
     var onToggleTodo: (CityKitItem.Kind) -> Void = { _ in }
+    /// City OS v3 · the traveler's current lifecycle stage in this city
+    /// (抵达 → 立足 → 生活 → 回顾). When set (Live mode with an entry date), the
+    /// sheet grows a stage banner up top and floats the stage's most relevant
+    /// row (SIM on 抵达, visa on 立足/生活) to the front — the same "生存 OS"
+    /// framing a digital nomad thinks in. Nil (Plan / no entry date) keeps the
+    /// static net → money → visa → safety order and hides the banner.
+    var stage: CityStage? = nil
     let onDismiss: () -> Void
 
     @Environment(\.colorScheme) private var colorScheme
@@ -29,10 +36,33 @@ struct KitSheet: View {
     @State private var toast: String?
 
     /// Kit rows ordered net → money → visa → safety regardless of server order,
-    /// so the sheet's shape is stable.
+    /// so the sheet's shape is stable. When a lifecycle `stage` is set, the
+    /// stage's most relevant row (see `Self.priorityKind`) is floated to the
+    /// front so the nomad sees "what matters now" first — the rest keep their
+    /// canonical relative order.
     private var orderedKit: [CityKitItem] {
-        let rank: [CityKitItem.Kind: Int] = [.net: 0, .money: 1, .visa: 2, .safety: 3]
-        return kit.sorted { (rank[$0.kind] ?? 9) < (rank[$1.kind] ?? 9) }
+        let baseRank: [CityKitItem.Kind: Int] = [.net: 0, .money: 1, .visa: 2, .safety: 3]
+        let priority = stage.flatMap(Self.priorityKind)
+        return kit.sorted { lhs, rhs in
+            // Stage-priority row wins outright; ties fall back to canonical order.
+            if let priority {
+                if lhs.kind == priority && rhs.kind != priority { return true }
+                if rhs.kind == priority && lhs.kind != priority { return false }
+            }
+            return (baseRank[lhs.kind] ?? 9) < (baseRank[rhs.kind] ?? 9)
+        }
+    }
+
+    /// The kit row a given lifecycle stage most wants front-and-centre. 抵达 →
+    /// connectivity (get a SIM, get online); 立足 & 生活 → visa (days left, the
+    /// 183-day tax line, renew-or-move decision — the nomad's steady anxiety);
+    /// 回顾 has no operational priority, so the static order stands.
+    static func priorityKind(for stage: CityStage) -> CityKitItem.Kind? {
+        switch stage {
+        case .land:            return .net
+        case .settle, .live:   return .visa
+        case .leave:           return nil
+        }
     }
 
     var body: some View {
@@ -40,6 +70,9 @@ struct KitSheet: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     VStack(spacing: 12) {
+                        if let stage, !planMode, let line = Self.stagePrompt(for: stage) {
+                            stageBanner(stage: stage, prompt: line)
+                        }
                         ForEach(orderedKit) { item in
                             KitRowCard(
                                 item: item,
@@ -80,6 +113,57 @@ struct KitSheet: View {
 
     private var groupBackground: Color {
         colorScheme == .dark ? CT.warmSheetDark : CT.surfaceSunken
+    }
+
+    // MARK: - Stage banner (v3 · 生存 OS framing)
+
+    /// One localized, action-first line per stage — what a nomad should do *now*.
+    /// 回顾 returns nil (no operational nudge once you're leaving).
+    static func stagePrompt(for stage: CityStage) -> String? {
+        switch stage {
+        case .land:
+            return NSLocalizedString("cityos.kit.stage.land.prompt", comment: "抵达 stage nudge — get connected")
+        case .settle:
+            return NSLocalizedString("cityos.kit.stage.settle.prompt", comment: "立足 stage nudge — visa + base")
+        case .live:
+            return NSLocalizedString("cityos.kit.stage.live.prompt", comment: "生活 stage nudge — tax line + rhythm")
+        case .leave:
+            return nil
+        }
+    }
+
+    /// The stage banner: a warm accent strip carrying the stage label + its
+    /// action line. Mirrors the lens-line idiom (sparkle + accentSoft) so it
+    /// reads as part of the sheet, not a foreign alert.
+    private func stageBanner(stage: CityStage, prompt: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "location.north.line.fill")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(CT.accent)
+                .frame(width: 30, height: 30)
+                .background(
+                    RoundedRectangle(cornerRadius: 9, style: .continuous)
+                        .fill(colorScheme == .dark ? CT.warmSunkenDark : CT.accentSoft)
+                )
+            VStack(alignment: .leading, spacing: 3) {
+                Text(stage.localizedLabel)
+                    .font(CT.display(14, .bold))
+                    .foregroundStyle(colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary)
+                Text(prompt)
+                    .font(CT.body(12.5, .medium))
+                    .foregroundStyle(CT.accent)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(colorScheme == .dark ? CT.warmSunkenDark : CT.accentSoft)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text("\(stage.localizedLabel): \(prompt)"))
     }
 
     // MARK: - Deep link + toast

--- a/apps/ios/SoloCompass/Views/Experience/TravelerNotesSection.swift
+++ b/apps/ios/SoloCompass/Views/Experience/TravelerNotesSection.swift
@@ -1,5 +1,19 @@
 import SwiftUI
 
+/// Shared formatters for the traveler-notes feed. `ISO8601DateFormatter` and
+/// `RelativeDateTimeFormatter` are expensive to build (each spins up ICU), and
+/// `relativeTime(_:)` runs inside the notes `ForEach` body — a fresh pair per
+/// row per frame was measurable scroll jank. Hoisted here so the whole section
+/// reuses one of each. Both types are read-only after setup and safe to share.
+private enum TravelerNotesFormatters {
+    static let isoParser = ISO8601DateFormatter()
+    static let relative: RelativeDateTimeFormatter = {
+        let fmt = RelativeDateTimeFormatter()
+        fmt.unitsStyle = .short
+        return fmt
+    }()
+}
+
 // MARK: - Traveler co-build sections (extension on ExperienceDetailView)
 
 /// The "AI + travelers co-write" layer rendered inside the detail page: pending
@@ -414,10 +428,8 @@ extension ExperienceDetailView {
 
     /// Relative-time label ("3 天前") from an ISO 8601 string.
     func relativeTime(_ iso: String) -> String {
-        guard let date = ISO8601DateFormatter().date(from: iso) else { return "" }
-        let fmt = RelativeDateTimeFormatter()
-        fmt.unitsStyle = .short
-        return fmt.localizedString(for: date, relativeTo: Date())
+        guard let date = TravelerNotesFormatters.isoParser.date(from: iso) else { return "" }
+        return TravelerNotesFormatters.relative.localizedString(for: date, relativeTo: Date())
     }
 
     // MARK: Mood presets (category-specific)

--- a/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
+++ b/apps/ios/SoloCompass/Views/Filter/FilterBarView.swift
@@ -14,10 +14,17 @@ public struct FilterBarView: View {
     let selectedCustomTag: String?
     /// True when the "Saved" filter is active (mirrors `MapViewModel.isFavoriteFilter`).
     let isFavoriteSelected: Bool
+    /// True when the "可办公 / Work-ready" filter is active (mirrors
+    /// `MapViewModel.isWorkFilter`). The digital-nomad entry point — keeps only
+    /// places you can actually work from.
+    let isWorkSelected: Bool
     let onSelectNow: () -> Void
     let onSelectAll: () -> Void
     /// Tap handler for the "Saved" pill — shows only favourited experiences.
     let onSelectFavorite: () -> Void
+    /// Tap handler for the "可办公" pill. Optional so existing callers/tests/previews
+    /// that predate the nomad filter keep compiling; when nil the pill is hidden.
+    let onSelectWork: (() -> Void)?
     /// Called when the user re-taps an already-active pill to deselect it back to 'All'.
     let onClear: () -> Void
     let onSelectCategory: (ExperienceCategory) -> Void
@@ -118,10 +125,12 @@ public struct FilterBarView: View {
         isNowSelected: Bool,
         selectedCustomTag: String? = nil,
         isFavoriteSelected: Bool = false,
+        isWorkSelected: Bool = false,
         nowCount: Int = 0,
         onSelectNow: @escaping () -> Void,
         onSelectAll: @escaping () -> Void,
         onSelectFavorite: @escaping () -> Void = {},
+        onSelectWork: (() -> Void)? = nil,
         onClear: @escaping () -> Void = {},
         onSelectCategory: @escaping (ExperienceCategory) -> Void,
         onSelectCustomTag: @escaping (String) -> Void = { _ in },
@@ -136,10 +145,12 @@ public struct FilterBarView: View {
         self.isNowSelected = isNowSelected
         self.selectedCustomTag = selectedCustomTag
         self.isFavoriteSelected = isFavoriteSelected
+        self.isWorkSelected = isWorkSelected
         self.nowCount = nowCount
         self.onSelectNow = onSelectNow
         self.onSelectAll = onSelectAll
         self.onSelectFavorite = onSelectFavorite
+        self.onSelectWork = onSelectWork
         self.onClear = onClear
         self.onSelectCategory = onSelectCategory
         self.onSelectCustomTag = onSelectCustomTag
@@ -153,6 +164,7 @@ public struct FilterBarView: View {
     /// Stable string ID for the currently selected pill — drives matchedGeometryEffect.
     private var selectionID: String {
         if isNowSelected { return "now" }
+        if isWorkSelected { return "work" }
         if isFavoriteSelected { return "saved" }
         if let tag = selectedCustomTag { return "tag-\(tag)" }
         if let cat = selectedCategory { return cat.rawValue }
@@ -221,6 +233,15 @@ public struct FilterBarView: View {
                             action: onSelectAll
                         )
                         .id("all")
+                        // 可办公 / Work-ready — the digital-nomad entry point.
+                        // Placed right after All so "where can I work" is a
+                        // first-class filter, not the `.work` category buried at
+                        // the far end of the horizontal strip. Hidden until a
+                        // caller wires `onSelectWork` (previews/tests stay lean).
+                        if let onWork = onSelectWork {
+                            workPill(isSelected: isWorkSelected, action: onWork)
+                                .id("work")
+                        }
                         favoritePill(isSelected: isFavoriteSelected, action: onSelectFavorite)
                             .id("saved")
                         // P2.5 #250: Solo Agent chip — shortcut to
@@ -578,6 +599,59 @@ public struct FilterBarView: View {
             // bar (Now/All/Saved/category) so the row reads as one component
             // instead of a parade of red/orange/green outlines. The category
             // identity color survives as the inline glyph tint (heart icon).
+            .foregroundStyle(isSelected ? .white : .primary)
+            .background {
+                if isSelected {
+                    Capsule()
+                        .fill(tint)
+                        .matchedGeometryEffect(id: "filterHighlight", in: pillHighlight)
+                }
+            }
+            .overlay(
+                Capsule().stroke(isSelected ? Color.clear : CT.borderDefault, lineWidth: 1)
+            )
+            .animation(.spring(response: 0.3, dampingFraction: 0.65), value: resultCount)
+        }
+        .buttonStyle(PressableButtonStyle())
+        .accessibilityLabel(Text(label))
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityValue(isSelected && resultCount > 0 ? Text("\(resultCount) results") : Text(""))
+    }
+
+    /// 可办公 / Work-ready pill — the digital-nomad entry point. A laptop glyph +
+    /// localized label that filters the map to places you can actually work from
+    /// (coworking, libraries, wifi/power cafés — see `MapViewModel.isWorkReady`).
+    /// Toggles like the Saved pill: taps always route to `action`, which flips
+    /// `isWorkFilter`. Selected state uses `systemBlue` — the same blue as the
+    /// `.work` category marker on the map, so the filter and the pins read as one
+    /// system.
+    private func workPill(isSelected: Bool, action: @escaping () -> Void) -> some View {
+        let label = NSLocalizedString("filter.work", comment: "Work-ready (可办公) filter")
+        let tint = Color(.systemBlue)
+        return Button {
+            #if canImport(UIKit)
+            Haptics.impact(isSelected ? .light : .medium)
+            #endif
+            action()
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "laptopcomputer")
+                    .font(.caption.weight(.semibold))
+                Text(label)
+                    .font(.subheadline.weight(.medium))
+                if isSelected && resultCount > 0 {
+                    Text(Self.compactCount(resultCount))
+                        .font(.caption2.monospacedDigit().weight(.semibold))
+                        .contentTransition(reduceMotion ? .identity : .numericText(value: Double(resultCount)))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(Color.white.opacity(0.28)))
+                        .opacity(countBadgeOpacity)
+                        .transition(.scale.combined(with: .opacity))
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
             .foregroundStyle(isSelected ? .white : .primary)
             .background {
                 if isSelected {

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -209,6 +209,11 @@ public enum BottomSheetDetent: CaseIterable {
 // on how to preserve the R0 first-frame value elsewhere.
 
 public struct BottomInfoSheet<Content: View>: View {
+    /// Named coordinate space for sampling the sheet's live (animation-aware)
+    /// vertical position, so a re-grab mid-settle picks up from where the sheet
+    /// visually is rather than its target detent.
+    private static var sheetSpace: String { "bottomInfoSheet.slab" }
+
     @State private var currentDetent: BottomSheetDetent = BottomInfoSheet.initialDetent
 
     /// Resting detent on appear. DEBUG-only `-expandSheet` launch argument forces
@@ -224,6 +229,18 @@ public struct BottomInfoSheet<Content: View>: View {
     }
     @State private var dragOffset: CGFloat = 0
     @State private var isDragging: Bool = false
+    /// Sheet height captured at the instant a drag begins — the origin the
+    /// finger tracks from. Seeded to the live rendered height so re-grabbing
+    /// mid-settle is seamless.
+    @State private var dragStartHeight: CGFloat = 0
+    /// The sheet's *actually rendered* height, sampled every frame via
+    /// `onGeometryChange`. While a settle spring is flying, `currentDetent` has
+    /// already jumped to its target but the view is still interpolating toward
+    /// it — so this trails the target. On a fresh grab we rebase `dragOffset`
+    /// against this live value so the finger picks the sheet up exactly where it
+    /// visually is, instead of snapping to the target detent's baseline first
+    /// (the "jump then follow" glitch when you re-grab mid-animation).
+    @State private var renderedHeight: CGFloat = 0
     /// Latches true the first time the sheet leaves .peek. Drives content
     /// pre-building: once the user has expanded, the list stays constructed
     /// across collapses so re-expansion never pays the build cost again.
@@ -415,7 +432,18 @@ public struct BottomInfoSheet<Content: View>: View {
             // Slide instead of resize: the visible height is
             // `maxHeight − offset`, i.e. exactly `displayHeight`.
             .offset(y: maxHeight - displayHeight)
+            // Sample the *interpolated* offset every frame — during a settle
+            // spring this reports the in-flight position, not the target. The
+            // visible height is `maxHeight − (rendered vertical offset)`, and
+            // `frame.minY` inside the ZStack IS that offset (the ZStack pins the
+            // slab to `maxHeight`, so an unoffset slab sits at minY 0).
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                maxHeight - proxy.frame(in: .named(Self.sheetSpace)).minY
+            } action: { liveHeight in
+                renderedHeight = liveHeight
+            }
         }
+        .coordinateSpace(name: Self.sheetSpace)
         // Animate ONLY the discrete detent settle (which changes once, on
         // release), never the continuously finger-driven offset. Watching the
         // per-frame value meant every drag frame nudged a value an active
@@ -568,11 +596,32 @@ public struct BottomInfoSheet<Content: View>: View {
         .gesture(
             DragGesture(minimumDistance: 4)
                 .onChanged { value in
-                    isDragging = true
-                    dragOffset = value.translation.height
+                    if !isDragging {
+                        // First frame of a fresh grab. If a settle spring is
+                        // still flying, `renderedHeight` trails the target
+                        // detent; capture the live rendered height as the drag's
+                        // origin so the finger picks the sheet up exactly where
+                        // it visually sits (no jump-to-target). Before the first
+                        // geometry sample (renderedHeight == 0) fall back to the
+                        // resting detent height.
+                        dragStartHeight = renderedHeight > 0 ? renderedHeight : detentHeight
+                        // Freeze the in-flight spring at this instant so seeding
+                        // the offset doesn't itself animate.
+                        var tx = Transaction()
+                        tx.disablesAnimations = true
+                        withTransaction(tx) { isDragging = true }
+                    }
+                    // 1:1 finger tracking from the captured origin. Dragging up
+                    // (negative translation) grows the sheet; `displayHeight`
+                    // clamps the extremes, so map back through `detentHeight`.
+                    let targetHeight = dragStartHeight - value.translation.height
+                    dragOffset = detentHeight - targetHeight
                 }
                 .onEnded { value in
-                    let projectedHeight = detentHeight - value.predictedEndTranslation.height
+                    // Project from the same origin the drag tracked
+                    // (`dragStartHeight`), not the resting detent — otherwise a
+                    // flick begun mid-settle picks the wrong target detent.
+                    let projectedHeight = dragStartHeight - value.predictedEndTranslation.height
                     let clampedHeight = max(minHeight, min(maxHeight, projectedHeight))
                     // Settle to the nearest detent with an EXPLICIT spring. Both
                     // `currentDetent` and `dragOffset` feed `displayHeight`, but the

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -1943,6 +1943,7 @@ struct CompassMapContentView: View {
                 guard let city = viewModel.selectedCity else { return }
                 cityOSStore.toggleKitTodo(kind, cityCode: city)
             },
+            stage: currentCityStage,
             onDismiss: { isShowingKitSheet = false }
         )
     }
@@ -2906,10 +2907,12 @@ private struct MapOverlayView: View {
                 isNowSelected: viewModel.isNowFilter,
                 selectedCustomTag: viewModel.selectedCustomTag,
                 isFavoriteSelected: viewModel.isFavoriteFilter,
+                isWorkSelected: viewModel.isWorkFilter,
                 nowCount: viewModel.nowCount,
                 onSelectNow: { viewModel.selectNowFilter() },
                 onSelectAll: { viewModel.clearFilters() },
                 onSelectFavorite: { viewModel.selectFavoriteFilter() },
+                onSelectWork: { viewModel.selectWorkFilter() },
                 onClear: { viewModel.clearFilters() },
                 onSelectCategory: { viewModel.selectCategory($0) },
                 onSelectCustomTag: { viewModel.selectCustomTag($0) },


### PR DESCRIPTION
Two independent, bisectable commits.

## 1. Digital-nomad entry points (`feat`)

Nomads had every piece but no *entry point*: `.work` was buried in the filter strip, wifi/visa/money lived one tap deep in the kit sheet, and the lifecycle stage only lit a pill.

- **可办公 / Work-ready filter** — a fourth filter pill right after All (laptop glyph, `systemBlue` to match the `.work` map marker). `MapViewModel.isWorkReady` qualifies a place as `.work` **or** a café already advertising a wifi/power `CategoryHighlight` — reusing signals the enrichment pipeline emits, **no new schema**. Joins the existing mutual-exclusion set. `FilterBarView` gains an optional `workPill` (hidden until wired, so previews/tests are untouched); `CompassMapView` wires it; `filter.work` localized en/zh.
- **Landing kit adapts to CityStage** — `KitSheet` takes an optional `stage`; in Live mode it floats the stage's most relevant row to the front (SIM on 抵达, visa on 立足/生活) and shows a stage banner with an action-first nudge. Pure presentation-layer reorder over existing `city_kits` data — **no pipeline change**.

On-device (Shenzhen), the filter bar now reads `Now / All / 💻 Work-ready / ♡ Saved`.

## 2. Main-thread / gesture refactor (`perf`)

Two invariants across the interactive surfaces:

- **Finger-driven displacement tracks input 1:1 and is interruptible.** `BottomInfoSheet` re-grabs the live rendered height on each drag start (`onGeometryChange` + `dragStartHeight`) inside a `disablesAnimations` transaction, so re-grabbing during a settle no longer jumps.
- **Work over a few ms leaves the main actor.** SyncService per-row `fetch(#Predicate)` merges → one `FetchDescriptor` + in-memory diff, decode off-actor; CityBrief decode off-actor on city switch; chat attachment decode off-actor via shared `ChatAttachmentDecoder`; `VoiceService` `AmplitudeGate` throttles the ~43 Hz audio-tap publish to ~20 Hz; TravelerNotes formatters hoisted to statics.

## Verification

- ✅ `BUILD SUCCEEDED` (both features) · `TEST BUILD SUCCEEDED`
- ✅ `WorkFilterTests` added (truth table + end-to-end + mutual exclusivity); `isWorkReady` truth table also verified standalone **7/7**
- ✅ On-device screenshot confirms the Work-ready pill renders
- ⚠️ Full XCTest run blocked by an Xcode 26.4 *"test runner hung before establishing connection"* infra flake (hangs at app launch, before any test case) — unrelated to these changes. CI's iOS gate is build-only.