### PR TITLE
refactor(ios): adopt Dynamic Type — migrate 155 fixed-size CT fonts to .ct* modifiers

### DIFF
--- a/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatSheet.swift
@@ -702,7 +702,7 @@ public struct ChatSheet: View {
                 .padding(.bottom, 20)
 
             Text(NSLocalizedString("chat.empty.title", comment: "Ask me anything about places near you"))
-                .font(CT.displayRounded(22, .bold))
+                .ctDisplay(22, .bold)
                 .foregroundStyle(emptyTitleColor)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
@@ -852,7 +852,7 @@ public struct ChatSheet: View {
                     .tracking(1.6)
                     .foregroundStyle(CT.accent.opacity(0.65))
                 Text(Self.shortName(place))
-                    .font(CT.displayRounded(20, .bold))
+                    .ctDisplay(20, .bold)
                     .foregroundStyle(.primary)
                     .multilineTextAlignment(.center)
                     .lineLimit(2)

--- a/apps/ios/SoloCompass/Views/CityOS/BaseCard.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/BaseCard.swift
@@ -42,7 +42,7 @@ struct BaseCard: View {
                         format: NSLocalizedString("cityos.base.title", comment: "%@ · 基地"),
                         cityName
                     ))
-                    .font(CT.displayRounded(17, .semibold))
+                    .ctDisplay(17, .semibold)
                     .foregroundStyle(primaryText)
                     .lineLimit(1)
                     signalLine
@@ -89,7 +89,7 @@ struct BaseCard: View {
             ForEach(Array(stats.prefix(2).enumerated()), id: \.offset) { index, stat in
                 if index > 0 {
                     Text("·")
-                        .font(CT.body(12))
+                        .ctBody(12)
                         .foregroundStyle(CT.fgSubtle)
                 }
                 HStack(spacing: 3.5) {
@@ -97,7 +97,7 @@ struct BaseCard: View {
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundStyle(face.tagColor)
                     Text(stat.text)
-                        .font(CT.body(12, .medium))
+                        .ctBody(12, .medium)
                         .foregroundStyle(CT.fgMuted)
                         .lineLimit(1)
                 }
@@ -257,11 +257,11 @@ struct BaseCountdownRing: View {
                 .animation(.easeInOut(duration: 0.4), value: fraction)
             VStack(spacing: -1) {
                 Text("\(max(remaining, 0))")
-                    .font(CT.mono(size * 0.30, .semibold))
+                    .ctMono(size * 0.30, .semibold)
                     .foregroundStyle(tone)
                     .contentTransition(.numericText())
                 Text(NSLocalizedString("cityos.base.ring.unit", comment: "天"))
-                    .font(CT.mono(size * 0.16, .medium))
+                    .ctMono(size * 0.16, .medium)
                     .foregroundStyle(CT.fgSubtle)
             }
         }

--- a/apps/ios/SoloCompass/Views/CityOS/BasePanelSheet.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/BasePanelSheet.swift
@@ -107,12 +107,12 @@ struct BasePanelSheet: View {
                     .padding(.vertical, 3.5)
                     .background(Capsule().fill(face.tagColor.opacity(0.12)))
                 Text(cityName)
-                    .font(CT.displayRounded(26, .bold))
+                    .ctDisplay(26, .bold)
                     .foregroundStyle(primaryText)
                     .lineLimit(1)
                     .minimumScaleFactor(0.7)
                 Text(NSLocalizedString("cityos.base.subtitle.\(face.rawValue)", comment: "Base face subtitle"))
-                    .font(CT.body(13))
+                    .ctBody(13)
                     .foregroundStyle(CT.fgMuted)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -453,7 +453,7 @@ private struct SectionCard<Content: View>: View {
                         trailing.1()
                     } label: {
                         Text(trailing.0)
-                            .font(CT.body(12.5, .semibold))
+                            .ctBody(12.5, .semibold)
                             .foregroundStyle(CT.accent)
                     }
                     .buttonStyle(.plain)
@@ -509,13 +509,13 @@ private struct PanelRow: View {
                 .background(RoundedRectangle(cornerRadius: 9, style: .continuous).fill(tint.opacity(0.10)))
             VStack(alignment: .leading, spacing: 2.5) {
                 Text(title)
-                    .font(CT.body(14.5, .semibold))
+                    .ctBody(14.5, .semibold)
                     .foregroundStyle(primaryText)
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)
                 if let subtitle {
                     Text(subtitle)
-                        .font(CT.body(12.5))
+                        .ctBody(12.5)
                         .foregroundStyle(CT.fgMuted)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
@@ -524,7 +524,7 @@ private struct PanelRow: View {
             Spacer(minLength: 0)
             if let badge {
                 Text(badge)
-                    .font(CT.mono(12, .semibold))
+                    .ctMono(12, .semibold)
                     .foregroundStyle(CT.accent)
                     .padding(.horizontal, 7)
                     .padding(.vertical, 2.5)

--- a/apps/ios/SoloCompass/Views/CityOS/CityOSComponents.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/CityOSComponents.swift
@@ -51,7 +51,7 @@ struct RelativeTimeText: View {
 
     var body: some View {
         Text(label)
-            .font(CT.mono(10.5))
+            .ctMono(10.5)
             .foregroundStyle(CT.fgSubtle)
     }
 }

--- a/apps/ios/SoloCompass/Views/CityOS/ComplianceBanner.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/ComplianceBanner.swift
@@ -24,7 +24,7 @@ struct ComplianceBanner: View {
 
             Button(action: onHandle) {
                 Text(NSLocalizedString("cityos.compliance.handle", comment: "处理"))
-                    .font(CT.body(13, .semibold))
+                    .ctBody(13, .semibold)
                     .foregroundStyle(.white)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
@@ -65,9 +65,13 @@ struct ComplianceBanner: View {
                     format: NSLocalizedString("cityos.compliance.overstay", comment: "已逾期 N 天"),
                     abs(daysRemaining)
                 ))
-                .font(CT.body(13, .semibold))
+                .ctBody(13, .semibold)
                 .foregroundStyle(CT.warningText)
             } else {
+                // Text(+)-concatenation requires each operand stay a `Text`, so
+                // these keep the fixed-size CT.* Font factory — the `.ct*` view
+                // modifiers return `some View` and can't be `+`-joined. Dynamic
+                // Type is partially honored via `.minimumScaleFactor` below.
                 (
                     Text(NSLocalizedString("cityos.compliance.prefix", comment: "签证还剩 "))
                         .font(CT.body(13, .medium))

--- a/apps/ios/SoloCompass/Views/CityOS/KitSheet.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/KitSheet.swift
@@ -103,7 +103,7 @@ struct KitSheet: View {
     private var toastOverlay: some View {
         if let toast {
             Text(toast)
-                .font(CT.body(13, .medium))
+                .ctBody(13, .medium)
                 .foregroundStyle(.white)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 10)
@@ -140,7 +140,7 @@ private struct KitRowCard: View {
         VStack(alignment: .leading, spacing: 10) {
             header
             Text(item.main)
-                .font(CT.body(14))
+                .ctBody(14)
                 .foregroundStyle(primaryText)
                 .fixedSize(horizontal: false, vertical: true)
             if let lens = item.lens, !lens.isEmpty {
@@ -173,7 +173,7 @@ private struct KitRowCard: View {
                         .fill(iconTileFill)
                 )
             Text(item.name)
-                .font(CT.display(15, .bold))
+                .ctDisplay(15, .bold)
                 .foregroundStyle(primaryText)
             Spacer(minLength: 0)
             if let planTick {
@@ -217,7 +217,7 @@ private struct KitRowCard: View {
             Image(systemName: "sparkle")
                 .font(.system(size: 10, weight: .semibold))
             Text(lens)
-                .font(CT.body(12.5, .medium))
+                .ctBody(12.5, .medium)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .foregroundStyle(CT.accent)
@@ -257,7 +257,7 @@ private struct KitRowCard: View {
                     Image(systemName: "arrow.up.forward.app")
                         .font(.system(size: 11, weight: .semibold))
                     Text(label)
-                        .font(CT.body(12.5, .semibold))
+                        .ctBody(12.5, .semibold)
                 }
                 .foregroundStyle(CT.accent)
                 .padding(.horizontal, 11)
@@ -282,10 +282,10 @@ private struct KitRowCard: View {
                             Image(systemName: "phone.fill")
                                 .font(.system(size: 12, weight: .semibold))
                             Text(entry.label)
-                                .font(CT.body(13, .medium))
+                                .ctBody(13, .medium)
                             Spacer(minLength: 0)
                             Text(entry.number)
-                                .font(CT.mono(14, .semibold))
+                                .ctMono(14, .semibold)
                         }
                         .foregroundStyle(CT.accent)
                         .padding(.horizontal, 12)
@@ -351,7 +351,7 @@ private struct VisaComplianceControl: View {
             }
             Toggle(isOn: $preferences.visaReminderEnabled) {
                 Text(NSLocalizedString("cityos.visa.reminder.toggle", comment: "到期提醒"))
-                    .font(CT.body(13, .medium))
+                    .ctBody(13, .medium)
                     .foregroundStyle(primaryText)
             }
             .tint(CT.accent)
@@ -364,11 +364,11 @@ private struct VisaComplianceControl: View {
     private func counter(value: Int, label: String, isCritical: Bool) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             Text("\(value)")
-                .font(CT.mono(26, .bold))
+                .ctMono(26, .bold)
                 .foregroundStyle(isCritical ? CT.warningText : CT.accent)
                 .contentTransition(.numericText())
             Text(label)
-                .font(CT.body(10.5))
+                .ctBody(10.5)
                 .foregroundStyle(CT.fgMuted)
                 .fixedSize(horizontal: false, vertical: true)
         }
@@ -384,7 +384,7 @@ private struct VisaComplianceControl: View {
                 selection: entryDateBinding,
                 displayedComponents: .date
             )
-            .font(CT.body(13, .medium))
+            .ctBody(13, .medium)
             Stepper(
                 value: visaLengthBinding,
                 in: 1...365
@@ -393,7 +393,7 @@ private struct VisaComplianceControl: View {
                     format: NSLocalizedString("cityos.visa.length", comment: "签证 N 天"),
                     visaLengthBinding.wrappedValue
                 ))
-                .font(CT.body(13, .medium))
+                .ctBody(13, .medium)
                 .foregroundStyle(primaryText)
             }
         }

--- a/apps/ios/SoloCompass/Views/CityOS/LiveSheet.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/LiveSheet.swift
@@ -65,10 +65,10 @@ struct LiveSheet: View {
                 .font(.system(size: 40))
                 .foregroundStyle(CT.fgSubtle)
             Text(NSLocalizedString("cityos.live.empty.title", comment: "No local events this week"))
-                .font(CT.display(16, .semibold))
+                .ctDisplay(16, .semibold)
                 .foregroundStyle(colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary)
             Text(NSLocalizedString("cityos.live.empty.hint", comment: "Check back — the city brief refreshes twice a week."))
-                .font(CT.body(13))
+                .ctBody(13)
                 .foregroundStyle(CT.fgMuted)
                 .multilineTextAlignment(.center)
         }
@@ -108,7 +108,7 @@ struct LiveEventCard: View {
             metaRow
             if let note = event.soloNote, !note.isEmpty {
                 Text(note)
-                    .font(CT.body(13))
+                    .ctBody(13)
                     .foregroundStyle(event.isNotice ? CT.warningText : primaryText)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -135,7 +135,7 @@ struct LiveEventCard: View {
                     .foregroundStyle(CT.warningText)
             }
             Text(event.name)
-                .font(CT.displayRounded(15, .semibold))
+                .ctDisplay(15, .semibold)
                 .foregroundStyle(event.isNotice ? CT.warningText : primaryText)
                 .fixedSize(horizontal: false, vertical: true)
             Spacer(minLength: 0)
@@ -157,7 +157,7 @@ struct LiveEventCard: View {
     private var metaRow: some View {
         HStack(spacing: 8) {
             Text(event.whenLabel)
-                .font(CT.mono(11))
+                .ctMono(11)
                 .foregroundStyle(CT.fgMuted)
             if !event.isNotice, let score = event.soloScore {
                 soloChip(score)
@@ -187,7 +187,7 @@ struct LiveEventCard: View {
             HealthDot(status: health)
             if let seen = event.seenLabel, !seen.isEmpty {
                 Text(seen)
-                    .font(CT.mono(10))
+                    .ctMono(10)
                     .foregroundStyle(CT.fgMuted)
                     .lineLimit(1)
             }
@@ -201,7 +201,7 @@ struct LiveEventCard: View {
                         Image(systemName: "mappin.and.ellipse")
                             .font(.system(size: 10, weight: .semibold))
                         Text(NSLocalizedString("cityos.live.showOnMap", comment: "在地图上看"))
-                            .font(CT.body(12, .semibold))
+                            .ctBody(12, .semibold)
                     }
                     .foregroundStyle(CT.accent)
                     .padding(.horizontal, 10)

--- a/apps/ios/SoloCompass/Views/CityOS/VerifySheet.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/VerifySheet.swift
@@ -62,7 +62,7 @@ struct VerifySheet: View {
     private var header: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(NSLocalizedString("cityos.verify.title", comment: "30 秒，帮下一个独行者"))
-                .font(CT.displayRounded(18, .bold))
+                .ctDisplay(18, .bold)
                 .foregroundStyle(primaryText)
             Text(String(
                 format: NSLocalizedString(
@@ -71,7 +71,7 @@ struct VerifySheet: View {
                 ),
                 placeName
             ))
-            .font(CT.body(12.5))
+            .ctBody(12.5)
             .foregroundStyle(CT.fgMuted)
             .fixedSize(horizontal: false, vertical: true)
         }
@@ -80,7 +80,7 @@ struct VerifySheet: View {
     private func question(text: String, options: [String], selection: Binding<Int?>) -> some View {
         VStack(alignment: .leading, spacing: 7) {
             Text(text)
-                .font(CT.body(13.5, .semibold))
+                .ctBody(13.5, .semibold)
                 .foregroundStyle(primaryText)
             HStack(spacing: 8) {
                 ForEach(options.indices, id: \.self) { index in
@@ -99,7 +99,7 @@ struct VerifySheet: View {
     private func optionPill(label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Text(label)
-                .font(CT.body(13, .medium))
+                .ctBody(13, .medium)
                 .foregroundStyle(isSelected ? CT.accent : CT.fgMuted)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 9)
@@ -124,7 +124,7 @@ struct VerifySheet: View {
             onDismiss()
         } label: {
             Text(NSLocalizedString("cityos.verify.submit", comment: "提交印证"))
-                .font(CT.body(14.5, .semibold))
+                .ctBody(14.5, .semibold)
                 .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 12)

--- a/apps/ios/SoloCompass/Views/Companion/Components/RecruitingModule.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Components/RecruitingModule.swift
@@ -103,7 +103,7 @@ public struct RecruitingModule: View {
 
     private func statusCapsule(status: CompanionStatus) -> some View {
         Text(status.localizedLabel)
-            .font(CT.display(10, .bold))
+            .ctDisplay(10, .bold)
             .tracking(0.1)
             .textCase(.uppercase)
             .foregroundStyle(status.toneColor)
@@ -123,7 +123,7 @@ public struct RecruitingModule: View {
                 .frame(width: 36, height: 36)
                 .overlay(
                     Text(String(hostId.prefix(1)).uppercased())
-                        .font(CT.display(15, .bold))
+                        .ctDisplay(15, .bold)
                         .foregroundStyle(.white)
                 )
 
@@ -203,7 +203,7 @@ public struct RecruitingModule: View {
 
     private func hostMessageView(_ message: String) -> some View {
         Text("\u{201C}\(message)\u{201D}")
-            .font(CT.body(12.5).italic())
+            .ctBody(12.5).italic()
             .foregroundStyle(CT.fgPrimary)
             .lineLimit(3)
             .fixedSize(horizontal: false, vertical: true)

--- a/apps/ios/SoloCompass/Views/Companion/Components/RouteCard.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Components/RouteCard.swift
@@ -87,7 +87,7 @@ public struct RouteCard: View {
             headRow
 
             Text(route.title)
-                .font(CT.body(16, .semibold))
+                .ctBody(16, .semibold)
                 .foregroundStyle(CT.fgPrimary)
                 .lineLimit(2)
                 .padding(.bottom, 10)
@@ -145,7 +145,7 @@ public struct RouteCard: View {
             Image(systemName: "sparkles")
                 .font(.system(size: 11, weight: .semibold))
             Text(reason)
-                .font(CT.body(11.5, .semibold))
+                .ctBody(11.5, .semibold)
                 .lineLimit(2)
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -171,7 +171,7 @@ public struct RouteCard: View {
                     .frame(width: 6, height: 6)
 
                 Text(tagLabel)
-                    .font(CT.display(10, .bold))
+                    .ctDisplay(10, .bold)
                     .tracking(1.2)
                     .textCase(.uppercase)
                     .foregroundStyle(CT.fgMuted)
@@ -197,7 +197,7 @@ public struct RouteCard: View {
             Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: 9.5, weight: .semibold))
             Text(NSLocalizedString("route.card.verified", comment: "Verified pill"))
-                .font(CT.mono(9.5, .semibold))
+                .ctMono(9.5, .semibold)
         }
         .foregroundStyle(CT.verifiedGreen)
         .padding(.horizontal, 6)
@@ -211,7 +211,7 @@ public struct RouteCard: View {
             Image(systemName: "sparkles")
                 .font(.system(size: 10, weight: .bold))
             Text(NSLocalizedString("route.card.now", comment: "此刻 now pill"))
-                .font(CT.display(10, .bold))
+                .ctDisplay(10, .bold)
                 .tracking(0.6)
         }
         .foregroundStyle(CT.sunGoldDeep)
@@ -331,14 +331,14 @@ public struct RouteCard: View {
         return HStack(spacing: 8) {
             statusDot(dotColor, pulsing: !isCompleted)
             Text(mini.text)
-                .font(CT.body(11.5, .regular))
+                .ctBody(11.5, .regular)
                 .foregroundStyle(mini.tone)
                 .lineLimit(2)
                 .frame(maxWidth: .infinity, alignment: .leading)
             if showsChevron {
                 HStack(spacing: 2) {
                     Text(NSLocalizedString("route.card.recruit.view", comment: "查看 — open recruit detail"))
-                        .font(CT.mono(10.5, .semibold))
+                        .ctMono(10.5, .semibold)
                     Image(systemName: "chevron.right")
                         .font(.system(size: 9, weight: .semibold))
                 }
@@ -415,7 +415,7 @@ public struct RouteCard: View {
         HStack(spacing: 8) {
             AvatarStack(ids: walkedByIds, maxVisible: 4, size: 18, ring: CT.surfaceWhite)
             Text(walkedByLabel)
-                .font(CT.mono(11, .regular))
+                .ctMono(11, .regular)
                 .foregroundStyle(CT.fgMuted)
                 .lineLimit(1)
             Spacer(minLength: 4)

--- a/apps/ios/SoloCompass/Views/Companion/Components/StopsList.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Components/StopsList.swift
@@ -108,7 +108,7 @@ private struct StopRow: View {
                 .fill(experience.category.color)
                 .frame(width: discSize, height: discSize)
             Text(String(format: "%02d", index + 1))
-                .font(CT.mono(11, .semibold))
+                .ctMono(11, .semibold)
                 .foregroundStyle(.white)
         }
     }
@@ -118,13 +118,13 @@ private struct StopRow: View {
     private var textColumn: some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(experience.title)
-                .font(CT.body(14.5, .semibold))
+                .ctBody(14.5, .semibold)
                 .foregroundStyle(CT.fgPrimary)
                 .fixedSize(horizontal: false, vertical: true)
 
             if let romanized = experience.location.placeNameRomanized {
                 Text(romanized)
-                    .font(CT.body(11.5))
+                    .ctBody(11.5)
                     .foregroundStyle(CT.fgMuted)
             }
 

--- a/apps/ios/SoloCompass/Views/Companion/Components/VerifiedBadge.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Components/VerifiedBadge.swift
@@ -57,14 +57,14 @@ public struct VerifiedBadge: View {
                 Text(isVerified
                     ? NSLocalizedString("verified.title.verified", comment: "")
                     : NSLocalizedString("verified.title.watching", comment: ""))
-                    .font(CT.display(13, .semibold))
+                    .ctDisplay(13, .semibold)
                     .foregroundStyle(isVerified ? CT.verifiedGreen : CT.fgPrimary)
 
                 Text(String(
                     format: NSLocalizedString("verified.subtitle", comment: ""),
                     walkedByCount
                 ))
-                    .font(CT.body(12))
+                    .ctBody(12)
                     .foregroundStyle(CT.fgMuted)
             }
 
@@ -107,7 +107,7 @@ public struct VerifiedBadge: View {
             Text(isVerified
                 ? NSLocalizedString("verified.title.verified", comment: "")
                 : NSLocalizedString("verified.title.watching", comment: ""))
-                .font(CT.display(12, .semibold))
+                .ctDisplay(12, .semibold)
                 .foregroundStyle(isVerified ? CT.verifiedGreen : CT.fgMuted)
 
             Spacer(minLength: 4)
@@ -119,7 +119,7 @@ public struct VerifiedBadge: View {
                 format: NSLocalizedString("verified.subtitle", comment: ""),
                 walkedByCount
             ))
-                .font(CT.mono(10, .medium))
+                .ctMono(10, .medium)
                 .foregroundStyle((isVerified ? CT.verifiedGreen : CT.fgMuted).opacity(0.85))
         }
         .padding(.horizontal, 14)
@@ -142,7 +142,7 @@ public struct VerifiedBadge: View {
                     : NSLocalizedString("verified.short.watching", comment: ""),
                 walkedByCount
             ))
-                .font(CT.body(11, .medium))
+                .ctBody(11, .medium)
         }
         .foregroundStyle(isVerified ? CT.verifiedGreen : CT.fgMuted)
         .padding(.horizontal, 8)

--- a/apps/ios/SoloCompass/Views/Companion/RouteDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/RouteDetailView.swift
@@ -134,7 +134,7 @@ public struct RouteDetailView: View {
                     .font(.system(size: 40))
 
                 Text(liveRoute.title)
-                    .font(CT.displayRounded(26, .bold))
+                    .ctDisplay(26, .bold)
                     .foregroundStyle(.white)
                     .fixedSize(horizontal: false, vertical: true)
 
@@ -223,7 +223,7 @@ public struct RouteDetailView: View {
     private var metaRow: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(monoBaseline)
-                .font(CT.mono(12))
+                .ctMono(12)
                 .foregroundStyle(CT.fgMuted)
                 .padding(.vertical, 14)
             Rectangle()
@@ -239,7 +239,7 @@ public struct RouteDetailView: View {
     private var aiInsightLocked: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(NSLocalizedString("route.detail.aiInsight.title", comment: "AI insight section title"))
-                .font(CT.display(12, .bold))
+                .ctDisplay(12, .bold)
                 .tracking(0.8)
                 .textCase(.uppercase)
                 .foregroundStyle(CT.fgMuted)
@@ -254,12 +254,12 @@ public struct RouteDetailView: View {
                         .foregroundStyle(CT.fgMuted)
                 }
                 Text(NSLocalizedString("route.detail.aiInsight.locked", comment: "AI insight unlock copy"))
-                    .font(CT.body(12))
+                    .ctBody(12)
                     .foregroundStyle(CT.fgMuted)
                     .fixedSize(horizontal: false, vertical: true)
                 Spacer(minLength: 4)
                 Text(NSLocalizedString("route.detail.aiInsight.unlock", comment: "Unlock CTA"))
-                    .font(CT.body(12, .semibold))
+                    .ctBody(12, .semibold)
                     .foregroundStyle(CT.accent)
             }
             .padding(.horizontal, 16)
@@ -284,7 +284,7 @@ public struct RouteDetailView: View {
     private var tagRow: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(NSLocalizedString("route.detail.tags.title", comment: "Route tags section title"))
-                .font(CT.display(12, .bold))
+                .ctDisplay(12, .bold)
                 .tracking(0.8)
                 .textCase(.uppercase)
                 .foregroundStyle(CT.fgMuted)
@@ -292,7 +292,7 @@ public struct RouteDetailView: View {
             FlowLayout(spacing: 6) {
                 ForEach(liveRoute.tags, id: \.self) { tag in
                     Text(tag)
-                        .font(CT.body(12))
+                        .ctBody(12)
                         .foregroundStyle(CT.accent)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 4)
@@ -435,7 +435,7 @@ public struct RouteDetailView: View {
                         Image(systemName: cta.systemImage)
                             .font(.system(size: 15, weight: .semibold))
                         Text(cta.label)
-                            .font(CT.body(15, .semibold))
+                            .ctBody(15, .semibold)
                     }
                     .frame(maxWidth: .infinity)
                     .frame(height: 44)

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceCardView.swift
@@ -89,7 +89,7 @@ public struct ExperienceCardView: View {
                 Image(systemName: symbol)
                     .font(.system(size: 10, weight: .semibold))
                 Text(label)
-                    .font(CT.body(10, .medium))
+                    .ctBody(10, .medium)
             }
             .foregroundStyle(tint)
             .padding(.horizontal, 6)
@@ -1051,7 +1051,7 @@ struct BestNowBadge: View {
         let score = experience.nowScore(at: date)
         if score.value >= 0.7 {
             Text(Self.reasonSubtitle(for: score))
-                .font(CT.body(11, .medium))
+                .ctBody(11, .medium)
                 .foregroundStyle(colorScheme == .dark ? CT.fgMutedDark : CT.fgMuted)
                 .lineLimit(1)
                 .accessibilityHidden(true)

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -361,11 +361,11 @@ public struct ExperienceDetailView: View {
             HStack(spacing: 4) {
                 Image(systemName: "sparkles").font(.system(size: 10))
                 Text(text.contains("L2") ? "L1 → L2" : NSLocalizedString("notes.signal.plus", comment: "+1 signal"))
-                    .font(CT.mono(11, .semibold))
+                    .ctMono(11, .semibold)
             }
             .foregroundStyle(CT.accent)
             Text(text)
-                .font(CT.body(12.5, .medium))
+                .ctBody(12.5, .medium)
                 .foregroundStyle(CT.fgPrimary)
         }
         .padding(.horizontal, 14).padding(.vertical, 9)
@@ -457,13 +457,13 @@ public struct ExperienceDetailView: View {
                     .frame(width: 18, height: 18)
                     .background(Circle().fill(viewModel.experience.category.color))
                 Text(viewModel.experience.category.localizedTitle.uppercased())
-                    .font(CT.displayRounded(11.5, .bold))
+                    .ctDisplay(11.5, .bold)
                     .tracking(1.4)
                     .foregroundStyle(CT.fgMuted)
                     .minimumScaleFactor(0.8)
                     .lineLimit(1)
                 Text(levelSignalText)
-                    .font(CT.mono(10.5, userContributed ? .semibold : .regular))
+                    .ctMono(10.5, userContributed ? .semibold : .regular)
                     .tracking(0.5)
                     .foregroundStyle(userContributed ? CT.accent : CT.fgMuted)
                     .contentTransition(.numericText())
@@ -473,7 +473,7 @@ public struct ExperienceDetailView: View {
             .fixedSize(horizontal: false, vertical: true)
 
             Text(viewModel.experience.title)
-                .font(CT.displayRounded(27, .bold))
+                .ctDisplay(27, .bold)
                 .foregroundStyle(CT.fgPrimary)
                 .lineLimit(nil)
                 .minimumScaleFactor(0.8)
@@ -491,7 +491,7 @@ public struct ExperienceDetailView: View {
                 .accessibilityHidden(!heroTitleVisible)
 
             Text(viewModel.experience.oneLiner)
-                .font(CT.body(15))
+                .ctBody(15)
                 .foregroundStyle(CT.fgMuted)
                 .fixedSize(horizontal: false, vertical: true)
 
@@ -500,14 +500,14 @@ public struct ExperienceDetailView: View {
                 let romanized = viewModel.experience.location.placeNameRomanized
                 if let romanized, !romanized.isEmpty {
                     Text(romanized)
-                        .font(CT.mono(12.5))
+                        .ctMono(12.5)
                         .foregroundStyle(CT.fgMuted)
                     Text(local)
-                        .font(CT.body(13))
+                        .ctBody(13)
                         .foregroundStyle(CT.fgMuted)
                 } else {
                     Text(local)
-                        .font(CT.body(13))
+                        .ctBody(13)
                         .foregroundStyle(CT.fgMuted)
                 }
             }
@@ -546,10 +546,10 @@ public struct ExperienceDetailView: View {
             Image(systemName: symbol)
                 .font(.system(size: 9))
             Text(NSLocalizedString(labelKey, comment: "Trust state label"))
-                .font(CT.mono(10))
+                .ctMono(10)
             if signals > 0 {
                 Text("· \(signals)")
-                    .font(CT.mono(10))
+                    .ctMono(10)
             }
         }
         .foregroundStyle(fg)
@@ -606,7 +606,7 @@ public struct ExperienceDetailView: View {
             }
             Spacer(minLength: 0)
         }
-        .font(CT.mono(12))
+        .ctMono(12)
         .foregroundStyle(CT.fgMuted)
         .padding(.bottom, 16)
         .overlay(alignment: .bottom) {
@@ -793,7 +793,7 @@ public struct ExperienceDetailView: View {
                         .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
                 } else {
                     Text(content)
-                        .font(CT.body(14.5))
+                        .ctBody(14.5)
                         .foregroundStyle(CT.fgPrimary)
                         .lineSpacing(3)
                         .fixedSize(horizontal: false, vertical: true)
@@ -803,7 +803,7 @@ public struct ExperienceDetailView: View {
                         FlowLayout(spacing: 6) {
                             ForEach(tags, id: \.self) { tag in
                                 Text(tag)
-                                    .font(CT.body(12))
+                                    .ctBody(12)
                                     .foregroundStyle(CT.accent)
                                     .padding(.horizontal, 10)
                                     .padding(.vertical, 4)
@@ -828,14 +828,14 @@ public struct ExperienceDetailView: View {
                     HStack(spacing: 8) {
                         ProgressView().tint(CT.accent)
                         Text(NSLocalizedString("ai.explanation.loading", comment: "AI insight loading indicator"))
-                            .font(CT.body(14))
+                            .ctBody(14)
                             .foregroundStyle(CT.fgMuted)
                     }
                     .id("aiInsight-skeleton")
                     .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
                 } else if let explanation = viewModel.aiExplanation {
                     Text(explanation)
-                        .font(CT.body(14.5))
+                        .ctBody(14.5)
                         .foregroundStyle(CT.fgPrimary)
                         .lineSpacing(3)
                         .fixedSize(horizontal: false, vertical: true)
@@ -866,11 +866,11 @@ public struct ExperienceDetailView: View {
                         .background(RoundedRectangle(cornerRadius: Radius.sm, style: .continuous).fill(CT.accentSoft))
                     VStack(alignment: .leading, spacing: 2) {
                         Text(name)
-                            .font(CT.body(13, .medium))
+                            .ctBody(13, .medium)
                             .foregroundStyle(CT.fgPrimary)
                             .lineLimit(1)
                         Text(String(format: "%.4f, %.4f", coord.latitude, coord.longitude))
-                            .font(CT.mono(10.5))
+                            .ctMono(10.5)
                             .foregroundStyle(CT.fgMuted)
                     }
                     Spacer(minLength: 0)
@@ -886,7 +886,7 @@ public struct ExperienceDetailView: View {
                             Image(systemName: "arrow.triangle.turn.up.right.diamond.fill")
                                 .font(.system(size: 12, weight: .bold))
                             Text(NSLocalizedString("location.navigate", comment: "Navigate"))
-                                .font(CT.body(12.5, .semibold))
+                                .ctBody(12.5, .semibold)
                         }
                         .foregroundStyle(.white)
                         .padding(.horizontal, 13)
@@ -916,7 +916,7 @@ public struct ExperienceDetailView: View {
                             .font(.system(size: 13))
                             .foregroundStyle(CT.fgMuted)
                         Text(hours)
-                            .font(CT.mono(12.5))
+                            .ctMono(12.5)
                             .foregroundStyle(CT.fgMuted)
                             .fixedSize(horizontal: false, vertical: true)
                         Spacer(minLength: 0)
@@ -1038,7 +1038,7 @@ public struct ExperienceDetailView: View {
                     HStack {
                         let range = viewModel.experience.durationMinutes
                         Text(String(format: NSLocalizedString("section.duration", comment: ""), range.min, range.max))
-                            .font(CT.mono(11))
+                            .ctMono(11)
                             .foregroundStyle(CT.fgMuted)
                         Spacer()
                         bestTimeStatusPill
@@ -1058,12 +1058,12 @@ public struct ExperienceDetailView: View {
                     }
                     HStack(alignment: .top, spacing: 12) {
                         Text("\(step.order)")
-                            .font(CT.mono(11.5, .semibold))
+                            .ctMono(11.5, .semibold)
                             .foregroundStyle(CT.accent)
                             .frame(width: 24, height: 24)
                             .background(Circle().fill(CT.accentSoft))
                         Text(step.text)
-                            .font(CT.body(14))
+                            .ctBody(14)
                             .foregroundStyle(CT.fgPrimary)
                             .lineSpacing(2)
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -1093,13 +1093,13 @@ public struct ExperienceDetailView: View {
                                 .font(.system(size: 12))
                                 .accessibilityHidden(true)
                             Text(inconvenienceCategoryName(item.category).uppercased())
-                                .font(CT.displayRounded(10, .bold))
+                                .ctDisplay(10, .bold)
                                 .tracking(1.2)
                                 .accessibilityHidden(true)
                         }
                         .foregroundStyle(CT.warningTextStrong)
                         Text(item.text)
-                            .font(CT.body(13.5))
+                            .ctBody(13.5)
                             .foregroundStyle(CT.fgPrimary)
                             .lineSpacing(2)
                             .fixedSize(horizontal: false, vertical: true)
@@ -1162,12 +1162,12 @@ public struct ExperienceDetailView: View {
         return VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .firstTextBaseline) {
                 Text(NSLocalizedString(titleKey, comment: "").uppercased())
-                    .font(CT.displayRounded(11, .bold))
+                    .ctDisplay(11, .bold)
                     .tracking(1.6)
                     .foregroundStyle(CT.fgMuted)
                 Spacer()
                 Text(String(format: "%.1f", score.overall))
-                    .font(CT.displayRounded(34, .bold))
+                    .ctDisplay(34, .bold)
                     .foregroundStyle(isEstimate ? CT.accent.opacity(0.55) : CT.accent)
                     .monospacedDigit()
                     .accessibilityLabel(Text(String(
@@ -1188,7 +1188,7 @@ public struct ExperienceDetailView: View {
         return VStack(alignment: .leading, spacing: 0) {
             if let hint = score.hint, !hint.isEmpty {
                 Text(hint)
-                    .font(CT.body(14.5))
+                    .ctBody(14.5)
                     .foregroundStyle(CT.fgPrimary)
                     .lineSpacing(2)
                     .fixedSize(horizontal: false, vertical: true)
@@ -1196,7 +1196,7 @@ public struct ExperienceDetailView: View {
             }
             if let subtitle {
                 Text(isEstimate ? NSLocalizedString("solo.estimate.pill", comment: "AI estimate pill") : subtitle)
-                    .font(CT.mono(10.5))
+                    .ctMono(10.5)
                     .foregroundStyle(CT.fgMuted)
                     .padding(.bottom, 14)
             }
@@ -1218,7 +1218,7 @@ public struct ExperienceDetailView: View {
                     Image(systemName: showingRadarTooltip ? "chevron.up" : "chevron.down")
                         .font(.system(size: 11, weight: .semibold))
                 }
-                .font(CT.body(12))
+                .ctBody(12)
                 .foregroundStyle(CT.fgMuted)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.top, 10)
@@ -1231,7 +1231,7 @@ public struct ExperienceDetailView: View {
                     Image(systemName: "sparkles").font(.system(size: 11))
                     Text(String(format: NSLocalizedString("solo.bestCall", comment: "Best solo dimension callout"), strongest.label))
                 }
-                .font(CT.body(12.5))
+                .ctBody(12.5)
                 .foregroundStyle(CT.accent)
                 .padding(.top, 8)
                 .overlay(alignment: .top) {
@@ -1273,7 +1273,7 @@ public struct ExperienceDetailView: View {
         let isTop = clamped >= 10
         return HStack(spacing: 10) {
             Text(dim.label)
-                .font(CT.body(12))
+                .ctBody(12)
                 .foregroundStyle(CT.fgMuted)
                 .frame(width: 52, alignment: .leading)
             GeometryReader { geo in
@@ -1285,7 +1285,7 @@ public struct ExperienceDetailView: View {
             }
             .frame(height: 6)
             Text(String(format: "%.0f", clamped))
-                .font(CT.mono(11.5, isTop ? .semibold : .regular))
+                .ctMono(11.5, isTop ? .semibold : .regular)
                 .foregroundStyle(isTop ? CT.accent : CT.fgMuted)
                 .frame(width: 20, alignment: .trailing)
         }
@@ -1433,11 +1433,11 @@ public struct ExperienceDetailView: View {
                 .font(.system(size: 12))
                 .foregroundStyle(CT.fgMuted)
             Text(label)
-                .font(CT.body(12.5))
+                .ctBody(12.5)
                 .foregroundStyle(CT.fgMuted)
             Spacer(minLength: 8)
             Text(date, style: .date)
-                .font(CT.mono(10.5))
+                .ctMono(10.5)
                 .foregroundStyle(CT.fgMuted)
             if isLink {
                 Image(systemName: "arrow.up.right")
@@ -1671,7 +1671,7 @@ public struct ExperienceDetailView: View {
                     Text(viewModel.isCompleted
                         ? NSLocalizedString("action.completed", comment: "")
                         : NSLocalizedString("action.markDone", comment: ""))
-                        .font(CT.body(14.5, .semibold))
+                        .ctBody(14.5, .semibold)
                 }
                 .foregroundStyle(viewModel.isCompleted ? CT.successText : .white)
                 .frame(maxWidth: .infinity)
@@ -1736,7 +1736,7 @@ public struct ExperienceDetailView: View {
     private func sectionContainer<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             Text(title.uppercased())
-                .font(CT.displayRounded(11, .bold))
+                .ctDisplay(11, .bold)
                 .tracking(1.6)
                 .foregroundStyle(CT.fgMuted)
                 .minimumScaleFactor(0.85)

--- a/apps/ios/SoloCompass/Views/Experience/TravelerNotesSection.swift
+++ b/apps/ios/SoloCompass/Views/Experience/TravelerNotesSection.swift
@@ -68,29 +68,29 @@ extension ExperienceDetailView {
                     .frame(width: 18, height: 18)
                     .background(Circle().fill(CT.warningText.opacity(0.16)))
                 Text(NSLocalizedString("correction.heading", comment: "Info may need updating").uppercased())
-                    .font(CT.displayRounded(10.5, .bold))
+                    .ctDisplay(10.5, .bold)
                     .tracking(1.2)
                     .foregroundStyle(CT.warningText)
             }
             VStack(alignment: .leading, spacing: 5) {
                 Text(c.field)
-                    .font(CT.body(13.5, .medium))
+                    .ctBody(13.5, .medium)
                     .foregroundStyle(CT.fgPrimary)
                 HStack(spacing: 6) {
                     Text(c.oldVal)
-                        .font(CT.mono(12.5))
+                        .ctMono(12.5)
                         .strikethrough()
                         .foregroundStyle(CT.fgSubtle)
                     Image(systemName: "arrow.right").font(.system(size: 10)).foregroundStyle(CT.fgSubtle)
                     Text(c.newVal)
-                        .font(CT.mono(12.5, .semibold))
+                        .ctMono(12.5, .semibold)
                         .foregroundStyle(CT.successText)
                         .padding(.horizontal, 5)
                         .padding(.vertical, 1)
                         .background(RoundedRectangle(cornerRadius: 4).fill(CT.successSoft))
                 }
                 Text(c.sourceNote)
-                    .font(CT.mono(10.5))
+                    .ctMono(10.5)
                     .foregroundStyle(CT.fgSubtle)
             }
             HStack(spacing: 7) {
@@ -106,7 +106,7 @@ extension ExperienceDetailView {
                         Image(systemName: "checkmark").font(.system(size: 10, weight: .bold))
                         Text(NSLocalizedString("correction.confirm", comment: "Confirm"))
                     }
-                    .font(CT.body(12, .semibold))
+                    .ctBody(12, .semibold)
                     .foregroundStyle(.white)
                     .padding(.horizontal, 13).padding(.vertical, 6)
                     .background(Capsule().fill(CT.accent))
@@ -118,7 +118,7 @@ extension ExperienceDetailView {
                     reloadCoBuild()
                 } label: {
                     Text(NSLocalizedString("correction.dismiss", comment: "Inaccurate"))
-                        .font(CT.body(12, .semibold))
+                        .ctBody(12, .semibold)
                         .foregroundStyle(CT.fgPrimary)
                         .padding(.horizontal, 13).padding(.vertical, 6)
                         .background(Capsule().fill(Color.black.opacity(0.04)))
@@ -142,7 +142,7 @@ extension ExperienceDetailView {
                 let filtered = filteredNotes
                 if filtered.isEmpty {
                     Text(NSLocalizedString("notes.empty", comment: "No notes of this kind"))
-                        .font(CT.body(13))
+                        .ctBody(13)
                         .foregroundStyle(CT.fgSubtle)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 18)
@@ -165,7 +165,7 @@ extension ExperienceDetailView {
                             Text(notesExpanded
                                 ? NSLocalizedString("notes.collapse", comment: "Collapse notes")
                                 : String(format: NSLocalizedString("notes.expandAll", comment: "Expand all N notes"), filtered.count))
-                                .font(CT.body(12, .medium))
+                                .ctBody(12, .medium)
                                 .foregroundStyle(CT.accent)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.vertical, 9)
@@ -185,11 +185,11 @@ extension ExperienceDetailView {
         HStack(alignment: .firstTextBaseline) {
             HStack(spacing: 6) {
                 Text(NSLocalizedString("notes.title", comment: "Traveler notes").uppercased())
-                    .font(CT.displayRounded(11, .bold))
+                    .ctDisplay(11, .bold)
                     .tracking(1.6)
                     .foregroundStyle(CT.fgMuted)
                 Text("\(notes.count)")
-                    .font(CT.mono(10))
+                    .ctMono(10)
                     .foregroundStyle(CT.fgSubtle)
             }
             Spacer()
@@ -201,7 +201,7 @@ extension ExperienceDetailView {
                         notesFilter = filter
                     } label: {
                         Text(noteFilterLabel(filter))
-                            .font(CT.body(11, notesFilter == filter ? .semibold : .regular))
+                            .ctBody(11, notesFilter == filter ? .semibold : .regular)
                             .foregroundStyle(notesFilter == filter ? CT.fgPrimary : CT.fgMuted)
                             .padding(.horizontal, 9).padding(.vertical, 3)
                             .background {
@@ -238,7 +238,7 @@ extension ExperienceDetailView {
         VStack(alignment: .leading, spacing: 7) {
             HStack(spacing: 8) {
                 Text(note.authorInitial)
-                    .font(CT.displayRounded(11, .bold))
+                    .ctDisplay(11, .bold)
                     .foregroundStyle(.white)
                     .frame(width: 22, height: 22)
                     .background(Circle().fill(noteAvatarColor(note)))
@@ -246,22 +246,22 @@ extension ExperienceDetailView {
                     Text(note.isMine
                         ? NSLocalizedString("notes.author.you", comment: "You")
                         : String(format: NSLocalizedString("notes.author.traveler", comment: "Traveler X"), note.authorInitial))
-                        .font(CT.body(12.5, .medium))
+                        .ctBody(12.5, .medium)
                         .foregroundStyle(CT.fgPrimary)
                     Text((note.kind == .correction
                         ? NSLocalizedString("notes.tag.correction", comment: "Correction")
                         : NSLocalizedString("notes.tag.experience", comment: "Experience")).uppercased())
-                        .font(CT.displayRounded(9.5, .bold))
+                        .ctDisplay(9.5, .bold)
                         .tracking(1.0)
                         .foregroundStyle(note.kind == .correction ? CT.warningText : CT.sunGoldDeep)
                 }
                 Spacer(minLength: 6)
                 Text(relativeTime(note.createdAt))
-                    .font(CT.mono(10.5))
+                    .ctMono(10.5)
                     .foregroundStyle(CT.fgSubtle)
             }
             Text(note.text)
-                .font(CT.body(13.5))
+                .ctBody(13.5)
                 .foregroundStyle(CT.fgPrimary)
                 .lineSpacing(2)
                 .fixedSize(horizontal: false, vertical: true)
@@ -284,7 +284,7 @@ extension ExperienceDetailView {
                                 ? NSLocalizedString("notes.confirmed", comment: "Confirmed")
                                 : NSLocalizedString("notes.confirm", comment: "Confirm too"))
                         }
-                        .font(CT.mono(11))
+                        .ctMono(11)
                         .foregroundStyle(confirmed ? CT.successText : CT.fgMuted)
                         .padding(.horizontal, 9).padding(.vertical, 4)
                         .background(Capsule().fill(confirmed ? CT.successSoft : .clear))
@@ -319,7 +319,7 @@ extension ExperienceDetailView {
     private func noteBadge(icon: String, text: String, fg: Color, bg: Color, border: Color) -> some View {
         HStack(spacing: 4) {
             Image(systemName: icon).font(.system(size: 9))
-            Text(text).font(CT.mono(10.5))
+            Text(text).ctMono(10.5)
         }
         .foregroundStyle(fg)
         .padding(.horizontal, 8).padding(.vertical, 3)
@@ -334,11 +334,11 @@ extension ExperienceDetailView {
             HStack(spacing: 6) {
                 Image(systemName: "pencil").font(.system(size: 11))
                 Text(NSLocalizedString("notes.addPrompt", comment: "Leave a note for others").uppercased())
-                    .font(CT.displayRounded(10.5, .bold))
+                    .ctDisplay(10.5, .bold)
                     .tracking(1.2)
                 Spacer(minLength: 0)
                 Text(NSLocalizedString("notes.addHint", comment: "AI cross-verifies"))
-                    .font(CT.mono(9.5))
+                    .ctMono(9.5)
                     .foregroundStyle(CT.fgSubtle)
                     .textCase(nil)
             }
@@ -353,7 +353,7 @@ extension ExperienceDetailView {
                         if picked { pickedMoods.remove(mood) } else { pickedMoods.insert(mood) }
                     } label: {
                         Text(mood)
-                            .font(CT.body(12))
+                            .ctBody(12)
                             .foregroundStyle(picked ? .white : CT.fgPrimary)
                             .padding(.horizontal, 11).padding(.vertical, 5)
                             .background(Capsule().fill(picked ? CT.accent : CT.surfaceSunken))
@@ -369,7 +369,7 @@ extension ExperienceDetailView {
                         : NSLocalizedString("notes.input.placeholderWithMood", comment: "Add a line (optional)"),
                     text: $noteDraft
                 )
-                .font(CT.body(13))
+                .ctBody(13)
                 .textFieldStyle(.plain)
                 .submitLabel(.send)
                 .onSubmit(submitNote)
@@ -478,7 +478,7 @@ struct BestTimeRibbon: View {
             // 0 / 6 / 12 / 18 / 24 scale
             HStack {
                 ForEach([0, 6, 12, 18, 24], id: \.self) { h in
-                    Text("\(h)").font(CT.mono(9.5)).foregroundStyle(CT.fgSubtle)
+                    Text("\(h)").ctMono(9.5).foregroundStyle(CT.fgSubtle)
                     if h != 24 { Spacer() }
                 }
             }

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -535,7 +535,7 @@ public struct BottomInfoSheet<Content: View>: View {
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(CT.sunGoldDeep)
             Text(NSLocalizedString("peek.pick.header", comment: "此刻最值得去 peek section header"))
-                .font(CT.display(11, .bold))
+                .ctDisplay(11, .bold)
                 .tracking(1.3)
                 .textCase(.uppercase)
                 .foregroundStyle(CT.sunGoldDeep)

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -1622,7 +1622,7 @@ struct CompassMapContentView: View {
                     VStack {
                         Spacer()
                         Text(cityOSToast)
-                            .font(CT.body(13, .medium))
+                            .ctBody(13, .medium)
                             .foregroundStyle(.white)
                             .padding(.horizontal, 16)
                             .padding(.vertical, 10)
@@ -3442,7 +3442,7 @@ private struct MapOverlayView: View {
                 if let cityModeLine {
                     HStack(spacing: 4) {
                         Text(cityModeLine)
-                            .font(CT.mono(9, .medium))
+                            .ctMono(9, .medium)
                             .foregroundStyle(CT.sunGoldDeep)
                         if let cityStageIndex {
                             HStack(spacing: 2.5) {
@@ -4200,7 +4200,7 @@ private struct NowEmptyOverlay: View {
                     HStack(spacing: 10) {
                         VStack(alignment: .leading, spacing: 2) {
                             Text(NSLocalizedString("filter.now.empty.nextBest", comment: "Next best label"))
-                                .font(CT.mono(10, .semibold))
+                                .ctMono(10, .semibold)
                                 .foregroundStyle(CT.sunGoldDeep)
                                 .textCase(.uppercase)
                             Text(title)

--- a/apps/ios/SoloCompass/Views/Map/ExploreHandoffCard.swift
+++ b/apps/ios/SoloCompass/Views/Map/ExploreHandoffCard.swift
@@ -87,7 +87,7 @@ struct ExploreHandoffCard: View {
                     .foregroundStyle(CT.sunGoldDeep)
                     .font(.system(size: 15, weight: .semibold))
                 Text(mainText)
-                    .font(CT.displayRounded(15, .semibold))
+                    .ctDisplay(15, .semibold)
                     .foregroundStyle(CT.fgPrimary)
                     .fixedSize(horizontal: false, vertical: true)
                 Spacer(minLength: 0)
@@ -112,7 +112,7 @@ struct ExploreHandoffCard: View {
                     ),
                     result.verifiedCount
                 ))
-                .font(CT.mono(11, .medium))
+                .ctMono(11, .medium)
                 .foregroundStyle(CT.verifiedGreen)
             }
         }
@@ -155,7 +155,7 @@ struct ExploreHandoffCard: View {
                 onClear()
             }) {
                 Text(NSLocalizedString("exploreMode.handoff.clear", comment: "Clear these"))
-                    .font(CT.displayRounded(12.5, .medium))
+                    .ctDisplay(12.5, .medium)
                     .foregroundStyle(CT.fgMuted)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 8)
@@ -180,7 +180,7 @@ struct ExploreHandoffCard: View {
                 Image(systemName: icon)
                     .font(.system(size: 13, weight: .semibold))
                 Text(title)
-                    .font(CT.displayRounded(13, .semibold))
+                    .ctDisplay(13, .semibold)
                     .lineLimit(1)
                     .minimumScaleFactor(0.85)
             }

--- a/apps/ios/SoloCompass/Views/Map/ExploreModeOverlay.swift
+++ b/apps/ios/SoloCompass/Views/Map/ExploreModeOverlay.swift
@@ -97,13 +97,13 @@ struct ExploreModeOverlay: View {
                 .frame(width: 22, height: 12)
             VStack(alignment: .leading, spacing: 1) {
                 Text("\(verb) · \(locale) · \(km) km")
-                    .font(CT.displayRounded(13.5, .semibold))
+                    .ctDisplay(13.5, .semibold)
                     .foregroundStyle(CT.fgPrimary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.85)
                 if !countFragment.isEmpty {
                     Text(countFragment)
-                        .font(CT.mono(10.5, .medium))
+                        .ctMono(10.5, .medium)
                         .foregroundStyle(CT.sunGoldDeep)
                         .lineLimit(1)
                         .transition(.opacity)
@@ -145,7 +145,7 @@ struct ExploreModeOverlay: View {
                     Image(systemName: "xmark")
                         .font(.system(size: 13, weight: .semibold))
                     Text(NSLocalizedString("exploreMode.cancel", comment: "Cancel Explore"))
-                        .font(CT.displayRounded(13, .semibold))
+                        .ctDisplay(13, .semibold)
                 }
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)

--- a/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
@@ -730,7 +730,7 @@ private struct CityModePicker: View {
                     onSelect(candidate)
                 } label: {
                     Text(Self.label(for: candidate))
-                        .font(CT.body(13, mode == candidate ? .semibold : .regular))
+                        .ctBody(13, mode == candidate ? .semibold : .regular)
                         .foregroundStyle(mode == candidate ? .white : Self.tint(for: candidate))
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 8)

--- a/apps/ios/SoloCompass/Views/Map/PeekSummaryCard.swift
+++ b/apps/ios/SoloCompass/Views/Map/PeekSummaryCard.swift
@@ -160,7 +160,7 @@ struct PeekSummaryCard: View {
                     format: NSLocalizedString("peek.now.goodTime", comment: "Now-score line, e.g. '现在 87% 好时机'"),
                     percent
                 ))
-                .font(CT.display(12, .bold))
+                .ctDisplay(12, .bold)
                 .monospacedDigit()
                 .foregroundStyle(CT.sunGoldDeep)
                 if state.isClosingSoon {
@@ -207,7 +207,7 @@ struct PeekSummaryCard: View {
                 .fill(facts.dotColor)
                 .frame(width: 6, height: 6)
             Text(facts.text)
-                .font(CT.mono(10))
+                .ctMono(10)
                 .foregroundStyle(CT.fgMuted)
                 .lineLimit(1)
                 .truncationMode(.tail)
@@ -264,7 +264,7 @@ struct PeekSummaryCard: View {
                 Image(systemName: "arrow.triangle.turn.up.right.diamond.fill")
                     .font(.system(size: 11, weight: .bold))
                 Text(NSLocalizedString("peek.action.go", comment: "Take me there"))
-                    .font(CT.body(12, .semibold))
+                    .ctBody(12, .semibold)
             }
             .foregroundStyle(.white)
             .padding(.horizontal, 12)
@@ -289,7 +289,7 @@ struct PeekSummaryCard: View {
                 Image(systemName: "arrow.2.circlepath")
                     .font(.system(size: 10, weight: .semibold))
                 Text(NSLocalizedString("peek.action.shuffle", comment: "Show another pick"))
-                    .font(CT.body(12, .medium))
+                    .ctBody(12, .medium)
             }
             .foregroundStyle(CT.fgMuted)
             .padding(.horizontal, 11)

--- a/apps/ios/SoloCompass/Views/Map/RoutesSectionView.swift
+++ b/apps/ios/SoloCompass/Views/Map/RoutesSectionView.swift
@@ -165,14 +165,14 @@ struct RouteNowSectionHeader: View {
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(CT.sunGoldDeep)
                 Text(NSLocalizedString("sheet.section.routes.now", comment: "路線 · 此刻適合 section header"))
-                    .font(CT.display(11, .bold))
+                    .ctDisplay(11, .bold)
                     .tracking(1.3)
                     .textCase(.uppercase)
                     .foregroundStyle(CT.sunGoldDeep)
             }
             Spacer(minLength: 8)
             Text(verbatim: "AI · NOW")
-                .font(CT.mono(11, .regular))
+                .ctMono(11, .regular)
                 .tracking(0.4)
                 .foregroundStyle(CT.fgSubtle)
         }

--- a/apps/ios/SoloCompass/Views/Shared/ExperiencePreviewCard.swift
+++ b/apps/ios/SoloCompass/Views/Shared/ExperiencePreviewCard.swift
@@ -101,7 +101,7 @@ struct ExperiencePreviewCard: View {
             Image(systemName: experience.category.symbol)
                 .font(.system(size: 10, weight: .bold))
             Text(experience.category.localizedTitle)
-                .font(CT.body(11, .semibold))
+                .ctBody(11, .semibold)
         }
         .foregroundStyle(.white)
         .padding(.horizontal, 8).padding(.vertical, 4)
@@ -111,7 +111,7 @@ struct ExperiencePreviewCard: View {
     private func bestNowChip(_ chip: BestNowChipState) -> some View {
         HStack(spacing: 4) {
             Image(systemName: chip.symbol).font(.system(size: 9, weight: .bold))
-            Text(chip.label).font(CT.body(10.5, .semibold))
+            Text(chip.label).ctBody(10.5, .semibold)
         }
         .foregroundStyle(chip.foreground)
         .padding(.horizontal, 7).padding(.vertical, 3)
@@ -126,13 +126,13 @@ struct ExperiencePreviewCard: View {
     private var details: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(placeName)
-                .font(CT.displayRounded(17, .semibold))
+                .ctDisplay(17, .semibold)
                 .foregroundStyle(CT.fgPrimary)
                 .lineLimit(1)
 
             if !experience.oneLiner.isEmpty {
                 Text(experience.oneLiner)
-                    .font(CT.body(13))
+                    .ctBody(13)
                     .foregroundStyle(CT.fgMuted)
                     .lineLimit(2)
                     .fixedSize(horizontal: false, vertical: true)
@@ -152,7 +152,7 @@ struct ExperiencePreviewCard: View {
                     .font(.system(size: 10, weight: .bold))
                     .foregroundStyle(CT.verifiedGreen)
                 Text(String(format: "Solo %.1f", experience.soloScore.overall))
-                    .font(CT.mono(12, .medium))
+                    .ctMono(12, .medium)
                     .foregroundStyle(CT.verifiedGreen)
                     .lineLimit(1)
             }
@@ -166,7 +166,7 @@ struct ExperiencePreviewCard: View {
                         .font(.system(size: 10, weight: .bold))
                         .foregroundStyle(CT.fgMuted)
                     Text(String(format: NSLocalizedString("nearby.chip.walkMin", comment: "Walk minutes chip, e.g. '4 min'"), mins))
-                        .font(CT.mono(12, .medium))
+                        .ctMono(12, .medium)
                         .foregroundStyle(CT.fgMuted)
                         .lineLimit(1)
                 }

--- a/apps/ios/SoloCompass/Views/Shared/SkeletonBadgeView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/SkeletonBadgeView.swift
@@ -10,7 +10,7 @@ public struct SkeletonBadgeView: View {
 
     public var body: some View {
         Text(Self.label)
-            .font(CT.body(10, .medium))
+            .ctBody(10, .medium)
             .foregroundStyle(CT.fgMuted)
             .padding(.horizontal, 8)
             .padding(.vertical, 3)


### PR DESCRIPTION
## 背景

审计项 **font-01** 指出:~158 处正文调用点用 `CT.body/display/displayRounded/mono(size:)` 工厂,它们返回**固定** `.system(size:)`,完全无视用户的文字大小设置 —— Dynamic Type 事实上半死。

配套的 size-preserving `@ScaledMetric` 修饰符(`.ctBody/.ctDisplay/.ctMono`)在 **PR #601** 已建好但近乎零采纳。本 PR 让它们真正生效。

## 改动

25 文件机械前缀替换:

| 旧 | 新 |
|---|---|
| `.font(CT.body(N,w))` | `.ctBody(N,w)` |
| `.font(CT.display(N,w))` | `.ctDisplay(N,w)` |
| `.font(CT.displayRounded(N,w))` | `.ctDisplay(N,w)` (design=.rounded) |
| `.font(CT.mono(N,w))` | `.ctMono(N,w)` |

每处现在随 Dynamic Type 按比例缩放,同时在默认设置下保留精确点值(Apple 认可的「既保留定制字号又兼顾无障碍」做法)。用默认 `relativeTo` 锚点;按字号分档的锚点微调留作后续小 PR。

## 3 处刻意保留固定 `CT.*` Font 工厂

它们需要 **`Font` 值**而非 `some View` 修饰符:

- **ComplianceBanner 签证倒计时**:`Text(+)` 拼接要求每个操作数是 `Text`(Dynamic Type 靠 `.minimumScaleFactor` 部分兼顾)
- **RecruitingModule 房主留言**:`.italic()` 改写成 `View.italic()` modifier

## 验证

- ✅ `BUILD SUCCEEDED`
- ✅ `DesignSystemVisualTest` 2/2 passed(深色 luminance 回归断言完整)

零行为变更 —— 仅让既有字号响应无障碍文字设置。