### PR TITLE
refactor(ios): adopt SoloEmptyState across 7 amber/neutral empty states

### DIFF
--- a/apps/ios/SoloCompass/Views/Admin/ModerationView.swift
+++ b/apps/ios/SoloCompass/Views/Admin/ModerationView.swift
@@ -35,11 +35,12 @@ public struct ModerationView: View {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if service.reports.isEmpty {
-                ContentUnavailableView(
-                    NSLocalizedString("moderation.empty.title", comment: "No reports title"),
+                SoloEmptyState(
                     systemImage: "checkmark.shield",
-                    description: Text(NSLocalizedString("moderation.empty.message", comment: "No reports message"))
+                    title: NSLocalizedString("moderation.empty.title", comment: "No reports title"),
+                    message: NSLocalizedString("moderation.empty.message", comment: "No reports message")
                 )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 queueList
             }

--- a/apps/ios/SoloCompass/Views/Chat/ChatHistoryListView.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatHistoryListView.swift
@@ -83,21 +83,12 @@ public struct ChatHistoryListView: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "clock.arrow.circlepath")
-                .font(.title2.weight(.medium))
-                .foregroundStyle(.secondary)
-            Text(NSLocalizedString("chat.history.empty.title", comment: "No conversations yet"))
-                .font(.headline)
-                .foregroundStyle(.primary)
-                .multilineTextAlignment(.center)
-            Text(NSLocalizedString("chat.history.empty", comment: "Hint to start a conversation"))
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-        }
+        SoloEmptyState(
+            systemImage: "clock.arrow.circlepath",
+            title: NSLocalizedString("chat.history.empty.title", comment: "No conversations yet"),
+            message: NSLocalizedString("chat.history.empty", comment: "Hint to start a conversation")
+        )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(32)
     }
 
     // MARK: - Actions

--- a/apps/ios/SoloCompass/Views/CityOS/LiveSheet.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/LiveSheet.swift
@@ -60,19 +60,11 @@ struct LiveSheet: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "calendar")
-                .font(.system(size: 40))
-                .foregroundStyle(CT.fgSubtle)
-            Text(NSLocalizedString("cityos.live.empty.title", comment: "No local events this week"))
-                .ctDisplay(16, .semibold)
-                .foregroundStyle(colorScheme == .dark ? CT.fgPrimaryDark : CT.fgPrimary)
-            Text(NSLocalizedString("cityos.live.empty.hint", comment: "Check back — the city brief refreshes twice a week."))
-                .ctBody(13)
-                .foregroundStyle(CT.fgMuted)
-                .multilineTextAlignment(.center)
-        }
-        .padding(32)
+        SoloEmptyState(
+            systemImage: "calendar",
+            title: NSLocalizedString("cityos.live.empty.title", comment: "No local events this week"),
+            message: NSLocalizedString("cityos.live.empty.hint", comment: "Check back — the city brief refreshes twice a week.")
+        )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(background.ignoresSafeArea())
     }

--- a/apps/ios/SoloCompass/Views/Companion/InviteFriendsSheet.swift
+++ b/apps/ios/SoloCompass/Views/Companion/InviteFriendsSheet.swift
@@ -165,17 +165,14 @@ public struct InviteFriendsSheet: View {
     // MARK: - Empty state
 
     private var emptyState: some View {
-        ContentUnavailableView {
-            Label(
-                NSLocalizedString("invite.friends.empty.title", comment: "No invitable friends title"),
-                systemImage: "person.2.slash"
-            )
-        } description: {
-            Text(NSLocalizedString(
+        SoloEmptyState(
+            systemImage: "person.2.slash",
+            title: NSLocalizedString("invite.friends.empty.title", comment: "No invitable friends title"),
+            message: NSLocalizedString(
                 "invite.friends.empty.description",
                 comment: "No invitable friends description"
-            ))
-        }
+            )
+        )
     }
 
     // MARK: - Invite (direct → confirmedMembers, no approval)

--- a/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
@@ -360,49 +360,22 @@ private struct ItineraryRow: View {
 private struct EmptyItineraryView: View {
     var onCreate: (() -> Void)? = nil
 
-    @State private var isBreathing = false
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
     var body: some View {
-        VStack(spacing: 12) {
-            ZStack {
-                Circle()
-                    .fill(CT.accent.opacity(0.12))
-                    .frame(width: 80, height: 80)
-                Image(systemName: "map.fill")
-                    .font(.system(size: 40))
-                    .foregroundStyle(CT.accent.opacity(0.7))
-                    .scaleEffect(isBreathing ? 1.08 : 0.94)
-                    .opacity(isBreathing ? 1.0 : 0.7)
-                    .animation(
-                        reduceMotion ? nil : .easeInOut(duration: 1.6).repeatForever(autoreverses: true),
-                        value: isBreathing
-                    )
-            }
-            Text(NSLocalizedString("itinerary.empty.title", comment: "No itineraries yet"))
-                .font(.headline)
-            Text(NSLocalizedString("itinerary.empty.hint", comment: "Tap + to plan your first trip"))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-            if let onCreate {
-                Button {
+        SoloEmptyState(
+            systemImage: "map.fill",
+            title: NSLocalizedString("itinerary.empty.title", comment: "No itineraries yet"),
+            message: NSLocalizedString("itinerary.empty.hint", comment: "Tap + to plan your first trip"),
+            actionTitle: onCreate == nil
+                ? nil
+                : NSLocalizedString("itinerary.empty.cta", comment: "Plan a trip button in empty itinerary state"),
+            action: onCreate.map { create in
+                {
                     Haptics.selection()
-                    onCreate()
-                } label: {
-                    Label(NSLocalizedString("itinerary.empty.cta", comment: "Plan a trip button in empty itinerary state"), systemImage: "plus")
+                    create()
                 }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.regular)
-                .padding(.top, 4)
             }
-        }
-        .padding(32)
+        )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear {
-            guard !isBreathing, !reduceMotion else { return }
-            isBreathing = true
-        }
     }
 }
 

--- a/apps/ios/SoloCompass/Views/Companion/RequestInboxView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/RequestInboxView.swift
@@ -263,37 +263,12 @@ public struct RequestInboxView: View {
 // MARK: - EmptyInboxView
 
 private struct EmptyInboxView: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var isBreathing = false
-
     var body: some View {
-        VStack(spacing: 12) {
-            ZStack {
-                Circle()
-                    .fill(CT.accent.opacity(0.12))
-                    .frame(width: 80, height: 80)
-                Image(systemName: "tray")
-                    .font(.system(size: 40))
-                    .foregroundStyle(CT.accent.opacity(0.7))
-                    .scaleEffect(isBreathing ? 1.08 : 0.94)
-                    .opacity(isBreathing ? 1.0 : 0.7)
-                    .animation(
-                        reduceMotion ? nil : .easeInOut(duration: 1.6).repeatForever(autoreverses: true),
-                        value: isBreathing
-                    )
-            }
-            Text(NSLocalizedString("companion.inbox.empty.title", comment: "Empty inbox title"))
-                .font(.headline)
-            Text(NSLocalizedString("companion.inbox.empty.description", comment: "Empty inbox description"))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-        }
-        .padding(32)
-        .onAppear {
-            guard !isBreathing, !reduceMotion else { return }
-            isBreathing = true
-        }
+        SoloEmptyState(
+            systemImage: "tray",
+            title: NSLocalizedString("companion.inbox.empty.title", comment: "Empty inbox title"),
+            message: NSLocalizedString("companion.inbox.empty.description", comment: "Empty inbox description")
+        )
     }
 }
 

--- a/apps/ios/SoloCompass/Views/Friends/FriendsListView.swift
+++ b/apps/ios/SoloCompass/Views/Friends/FriendsListView.swift
@@ -588,49 +588,22 @@ private struct FriendRow: View {
 private struct EmptyFriendsView: View {
     var onAddFriend: (() -> Void)? = nil
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var isBreathing = false
-
     var body: some View {
-        VStack(spacing: 12) {
-            ZStack {
-                Circle()
-                    .fill(CT.accent.opacity(0.12))
-                    .frame(width: 80, height: 80)
-                Image(systemName: "person.2")
-                    .font(.system(size: 36))
-                    .foregroundStyle(CT.accent.opacity(0.7))
-                    .scaleEffect(isBreathing ? 1.08 : 0.94)
-                    .opacity(isBreathing ? 1.0 : 0.7)
-                    .animation(
-                        reduceMotion ? nil : .easeInOut(duration: 1.6).repeatForever(autoreverses: true),
-                        value: isBreathing
-                    )
-            }
-            Text(NSLocalizedString("friends.list.empty.title", comment: "Empty friends title"))
-                .font(.headline)
-            Text(NSLocalizedString("friends.list.empty.description", comment: "Empty friends description"))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-            if let onAddFriend {
-                Button {
+        SoloEmptyState(
+            systemImage: "person.2",
+            title: NSLocalizedString("friends.list.empty.title", comment: "Empty friends title"),
+            message: NSLocalizedString("friends.list.empty.description", comment: "Empty friends description"),
+            actionTitle: onAddFriend == nil
+                ? nil
+                : NSLocalizedString("friends.list.empty.cta", comment: "Add a friend button in empty friends state"),
+            action: onAddFriend.map { add in
+                {
                     Haptics.selection()
-                    onAddFriend()
-                } label: {
-                    Label(NSLocalizedString("friends.list.empty.cta", comment: "Add a friend button in empty friends state"), systemImage: "person.badge.plus")
+                    add()
                 }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.regular)
-                .padding(.top, 4)
             }
-        }
-        .padding(32)
+        )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear {
-            guard !isBreathing, !reduceMotion else { return }
-            isBreathing = true
-        }
     }
 }
 


### PR DESCRIPTION
## What

Migrate 7 empty-state surfaces to the shared **`SoloEmptyState`** component (built in `emptystate-01`, previously adopted only by `MyRequestsListView`):

| File | Was | Icon / CTA |
|------|-----|-----------|
| `RequestInboxView` (`EmptyInboxView`) | hand-rolled amber + breathing | `tray` / — |
| `ItineraryListView` (`EmptyItineraryView`) | hand-rolled amber + breathing | `map.fill` / create |
| `FriendsListView` (`EmptyFriendsView`) | hand-rolled amber + breathing | `person.2` / add friend |
| `ChatHistoryListView` (`emptyState`) | hand-rolled neutral | `clock.arrow.circlepath` / — |
| `LiveSheet` (`emptyState`) | hand-rolled neutral | `calendar` / — |
| `ModerationView` | `ContentUnavailableView` | `checkmark.shield` / — |
| `InviteFriendsSheet` (`emptyState`) | `ContentUnavailableView` | `person.2.slash` / — |

Net **−98 lines** (−145 / +47).

## Why only these 7 (not a blanket sweep)

`SoloEmptyState` is **amber-only** (`CT.accent` on `CT.accentSoft`), so this is a design judgment, not a mechanical cleanup. Deliberately **left untouched**:

- **teal** route/companion states (`MyHostedRoutes`, `MyWalkedRoutes`) + **sunGold** Archive state — their color is an intentional identity; forcing amber would erase it.
- **error/retry** states (`exclamationmark.triangle` + retry) — load-failure UI, not empty-list UI.
- **search "no results"** states — need the user's query interpolated; the component takes static strings.
- **map overlays / banners** and **carousel / animated** states — multi-action or bespoke layouts beyond the single-CTA API.

## Behavior notes

- The bespoke breathing animation collapses to a static amber icon tile — the component's intent (consistent empty-state look). CTA closures thread through `action:` unchanged (`Haptics.selection()` preserved).
- `LiveSheet` keeps its custom sheet background on the wrapper, not inside the component.

## Verification

- ✅ `BUILD SUCCEEDED`
- ✅ `DesignSystemVisualTest` (incl. `testSoloEmptyStateLightAndDark`) — **Executed 2 tests, 0 failures**