### PR TITLE
refactor(ios): consolidate SettingsView from 14 sections to 6

### DIFF
--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1728,7 +1728,7 @@
 "my.hosted.routes.empty.title" = "No hosted routes yet";
 "my.hosted.routes.empty.hint" = "Create a route and invite companions to join you on your journey.";
 "my.hosted.routes.empty.cta" = "Create a route";
-"settings.companion.hosted.routes" = "我主理的路线";
+"settings.companion.hosted.routes" = "My hosted routes";
 
 /* US-038 — CompletionMoment */
 "completion.mark.done" = "标记完成";
@@ -2343,3 +2343,19 @@
 
 "dev.lock" = "Lock developer options";
 "dev.lock.footer" = "Hides this panel until you unlock again with a tester email. Your Pro access is kept.";
+
+// MARK: Settings consolidation (#130)
+"settings.personalize" = "Your Taste";
+"settings.personalize.footer" = "Your style and category taste shape which experiences float to the top of the map.";
+"settings.categories.value" = "%1$d loved · %2$d hidden";
+"settings.discovery" = "Discovery";
+"settings.discovery.footer" = "Only experiences within this radius appear on the map. Nearby nudges are quiet — no marketing, ever.";
+"settings.appearanceLanguage" = "Appearance & Language";
+"settings.companion.hub" = "Companion hub";
+"settings.account" = "Account";
+"settings.dataAbout" = "Data & About";
+"settings.about.version" = "Version";
+"settings.advanced" = "Advanced";
+"settings.advanced.footer" = "Power-user tools: AI provider, tester unlock, and developer options.";
+"settings.theme.system" = "System";
+"settings.theme.obsidian" = "Obsidian";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -2353,3 +2353,19 @@
 
 "dev.lock" = "锁定开发者选项";
 "dev.lock.footer" = "隐藏该面板，直到你再次用测试邮箱解锁。你的 Pro 权益会保留。";
+
+// MARK: Settings consolidation (#130)
+"settings.personalize" = "你的喜好";
+"settings.personalize.footer" = "你的旅行风格与类别喜好，决定哪些体验浮上地图。";
+"settings.categories.value" = "%1$d 喜欢 · %2$d 隐藏";
+"settings.discovery" = "发现";
+"settings.discovery.footer" = "只有此半径内的体验会出现在地图上。经过收藏地点时会轻声提醒——绝无营销打扰。";
+"settings.appearanceLanguage" = "外观与语言";
+"settings.companion.hub" = "同行中心";
+"settings.account" = "账户";
+"settings.dataAbout" = "数据与关于";
+"settings.about.version" = "版本";
+"settings.advanced" = "高级";
+"settings.advanced.footer" = "面向高级用户的工具：AI 服务、测试员解锁与开发者选项。";
+"settings.theme.system" = "跟随系统";
+"settings.theme.obsidian" = "曜石黑";

--- a/apps/ios/SoloCompass/Services/ThemeService.swift
+++ b/apps/ios/SoloCompass/Services/ThemeService.swift
@@ -12,7 +12,14 @@ public final class ThemeService {
         case system = "System"
         case obsidian = "Obsidian"
         public var id: String { rawValue }
-        public var localizedName: String { rawValue }
+        public var localizedName: String {
+            switch self {
+            case .system:
+                return NSLocalizedString("settings.theme.system", comment: "System theme option")
+            case .obsidian:
+                return NSLocalizedString("settings.theme.obsidian", comment: "Obsidian theme option")
+            }
+        }
     }
 
     public var currentTheme: any Theme { Self.theme(for: selectedOption) }

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -1818,7 +1818,6 @@ struct CompassMapContentView: View {
     private var settingsSheetContent: some View {
         SettingsView(
             onClose: { viewModel.isShowingSettings = false },
-            onShowFavorites: { isShowingFavorites = true },
             onDistanceCommitted: { viewModel.reloadForDistanceChange() }
         )
         .environment(preferences)

--- a/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
@@ -4,27 +4,21 @@ import SwiftUI
 /// User preferences editor — travel style, category filters, max distance.
 /// Accessed via the map's navigation bar settings button.
 ///
-/// P1.3 #130 REFACTOR PLAN — deferred to an independent Phase 2 PR
-/// because this file is >1500 lines and touches highly coupled surfaces
-/// (Companion opt-in with 5 NavigationLink descendants, Apple SignIn
-/// destructive flow, StoreKit + admin unlock, restart alerts).
+/// P1.3 #130 — consolidated from 14 sections to 6 + a hidden Advanced group:
 ///
-/// Consolidation target: **14 sections → 6**.
+/// 1. **Your Taste** — travel style, category preferences, filter-bar
+///    customization (all child pages, current value shown on the row).
+/// 2. **Discovery** — radius slider + nearby-nudge toggle.
+/// 3. **Appearance & Language** — theme, haptics, language (menu picker;
+///    a real language change still schedules the restart alert).
+/// 4. **Companion** — the opt-in toggle plus a single hub link that
+///    replaces the former 5 inline NavigationLinks.
+/// 5. **Account** — Apple ID link + subscription status / restore / manage.
+/// 6. **Data & About** — export toggle, destructive resets, version row.
 ///
-/// - Merge "Travel Style" + "Preferred" + "Disliked" → **"你的喜好"**
-///   (reuses `PreferenceEditorView`).
-/// - Merge "Distance" + "Language" → **"地理"**.
-/// - Hide "AI Provider" + "Admin unlock" behind a 7-tap gesture on the
-///   About row.
-/// - Move "Stats" into the Archive tab (already lives there).
-/// - Fold "Companion opt-in" into the Notifications child page.
-/// - Fold "Export" into the Data child page.
-/// - Move "Filter Bar Customization" into an inline long-press on the
-///   FilterBar itself.
-///
-/// The refactor MUST land as its own PR — no unrelated feature work in
-/// the same diff, and it MUST re-verify the 4 UI regression tests
-/// enumerated in `docs/BETA_TEST_CHECKLIST.md §3`.
+/// Power-user surfaces (AI provider, tester-email unlock, developer
+/// options) are hidden behind a 7-tap gesture on the version row. The
+/// former Stats section was removed — the same numbers live in MeSheet.
 public struct SettingsView: View {
     @Environment(UserPreferences.self) private var preferences
     @Environment(ExperienceService.self) private var experienceService
@@ -34,7 +28,6 @@ public struct SettingsView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.themeService) private var themeService
     var onClose: () -> Void
-    var onShowFavorites: (() -> Void)?
     var onDistanceCommitted: (() -> Void)?
 
     @State private var showingClearConfirm = false
@@ -68,44 +61,29 @@ public struct SettingsView: View {
     // US-012: Companion opt-in safety consent gate
     @State private var showingCompanionConsent = false
 
+    // #130: Advanced tools reveal — 7 taps on the version row, persisted so
+    // the user never has to rediscover the gesture.
+    @AppStorage("settings.advancedUnlocked") private var advancedUnlocked = false
+    @State private var versionTapCount = 0
+
     public init(
         onClose: @escaping () -> Void = {},
-        onShowFavorites: (() -> Void)? = nil,
         onDistanceCommitted: (() -> Void)? = nil
     ) {
         self.onClose = onClose
-        self.onShowFavorites = onShowFavorites
         self.onDistanceCommitted = onDistanceCommitted
     }
 
     public var body: some View {
         NavigationStack {
             List {
-                // US-020: Apple Settings-style InsetGrouped layout
-                // Section: Preferences
-                travelStyleSection
-                preferredCategoriesSection
-                dislikedCategoriesSection
-                distanceSection
-                // Section: Filter bar (US-007)
-                filterBarSection
-                // Section: Appearance (US-039)
+                tasteSection
+                discoverySection
                 appearanceSection
-                // Section: AI Provider
-                aiProviderSection
-                // Section: Language & Privacy
-                languageSection
-                notificationsSection
-                exportSection
-                // Section: Subscription
-                subscriptionSection
-                // Section: Developer Options — only after a tester-email unlock
-                developerSection
-                // Section: Companion (US-012) — experimental opt-in
                 companionSection
-                // Section: About / Stats / Data
-                statsSection
-                dataSection
+                accountSection
+                dataAboutSection
+                advancedSection
             }
             .listStyle(.insetGrouped)
             .navigationTitle(NSLocalizedString("settings.title", comment: "Settings"))
@@ -124,10 +102,10 @@ public struct SettingsView: View {
             // US-020: Companion safety consent. Anchored to the stable List —
             // NOT to `companionSection` — so List row recycling can't tear
             // down the presentation source mid-transition. Accepting flips
-            // `companionEnabled`, which grows that Section from 1 row to 6;
-            // when the sheet was anchored to the Section, that row churn
-            // destroyed its own presentation anchor and crashed on device,
-            // leaving the flag unwritten ("enable failed").
+            // `companionEnabled`, which grows that Section by a row; when the
+            // sheet was anchored to the Section, that row churn destroyed its
+            // own presentation anchor and crashed on device, leaving the flag
+            // unwritten ("enable failed").
             .sheet(isPresented: $showingCompanionConsent) {
                 // Cancel path: companionEnabled stays false (only accept
                 // writes it). The Toggle re-reads from preferences and
@@ -142,125 +120,67 @@ public struct SettingsView: View {
         }
     }
 
-    // MARK: - Travel Style
+    // MARK: - 1. Your Taste
 
-    private var travelStyleSection: some View {
+    private var tasteSection: some View {
         Section {
-            ForEach(UserPreferences.SoloTravelStyle.allCases) { style in
-                HStack {
-                    // US-020: Rounded filled icon on the left
-                    Image(systemName: travelStyleIcon(style))
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(.white)
-                        .frame(width: 30, height: 30)
-                        .background(travelStyleColor(style), in: RoundedRectangle(cornerRadius: 7))
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(style.localizedTitle).font(.body)
-                        Text(style.localizedDescription).font(.caption).foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    if preferences.soloTravelStyle == style {
-                        Image(systemName: "checkmark").foregroundStyle(.blue).fontWeight(.semibold)
-                    }
-                }
-                .contentShape(Rectangle())
-                .onTapGesture { Haptics.selection(); preferences.soloTravelStyle = style }
+            NavigationLink {
+                TravelStyleSettingsView()
+                    .environment(preferences)
+            } label: {
+                settingsIconRow(
+                    icon: "figure.walk", color: .blue,
+                    label: NSLocalizedString("settings.travelStyle", comment: "Travel Style"),
+                    value: preferences.soloTravelStyle.localizedTitle
+                )
+            }
+
+            NavigationLink {
+                CategoryPreferencesView()
+                    .environment(preferences)
+            } label: {
+                settingsIconRow(
+                    icon: "square.grid.2x2", color: .pink,
+                    label: NSLocalizedString("settings.preferences", comment: "Category Preferences"),
+                    value: String(
+                        format: NSLocalizedString("settings.categories.value", comment: "Loved/hidden counts"),
+                        preferences.preferredCategories.count,
+                        preferences.dislikedCategories.count
+                    )
+                )
+            }
+
+            NavigationLink {
+                VisibleCategoriesView()
+                    .environment(preferences)
+            } label: {
+                settingsIconRow(
+                    icon: "line.3.horizontal.decrease.circle", color: .indigo,
+                    label: NSLocalizedString("settings.filter.visible_categories", comment: "Visible categories"),
+                    value: "\(preferences.visibleCategories.count)/\(ExperienceCategory.allCases.count)"
+                )
+            }
+
+            NavigationLink {
+                CustomTagsView()
+                    .environment(preferences)
+            } label: {
+                settingsIconRow(
+                    icon: "tag", color: .purple,
+                    label: NSLocalizedString("settings.filter.custom_tags", comment: "Custom tags"),
+                    value: "\(preferences.customTags.count)"
+                )
             }
         } header: {
-            settingsSectionHeader("figure.walk", label: NSLocalizedString("settings.travelStyle", comment: "Travel Style"))
+            settingsSectionHeader("heart", label: NSLocalizedString("settings.personalize", comment: "Your Taste"))
         } footer: {
-            Text(NSLocalizedString("settings.travelStyle.footer", comment: "Your style shapes which experiences float to the top."))
+            Text(NSLocalizedString("settings.personalize.footer", comment: "Taste section footer"))
         }
     }
 
-    private func travelStyleIcon(_ style: UserPreferences.SoloTravelStyle) -> String {
-        switch style {
-        case .explorer: return "map"
-        case .worker: return "laptopcomputer"
-        case .foodie: return "fork.knife"
-        case .cultureSeeker: return "building.columns"
-        }
-    }
+    // MARK: - 2. Discovery
 
-    private func travelStyleColor(_ style: UserPreferences.SoloTravelStyle) -> Color {
-        switch style {
-        case .explorer: return .blue
-        case .worker: return .purple
-        case .foodie: return .orange
-        case .cultureSeeker: return .brown
-        }
-    }
-
-    // MARK: - Preferred Categories
-
-    private var preferredCategoriesSection: some View {
-        Section {
-            ForEach(ExperienceCategory.allCases) { category in
-                let isPreferred = preferences.preferredCategories.contains(category)
-                let isDisliked = preferences.dislikedCategories.contains(category)
-                HStack(spacing: 12) {
-                    // US-020: Rounded filled icon
-                    Image(systemName: category.symbol)
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(.white)
-                        .frame(width: 30, height: 30)
-                        .background(category.color, in: RoundedRectangle(cornerRadius: 7))
-                    Text(category.localizedTitle)
-                    Spacer()
-                    if isPreferred {
-                        Image(systemName: "heart.fill").foregroundStyle(.pink)
-                    } else if isDisliked {
-                        Image(systemName: "hand.thumbsdown.fill").foregroundStyle(.secondary)
-                    }
-                }
-                .contentShape(Rectangle())
-                .onTapGesture { togglePreferred(category) }
-                .swipeActions(edge: .trailing) {
-                    Button(role: .destructive) { toggleDisliked(category) } label: {
-                        Label(NSLocalizedString("settings.hide", comment: "Hide"), systemImage: "eye.slash")
-                    }
-                }
-            }
-        } header: {
-            settingsSectionHeader("slider.horizontal.3", label: NSLocalizedString("settings.preferences", comment: "Preferences"))
-        } footer: {
-            Text(NSLocalizedString("settings.preferences.footer", comment: "Tap to love a category. Swipe left to hide it."))
-        }
-    }
-
-    // MARK: - Disliked Categories
-
-    @ViewBuilder
-    private var dislikedCategoriesSection: some View {
-        if !preferences.dislikedCategories.isEmpty {
-            Section {
-                ForEach(preferences.dislikedCategories) { category in
-                    HStack(spacing: 12) {
-                        Image(systemName: category.symbol)
-                            .font(.system(size: 16, weight: .medium))
-                            .foregroundStyle(.white)
-                            .frame(width: 30, height: 30)
-                            .background(Color.secondary, in: RoundedRectangle(cornerRadius: 7))
-                        Text(category.localizedTitle).foregroundStyle(.secondary)
-                        Spacer()
-                        Button {
-                            Haptics.selection()
-                            preferences.dislikedCategories.removeAll { $0 == category }
-                        } label: {
-                            Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-            } header: {
-                settingsSectionHeader("eye.slash", label: NSLocalizedString("settings.hidden", comment: "Hidden Categories"))
-            }
-        }
-    }
-
-    // MARK: - Distance
-
-    private var distanceSection: some View {
+    private var discoverySection: some View {
         Section {
             let displayedKm = draftDistanceKm ?? preferences.maxDistanceKm
             VStack(alignment: .leading, spacing: 8) {
@@ -292,92 +212,7 @@ public struct SettingsView: View {
                     }
                 ).tint(.blue)
             }
-        } header: {
-            settingsSectionHeader("location.circle", label: NSLocalizedString("settings.distance", comment: "Discovery Radius"))
-        } footer: {
-            Text(NSLocalizedString("settings.distance.footer", comment: "Only experiences within this radius appear on the map."))
-        }
-    }
 
-    // MARK: - Filter Bar (US-007)
-
-    private var filterBarSection: some View {
-        Section {
-            NavigationLink {
-                VisibleCategoriesView()
-                    .environment(preferences)
-            } label: {
-                HStack(spacing: 10) {
-                    Image(systemName: "line.3.horizontal.decrease.circle")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(.white)
-                        .frame(width: 30, height: 30)
-                        .background(Color.indigo, in: RoundedRectangle(cornerRadius: 7))
-                    Text(NSLocalizedString("settings.filter.visible_categories", comment: "Visible categories"))
-                    Spacer()
-                    Text("\(preferences.visibleCategories.count)/\(ExperienceCategory.allCases.count)")
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
-            }
-
-            // US-009: Custom tags management
-            NavigationLink {
-                CustomTagsView()
-                    .environment(preferences)
-            } label: {
-                HStack(spacing: 10) {
-                    Image(systemName: "tag")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(.white)
-                        .frame(width: 30, height: 30)
-                        .background(Color.purple, in: RoundedRectangle(cornerRadius: 7))
-                    Text(NSLocalizedString("settings.filter.custom_tags", comment: "Custom tags"))
-                    Spacer()
-                    Text("\(preferences.customTags.count)")
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
-            }
-        } header: {
-            settingsSectionHeader(
-                "slider.horizontal.below.rectangle",
-                label: NSLocalizedString("settings.filterBar", comment: "Filter bar")
-            )
-        } footer: {
-            Text(NSLocalizedString(
-                "settings.filter.visible_categories.footer",
-                comment: "Filter bar visible categories footer"
-            ))
-        }
-    }
-
-    // MARK: - Export
-
-    private var exportSection: some View {
-        Section {
-            Toggle(isOn: Binding(
-                get: { preferences.includeMapInExport },
-                set: { preferences.includeMapInExport = $0 }
-            )) {
-                HStack(spacing: 10) {
-                    Image(systemName: "map")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(.white)
-                        .frame(width: 30, height: 30)
-                        .background(Color.teal, in: RoundedRectangle(cornerRadius: 7))
-                    Text(NSLocalizedString("settings.exportMapPreview", comment: "Include map preview in exports"))
-                }
-            }
-        } header: {
-            settingsSectionHeader("square.and.arrow.up", label: NSLocalizedString("export.preview", comment: "Export preview"))
-        }
-    }
-
-    // MARK: - Notifications
-
-    private var notificationsSection: some View {
-        Section {
             Toggle(isOn: Binding(
                 get: { preferences.notificationsEnabled },
                 set: { enabled in
@@ -387,51 +222,78 @@ public struct SettingsView: View {
                     }
                 }
             )) {
-                HStack(spacing: 10) {
-                    Image(systemName: "bell.badge")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(.white)
-                        .frame(width: 30, height: 30)
-                        .background(Color.red, in: RoundedRectangle(cornerRadius: 7))
-                    Text(NSLocalizedString("settings.notifications", comment: "Notifications"))
-                }
+                settingsIconLabel(
+                    icon: "bell.badge", color: .red,
+                    label: NSLocalizedString("settings.notifications", comment: "Notifications")
+                )
             }
         } header: {
-            settingsSectionHeader("bell", label: NSLocalizedString("settings.notifications.header", comment: "Notifications section header"))
+            settingsSectionHeader("location.circle", label: NSLocalizedString("settings.discovery", comment: "Discovery"))
         } footer: {
-            Text(NSLocalizedString("settings.notifications.footer", comment: "Notifications footer"))
+            Text(NSLocalizedString("settings.discovery.footer", comment: "Discovery section footer"))
         }
     }
 
-    // MARK: - Language
+    // MARK: - 3. Appearance & Language
 
-    private var languageSection: some View {
+    private var appearanceSection: some View {
         Section {
-            ForEach(LanguageService.Option.allCases) { option in
-                HStack {
-                    Image(systemName: "globe")
+            Picker(NSLocalizedString("settings.theme", comment: "Theme"), selection: Binding(
+                get: { themeService.selectedOption },
+                set: { themeService.selectedOption = $0 }
+            )) {
+                ForEach(ThemeService.ThemeOption.allCases) { option in
+                    Text(option.localizedName).tag(option)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Toggle(isOn: Binding(
+                get: { HapticService.shared.isEnabled },
+                set: { newValue in
+                    HapticService.shared.isEnabled = newValue
+                    if newValue {
+                        HapticService.shared.impact(style: .light)
+                    }
+                }
+            )) {
+                HStack(spacing: 10) {
+                    Image(systemName: "hand.tap.fill")
                         .font(.system(size: 16, weight: .medium))
                         .foregroundStyle(.white)
                         .frame(width: 30, height: 30)
-                        .background(Color.blue, in: RoundedRectangle(cornerRadius: 7))
-                    Text(languageOptionLabel(option))
-                    Spacer()
-                    if languageService.current == option {
-                        Image(systemName: "checkmark")
-                            .foregroundStyle(.blue)
-                            .fontWeight(.semibold)
-                    }
+                        .background(
+                            LinearGradient(colors: [Color.purple, Color.indigo], startPoint: .topLeading, endPoint: .bottomTrailing),
+                            in: RoundedRectangle(cornerRadius: 7)
+                        )
+                    Text(NSLocalizedString("settings.haptics.toggle", comment: "Haptic Feedback"))
                 }
-                .contentShape(Rectangle())
-                .onTapGesture {
+            }
+            .accessibilityLabel(NSLocalizedString("settings.haptics.toggle.a11y", comment: "Toggle haptic feedback"))
+
+            // Language collapsed from 3 checkmark rows to one menu picker.
+            // A *real* change still schedules the restart alert (US-044).
+            Picker(selection: Binding(
+                get: { languageService.current },
+                set: { option in
                     Haptics.selection()
                     if languageService.setLanguage(option) {
                         showingLanguageRestartAlert = true
                     }
                 }
+            )) {
+                ForEach(LanguageService.Option.allCases) { option in
+                    Text(languageOptionLabel(option)).tag(option)
+                }
+            } label: {
+                settingsIconLabel(
+                    icon: "globe", color: .blue,
+                    label: NSLocalizedString("settings.language", comment: "Language")
+                )
             }
+            .pickerStyle(.menu)
         } header: {
-            settingsSectionHeader("brain.head.profile", label: NSLocalizedString("settings.language", comment: "Language section header"))
+            settingsSectionHeader("paintpalette", label: NSLocalizedString("settings.appearanceLanguage", comment: "Appearance & Language"))
         } footer: {
             Text(NSLocalizedString("settings.language.footer", comment: "Language footer"))
         }
@@ -456,148 +318,105 @@ public struct SettingsView: View {
         }
     }
 
-    // MARK: - Stats
+    // MARK: - 4. Companion (US-012)
 
-    private static let milestones = [3, 10, 25, 50, 100]
-
-    private var nextMilestone: Int {
-        let count = preferences.completedExperiences.count
-        return Self.milestones.first { $0 > count } ?? 100
-    }
-
-    private var journeyCaption: String {
-        let count = preferences.completedExperiences.count
-        if count < 3 {
-            return NSLocalizedString("journey.caption.start", comment: "Journey caption just started")
-        } else if count < 25 {
-            return NSLocalizedString("journey.caption.rolling", comment: "Journey caption on a roll")
-        } else {
-            return NSLocalizedString("journey.caption.seasoned", comment: "Journey caption seasoned")
-        }
-    }
-
-    /// Groups completed experience IDs by category, sorted descending by count.
-    private var categoryCounts: [(ExperienceCategory, Int)] {
-        var counts: [ExperienceCategory: Int] = [:]
-        for id in preferences.completedExperiences {
-            guard let exp = experienceService.getExperience(id: id) else { continue }
-            counts[exp.category, default: 0] += 1
-        }
-        return counts
-            .filter { $0.value > 0 }
-            .sorted { $0.value > $1.value }
-            .map { ($0.key, $0.value) }
-    }
-
-    private var statsSection: some View {
+    /// US-012: Single experimental opt-in gate for the companion feature.
+    /// false→true requires accepting the safety consent sheet; true→false
+    /// is persisted immediately with no confirmation. When enabled, one hub
+    /// link replaces the former 5 inline NavigationLinks.
+    private var companionSection: some View {
         Section {
-            journeyProgressCard
-
-            if !categoryCounts.isEmpty {
-                CategoryBreakdownBar(categoryCounts: categoryCounts)
+            Toggle(isOn: Binding(
+                get: { preferences.companionEnabled },
+                set: { newValue in
+                    if newValue && !preferences.companionEnabled {
+                        // false → true: gate behind safety consent
+                        showingCompanionConsent = true
+                    } else {
+                        preferences.companionEnabled = newValue
+                    }
+                }
+            )) {
+                settingsIconLabel(
+                    icon: "person.2.fill", color: .pink,
+                    label: NSLocalizedString("settings.companion.toggle", comment: "Companion toggle label")
+                )
             }
 
-            Button {
-                onShowFavorites?()
-                onClose()
-            } label: {
-                settingsIconRow(icon: "heart.fill", color: .red,
-                                label: NSLocalizedString("settings.favorites", comment: "Favorites"),
-                                value: "\(preferences.favoritedExperiences.count)")
+            if preferences.companionEnabled {
+                NavigationLink {
+                    CompanionHubView()
+                        .environment(preferences)
+                } label: {
+                    settingsIconLabel(
+                        icon: "person.2.wave.2", color: .teal,
+                        label: NSLocalizedString("settings.companion.hub", comment: "Companion hub link")
+                    )
+                }
             }
-            .foregroundStyle(.primary)
         } header: {
-            settingsSectionHeader("trophy", label: NSLocalizedString("settings.stats", comment: "Your Journey"))
+            settingsSectionHeader(
+                "person.2",
+                label: NSLocalizedString("settings.companion.header", comment: "Companion (Experimental) section header")
+            )
+        } footer: {
+            Text(NSLocalizedString("settings.companion.footer", comment: "Companion section footer"))
         }
     }
 
-    private var journeyProgressCard: some View {
-        JourneyProgressCard(
-            completed: preferences.completedExperiences.count,
-            milestone: nextMilestone,
-            caption: journeyCaption
-        )
-    }
+    // MARK: - 5. Account
 
-    // MARK: - Data
-
-    private var dataSection: some View {
+    private var accountSection: some View {
         Section {
             // US-036: Save with Apple (anonymous only) / Linked to Apple ID
             appleIDRow
 
-            Button(role: .destructive) {
-                showingClearConfirm = true
-            } label: {
-                HStack(spacing: 10) {
-                    Image(systemName: "trash")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(.white)
-                        .frame(width: 30, height: 30)
-                        .background(Color.red, in: RoundedRectangle(cornerRadius: 7))
-                    Text(NSLocalizedString("settings.clearData", comment: "Clear all data"))
-                }
-            }
-            .confirmationDialog(
-                NSLocalizedString("settings.clearData.confirm.title", comment: "Clear all data confirm"),
-                isPresented: $showingClearConfirm,
-                titleVisibility: .visible
-            ) {
-                Button(NSLocalizedString("settings.clearData.confirm.action", comment: "Clear"), role: .destructive) {
-                    preferences.completedExperiences = []
-                    preferences.favoritedExperiences = []
-                    preferences.favoritedAt = [:]
-                    preferences.visitHistory = [:]
-                    preferences.pendingCheckIns = [:]
-                    preferences.preferredCategories = []
-                    preferences.dislikedCategories = []
-                    experienceService.repo.clearAllUserData()
-                }
-                Button(NSLocalizedString("common.cancel", comment: "Cancel"), role: .cancel) {}
-            } message: {
-                Text(NSLocalizedString("settings.clearData.confirm.message", comment: "Clear all data message"))
+            HStack {
+                settingsIconLabel(
+                    icon: "crown", color: .orange,
+                    label: NSLocalizedString("settings.subscription", comment: "Subscription")
+                )
+                Spacer()
+                Text(entitlementLabel)
+                    .foregroundStyle(.secondary)
             }
 
-            // P2.0 #204: "Forget me" — narrower than Clear All Data. Wipes
-            // the AgentMemorySnapshot + TasteProfile singletons so the
-            // Chat Agent forgets any accumulated personalisation. Routes,
-            // favorites, and preferences stay intact. Deliberately placed
-            // AFTER Clear All Data because it's the softer of two nukes.
-            Button(role: .destructive) {
-                showingForgetMeConfirm = true
+            Button {
+                Task { await runRestore() }
             } label: {
-                HStack(spacing: 10) {
-                    Image(systemName: "brain.head.profile")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(.white)
-                        .frame(width: 30, height: 30)
-                        .background(Color.orange, in: RoundedRectangle(cornerRadius: 7))
-                    Text(NSLocalizedString("settings.forgetMe", comment: "Forget me"))
+                HStack {
+                    Text(NSLocalizedString("settings.restore", comment: "Restore purchases"))
+                    Spacer()
+                    if restoreInFlight {
+                        ProgressView()
+                    }
                 }
             }
-            .confirmationDialog(
-                NSLocalizedString("settings.forgetMe.confirm.title", comment: "Forget me confirm title"),
-                isPresented: $showingForgetMeConfirm,
-                titleVisibility: .visible
-            ) {
-                Button(NSLocalizedString("settings.forgetMe.confirm.action", comment: "Forget me action"), role: .destructive) {
-                    let ok = MemoryDigestService.shared.forgetMe()
-                    forgetMeToast = ok
-                        ? NSLocalizedString("settings.forgetMe.toast.success", comment: "Forget me success")
-                        : NSLocalizedString("settings.forgetMe.toast.failure", comment: "Forget me failure")
-                }
-                Button(NSLocalizedString("common.cancel", comment: "Cancel"), role: .cancel) {}
-            } message: {
-                Text(NSLocalizedString("settings.forgetMe.confirm.message", comment: "Forget me message"))
-            }
+            .disabled(restoreInFlight)
+
+            Link(
+                NSLocalizedString("settings.manage", comment: "Manage subscription"),
+                destination: URL(string: "https://apps.apple.com/account/subscriptions")!
+            )
         } header: {
-            settingsSectionHeader("externaldrive", label: NSLocalizedString("settings.data.header", comment: "Data section header"))
+            settingsSectionHeader("person.crop.circle", label: NSLocalizedString("settings.account", comment: "Account"))
         }
         .alert(
+            restoreToast ?? "",
+            // Writable binding so any dismiss path clears the toast;
+            // `.constant(...)` stayed true and could immediately re-present.
+            isPresented: Binding(
+                get: { restoreToast != nil },
+                set: { if !$0 { restoreToast = nil } }
+            ),
+            actions: {
+                Button(NSLocalizedString("common.ok", comment: "OK")) {
+                    restoreToast = nil
+                }
+            }
+        )
+        .alert(
             appleSignInToast ?? "",
-            // A writable binding so SwiftUI can clear the toast on any dismiss
-            // path (incl. tap-outside); `.constant(...)` stayed true and could
-            // immediately re-present the alert.
             isPresented: Binding(
                 get: { appleSignInToast != nil },
                 set: { if !$0 { appleSignInToast = nil } }
@@ -605,19 +424,6 @@ public struct SettingsView: View {
             actions: {
                 Button(NSLocalizedString("common.ok", comment: "OK")) {
                     appleSignInToast = nil
-                }
-            }
-        )
-        // P2.0 #204: forget-me result toast. Same writable-binding pattern.
-        .alert(
-            forgetMeToast ?? "",
-            isPresented: Binding(
-                get: { forgetMeToast != nil },
-                set: { if !$0 { forgetMeToast = nil } }
-            ),
-            actions: {
-                Button(NSLocalizedString("common.ok", comment: "OK")) {
-                    forgetMeToast = nil
                 }
             }
         )
@@ -678,88 +484,214 @@ public struct SettingsView: View {
         }
     }
 
-    // MARK: - Helpers
+    // MARK: - 6. Data & About
 
-    /// US-020: Apple Settings-style section header with subheadline medium weight.
-    private func settingsSectionHeader(_ symbol: String, label: String) -> some View {
-        Label(label, systemImage: symbol)
-            .font(.subheadline.weight(.medium))
-            .foregroundStyle(.secondary)
-    }
-
-    /// US-020: Row with a 30×30 rounded filled icon on the left.
-    private func settingsIconRow(icon: String, color: Color, label: String, value: String) -> some View {
-        HStack {
-            Image(systemName: icon)
-                .font(.system(size: 16, weight: .medium))
-                .foregroundStyle(.white)
-                .frame(width: 30, height: 30)
-                .background(color, in: RoundedRectangle(cornerRadius: 7))
-            Text(label)
-            Spacer()
-            Text(value).foregroundStyle(.secondary).monospacedDigit()
-        }
-    }
-
-    private func labelRow(icon: String, color: Color, label: String, value: String) -> some View {
-        settingsIconRow(icon: icon, color: color, label: label, value: value)
-    }
-
-    private func distanceLabel(_ km: Double) -> String {
-        if Locale.current.measurementSystem == .us {
-            return String(format: "%.1f mi", km * 0.621371)
-        }
-        return km >= 10 ? String(format: "%.0f km", km) : String(format: "%.1f km", km)
-    }
-
-    private func togglePreferred(_ category: ExperienceCategory) {
-        Haptics.selection()
-        preferences.dislikedCategories.removeAll { $0 == category }
-        if preferences.preferredCategories.contains(category) {
-            preferences.preferredCategories.removeAll { $0 == category }
-        } else {
-            preferences.preferredCategories.append(category)
-        }
-    }
-
-    private func toggleDisliked(_ category: ExperienceCategory) {
-        Haptics.notify(.warning)
-        preferences.preferredCategories.removeAll { $0 == category }
-        if preferences.dislikedCategories.contains(category) {
-            preferences.dislikedCategories.removeAll { $0 == category }
-        } else {
-            preferences.dislikedCategories.append(category)
-        }
-    }
-
-    // MARK: - AI Provider
-
-    private var aiProviderSection: some View {
+    private var dataAboutSection: some View {
         Section {
-            NavigationLink {
-                AIProviderSettingsView()
-                    .environment(preferences)
+            Toggle(isOn: Binding(
+                get: { preferences.includeMapInExport },
+                set: { preferences.includeMapInExport = $0 }
+            )) {
+                settingsIconLabel(
+                    icon: "map", color: .teal,
+                    label: NSLocalizedString("settings.exportMapPreview", comment: "Include map preview in exports")
+                )
+            }
+
+            Button(role: .destructive) {
+                showingClearConfirm = true
             } label: {
-                HStack(spacing: 10) {
-                    Image(systemName: "brain.head.profile")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(.white)
-                        .frame(width: 30, height: 30)
-                        .background(aiStatusColor, in: RoundedRectangle(cornerRadius: 7))
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(NSLocalizedString("settings.aiProvider", comment: "AI Provider row label"))
-                            .font(.body)
-                        Text(aiStatusSubtitle)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
+                settingsIconLabel(
+                    icon: "trash", color: .red,
+                    label: NSLocalizedString("settings.clearData", comment: "Clear all data")
+                )
+            }
+            .confirmationDialog(
+                NSLocalizedString("settings.clearData.confirm.title", comment: "Clear all data confirm"),
+                isPresented: $showingClearConfirm,
+                titleVisibility: .visible
+            ) {
+                Button(NSLocalizedString("settings.clearData.confirm.action", comment: "Clear"), role: .destructive) {
+                    preferences.completedExperiences = []
+                    preferences.favoritedExperiences = []
+                    preferences.favoritedAt = [:]
+                    preferences.visitHistory = [:]
+                    preferences.pendingCheckIns = [:]
+                    preferences.preferredCategories = []
+                    preferences.dislikedCategories = []
+                    experienceService.repo.clearAllUserData()
+                }
+                Button(NSLocalizedString("common.cancel", comment: "Cancel"), role: .cancel) {}
+            } message: {
+                Text(NSLocalizedString("settings.clearData.confirm.message", comment: "Clear all data message"))
+            }
+
+            // P2.0 #204: "Forget me" — narrower than Clear All Data. Wipes
+            // the AgentMemorySnapshot + TasteProfile singletons so the
+            // Chat Agent forgets any accumulated personalisation. Routes,
+            // favorites, and preferences stay intact. Deliberately placed
+            // AFTER Clear All Data because it's the softer of two nukes.
+            Button(role: .destructive) {
+                showingForgetMeConfirm = true
+            } label: {
+                settingsIconLabel(
+                    icon: "brain.head.profile", color: .orange,
+                    label: NSLocalizedString("settings.forgetMe", comment: "Forget me")
+                )
+            }
+            .confirmationDialog(
+                NSLocalizedString("settings.forgetMe.confirm.title", comment: "Forget me confirm title"),
+                isPresented: $showingForgetMeConfirm,
+                titleVisibility: .visible
+            ) {
+                Button(NSLocalizedString("settings.forgetMe.confirm.action", comment: "Forget me action"), role: .destructive) {
+                    let ok = MemoryDigestService.shared.forgetMe()
+                    forgetMeToast = ok
+                        ? NSLocalizedString("settings.forgetMe.toast.success", comment: "Forget me success")
+                        : NSLocalizedString("settings.forgetMe.toast.failure", comment: "Forget me failure")
+                }
+                Button(NSLocalizedString("common.cancel", comment: "Cancel"), role: .cancel) {}
+            } message: {
+                Text(NSLocalizedString("settings.forgetMe.confirm.message", comment: "Forget me message"))
+            }
+
+            // #130: 7 taps here reveal the Advanced section (AI provider,
+            // tester unlock, developer options). Persisted via @AppStorage.
+            HStack {
+                settingsIconLabel(
+                    icon: "info.circle", color: .gray,
+                    label: NSLocalizedString("settings.about.version", comment: "Version")
+                )
+                Spacer()
+                Text(appVersion)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            .contentShape(Rectangle())
+            .onTapGesture { handleVersionTap() }
+        } header: {
+            settingsSectionHeader("externaldrive", label: NSLocalizedString("settings.dataAbout", comment: "Data & About"))
+        }
+        // P2.0 #204: forget-me result toast. Writable-binding pattern (see
+        // the restoreToast alert above for why `.constant` was wrong).
+        .alert(
+            forgetMeToast ?? "",
+            isPresented: Binding(
+                get: { forgetMeToast != nil },
+                set: { if !$0 { forgetMeToast = nil } }
+            ),
+            actions: {
+                Button(NSLocalizedString("common.ok", comment: "OK")) {
+                    forgetMeToast = nil
                 }
             }
-        } header: {
-            settingsSectionHeader(
-                "brain",
-                label: NSLocalizedString("settings.aiProvider.header", comment: "AI Provider section header")
-            )
+        )
+    }
+
+    private var appVersion: String {
+        let v = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+        let b = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+        return "\(v) (\(b))"
+    }
+
+    private func handleVersionTap() {
+        guard !advancedUnlocked else { return }
+        versionTapCount += 1
+        if versionTapCount >= 7 {
+            advancedUnlocked = true
+            Haptics.notify(.success)
+        } else if versionTapCount >= 4 {
+            // Progressive feedback so the gesture feels discoverable once found.
+            Haptics.selection()
+        }
+    }
+
+    // MARK: - Advanced (hidden behind 7-tap / tester unlock)
+
+    /// Power-user tools kept out of the everyday list: AI provider config,
+    /// the tester-email Pro unlock, and (once email-unlocked) developer
+    /// options. `@ViewBuilder` so the section fully disappears otherwise.
+    @ViewBuilder
+    private var advancedSection: some View {
+        if advancedUnlocked || subscriptionService.developerModeUnlocked {
+            Section {
+                NavigationLink {
+                    AIProviderSettingsView()
+                        .environment(preferences)
+                } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "brain.head.profile")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(.white)
+                            .frame(width: 30, height: 30)
+                            .background(aiStatusColor, in: RoundedRectangle(cornerRadius: 7))
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(NSLocalizedString("settings.aiProvider", comment: "AI Provider row label"))
+                                .font(.body)
+                            Text(aiStatusSubtitle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                // Tester / admin email unlock — only unlocks when the entered
+                // email is on the allow-list.
+                Button {
+                    adminEmailInput = ""
+                    showingAdminUnlock = true
+                } label: {
+                    settingsIconLabel(
+                        icon: "envelope.badge", color: .blue,
+                        label: NSLocalizedString("settings.adminUnlock", comment: "Unlock with tester email")
+                    )
+                }
+                .foregroundStyle(.primary)
+
+                if subscriptionService.developerModeUnlocked {
+                    NavigationLink {
+                        DeveloperOptionsView()
+                            .environment(preferences)
+                            .environment(subscriptionService)
+                    } label: {
+                        HStack(spacing: 10) {
+                            Image(systemName: "hammer.fill")
+                                .font(.system(size: 16, weight: .medium))
+                                .foregroundStyle(.white)
+                                .frame(width: 30, height: 30)
+                                .background(Color.gray, in: RoundedRectangle(cornerRadius: 7))
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(NSLocalizedString("dev.title", comment: "Developer Options"))
+                                    .font(.body)
+                                Text(NSLocalizedString("dev.entry.subtitle", comment: "Developer options subtitle"))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            } header: {
+                settingsSectionHeader("wrench.and.screwdriver", label: NSLocalizedString("settings.advanced", comment: "Advanced"))
+            } footer: {
+                Text(NSLocalizedString("settings.advanced.footer", comment: "Advanced section footer"))
+            }
+            .alert(
+                NSLocalizedString("settings.adminUnlock.title", comment: "Admin unlock title"),
+                isPresented: $showingAdminUnlock
+            ) {
+                TextField(
+                    NSLocalizedString("settings.adminUnlock.placeholder", comment: "Email placeholder"),
+                    text: $adminEmailInput
+                )
+                .textInputAutocapitalization(.never)
+                .keyboardType(.emailAddress)
+                Button(NSLocalizedString("common.cancel", comment: "Cancel"), role: .cancel) {}
+                Button(NSLocalizedString("settings.adminUnlock.action", comment: "Unlock")) {
+                    runAdminUnlock()
+                }
+            } message: {
+                Text(NSLocalizedString("settings.adminUnlock.message", comment: "Admin unlock message"))
+            }
         }
     }
 
@@ -774,118 +706,6 @@ public struct SettingsView: View {
                 format: NSLocalizedString("settings.aiProvider.status.configured", comment: "AI configured subtitle"),
                 preferences.aiProvider.displayName
               )
-    }
-
-    // MARK: - Subscription section (Epic D US-025)
-
-    private var subscriptionSection: some View {
-        Section {
-            HStack {
-                Text(NSLocalizedString("settings.subscription", comment: "Subscription"))
-                Spacer()
-                Text(entitlementLabel)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Button {
-                Task { await runRestore() }
-            } label: {
-                HStack {
-                    Text(NSLocalizedString("settings.restore", comment: "Restore purchases"))
-                    Spacer()
-                    if restoreInFlight {
-                        ProgressView()
-                    }
-                }
-            }
-            .disabled(restoreInFlight)
-
-            // Tester / admin email unlock — visible to everyone but only
-            // unlocks when the entered email is on the allow-list.
-            Button {
-                adminEmailInput = ""
-                showingAdminUnlock = true
-            } label: {
-                Text(NSLocalizedString("settings.adminUnlock", comment: "Unlock with tester email"))
-            }
-
-            Link(
-                NSLocalizedString("settings.manage", comment: "Manage subscription"),
-                destination: URL(string: "https://apps.apple.com/account/subscriptions")!
-            )
-        } header: {
-            settingsSectionHeader("crown", label: NSLocalizedString("settings.subscription", comment: "Subscription"))
-        }
-        .alert(
-            restoreToast ?? "",
-            // Writable binding so any dismiss path clears the toast (see the
-            // appleSignInToast alert above for why `.constant` was wrong).
-            isPresented: Binding(
-                get: { restoreToast != nil },
-                set: { if !$0 { restoreToast = nil } }
-            ),
-            actions: {
-                Button(NSLocalizedString("common.ok", comment: "OK")) {
-                    restoreToast = nil
-                }
-            }
-        )
-        .alert(
-            NSLocalizedString("settings.adminUnlock.title", comment: "Admin unlock title"),
-            isPresented: $showingAdminUnlock
-        ) {
-            TextField(
-                NSLocalizedString("settings.adminUnlock.placeholder", comment: "Email placeholder"),
-                text: $adminEmailInput
-            )
-            .textInputAutocapitalization(.never)
-            .keyboardType(.emailAddress)
-            Button(NSLocalizedString("common.cancel", comment: "Cancel"), role: .cancel) {}
-            Button(NSLocalizedString("settings.adminUnlock.action", comment: "Unlock")) {
-                runAdminUnlock()
-            }
-        } message: {
-            Text(NSLocalizedString("settings.adminUnlock.message", comment: "Admin unlock message"))
-        }
-    }
-
-    // MARK: - Developer Options
-
-    /// Entry point to `DeveloperOptionsView`. Only rendered once a tester email
-    /// has unlocked the device (`SubscriptionService.developerModeUnlocked`) —
-    /// a plain StoreKit Pro purchase does NOT reveal it. `@ViewBuilder` so the
-    /// section fully disappears (no empty row) for everyone else.
-    @ViewBuilder
-    private var developerSection: some View {
-        if subscriptionService.developerModeUnlocked {
-            Section {
-                NavigationLink {
-                    DeveloperOptionsView()
-                        .environment(preferences)
-                        .environment(subscriptionService)
-                } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: "hammer.fill")
-                            .font(.system(size: 16, weight: .medium))
-                            .foregroundStyle(.white)
-                            .frame(width: 30, height: 30)
-                            .background(Color.gray, in: RoundedRectangle(cornerRadius: 7))
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(NSLocalizedString("dev.title", comment: "Developer Options"))
-                                .font(.body)
-                            Text(NSLocalizedString("dev.entry.subtitle", comment: "Developer options subtitle"))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-            } header: {
-                settingsSectionHeader("hammer", label: NSLocalizedString("dev.header", comment: "Developer section header"))
-            } footer: {
-                Text(NSLocalizedString("dev.footer", comment: "Developer section footer"))
-            }
-        }
     }
 
     private var entitlementLabel: String {
@@ -915,117 +735,230 @@ public struct SettingsView: View {
         )
     }
 
-    // MARK: - Appearance (US-039)
+    // MARK: - Helpers
 
-    private var appearanceSection: some View {
-        Section {
-            Picker(NSLocalizedString("settings.theme", comment: "Theme"), selection: Binding(
-                get: { themeService.selectedOption },
-                set: { themeService.selectedOption = $0 }
-            )) {
-                ForEach(ThemeService.ThemeOption.allCases) { option in
-                    Text(option.localizedName).tag(option)
-                }
-            }
-            .pickerStyle(.segmented)
+    private func distanceLabel(_ km: Double) -> String {
+        if Locale.current.measurementSystem == .us {
+            return String(format: "%.1f mi", km * 0.621371)
+        }
+        return km >= 10 ? String(format: "%.0f km", km) : String(format: "%.1f km", km)
+    }
+}
 
-            Toggle(isOn: Binding(
-                get: { HapticService.shared.isEnabled },
-                set: { newValue in
-                    HapticService.shared.isEnabled = newValue
-                    if newValue {
-                        HapticService.shared.impact(style: .light)
+// MARK: - Shared row helpers
+
+/// US-020: Apple Settings-style section header with subheadline medium weight.
+func settingsSectionHeader(_ symbol: String, label: String) -> some View {
+    Label(label, systemImage: symbol)
+        .font(.subheadline.weight(.medium))
+        .foregroundStyle(.secondary)
+}
+
+/// US-020: 30×30 rounded filled icon + label (no trailing value).
+func settingsIconLabel(icon: String, color: Color, label: String) -> some View {
+    HStack(spacing: 10) {
+        Image(systemName: icon)
+            .font(.system(size: 16, weight: .medium))
+            .foregroundStyle(.white)
+            .frame(width: 30, height: 30)
+            .background(color, in: RoundedRectangle(cornerRadius: 7))
+        Text(label)
+    }
+}
+
+/// US-020: Row with a 30×30 rounded filled icon and a secondary trailing value.
+func settingsIconRow(icon: String, color: Color, label: String, value: String) -> some View {
+    HStack {
+        settingsIconLabel(icon: icon, color: color, label: label)
+        Spacer()
+        Text(value).foregroundStyle(.secondary).monospacedDigit()
+    }
+}
+
+// MARK: - Travel Style (child page)
+
+/// #130: The former inline 4-row travel style section, now a child page.
+struct TravelStyleSettingsView: View {
+    @Environment(UserPreferences.self) private var preferences
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(UserPreferences.SoloTravelStyle.allCases) { style in
+                    HStack {
+                        Image(systemName: travelStyleIcon(style))
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(.white)
+                            .frame(width: 30, height: 30)
+                            .background(travelStyleColor(style), in: RoundedRectangle(cornerRadius: 7))
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(style.localizedTitle).font(.body)
+                            Text(style.localizedDescription).font(.caption).foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        if preferences.soloTravelStyle == style {
+                            Image(systemName: "checkmark").foregroundStyle(.blue).fontWeight(.semibold)
+                        }
                     }
+                    .contentShape(Rectangle())
+                    .onTapGesture { Haptics.selection(); preferences.soloTravelStyle = style }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityAddTraits(preferences.soloTravelStyle == style ? [.isButton, .isSelected] : .isButton)
                 }
-            )) {
-                HStack(spacing: 10) {
-                    Image(systemName: "hand.tap.fill")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(.white)
-                        .frame(width: 30, height: 30)
-                        .background(
-                            LinearGradient(colors: [Color.purple, Color.indigo], startPoint: .topLeading, endPoint: .bottomTrailing),
-                            in: RoundedRectangle(cornerRadius: 7)
-                        )
-                    Text(NSLocalizedString("settings.haptics.toggle", comment: "Haptic Feedback"))
-                }
+            } footer: {
+                Text(NSLocalizedString("settings.travelStyle.footer", comment: "Travel style footer"))
             }
-            .accessibilityLabel(NSLocalizedString("settings.haptics.toggle.a11y", comment: "Toggle haptic feedback"))
-        } header: {
-            settingsSectionHeader("paintpalette", label: NSLocalizedString("settings.appearance", comment: "Appearance"))
-        } footer: {
-            Text(NSLocalizedString("settings.haptics.footer", comment: "Haptic feedback footer"))
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(NSLocalizedString("settings.travelStyle", comment: "Travel Style"))
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func travelStyleIcon(_ style: UserPreferences.SoloTravelStyle) -> String {
+        switch style {
+        case .explorer: return "map"
+        case .worker: return "laptopcomputer"
+        case .foodie: return "fork.knife"
+        case .cultureSeeker: return "building.columns"
         }
     }
 
-    // MARK: - Companion (US-012)
+    private func travelStyleColor(_ style: UserPreferences.SoloTravelStyle) -> Color {
+        switch style {
+        case .explorer: return .blue
+        case .worker: return .purple
+        case .foodie: return .orange
+        case .cultureSeeker: return .brown
+        }
+    }
+}
 
-    /// US-012: Single experimental opt-in gate for the companion feature.
-    /// false→true requires accepting the safety consent sheet; true→false
-    /// is persisted immediately with no confirmation. When enabled, three
-    /// navigation links appear (profile, requests, conversations).
-    private var companionSection: some View {
-        Section {
-            Toggle(isOn: Binding(
-                get: { preferences.companionEnabled },
-                set: { newValue in
-                    if newValue && !preferences.companionEnabled {
-                        // false → true: gate behind safety consent
-                        showingCompanionConsent = true
-                    } else {
-                        preferences.companionEnabled = newValue
+// MARK: - Category Preferences (child page)
+
+/// #130: Merges the former "Preferred" + "Hidden" sections into one page —
+/// tap to love, swipe left to hide, hidden list underneath.
+struct CategoryPreferencesView: View {
+    @Environment(UserPreferences.self) private var preferences
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(ExperienceCategory.allCases) { category in
+                    let isPreferred = preferences.preferredCategories.contains(category)
+                    let isDisliked = preferences.dislikedCategories.contains(category)
+                    HStack(spacing: 12) {
+                        Image(systemName: category.symbol)
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(.white)
+                            .frame(width: 30, height: 30)
+                            .background(category.color, in: RoundedRectangle(cornerRadius: 7))
+                        Text(category.localizedTitle)
+                        Spacer()
+                        if isPreferred {
+                            Image(systemName: "heart.fill").foregroundStyle(.pink)
+                        } else if isDisliked {
+                            Image(systemName: "hand.thumbsdown.fill").foregroundStyle(.secondary)
+                        }
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture { togglePreferred(category) }
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) { toggleDisliked(category) } label: {
+                            Label(NSLocalizedString("settings.hide", comment: "Hide"), systemImage: "eye.slash")
+                        }
                     }
                 }
-            )) {
-                HStack(spacing: 10) {
-                    Image(systemName: "person.2.fill")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(.white)
-                        .frame(width: 30, height: 30)
-                        .background(Color.pink, in: RoundedRectangle(cornerRadius: 7))
-                    Text(NSLocalizedString("settings.companion.toggle", comment: "Companion toggle label"))
-                }
+            } footer: {
+                Text(NSLocalizedString("settings.preferences.footer", comment: "Category preferences footer"))
             }
 
-            if preferences.companionEnabled {
+            if !preferences.dislikedCategories.isEmpty {
+                Section {
+                    ForEach(preferences.dislikedCategories) { category in
+                        HStack(spacing: 12) {
+                            Image(systemName: category.symbol)
+                                .font(.system(size: 16, weight: .medium))
+                                .foregroundStyle(.white)
+                                .frame(width: 30, height: 30)
+                                .background(Color.secondary, in: RoundedRectangle(cornerRadius: 7))
+                            Text(category.localizedTitle).foregroundStyle(.secondary)
+                            Spacer()
+                            Button {
+                                Haptics.selection()
+                                preferences.dislikedCategories.removeAll { $0 == category }
+                            } label: {
+                                Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                } header: {
+                    settingsSectionHeader("eye.slash", label: NSLocalizedString("settings.hidden", comment: "Hidden Categories"))
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(NSLocalizedString("settings.preferences", comment: "Category Preferences"))
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func togglePreferred(_ category: ExperienceCategory) {
+        Haptics.selection()
+        preferences.dislikedCategories.removeAll { $0 == category }
+        if preferences.preferredCategories.contains(category) {
+            preferences.preferredCategories.removeAll { $0 == category }
+        } else {
+            preferences.preferredCategories.append(category)
+        }
+    }
+
+    private func toggleDisliked(_ category: ExperienceCategory) {
+        Haptics.notify(.warning)
+        preferences.preferredCategories.removeAll { $0 == category }
+        if preferences.dislikedCategories.contains(category) {
+            preferences.dislikedCategories.removeAll { $0 == category }
+        } else {
+            preferences.dislikedCategories.append(category)
+        }
+    }
+}
+
+// MARK: - Companion Hub (child page)
+
+/// #130: Single destination replacing the former 5 inline companion
+/// NavigationLinks in the main settings list.
+struct CompanionHubView: View {
+    @Environment(UserPreferences.self) private var preferences
+
+    var body: some View {
+        List {
+            Section {
                 NavigationLink {
                     CompanionProfileView()
                         .environment(preferences)
                 } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: "person.crop.circle")
-                            .font(.system(size: 16, weight: .medium))
-                            .foregroundStyle(.white)
-                            .frame(width: 30, height: 30)
-                            .background(Color.indigo, in: RoundedRectangle(cornerRadius: 7))
-                        Text(NSLocalizedString("settings.companion.profile", comment: "Companion profile link"))
-                    }
+                    settingsIconLabel(
+                        icon: "person.crop.circle", color: .indigo,
+                        label: NSLocalizedString("settings.companion.profile", comment: "Companion profile link")
+                    )
                 }
 
                 NavigationLink {
                     MyRequestsListView()
                 } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: "tray.and.arrow.up")
-                            .font(.system(size: 16, weight: .medium))
-                            .foregroundStyle(.white)
-                            .frame(width: 30, height: 30)
-                            .background(Color.orange, in: RoundedRectangle(cornerRadius: 7))
-                        Text(NSLocalizedString("settings.companion.requests", comment: "My recruitment requests link"))
-                    }
+                    settingsIconLabel(
+                        icon: "tray.and.arrow.up", color: .orange,
+                        label: NSLocalizedString("settings.companion.requests", comment: "My recruitment requests link")
+                    )
                 }
 
                 NavigationLink {
                     CompanionConversationsListView()
                 } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: "bubble.left.and.bubble.right")
-                            .font(.system(size: 16, weight: .medium))
-                            .foregroundStyle(.white)
-                            .frame(width: 30, height: 30)
-                            .background(Color.teal, in: RoundedRectangle(cornerRadius: 7))
-                        Text(NSLocalizedString("settings.companion.conversations", comment: "Joined conversations link"))
-                    }
+                    settingsIconLabel(
+                        icon: "bubble.left.and.bubble.right", color: .teal,
+                        label: NSLocalizedString("settings.companion.conversations", comment: "Joined conversations link")
+                    )
                 }
 
                 // US-032: Discover recruiting routes
@@ -1033,38 +966,29 @@ public struct SettingsView: View {
                     DiscoverRecruitingRoutesView()
                         .environment(preferences)
                 } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: "map.fill")
-                            .font(.system(size: 16, weight: .medium))
-                            .foregroundStyle(.white)
-                            .frame(width: 30, height: 30)
-                            .background(Color.green, in: RoundedRectangle(cornerRadius: 7))
-                        Text(NSLocalizedString("settings.companion.discover.routes", comment: "Discover recruiting routes link"))
-                    }
+                    settingsIconLabel(
+                        icon: "map.fill", color: .green,
+                        label: NSLocalizedString("settings.companion.discover.routes", comment: "Discover recruiting routes link")
+                    )
                 }
 
                 // US-034: My hosted routes (approval queue entry point)
                 NavigationLink {
                     MyHostedRoutesListView()
                 } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: "person.badge.key.fill") // anti-pattern-lint:allow standard Apple SF Symbol for key access, not gamification
-                            .font(.system(size: 16, weight: .medium))
-                            .foregroundStyle(.white)
-                            .frame(width: 30, height: 30)
-                            .background(Color.purple, in: RoundedRectangle(cornerRadius: 7))
-                        Text(NSLocalizedString("settings.companion.hosted.routes", comment: "My hosted routes link"))
-                    }
+                    settingsIconLabel(
+                        // anti-pattern-lint:allow standard Apple SF Symbol for key access, not gamification
+                        icon: "person.badge.key.fill", color: .purple,
+                        label: NSLocalizedString("settings.companion.hosted.routes", comment: "My hosted routes link")
+                    )
                 }
+            } footer: {
+                Text(NSLocalizedString("settings.companion.footer", comment: "Companion section footer"))
             }
-        } header: {
-            settingsSectionHeader(
-                "person.2",
-                label: NSLocalizedString("settings.companion.header", comment: "Companion (Experimental) section header")
-            )
-        } footer: {
-            Text(NSLocalizedString("settings.companion.footer", comment: "Companion section footer"))
         }
+        .listStyle(.insetGrouped)
+        .navigationTitle(NSLocalizedString("settings.companion.hub", comment: "Companion hub"))
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
 
@@ -1173,282 +1097,6 @@ extension UserPreferences.SoloTravelStyle {
     var localizedDescription: String {
         NSLocalizedString("style.\(rawValue).description", comment: "Travel style description")
     }
-}
-
-// MARK: - Category Breakdown Bar
-
-private struct CategoryBreakdownBar: View {
-    let categoryCounts: [(ExperienceCategory, Int)]
-
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var appeared = false
-
-    private var total: Int { categoryCounts.reduce(0) { $0 + $1.1 } }
-
-    private var a11yLabel: String {
-        let parts = categoryCounts.map { cat, count in
-            String(format: NSLocalizedString(
-                "journey.breakdown.a11y.item",
-                comment: "Category count accessibility item, e.g. '3 coffee'"
-            ), count, cat.localizedTitle)
-        }
-        return String(
-            format: NSLocalizedString(
-                "journey.breakdown.a11y.label",
-                comment: "Category breakdown accessibility label"
-            ),
-            parts.joined(separator: ", ")
-        )
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            // Proportional segmented bar
-            GeometryReader { geo in
-                HStack(spacing: 2) {
-                    ForEach(categoryCounts, id: \.0) { category, count in
-                        let fraction = total > 0 ? Double(count) / Double(total) : 0
-                        let width = geo.size.width * (appeared ? fraction : 0)
-                        RoundedRectangle(cornerRadius: 3)
-                            .fill(category.color)
-                            .frame(width: max(width, appeared ? 2 : 0), height: 12)
-                            .animation(
-                                reduceMotion ? nil : .easeInOut(duration: 0.45).delay(0.05),
-                                value: appeared
-                            )
-                    }
-                }
-                .clipShape(Capsule())
-            }
-            .frame(height: 12)
-
-            // Legend chips — top categories
-            let topCounts = Array(categoryCounts.prefix(5))
-            FlexibleLegend(items: topCounts)
-        }
-        .padding(.vertical, 4)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(a11yLabel)
-        .onAppear {
-            if reduceMotion {
-                appeared = true
-            } else {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                    appeared = true
-                }
-            }
-        }
-        .onChange(of: categoryCounts.map { $0.1 }) { _, _ in
-            appeared = false
-            if reduceMotion {
-                appeared = true
-            } else {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                    appeared = true
-                }
-            }
-        }
-    }
-}
-
-private struct FlexibleLegend: View {
-    let items: [(ExperienceCategory, Int)]
-
-    var body: some View {
-        // Wrapping row via a simple flow approach using fixed-size chips
-        HStack(alignment: .center, spacing: 6) {
-            ForEach(items, id: \.0) { category, count in
-                HStack(spacing: 3) {
-                    Image(systemName: category.symbol)
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundStyle(category.color)
-                    Text("\(count)")
-                        .font(.caption2.monospacedDigit())
-                        .foregroundStyle(category.color)
-                }
-                .padding(.horizontal, 6)
-                .padding(.vertical, 3)
-                .background(category.color.opacity(0.12), in: Capsule())
-            }
-            Spacer(minLength: 0)
-        }
-    }
-}
-
-// MARK: - Journey Progress Card
-
-private struct JourneyProgressCard: View {
-    let completed: Int
-    let milestone: Int
-    let caption: String
-
-    @State private var animateProgress = false
-    @State private var shimmerOffset: CGFloat = -1
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
-    private var progress: Double {
-        guard milestone > 0 else { return 1 }
-        return min(Double(completed) / Double(milestone), 1)
-    }
-
-    private var isAtMilestone: Bool { completed >= milestone }
-    private var isAlmostThere: Bool { (milestone - completed) == 1 && !isAtMilestone }
-
-    private var barFill: AnyShapeStyle {
-        if isAtMilestone {
-            return AnyShapeStyle(LinearGradient(
-                colors: [Color(hex: 0xD4A843), Color(hex: 0xD9B85C)],
-                startPoint: .leading,
-                endPoint: .trailing
-            ))
-        } else if isAlmostThere {
-            if #available(iOS 18.0, *) {
-                return AnyShapeStyle(Color.green.mix(with: .yellow, by: 0.25))
-            } else {
-                return AnyShapeStyle(Color.green)
-            }
-        } else {
-            return AnyShapeStyle(Color.green)
-        }
-    }
-
-    private var a11yLabel: String {
-        let base = String(
-            format: NSLocalizedString("journey.progress.a11y", comment: "Journey progress accessibility label"),
-            completed,
-            milestone
-        )
-        if isAtMilestone {
-            return base + ". " + NSLocalizedString("journey.milestone.reached", comment: "Milestone reached")
-        } else if isAlmostThere {
-            return base + ". " + NSLocalizedString("journey.milestone.almost", comment: "Almost there")
-        }
-        return base
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .firstTextBaseline, spacing: 4) {
-                Text(NSLocalizedString("journey.progress.title", comment: "Journey progress title"))
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                Spacer()
-                Text(
-                    String(
-                        format: NSLocalizedString("journey.progress.count", comment: "Journey progress count format"),
-                        completed,
-                        milestone
-                    )
-                )
-                .font(.title2.bold().monospacedDigit())
-                .foregroundStyle(.primary)
-
-                if isAtMilestone || isAlmostThere {
-                    let label = isAtMilestone
-                        ? NSLocalizedString("journey.milestone.reached", comment: "Milestone reached")
-                        : NSLocalizedString("journey.milestone.almost", comment: "Almost there")
-                    Label(label, systemImage: "sparkles")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(isAtMilestone ? Color(hex: 0xD4A843) : .green)
-                        .symbolEffect(.bounce, value: animateProgress && !reduceMotion)
-                        .transition(.scale.combined(with: .opacity))
-                }
-            }
-
-            GeometryReader { geo in
-                ZStack(alignment: .leading) {
-                    Capsule()
-                        .fill(Color(uiColor: .secondarySystemFill))
-                        .frame(height: 8)
-                    Capsule()
-                        .fill(barFill)
-                        .frame(
-                            width: geo.size.width * (animateProgress ? progress : 0),
-                            height: 8
-                        )
-                        .animation(
-                            reduceMotion ? nil : .spring(response: 0.6, dampingFraction: 0.8),
-                            value: animateProgress
-                        )
-                        .overlay {
-                            if isAtMilestone && !reduceMotion {
-                                LinearGradient(
-                                    colors: [.clear, .white.opacity(0.55), .clear],
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                )
-                                .offset(x: shimmerOffset * geo.size.width)
-                                .clipShape(Capsule())
-                                .allowsHitTesting(false)
-                            }
-                        }
-                }
-            }
-            .frame(height: 8)
-
-            Text(caption)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-        .padding(.vertical, 6)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(a11yLabel)
-        .onAppear {
-            if reduceMotion {
-                animateProgress = true
-            } else {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    animateProgress = true
-                    if isAtMilestone {
-                        shimmerOffset = -1
-                        withAnimation(.easeInOut(duration: 0.8).delay(0.5)) {
-                            shimmerOffset = 2
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-private extension Color {
-    init(hex: UInt32) {
-        let r = Double((hex >> 16) & 0xFF) / 255
-        let g = Double((hex >> 8) & 0xFF) / 255
-        let b = Double(hex & 0xFF) / 255
-        self.init(red: r, green: g, blue: b)
-    }
-}
-
-#Preview("Journey Progress Card") {
-    List {
-        JourneyProgressCard(completed: 3, milestone: 3, caption: "First milestone — gold!")
-        JourneyProgressCard(completed: 2, milestone: 3, caption: "Almost there!")
-        JourneyProgressCard(completed: 5, milestone: 10, caption: "You're on a roll!")
-        JourneyProgressCard(completed: 0, milestone: 3, caption: "Every journey starts here.")
-        JourneyProgressCard(completed: 25, milestone: 50, caption: "A seasoned solo traveler.")
-    }
-    .listStyle(.insetGrouped)
-}
-
-#Preview("Category Breakdown Bar — populated") {
-    List {
-        CategoryBreakdownBar(categoryCounts: [
-            (.coffee, 5),
-            (.culture, 3),
-            (.food, 2),
-            (.nature, 1),
-        ])
-    }
-    .listStyle(.insetGrouped)
-}
-
-#Preview("Category Breakdown Bar — empty (not shown)") {
-    List {
-        Text("Bar is hidden when categoryCounts is empty.")
-            .foregroundStyle(.secondary)
-    }
-    .listStyle(.insetGrouped)
 }
 
 #Preview {


### PR DESCRIPTION
…n Advanced group

Lands the long-deferred P1.3 #130 plan. The everyday settings list is now six focused sections — Your Taste, Discovery, Appearance & Language, Companion, Account, Data & About — with heavy content moved to child pages that show their current value on the row (travel style, category preferences, visible categories, custom tags, companion hub).

Why each removal is safe:
- Stats section (JourneyProgressCard, CategoryBreakdownBar, favorites row) deleted — MeSheet already surfaces the same numbers, so the onShowFavorites callback is gone from the SettingsView API.
- AI Provider, tester-email unlock, and Developer Options move behind a 7-tap gesture on the version row (persisted via @AppStorage; developer-unlocked devices see the group immediately).
- The 3-row language list collapses to a single menu picker; a real language change still schedules the restart alert (US-044 behavior).
- Companion consent sheet stays anchored to the List, not a Section, preserving the row-churn crash fix.

Also localizes ThemeOption names (they returned raw English rawValues even in zh-Hans) and fixes the en value of
settings.companion.hosted.routes which contained Chinese text.

14 new localization keys added to both en and zh-Hans; StringsParityTests passes. SettingsSheetPresentationTests' testSettingsSheetPresentsWhenFlagIsTrue fails identically on main (sim-harness baseline red, verified via stash) — the sheet presents fine on-device via the -openSettings deep link.

<!--
Thanks for the PR. Read CONTRIBUTING.md and CLAUDE.md if you haven't.
Skip sections that don't apply.
-->

## What

<!-- One sentence: what does this PR change? -->

## Why

<!-- One paragraph: what problem does this solve? Link the issue. -->

Closes #

## Three-pillar check

Before merging, confirm this change respects:

- [ ] **Map-First** — does not move users away from the map without strong reason
- [ ] **Experience-as-Unit** — does not introduce "place" / "POI" concepts at the domain level
- [ ] **AI doesn't decide** — recommendations remain options + reasons, not single answers

If any is violated, explain in **Why** above why an exception is justified.

## Schema impact

<!-- Did you add/remove/rename a field in packages/core? If yes, the iOS app must mirror. -->

- [ ] No schema change
- [ ] Schema changed — updated TS schema in `packages/core/` to match Swift changes (or vice-versa)
- [ ] Schema changed; iOS parity tracking issue: #

## Testing

<!-- How did you verify? -->

## Screenshots / video

<!-- If UI change. -->
