### PR TITLE
feat(ios): settings simplification + Apple-standard gesture/haptic polish

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		54941425223B5EBAC714ADE9 /* CityOSInterruptionBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58E512BB0C51F4C5887108 /* CityOSInterruptionBudget.swift */; };
 		54952646C79E8F29AF89F4D6 /* VoiceAgentToolRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20208D92E4F564C474E8AEED /* VoiceAgentToolRouter.swift */; };
 		5544DD796A2D4987A7CB9DC9 /* WebSearchEnrichmentSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 977F66FB36894EA4088C2905 /* WebSearchEnrichmentSource.swift */; };
+		559C2ADB38BF9A8E7144EBCF /* DismissibleBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4943B64768A825479867B6EC /* DismissibleBanner.swift */; };
 		561418100F2F7D4D88DE1BC4 /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086B3C207483BA0EBD27451F /* MessageBubble.swift */; };
 		56F3055416F4A5316100F9B2 /* ExperienceCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */; };
 		579468F851C408D34CDC7025 /* TravelerNoteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DB88CF9AE303E72C776B72 /* TravelerNoteStore.swift */; };
@@ -755,6 +756,7 @@
 		488103B60D7D46DB3467EE87 /* ThinkingBorderShimmer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinkingBorderShimmer.swift; sourceTree = "<group>"; };
 		48ADAE2497800574C4E8819B /* GroupConversationAutoCreateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupConversationAutoCreateTests.swift; sourceTree = "<group>"; };
 		48FF87CCF00DEEE87B290812 /* MapViewModelCityRegionSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModelCityRegionSyncTests.swift; sourceTree = "<group>"; };
+		4943B64768A825479867B6EC /* DismissibleBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissibleBanner.swift; sourceTree = "<group>"; };
 		49F36F9AC9ED0AE7E3F0E5EA /* NotificationServiceHandleURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceHandleURLTests.swift; sourceTree = "<group>"; };
 		4A5F0C6695E934C430648EA4 /* PrintFulfillmentClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintFulfillmentClient.swift; sourceTree = "<group>"; };
 		4ABE29FC4F9EBBBF8C3C61C4 /* LiveSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveSheet.swift; sourceTree = "<group>"; };
@@ -1204,6 +1206,7 @@
 				2294AF173D063B1F55894696 /* CompletionCelebrationView.swift */,
 				EC8F9EFD56A2C839428AA92D /* ConfidenceBadge.swift */,
 				03EC45C610C546626FABA9F7 /* DesignTokens.swift */,
+				4943B64768A825479867B6EC /* DismissibleBanner.swift */,
 				9DF52264EDAC06D283132721 /* ExperiencePreviewCard.swift */,
 				C5C3BA25EFA9F149FB4FAAB3 /* FavoritesListView.swift */,
 				B39F3D5F813E5C3B23C7EE30 /* FlowLayout.swift */,
@@ -2631,6 +2634,7 @@
 				B6B9B93525A5E3F8DD5EA34E /* DiscoverPostDetailView.swift in Sources */,
 				86FFAC8B5D235B7AEBA6408C /* DiscoverRecruitingRoutesView.swift in Sources */,
 				EDBD7B0E715165E71BC0C17D /* DiscoveredCityRecord.swift in Sources */,
+				559C2ADB38BF9A8E7144EBCF /* DismissibleBanner.swift in Sources */,
 				F11FDDDC600A1EF9C08E8193 /* EnrichmentAgent.swift in Sources */,
 				EC922EEF8917DDACE1388F06 /* EntitlementBanner.swift in Sources */,
 				1964F1B56FDCF7880F068967 /* EventMarkerView.swift in Sources */,

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -15,6 +15,7 @@
 "filter.saved.a11y" = "Saved, %d favourited experiences";
 "filter.solo.agent" = "Ask Solo";
 "filter.solo.agent.a11y" = "Ask Solo Agent for a nearby suggestion";
+"filter.solo.agent.seed" = "What's worth doing near me right now?";
 "filter.taste.rank" = "My taste";
 "filter.taste.rank.a11y" = "Sort results by your taste profile";
 "filter.pill.clear.hint" = "Double tap to clear this filter";
@@ -173,7 +174,7 @@
 /* Voice */
 "voice.processing" = "Thinking: %@";
 "voice.button" = "Voice input";
-"voice.button.hint" = "Double tap to start recording, double tap again to stop";
+"voice.button.hint" = "Hold to speak, release to send, slide up to cancel. Or double tap to start and stop.";
 "voice.button.value.recording" = "Recording";
 "voice.button.value.idle" = "Idle";
 "voice.a11y.toggle" = "Start/Stop voice input";
@@ -423,6 +424,9 @@
 /* Empty-release hints shown above the button when no speech was captured */
 "voice.recording.empty" = "Didn't catch that — hold to speak";
 "voice.recording.tooShort" = "Hold the mic to speak";
+"voice.recording.cancelled" = "Cancelled — slid up to discard";
+"voice.recording.slideToCancel" = "Slide up to cancel";
+"voice.recording.releaseToCancel" = "Release to cancel";
 
 /* Voice recognition error alert */
 "voice.error.title" = "Voice recognition error";
@@ -1635,6 +1639,8 @@
 "route.create.pickLabel" = "選擇地點（按點選順序串聯）";
 "route.create.selectedCount" = "已選 %d";
 "route.create.save" = "保存";
+"route.create.empty" = "No nearby places to build from yet — try Explore first, or widen your distance in Settings.";
+"route.create.ai.error" = "Couldn't build the route this time — check your connection and try again.";
 
 /* Active route drawn on the map (start route) */
 "route.active.stops" = "%d 站 · 路線中";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -15,6 +15,7 @@
 "filter.saved.a11y" = "收藏，%d 个已收藏的体验";
 "filter.solo.agent" = "问 Solo";
 "filter.solo.agent.a11y" = "让 Solo 给一个附近的建议";
+"filter.solo.agent.seed" = "此刻附近有什么值得去的？";
 "filter.taste.rank" = "我的菜";
 "filter.taste.rank.a11y" = "按你的口味画像排序结果";
 "filter.a11y.resultsAnnounce" = "%1$@：找到 %2$d 个";
@@ -1575,6 +1576,8 @@
 "route.create.pickLabel" = "选择地点（按点选顺序串联）";
 "route.create.selectedCount" = "已选 %d";
 "route.create.save" = "保存";
+"route.create.empty" = "附近还没有可以串联的地点——先去探索一下，或在设置里调大距离范围。";
+"route.create.ai.error" = "这次没能生成路线——检查网络后再试一次。";
 
 /* Active route drawn on the map (start route) */
 "route.active.stops" = "%d 站 · 路线中";
@@ -1621,7 +1624,7 @@
 "voice.a11y.toggle" = "开始/停止语音输入";
 "voice.announcement.listening" = "正在聆听…";
 "voice.announcement.stopped" = "已停止录音";
-"voice.button.hint" = "双击开始录音，再次双击停止";
+"voice.button.hint" = "长按说话，松开发送，上滑取消。或双击开始、再双击停止。";
 "voice.button.value.idle" = "空闲";
 "voice.button.value.recording" = "录音中";
 "voice.recording.maxReached" = "已达最大时长";
@@ -2054,6 +2057,9 @@
 "voice.recording.empty" = "没听清 — 长按说话";
 "voice.recording.secondsLeft" = "剩余 %d 秒";
 "voice.recording.tooShort" = "长按麦克风说话";
+"voice.recording.cancelled" = "已取消 — 上滑放弃";
+"voice.recording.slideToCancel" = "上滑取消";
+"voice.recording.releaseToCancel" = "松开取消";
 
 /* Map style picker */
 "map.style.standard" = "标准";

--- a/apps/ios/SoloCompass/Tests/PressableButtonStyleHapticTest.swift
+++ b/apps/ios/SoloCompass/Tests/PressableButtonStyleHapticTest.swift
@@ -18,13 +18,25 @@ final class PressableButtonStyleHapticTest: XCTestCase {
         }
     }
 
-    /// Invariant 1: `Haptics.selection()` must be called inside `makeBody` so
-    /// every press-down fires a light selection haptic.
+    /// Invariant 1: `Haptics.selection()` must still be wired in `makeBody` so
+    /// opted-in surfaces (`haptic: true`) get their commit haptic.
     func testHapticsSelectionIsCalled() throws {
         XCTAssertTrue(
             try source.contains("Haptics.selection()"),
-            "PressableButtonStyle must call `Haptics.selection()` on press-down "
-                + "to provide consistent tactile feedback across all tappable surfaces."
+            "PressableButtonStyle must retain the `Haptics.selection()` call so "
+                + "opt-in (`haptic: true`) surfaces still fire their commit haptic."
+        )
+    }
+
+    /// Invariant 1b: the haptic must fire on *release/commit*, not press-down.
+    /// A haptic on touch-down merely acknowledges a finger landing; the
+    /// meaningful confirmation is that the action committed. Enforced by
+    /// requiring the release-edge check `wasPressed && !isPressed`.
+    func testHapticFiresOnReleaseNotPressDown() throws {
+        XCTAssertTrue(
+            try source.contains("wasPressed && !isPressed"),
+            "PressableButtonStyle must gate the haptic on the release edge "
+                + "(`wasPressed && !isPressed`) so it confirms the commit, not the press-down."
         )
     }
 
@@ -48,13 +60,16 @@ final class PressableButtonStyleHapticTest: XCTestCase {
         )
     }
 
-    /// Invariant 4: the `haptic` parameter must default to `true` so existing
-    /// call sites gain haptic feedback without any modification.
-    func testHapticParameterDefaultsToTrue() throws {
+    /// Invariant 4: the `haptic` parameter must default to `false`. The audit
+    /// found this style on ~34 buttons with only 2 opting out, so the app buzzed
+    /// on essentially every button press — including plain navigation — which
+    /// trains users to ignore haptics (HIG). Meaningful commit surfaces opt in
+    /// explicitly with `haptic: true`; the default stays silent.
+    func testHapticParameterDefaultsToFalse() throws {
         XCTAssertTrue(
-            try source.contains("haptic: Bool = true"),
-            "PressableButtonStyle.init must declare `haptic: Bool = true` so "
-                + "all existing call sites compile without modification."
+            try source.contains("haptic: Bool = false"),
+            "PressableButtonStyle.init must declare `haptic: Bool = false` so the "
+                + "app doesn't buzz on every button press; commit surfaces opt in explicitly."
         )
     }
 

--- a/apps/ios/SoloCompass/Views/CityOS/VerifySheet.swift
+++ b/apps/ios/SoloCompass/Views/CityOS/VerifySheet.swift
@@ -60,20 +60,40 @@ struct VerifySheet: View {
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(NSLocalizedString("cityos.verify.title", comment: "30 秒，帮下一个独行者"))
-                .ctDisplay(18, .bold)
-                .foregroundStyle(primaryText)
-            Text(String(
-                format: NSLocalizedString(
-                    "cityos.verify.subtitle",
-                    comment: "%@ —— 三下点完，你的印证会直接进入这个点的信心分"
-                ),
-                placeName
-            ))
-            .ctBody(12.5)
-            .foregroundStyle(CT.fgMuted)
-            .fixedSize(horizontal: false, vertical: true)
+        // The submit stays gated on all-three-answered, but a traveler who
+        // opens this and decides not to answer must have a *visible* exit — not
+        // just the drag indicator. An explicit close button keeps the flow from
+        // being a dead-end (HIG: never trap the user) while preserving the
+        // "half-filled verification is worse than none" gate on Submit itself.
+        HStack(alignment: .top, spacing: 8) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(NSLocalizedString("cityos.verify.title", comment: "30 秒，帮下一个独行者"))
+                    .ctDisplay(18, .bold)
+                    .foregroundStyle(primaryText)
+                Text(String(
+                    format: NSLocalizedString(
+                        "cityos.verify.subtitle",
+                        comment: "%@ —— 三下点完，你的印证会直接进入这个点的信心分"
+                    ),
+                    placeName
+                ))
+                .ctBody(12.5)
+                .foregroundStyle(CT.fgMuted)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 8)
+            Button {
+                Haptics.selection()
+                onDismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(CT.fgMuted)
+                    .frame(width: 30, height: 30)
+                    .background(Circle().fill(optionFill))
+            }
+            .buttonStyle(PressableButtonStyle(pressedScale: 0.9, haptic: false))
+            .accessibilityLabel(Text(NSLocalizedString("common.close", comment: "Close")))
         }
     }
 

--- a/apps/ios/SoloCompass/Views/Companion/CompanionProfileView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/CompanionProfileView.swift
@@ -48,26 +48,31 @@ public struct MyProfileEditView: View {
 
     public var body: some View {
         @Bindable var prefs = preferences
-        NavigationStack {
-            Form {
-                avatarSection(prefs: $prefs)
-                handleSection
-                bioSection(prefs: $prefs)
-                languagesSection(prefs: $prefs)
-                visibilitySection(prefs: $prefs)
-                if preferences.companionEnabled {
-                    walkedRoutesSection
-                }
+        // NOTE: This view is always reached by `NavigationLink` push from a
+        // parent stack (MeSheet ×2, SettingsView.CompanionHubView). It must NOT
+        // declare its own `NavigationStack` — a nested stack renders a double
+        // nav bar and, critically, kills the system edge-swipe-back gesture for
+        // this whole screen and its inner walked-routes push. Every peer detail
+        // view in the module (RouteDetailView, ItineraryDetailView, ChatView…)
+        // correctly inherits the parent stack; this one now matches.
+        Form {
+            avatarSection(prefs: $prefs)
+            handleSection
+            bioSection(prefs: $prefs)
+            languagesSection(prefs: $prefs)
+            visibilitySection(prefs: $prefs)
+            if preferences.companionEnabled {
+                walkedRoutesSection
             }
-            .navigationTitle(NSLocalizedString("profile.edit.title", comment: "My Profile nav title"))
-            .navigationBarTitleDisplayMode(.large)
-            .onAppear {
-                loadWalkedRoutes()
-                handleDraft = preferences.displayHandle
-            }
-            .navigationDestination(isPresented: $showAllWalked) {
-                MyWalkedRoutesListView(routes: walkedRoutes)
-            }
+        }
+        .navigationTitle(NSLocalizedString("profile.edit.title", comment: "My Profile nav title"))
+        .navigationBarTitleDisplayMode(.large)
+        .onAppear {
+            loadWalkedRoutes()
+            handleDraft = preferences.displayHandle
+        }
+        .navigationDestination(isPresented: $showAllWalked) {
+            MyWalkedRoutesListView(routes: walkedRoutes)
         }
     }
 

--- a/apps/ios/SoloCompass/Views/Companion/Components/AvatarStack.swift
+++ b/apps/ios/SoloCompass/Views/Companion/Components/AvatarStack.swift
@@ -24,7 +24,6 @@ public struct AvatarStack: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var appeared = false
     @State private var showAll = false
-    @State private var pressed = false
 
     private var overlap: CGFloat { size * 0.32 }
 
@@ -126,28 +125,27 @@ public struct AvatarStack: View {
         }
     }
 
+    // A real Button, not a `.simultaneousGesture(DragGesture(minimumDistance:0))`
+    // acting as the tap. This component is embedded inside RouteCard, which
+    // lives in the BottomInfoSheet's ScrollView; a zero-distance drag there
+    // claims the touch the instant a finger lands, so the host scroll view
+    // classifies the release as a drag and the "show all" popover either
+    // misfires while scrolling or swallows the scroll. A Button + ButtonStyle
+    // lets the tap reach the action and the scroll pass through — the same fix
+    // already applied to RouteCard / CreateRouteView. See [[project_dead_fab_sheet_wiring]].
     private var overflowButton: some View {
-        overflowBubble
-            .scaleEffect(pressed ? 0.94 : 1.0)
-            .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.6), value: pressed)
-            .contentShape(Circle())
-            .simultaneousGesture(
-                DragGesture(minimumDistance: 0)
-                    .onChanged { _ in
-                        if !reduceMotion { pressed = true }
-                    }
-                    .onEnded { _ in
-                        pressed = false
-                        Haptics.selection()
-                        showAll = true
-                    }
-            )
-            .accessibilityAddTraits(.isButton)
-            .accessibilityHint(NSLocalizedString("avatarstack.overflow.hint", comment: ""))
-            .popover(isPresented: $showAll) {
-                membersPopover
-                    .presentationCompactAdaptation(.popover)
-            }
+        Button {
+            Haptics.selection()
+            showAll = true
+        } label: {
+            overflowBubble
+        }
+        .buttonStyle(PressableButtonStyle(pressedScale: 0.94, haptic: false))
+        .accessibilityHint(NSLocalizedString("avatarstack.overflow.hint", comment: ""))
+        .popover(isPresented: $showAll) {
+            membersPopover
+                .presentationCompactAdaptation(.popover)
+        }
     }
 
     private var membersPopover: some View {

--- a/apps/ios/SoloCompass/Views/Companion/CreateRouteView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/CreateRouteView.swift
@@ -77,6 +77,10 @@ struct CreateRouteView: View {
     let candidates: [Experience]
     let cityCode: String
     let userCoordinate: CLLocationCoordinate2D?
+    /// When true, the AI generation starts as soon as the sheet appears —
+    /// used by entries whose copy promises Solo picks the stops (the Now
+    /// section's "让 Solo 为你拼一条" placeholder). Manual entries pass false.
+    var autoGenerate: Bool = false
     /// Called with the saved route so the caller can persist + refresh.
     let onSave: (Route) -> Void
 
@@ -88,6 +92,10 @@ struct CreateRouteView: View {
     @State private var pace: Pace = .relaxed
     @State private var isGenerating = false
     @State private var aiSummary: String?
+    /// Non-nil after a failed AI generation. The old `try?`-and-return made
+    /// the ✨ button a silent no-op on any error (missing key, network, quota)
+    /// — the user tapped, nothing loaded, nothing explained itself.
+    @State private var generateErrorText: String?
 
     /// Selected experiences in selection order (the walk order).
     private var orderedSelection: [Experience] {
@@ -101,6 +109,7 @@ struct CreateRouteView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
                     aiGenerateButton
+                    generateErrorBanner
                     summaryHeader
                     titleField
                     pacePicker
@@ -111,6 +120,13 @@ struct CreateRouteView: View {
             .background(CT.bgWarm)
             .navigationTitle(NSLocalizedString("route.create.title", comment: "Create route nav title"))
             .navigationBarTitleDisplayMode(.inline)
+            // Honour the "Solo picks the stops" promise: kick the generation
+            // off on open. `.task` runs once per appearance; the guard keeps
+            // it from clobbering a session where the user already picked.
+            .task {
+                guard autoGenerate, selectedIds.isEmpty, candidates.count >= 2 else { return }
+                await generate()
+            }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(NSLocalizedString("action.cancel", comment: "Cancel")) { dismiss() }
@@ -122,6 +138,9 @@ struct CreateRouteView: View {
                 }
             }
         }
+        // Once stops are picked or a title is typed, block swipe-to-dismiss so a
+        // stray gesture can't discard the walk-in-progress; Cancel is the exit.
+        .interactiveDismissDisabled(!selectedIds.isEmpty || !title.trimmingCharacters(in: .whitespaces).isEmpty)
     }
 
     // MARK: - Sections
@@ -147,6 +166,30 @@ struct CreateRouteView: View {
         }
         .buttonStyle(.plain)
         .disabled(isGenerating || candidates.count < 2)
+        // `.disabled` alone doesn't dim a plain-style button with explicit
+        // foreground/background colors — it looked fully tappable while
+        // candidates were empty, reading as a dead button. Make the disabled
+        // state visible.
+        .opacity(candidates.count < 2 ? 0.4 : 1)
+    }
+
+    /// Error surface for a failed AI generation (replaces the silent no-op).
+    @ViewBuilder
+    private var generateErrorBanner: some View {
+        if let generateErrorText {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 11, weight: .semibold))
+                Text(generateErrorText)
+                    .font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .foregroundStyle(CT.fgMuted)
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(RoundedRectangle(cornerRadius: 9, style: .continuous).fill(CT.surfaceWhite))
+            .overlay(RoundedRectangle(cornerRadius: 9, style: .continuous).strokeBorder(CT.borderSubtle, lineWidth: 0.5))
+        }
     }
 
     @ViewBuilder
@@ -207,8 +250,22 @@ struct CreateRouteView: View {
                 .font(.caption2.monospacedDigit())
                 .foregroundStyle(CT.fgSubtle)
             }
-            ForEach(candidates) { exp in
-                selectRow(exp)
+            if candidates.isEmpty {
+                // Dead-end guard: with zero candidates both paths (manual pick
+                // + AI generate) are unusable — say so instead of rendering a
+                // blank section under an inert button.
+                Text(NSLocalizedString(
+                    "route.create.empty",
+                    comment: "Shown when no nearby experiences are available to build a route from"
+                ))
+                .font(.caption)
+                .foregroundStyle(CT.fgMuted)
+                .padding(.vertical, 12)
+                .frame(maxWidth: .infinity, alignment: .center)
+            } else {
+                ForEach(candidates) { exp in
+                    selectRow(exp)
+                }
             }
         }
     }
@@ -272,17 +329,27 @@ struct CreateRouteView: View {
 
     private func generate() async {
         isGenerating = true
+        generateErrorText = nil
         defer { isGenerating = false }
-        guard let route = try? await aiService.generateRoute(
-            from: candidates,
-            cityCode: cityCode,
-            userCoordinate: userCoordinate
-        ) else { return }
-        // Adopt the AI's ordering + copy as the editable starting point.
-        selectedIds = route.experienceIds
-        if title.isEmpty { title = route.title }
-        aiSummary = route.summary
-        pace = route.pace
+        do {
+            let route = try await aiService.generateRoute(
+                from: candidates,
+                cityCode: cityCode,
+                userCoordinate: userCoordinate
+            )
+            // Adopt the AI's ordering + copy as the editable starting point.
+            selectedIds = route.experienceIds
+            if title.isEmpty { title = route.title }
+            aiSummary = route.summary
+            pace = route.pace
+        } catch {
+            // Surface the failure — the previous `try?` swallowed every error
+            // (missing key, network, quota) and the button read as broken.
+            generateErrorText = NSLocalizedString(
+                "route.create.ai.error",
+                comment: "Shown when AI route generation fails"
+            )
+        }
     }
 
     private func save() {

--- a/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/DiscoverListView.swift
@@ -309,7 +309,6 @@ private struct DiscoverPostRow: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var appeared = false
-    @State private var pressed = false
 
     private static let dateFormatter: DateFormatter = {
         let f = DateFormatter()
@@ -414,18 +413,12 @@ private struct DiscoverPostRow: View {
         .buttonStyle(.bordered)
         .tint(hasSentRequest ? .green : CT.accent)
         .disabled(hasSentRequest)
-        .scaleEffect(pressed ? 0.96 : 1)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in
-                    guard !reduceMotion, !pressed else { return }
-                    withAnimation(.easeOut(duration: 0.12)) { pressed = true }
-                }
-                .onEnded { _ in
-                    guard !reduceMotion else { return }
-                    withAnimation(.easeOut(duration: 0.12)) { pressed = false }
-                }
-        )
+        // No overlaid `.simultaneousGesture(DragGesture(minimumDistance:0))`
+        // press-scale: this row sits in a List, where a zero-distance drag
+        // competes with the list's own scroll recognizer and flashes a phantom
+        // press-down as the user scrolls past. `.bordered` already provides a
+        // system press state, so the hand-rolled scale was both redundant and a
+        // scroll conflict. Matches the sibling addFriendButton.
     }
 
     /// US-016: opens the trust-gated [Add Friend] detail for this post.

--- a/apps/ios/SoloCompass/Views/Companion/ItineraryFormView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ItineraryFormView.swift
@@ -64,6 +64,28 @@ public struct ItineraryFormView: View {
 
     private var endBeforeStart: Bool { endDate < startDate }
 
+    /// True once the user has entered anything not yet saved. Drives
+    /// `interactiveDismissDisabled` so an accidental swipe-down can't silently
+    /// discard a half-filled form — HIG requires unsaved edits to be protected
+    /// (Mail/Contacts prompt "Discard Changes?"; here we simply block the swipe
+    /// so the explicit Cancel is the only way out). New form: dirty if any field
+    /// diverges from its empty default. Editing: dirty if any field diverges
+    /// from the record being edited.
+    private var isDirty: Bool {
+        if let editing {
+            return title != (editing.title)
+                || selectedCityCode != (editing.cityCode)
+                || note != (editing.note)
+                || openToCompanions != editing.openToCompanions
+                || startDate != (iso8601DateOrToday(editing.startDate) ?? startDate)
+                || endDate != (iso8601DateOrToday(editing.endDate) ?? endDate)
+        }
+        return !title.trimmingCharacters(in: .whitespaces).isEmpty
+            || !selectedCityCode.isEmpty
+            || !note.trimmingCharacters(in: .whitespaces).isEmpty
+            || openToCompanions
+    }
+
     // MARK: - Body
 
     public var body: some View {
@@ -154,12 +176,16 @@ public struct ItineraryFormView: View {
             ))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
+                // `.cancellationAction` / `.confirmationAction` let the system
+                // place Cancel (leading) and Save (trailing) per-platform
+                // convention, instead of hard-coding topBarLeading/Trailing.
+                // This is the app-wide standard the sheet audit calls for.
+                ToolbarItem(placement: .cancellationAction) {
                     Button(NSLocalizedString("itinerary.form.action.cancel", comment: "Cancel")) {
                         dismiss()
                     }
                 }
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: .confirmationAction) {
                     Button(NSLocalizedString("itinerary.form.action.save", comment: "Save")) {
                         save()
                     }
@@ -174,6 +200,9 @@ public struct ItineraryFormView: View {
                 )
             }
         }
+        // Block accidental swipe-to-dismiss while there are unsaved edits; the
+        // explicit Cancel stays the deliberate exit.
+        .interactiveDismissDisabled(isDirty)
     }
 
     // MARK: - Save

--- a/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/ItineraryListView.swift
@@ -13,7 +13,6 @@ public struct ItineraryListView: View {
     @State private var undoDismissTask: Task<Void, Never>?
     @State private var undoProgress: CGFloat = 1
     @State private var undoDragOffset: CGFloat = 0
-    @State private var undoDragCrossedThreshold = false
 
     /// Production init using the shared on-disk container.
     public init() {
@@ -172,34 +171,21 @@ public struct ItineraryListView: View {
         }
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
         .padding(.horizontal, 16)
-        .offset(y: undoDragOffset)
-        .gesture(
-            DragGesture()
-                .onChanged { gesture in
-                    undoDragOffset = max(0, gesture.translation.height * 0.85)
-                    let overThreshold = gesture.translation.height > 80
-                    if overThreshold && !undoDragCrossedThreshold {
-                        undoDragCrossedThreshold = true
-                        Haptics.selection()
-                    } else if !overThreshold && undoDragCrossedThreshold {
-                        undoDragCrossedThreshold = false
-                    }
+        // Shared drag-to-dismiss (down). Replaces the hand-rolled `* 0.85` +
+        // `translation > 80` code with the app's reference gesture model:
+        // 1:1 tracking, momentum projection (a quick flick dismisses), and a
+        // velocity-continuous settle.
+        .dismissibleBanner(
+            offset: $undoDragOffset,
+            edge: .down,
+            onDismiss: {
+                undoDismissTask?.cancel()
+                undoDismissTask = nil
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    withAnimation(.easeInOut) { lastDeleted = nil }
+                    undoDragOffset = 0
                 }
-                .onEnded { gesture in
-                    undoDragCrossedThreshold = false
-                    if gesture.translation.height > 80 {
-                        Haptics.impact(.soft)
-                        withAnimation(.easeOut(duration: 0.2)) { undoDragOffset = 300 }
-                        undoDismissTask?.cancel()
-                        undoDismissTask = nil
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                            withAnimation(.easeInOut) { lastDeleted = nil }
-                            undoDragOffset = 0
-                        }
-                    } else {
-                        withAnimation(.spring(response: 0.3)) { undoDragOffset = 0 }
-                    }
-                }
+            }
         )
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(String(

--- a/apps/ios/SoloCompass/Views/Companion/OpenForCompanionsSheet.swift
+++ b/apps/ios/SoloCompass/Views/Companion/OpenForCompanionsSheet.swift
@@ -60,12 +60,12 @@ public struct OpenForCompanionsSheet: View {
             ))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
+                ToolbarItem(placement: .cancellationAction) {
                     Button(NSLocalizedString("action.cancel", comment: "Cancel")) {
                         dismiss()
                     }
                 }
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: .confirmationAction) {
                     Button(NSLocalizedString(
                         "openForCompanions.submit",
                         comment: "Submit button: create recruiting route"
@@ -79,6 +79,14 @@ public struct OpenForCompanionsSheet: View {
         }
         .presentationDetents([.large])
         .presentationDragIndicator(.visible)
+        // Protect an edited recruiting form (host message typed, or any default
+        // pace/size/visibility changed) from a stray swipe-down.
+        .interactiveDismissDisabled(
+            !hostMessage.trimmingCharacters(in: .whitespaces).isEmpty
+                || pace != .standard
+                || maxMembers != 4
+                || visibility != .public
+        )
     }
 
     // MARK: - Sections

--- a/apps/ios/SoloCompass/Views/Companion/RouteDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Companion/RouteDetailView.swift
@@ -392,7 +392,7 @@ public struct RouteDetailView: View {
                 // Ghost button — favorite
                 Button {
                     let willFavorite = !isFavorited
-                    withAnimation(.spring(response: 0.3, dampingFraction: 0.45)) {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                         isFavorited.toggle()
                     }
                     if willFavorite {
@@ -407,7 +407,7 @@ public struct RouteDetailView: View {
                         .foregroundStyle(isFavorited ? CT.toneClosed : CT.fgMuted)
                         .symbolEffect(.bounce, value: isFavorited)
                         .scaleEffect(isFavorited ? 1.12 : 1.0)
-                        .animation(.spring(response: 0.3, dampingFraction: 0.45), value: isFavorited)
+                        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFavorited)
                         .frame(width: 44, height: 44)
                         .background(Circle().fill(CT.surfaceSunken))
                         .overlay { HeartBurstView(trigger: heartBurstTrigger) }

--- a/apps/ios/SoloCompass/Views/Companion/SendRequestSheet.swift
+++ b/apps/ios/SoloCompass/Views/Companion/SendRequestSheet.swift
@@ -101,12 +101,12 @@ struct SendRequestSheet: View {
             .navigationTitle(NSLocalizedString(titleKey, comment: "Send request sheet title"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
+                ToolbarItem(placement: .cancellationAction) {
                     Button(NSLocalizedString("action.cancel", comment: "Cancel")) {
                         dismiss()
                     }
                 }
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: .confirmationAction) {
                     Button(NSLocalizedString("companion.request.send.action", comment: "Send button")) {
                         onSend(note.trimmingCharacters(in: .whitespaces).isEmpty ? nil : note)
                         dismiss()
@@ -117,6 +117,8 @@ struct SendRequestSheet: View {
         }
         .presentationDetents([.medium])
         .presentationDragIndicator(.visible)
+        // Protect a typed-but-unsent icebreaker from an accidental swipe-down.
+        .interactiveDismissDisabled(!note.trimmingCharacters(in: .whitespaces).isEmpty)
     }
 }
 

--- a/apps/ios/SoloCompass/Views/Experience/CreateExperienceSheet.swift
+++ b/apps/ios/SoloCompass/Views/Experience/CreateExperienceSheet.swift
@@ -52,6 +52,16 @@ public struct CreateExperienceSheet: View {
         !placeName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    /// Any field touched or photo added → protect against an accidental
+    /// swipe-to-dismiss discarding the draft (HIG: guard unsaved edits).
+    private var isDirty: Bool {
+        !placeName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !placeNameLocal.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !oneLiner.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !images.isEmpty
+    }
+
     public var body: some View {
         NavigationStack {
             Form {
@@ -87,6 +97,7 @@ public struct CreateExperienceSheet: View {
                 Task { await loadPickedImages(newItems) }
             }
         }
+        .interactiveDismissDisabled(isDirty)
     }
 
     // MARK: - Sections

--- a/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ExperienceDetailView.swift
@@ -189,9 +189,15 @@ public struct ExperienceDetailView: View {
         .navigationTitle(heroTitleVisible ? "" : viewModel.experience.title)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
+            // Close uses the app-standard `xmark`, not a bespoke `chevron.down`.
+            // This is the most-opened sheet in the app; every other sheet closes
+            // with an xmark/Done, so a unique down-chevron here made users
+            // re-learn the dismiss affordance. `.cancellationAction` lets the
+            // system place it (leading) while the ··· menu keeps the trailing
+            // slot — a valid HIG split for a browse sheet with a secondary menu.
+            ToolbarItem(placement: .cancellationAction) {
                 Button(action: onClose) {
-                    Image(systemName: "chevron.down")
+                    Image(systemName: "xmark")
                 }
                 .accessibilityLabel(Text(NSLocalizedString("action.close", comment: "Close detail sheet")))
             }
@@ -1614,7 +1620,7 @@ public struct ExperienceDetailView: View {
                     : NSLocalizedString("action.favorite", comment: "Add favorite")
             ) {
                 let willFavorite = !viewModel.isFavorited
-                withAnimation(.spring(response: 0.3, dampingFraction: 0.45)) {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                     viewModel.toggleFavorite()
                 }
                 if willFavorite {

--- a/apps/ios/SoloCompass/Views/Experience/ReportIssueSheet.swift
+++ b/apps/ios/SoloCompass/Views/Experience/ReportIssueSheet.swift
@@ -59,10 +59,10 @@ public struct ReportIssueSheet: View {
             .navigationTitle(NSLocalizedString("report.title", comment: "Report an Issue"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
+                ToolbarItem(placement: .cancellationAction) {
                     Button(NSLocalizedString("report.cancel", comment: "Cancel"), action: onCancel)
                 }
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: .confirmationAction) {
                     Button(NSLocalizedString("report.submit", comment: "Submit")) {
                         guard let reason = selectedReason else { return }
                         UINotificationFeedbackGenerator().notificationOccurred(.success)
@@ -74,6 +74,12 @@ public struct ReportIssueSheet: View {
             }
         }
         .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        // Guard a partly-composed report (reason chosen or detail typed) from a
+        // stray swipe-down; Cancel remains the deliberate exit.
+        .interactiveDismissDisabled(
+            selectedReason != nil || !detail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        )
     }
 
     // MARK: - Helpers

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -767,9 +767,9 @@ struct SortCountToolbar: View {
 
     private var sortButton: some View {
         Button {
-            #if canImport(UIKit)
-            Haptics.selection()
-            #endif
+            // No haptic on open: merely surfacing the sort options isn't a
+            // commit. The single meaningful buzz fires in `onChange(of:sortMode)`
+            // when the sort actually changes.
             showSortSheet = true
         } label: {
             HStack(spacing: 4) {
@@ -837,10 +837,11 @@ struct SortModeSheet: View {
 
             ForEach(SortMode.allCases) { mode in
                 Button {
-                    #if canImport(UIKit)
-                    Haptics.selection()
-                    #endif
-                    withAnimation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7)) {
+                    // No haptic here: changing `sortMode` propagates to the
+                    // parent SortCountToolbar's `onChange(of: sortMode)`, which
+                    // owns the single selection haptic. Buzzing here too made
+                    // one pick fire twice.
+                    withAnimation(reduceMotion ? nil : Motion.momentumPop) {
                         sortMode = mode
                     }
                     dismiss()

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -46,8 +46,11 @@ enum MapStyleChoice: String, CaseIterable {
 enum RouteSheet: Identifiable {
     /// Open a route's detail view.
     case detail(Route)
-    /// Open the create-your-own-route flow.
-    case create
+    /// Open the create-your-own-route flow. `autoGenerate: true` kicks off
+    /// the AI stringing immediately on open — used by the Now section's
+    /// "让 Solo 为你拼一条" placeholder, whose copy promises Solo picks the
+    /// stops (landing on a blank manual form broke that promise).
+    case create(autoGenerate: Bool)
 
     var id: String {
         switch self {
@@ -1165,12 +1168,17 @@ struct CompassMapContentView: View {
                 )
                 .environment(experienceService)
             }
-        case .create:
+        case .create(let autoGenerate):
             CreateRouteView(
-                candidates: viewModel.visibleExperiences,
+                // Full nearby pool, NOT `visibleExperiences`: the entry card
+                // lives in the Now section, so visibleExperiences arrives
+                // pre-filtered by isBestNow() and is routinely empty — a blank
+                // stop picker and a dead AI button.
+                candidates: viewModel.routeCandidates(),
                 cityCode: viewModel.selectedCity ?? "",
                 userCoordinate: locationService.currentLocation?.coordinate
-                    ?? viewModel.defaultCenterForSelectedCity
+                    ?? viewModel.defaultCenterForSelectedCity,
+                autoGenerate: autoGenerate
             ) { route in
                 // Persist + open the new route's detail; RouteStore.didChange
                 // refreshes the sheet's routes section automatically. Swapping
@@ -1231,7 +1239,21 @@ struct CompassMapContentView: View {
                     isMapPanning: $isMapPanning,
                     mapStyleChoice: $mapStyleChoice,
                     pendingRequestCount: friendService.incomingRequests.count,
-                    onTapAvatar: { isShowingMe = true }
+                    onTapAvatar: { isShowingMe = true },
+                    // P2.5 #250: the FilterBar "Ask Solo" pill opens the chat
+                    // seeded with a "what's good right now" ask — the same
+                    // suggest_now_action shortcut the pill's a11y hint promises.
+                    // (It previously pointed at `selectNowFilter()`, a leftover
+                    // placeholder: with the Now filter already active the tap
+                    // was a visible no-op — a dead button on the main screen.)
+                    onAskSolo: {
+                        pendingDiagnosticsPrompt = NSLocalizedString(
+                            "filter.solo.agent.seed",
+                            comment: "Seed prompt sent when tapping the Ask Solo pill"
+                        )
+                        chatStartMode = .text
+                        ensureOrchestrator(viewModel: viewModel)
+                    }
                 )
 
                 VStack {
@@ -1435,13 +1457,16 @@ struct CompassMapContentView: View {
                                         // below so we keep a single create-route code
                                         // path (no new orchestration).
                                         onProposeRoute: {
-                                            routeSheet = .create
+                                            // The placeholder's copy promises "Solo
+                                            // picks 3 stops" — honour it by starting
+                                            // the AI generation on open.
+                                            routeSheet = .create(autoGenerate: true)
                                         }
                                     )
 
                                     // Create-your-own-route entry, between Routes and Nearby.
                                     CreateRouteEntryCard {
-                                        routeSheet = .create
+                                        routeSheet = .create(autoGenerate: false)
                                     }
                                     .padding(.horizontal, 16)
                                     .padding(.top, 8)
@@ -1726,10 +1751,10 @@ struct CompassMapContentView: View {
                     onSaveWalk: {
                         // Freeze the batch into a route candidate set.
                         // CreateRouteView pulls its candidates from
-                        // `viewModel.visibleExperiences`, which already
+                        // `viewModel.routeCandidates()`, which already
                         // contains the added set at this point.
                         viewModel.exploreClearHandoff()
-                        routeSheet = .create
+                        routeSheet = .create(autoGenerate: false)
                     },
                     onExpand: {
                         viewModel.exploreClearHandoff()
@@ -2115,7 +2140,8 @@ struct CompassMapContentView: View {
                     viewModel.selectExperience(exp)
                 }
             },
-            onExplore: { isShowingFavorites = false }
+            onExplore: { isShowingFavorites = false },
+            onClose: { isShowingFavorites = false }
         )
         .environment(experienceService)
         .environment(preferences)
@@ -2957,6 +2983,11 @@ private struct MapOverlayView: View {
     // the tap opens the personal hub (MeSheet).
     var pendingRequestCount: Int = 0
     var onTapAvatar: () -> Void = {}
+    /// P2.5 #250: the FilterBar's "Ask Solo" pill. The overlay can't reach the
+    /// chat presenter (`ensureOrchestrator` lives on CompassMapContentView),
+    /// so the parent hands the real open-chat action down as a closure —
+    /// same pattern as `onTapAvatar`.
+    var onAskSolo: () -> Void = {}
 
     @State private var checkInCelebrationTrigger = 0
     @State private var noMatchPop = false
@@ -3031,10 +3062,11 @@ private struct MapOverlayView: View {
                 onSelectCustomTag: { viewModel.selectCustomTag($0) },
                 isMapPanning: $isMapPanning,
                 resultCount: viewModel.visibleExperiences.count,
-                // P2.5 hooks: Solo Agent pill fires the map's ambient
-                // "Ask Solo" affordance; taste rank pill toggles the
-                // TasteProfile-weighted ordering.
-                onSoloAgentTap: { viewModel.selectNowFilter() },
+                // P2.5 hooks: Solo Agent pill opens the ChatSheet seeded with
+                // a "what's good right now" ask (the suggest_now_action
+                // shortcut); taste rank pill toggles the TasteProfile-weighted
+                // ordering.
+                onSoloAgentTap: onAskSolo,
                 isTasteRankOn: isTasteRankOn,
                 onTasteRankToggle: { isTasteRankOn = $0 }
             )
@@ -3758,7 +3790,12 @@ private struct MapControlBar: View {
             VStack(spacing: 4) {
                 PlusActionButton(
                     onShortTap: {
-                        Haptics.impact(.medium)
+                        // No haptic here: `PlusActionButton` already fired a
+                        // soft impact on touch-down (the "I've got it" cue that
+                        // pairs with the ring). A second `.medium` on release
+                        // made one tap buzz twice — and opening the chat is a
+                        // navigation, which HIG says shouldn't warrant a heavy
+                        // impact anyway.
                         onOpenChat(.text)
                     },
                     onLongPress: { onOpenChat(.voice) }

--- a/apps/ios/SoloCompass/Views/Shared/DesignTokens.swift
+++ b/apps/ios/SoloCompass/Views/Shared/DesignTokens.swift
@@ -104,6 +104,40 @@ public enum Elevation {
     public static let modal = Preset.modal
 }
 
+// MARK: Motion — semantic spring tokens
+//
+// Collapses the scattered `.spring(response:dampingFraction:)` literals onto a
+// few named intents, following the apple-design (WWDC 2018 "Designing Fluid
+// Interfaces") rule: **only momentum-driven interactions (flick / throw / drag
+// release) get overshoot; everything else is critically-damped.** The audit
+// found 55% of springs carried a bounce (dampingFraction < 0.8), a large share
+// of them on press-down and pure fade-in surfaces where overshoot reads as
+// "cheap wobble". Adopt these tokens to snap those onto one disciplined feel.
+//
+// `BottomInfoSheet` is the reference for `.settle`; its response/damping were
+// tuned on-device and these values mirror it exactly.
+public enum Motion {
+    /// Press-down / release feedback for tappable surfaces. A touch is a static
+    /// press with no momentum, so this is near-critically damped — crisp like a
+    /// system button, with only the faintest settle, never a visible wobble.
+    public static let press = Animation.spring(response: 0.22, dampingFraction: 0.82)
+
+    /// Content appearing / fading in (sheets, rows, disclosure). Pure arrival
+    /// carries no momentum → critically damped, zero overshoot. Overshoot on a
+    /// menu that just faded in feels wrong (apple-design §4).
+    public static let appear = Animation.spring(response: 0.32, dampingFraction: 0.95)
+
+    /// A small tactile "pop" that IS meant to overshoot a touch: a count badge
+    /// ticking, a heart bursting, an item snapping home. The one place a gentle
+    /// bounce is on-spec because it reads as physical feedback, not decoration.
+    public static let momentumPop = Animation.spring(response: 0.3, dampingFraction: 0.7)
+
+    /// A drag release settling to its resting position / nearest detent. Mirrors
+    /// `BottomInfoSheet`'s on-device-tuned settle. Slight give so a flick lands
+    /// with life, but damped enough not to ring.
+    public static let settle = Animation.spring(response: 0.3, dampingFraction: 0.85)
+}
+
 public extension View {
     /// Applies a named elevation preset. Replaces bespoke `.shadow(color:radius:x:y:)`
     /// calls so the app has exactly three shadow depths.

--- a/apps/ios/SoloCompass/Views/Shared/DismissibleBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/DismissibleBanner.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+// MARK: - DismissibleBanner
+//
+// A reusable "drag-to-dismiss" transient banner (undo toasts, check-in prompts).
+// It distils the on-device-tuned gesture model from `BottomInfoSheet` /
+// `ChatCardStack.ProvisionalCardRow` — the two reference implementations in the
+// app — into one modifier so the three hand-rolled copies (FavoritesListView,
+// ItineraryListView, PendingCheckInBanner) stop drifting apart.
+//
+// The three properties an Apple-grade drag-to-dismiss must have (WWDC 2018
+// "Designing Fluid Interfaces"), all of which the old copies were missing:
+//
+//   1. 1:1 tracking — content follows the finger exactly within the pull
+//      direction; resistance (rubber-band) appears ONLY past the threshold, not
+//      as a blanket `* 0.85` multiplier applied to the whole travel. The old
+//      code damped the entire drag, so the banner never quite kept up with the
+//      finger.
+//   2. Momentum projection — the release decision uses `predictedEndTranslation`
+//      (where the flick is *going*), not the raw release-point translation. A
+//      quick short flick now dismisses; the old `translation > 80` check ignored
+//      velocity, so a fast small flick did nothing and the user had to "drag it
+//      far enough".
+//   3. Velocity-continuous settle — on commit the banner flies off with a spring
+//      (Motion.settle) rather than a fixed `.easeOut(duration: 0.2)`, so there's
+//      no seam between the finger's motion and the animation.
+//
+// Direction is configurable: undo toasts sit at the bottom and dismiss *down*;
+// the check-in prompt sits at the top and dismisses *up*.
+
+/// Which way the banner is pulled to dismiss.
+enum BannerDismissEdge {
+    /// Pulled downward off the bottom of the screen (undo toasts).
+    case down
+    /// Pulled upward off the top of the screen (check-in prompt).
+    case up
+
+    /// Sign of a dismiss-ward translation for this edge (+1 down, -1 up).
+    fileprivate var sign: CGFloat { self == .down ? 1 : -1 }
+}
+
+extension View {
+    /// Makes the view draggable off-screen in `edge` direction to dismiss.
+    ///
+    /// - Parameters:
+    ///   - offset: Bound live drag offset (the caller owns it so the countdown
+    ///     bar / pause logic can read it). Non-dismiss-ward pulls are clamped to 0.
+    ///   - edge: Which way the banner leaves.
+    ///   - threshold: Projected travel (pt) past which a release commits dismiss.
+    ///   - isEnabled: When false the gesture is inert (e.g. already confirmed).
+    ///   - onCrossThreshold: Fired once each time the *projected* position crosses
+    ///     the threshold in either direction — for the "you can let go now" tick.
+    ///   - onDragBegan: Fired on the first move of a fresh drag (pause countdown).
+    ///   - onDismiss: Committed dismiss (past threshold or fast flick).
+    ///   - onCancel: Released below threshold; the banner springs home.
+    func dismissibleBanner(
+        offset: Binding<CGFloat>,
+        edge: BannerDismissEdge,
+        threshold: CGFloat = 80,
+        isEnabled: Bool = true,
+        onCrossThreshold: @escaping (Bool) -> Void = { _ in },
+        onDragBegan: @escaping () -> Void = {},
+        onDismiss: @escaping () -> Void,
+        onCancel: @escaping () -> Void = {}
+    ) -> some View {
+        modifier(DismissibleBannerModifier(
+            offset: offset,
+            edge: edge,
+            threshold: threshold,
+            isEnabled: isEnabled,
+            onCrossThreshold: onCrossThreshold,
+            onDragBegan: onDragBegan,
+            onDismiss: onDismiss,
+            onCancel: onCancel
+        ))
+    }
+}
+
+private struct DismissibleBannerModifier: ViewModifier {
+    @Binding var offset: CGFloat
+    let edge: BannerDismissEdge
+    let threshold: CGFloat
+    let isEnabled: Bool
+    let onCrossThreshold: (Bool) -> Void
+    let onDragBegan: () -> Void
+    let onDismiss: () -> Void
+    let onCancel: () -> Void
+
+    @State private var crossed = false
+    @State private var began = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// How far past `threshold` the banner keeps following before flying off —
+    /// the extra travel is rubber-banded so overshoot resists instead of running
+    /// away (apple-design §9).
+    private static let rubberBandDamping: CGFloat = 0.3
+
+    func body(content: Content) -> some View {
+        content
+            .offset(y: offset)
+            .gesture(
+                DragGesture()
+                    .onChanged { value in
+                        guard isEnabled else { return }
+                        if !began {
+                            began = true
+                            onDragBegan()
+                        }
+                        // Dismiss-ward travel is positive; ignore the opposite pull.
+                        let travel = value.translation.height * edge.sign
+                        let dismissWard = max(0, travel)
+                        // 1:1 up to the threshold; rubber-band only the overshoot.
+                        let followed: CGFloat
+                        if dismissWard > threshold {
+                            followed = threshold + (dismissWard - threshold) * Self.rubberBandDamping
+                        } else {
+                            followed = dismissWard
+                        }
+                        offset = followed * edge.sign
+
+                        // Cross feedback keys off the PROJECTED endpoint so the
+                        // "let go now" tick anticipates the flick, not the finger.
+                        let projected = value.predictedEndTranslation.height * edge.sign
+                        let over = projected > threshold
+                        if over != crossed {
+                            crossed = over
+                            Haptics.selection()
+                        }
+                    }
+                    .onEnded { value in
+                        guard isEnabled else { return }
+                        began = false
+                        crossed = false
+                        let projected = value.predictedEndTranslation.height * edge.sign
+                        let committed = projected > threshold
+                        if committed {
+                            Haptics.impact(.soft)
+                            // Fly off in the dismiss direction with a settle
+                            // spring so the finger's motion continues seamlessly.
+                            withAnimation(reduceMotion ? nil : Motion.settle) {
+                                offset = 320 * edge.sign
+                            }
+                            onDismiss()
+                        } else {
+                            withAnimation(reduceMotion ? nil : Motion.settle) {
+                                offset = 0
+                            }
+                            onCancel()
+                        }
+                    }
+            )
+    }
+}

--- a/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
+++ b/apps/ios/SoloCompass/Views/Shared/FavoritesListView.swift
@@ -17,13 +17,16 @@ public struct FavoritesListView: View {
     /// Long-pressing a favorite floats the quick preview card instead.
     var onLongPressExperience: ((Experience) -> Void)? = nil
     var onExplore: (() -> Void)? = nil
+    /// Explicit "Done" dismiss. Optional so existing call sites are unchanged;
+    /// when the host wires it, a toolbar Done button appears so users aren't
+    /// forced to discover the drag-indicator as the only way back to the map.
+    var onClose: (() -> Void)? = nil
 
     @State private var lastUnfavorited: (id: String, title: String, date: Date)?
     @State private var undoDismissTask: Task<Void, Never>?
     @State private var animatePulse = false
     @State private var undoProgress: CGFloat = 1
     @State private var undoDragOffset: CGFloat = 0
-    @State private var undoDragCrossedThreshold = false
     @State private var searchText = ""
     @State private var sortMode: FavSort = .recent
     @State private var showSwipeHint = false
@@ -471,6 +474,13 @@ public struct FavoritesListView: View {
             .animation(.easeInOut, value: filteredFavorites.isEmpty)
             .navigationTitle(NSLocalizedString("favorites.title", comment: "Favorites list title"))
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                if let onClose {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button(NSLocalizedString("common.done", comment: "Done")) { onClose() }
+                    }
+                }
+            }
             .searchable(
                 text: $searchText,
                 placement: .navigationBarDrawer(displayMode: .always),
@@ -780,7 +790,7 @@ private struct JourneyProgressBar: View {
             argument: String(format: NSLocalizedString("favorites.journey.halfway", comment: "VoiceOver halfway milestone announcement"), completed, total)
         )
         guard !reduceMotion else { return }
-        withAnimation(.spring(response: 0.18, dampingFraction: 0.45)) {
+        withAnimation(.spring(response: 0.18, dampingFraction: 0.7)) {
             fillScaleY = 1.18
         }
         withAnimation(.spring(response: 0.2, dampingFraction: 0.5)) {
@@ -926,7 +936,7 @@ private struct JourneyProgressBar: View {
         withAnimation(.easeInOut(duration: 0.7).delay(0.15)) {
             sweepPhase = 1.4
         }
-        withAnimation(.spring(response: 0.18, dampingFraction: 0.45).delay(0.1)) {
+        withAnimation(.spring(response: 0.18, dampingFraction: 0.7).delay(0.1)) {
             fillScaleY = 1.25
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.38) {
@@ -1311,34 +1321,20 @@ private extension FavoritesListView {
         }
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
         .padding(.horizontal, 16)
-        .offset(y: undoDragOffset)
-        .gesture(
-            DragGesture()
-                .onChanged { gesture in
-                    undoDragOffset = max(0, gesture.translation.height * 0.85)
-                    let overThreshold = gesture.translation.height > 80
-                    if overThreshold && !undoDragCrossedThreshold {
-                        undoDragCrossedThreshold = true
-                        Haptics.selection()
-                    } else if !overThreshold && undoDragCrossedThreshold {
-                        undoDragCrossedThreshold = false
-                    }
+        // Shared drag-to-dismiss (down). Same reference gesture model as the
+        // itinerary + check-in banners: 1:1 tracking, momentum projection,
+        // velocity-continuous settle.
+        .dismissibleBanner(
+            offset: $undoDragOffset,
+            edge: .down,
+            onDismiss: {
+                undoDismissTask?.cancel()
+                undoDismissTask = nil
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    withAnimation(.easeInOut) { lastUnfavorited = nil }
+                    undoDragOffset = 0
                 }
-                .onEnded { gesture in
-                    undoDragCrossedThreshold = false
-                    if gesture.translation.height > 80 {
-                        Haptics.impact(.soft)
-                        withAnimation(.easeOut(duration: 0.2)) { undoDragOffset = 300 }
-                        undoDismissTask?.cancel()
-                        undoDismissTask = nil
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                            withAnimation(.easeInOut) { lastUnfavorited = nil }
-                            undoDragOffset = 0
-                        }
-                    } else {
-                        withAnimation(.spring(response: 0.3)) { undoDragOffset = 0 }
-                    }
-                }
+            }
         )
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(String(format: NSLocalizedString("favorites.undo.named", comment: "Removed named experience undo banner"), lastUnfavorited?.title ?? "")))
@@ -1697,7 +1693,7 @@ private struct RowCompletionFlourish: View {
                 bloomScale = 0.2
                 sweepPhase = -1
                 // Two-spring bloom: 0.2 → 1.15 → 1.0 (mirrors CompletionRing.triggerCelebration)
-                withAnimation(.spring(response: 0.18, dampingFraction: 0.45)) {
+                withAnimation(.spring(response: 0.18, dampingFraction: 0.7)) {
                     bloomScale = 1.15
                 }
                 withAnimation(.spring(response: 0.2, dampingFraction: 0.6).delay(0.18)) {

--- a/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PendingCheckInBanner.swift
@@ -13,7 +13,6 @@ public struct PendingCheckInBanner: View {
     @Environment(\.accessibilityVoiceOverEnabled) private var voiceOverOn
     @State private var confirmed = false
     @State private var dragOffset: CGFloat = 0
-    @State private var crossedThreshold = false
     @State private var pulse = false
     @State private var countdownProgress: CGFloat = 1
     @State private var autoDismissTask: Task<Void, Never>?
@@ -148,48 +147,36 @@ public struct PendingCheckInBanner: View {
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
         .shadow(color: .black.opacity(0.12), radius: 8, y: 4)
         .padding(.horizontal, 16)
-        .offset(y: dragOffset)
-        .gesture(
-            DragGesture()
-                .onChanged { gesture in
-                    guard !confirmed else { return }
-                    dragOffset = min(0, gesture.translation.height * 0.85)
-                    let overThreshold = -gesture.translation.height > dismissThreshold
-                    if overThreshold && !crossedThreshold {
-                        crossedThreshold = true
-                        #if canImport(UIKit)
-                        Haptics.selection()
-                        #endif
-                    } else if !overThreshold && crossedThreshold {
-                        crossedThreshold = false
-                    }
-                    // Pause on first touch; guard prevents repeated calls per drag event.
-                    if !wasPaused {
-                        wasPaused = true
-                        isInteracting = true
-                        pauseCountdown()
-                    }
+        // Shared drag-to-dismiss: this banner sits at the top and leaves *up*.
+        // The reusable modifier gives it the same 1:1 tracking + momentum
+        // projection + velocity-continuous settle as BottomInfoSheet/ChatCard,
+        // replacing the old hand-rolled `* 0.85` + release-point-threshold code
+        // that neither tracked 1:1 nor honoured a quick flick. The countdown
+        // pause/resume hooks onto the modifier's began/cancel callbacks.
+        .dismissibleBanner(
+            offset: $dragOffset,
+            edge: .up,
+            threshold: dismissThreshold,
+            isEnabled: !confirmed,
+            onDragBegan: {
+                // Pause the auto-dismiss countdown the instant a drag starts.
+                if !wasPaused {
+                    wasPaused = true
+                    isInteracting = true
+                    pauseCountdown()
                 }
-                .onEnded { gesture in
-                    guard !confirmed else { return }
-                    if gesture.translation.height < -dismissThreshold {
-                        #if canImport(UIKit)
-                        Haptics.impact(.soft)
-                        #endif
-                        crossedThreshold = false
-                        autoDismissTask?.cancel()
-                        autoDismissTask = nil
-                        withAnimation(.easeOut(duration: 0.2)) { dragOffset = -200 }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { onDismiss() }
-                    } else {
-                        crossedThreshold = false
-                        withAnimation(.spring(response: 0.3)) { dragOffset = 0 }
-                        // Resume countdown from where it left off.
-                        isInteracting = false
-                        wasPaused = false
-                        startCountdown(remainingFraction: progressAtPause)
-                    }
-                }
+            },
+            onDismiss: {
+                autoDismissTask?.cancel()
+                autoDismissTask = nil
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { onDismiss() }
+            },
+            onCancel: {
+                // Released below threshold → resume the countdown where it paused.
+                isInteracting = false
+                wasPaused = false
+                startCountdown(remainingFraction: progressAtPause)
+            }
         )
         .onAppear {
             #if canImport(UIKit)

--- a/apps/ios/SoloCompass/Views/Shared/PressableButtonStyle.swift
+++ b/apps/ios/SoloCompass/Views/Shared/PressableButtonStyle.swift
@@ -7,23 +7,32 @@ public struct PressableButtonStyle: ButtonStyle {
     /// Press-down scale. Default 0.92 matches the filter pills; the send button
     /// passes a slightly punchier value.
     private let pressedScale: CGFloat
-    /// When true, fires a light selection haptic on press-down (default).
-    /// Set to false on surfaces that provide their own haptic feedback.
+    /// Whether to fire a light selection haptic. Default is **off** — the audit
+    /// found this style applied to ~34 buttons, of which only 2 opted out, so
+    /// the app buzzed on essentially every button *press-down*, including plain
+    /// navigation taps. That trains users to ignore all haptics (HIG: reserve
+    /// haptics for meaningful commits). Opt in (`haptic: true`) only on genuine
+    /// state-change/commit surfaces — a filter toggling, a message sending.
     private let haptic: Bool
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    public init(pressedScale: CGFloat = 0.92, haptic: Bool = true) {
+    public init(pressedScale: CGFloat = 0.92, haptic: Bool = false) {
         self.pressedScale = pressedScale
         self.haptic = haptic
     }
 
     public func makeBody(configuration: Configuration) -> some View {
         configuration.label
+            // Motion.press: near-critically damped (df 0.82) so the button
+            // settles crisply like a system control instead of the old df-0.6
+            // wobble that overshot on release.
             .scaleEffect(configuration.isPressed ? pressedScale : 1.0)
-            .animation(.spring(response: 0.25, dampingFraction: 0.6), value: configuration.isPressed)
-            .onChange(of: configuration.isPressed) { _, isPressed in
-                if isPressed && haptic && !reduceMotion {
+            .animation(reduceMotion ? nil : Motion.press, value: configuration.isPressed)
+            .onChange(of: configuration.isPressed) { wasPressed, isPressed in
+                // Fire on release (commit), not press-down: the haptic should
+                // confirm the action, not merely acknowledge a finger landing.
+                if wasPressed && !isPressed && haptic && !reduceMotion {
                     #if canImport(UIKit)
                     Haptics.selection()
                     #endif

--- a/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
+++ b/apps/ios/SoloCompass/Views/Shared/VoiceButton.swift
@@ -33,6 +33,16 @@ public struct VoiceButton: View {
 
     @State private var didDetectSpeech = false
 
+    /// True while the finger has slid far enough up during a hold that releasing
+    /// will DISCARD the recording instead of sending it — the "slide up to
+    /// cancel" affordance every voice-note UI has (WeChat, iMessage). Without it
+    /// a hold-to-talk button can only ever commit: you say something wrong and
+    /// your only exit is to send it. Drives the button's red cancel treatment
+    /// and the hint copy.
+    @State private var isInCancelZone = false
+    /// Upward travel (pt) past which the release cancels rather than sends.
+    private let cancelSlideThreshold: CGFloat = 80
+
     public init(voiceService: VoiceService, onTranscript: @escaping (String) -> Void) {
         self.voiceService = voiceService
         self.onTranscript = onTranscript
@@ -72,14 +82,17 @@ public struct VoiceButton: View {
             }
 
             Circle()
-                .fill(isRecording ? CT.savedRed : Color.black.opacity(0.85))
+                // In the cancel zone the button goes neutral-gray with an xmark
+                // so the "release now = discard" outcome is unmistakable before
+                // the finger lifts (apple-design §8: telegraph the outcome).
+                .fill(isInCancelZone ? Color(white: 0.45) : (isRecording ? CT.savedRed : Color.black.opacity(0.85)))
                 .frame(width: 56, height: 56)
                 .shadow(radius: isRecording ? 10 : 4)
 
-            Image(systemName: isRecording ? "waveform" : "mic.fill")
+            Image(systemName: isInCancelZone ? "xmark" : (isRecording ? "waveform" : "mic.fill"))
                 .font(.title2.weight(.semibold))
                 .foregroundStyle(.white)
-                .symbolEffect(.variableColor.iterative, isActive: isRecording)
+                .symbolEffect(.variableColor.iterative, isActive: isRecording && !isInCancelZone)
         }
         .gesture(
             LongPressGesture(minimumDuration: 0.2)
@@ -87,16 +100,34 @@ public struct VoiceButton: View {
         )
         .simultaneousGesture(
             DragGesture(minimumDistance: 0)
-                .onChanged { _ in
+                .onChanged { value in
                     // Pre-warm all generators at first touch so impactOccurred() fires without latency.
                     recordStartGenerator.prepare()
                     recordStopSuccessGenerator.prepare()
                     recordStopEmptyGenerator.prepare()
                     permissionDeniedGenerator.prepare()
                     speechDetectedGenerator.prepare()
+
+                    // Slide-up-to-cancel: while recording, track upward travel.
+                    // Crossing the threshold arms cancel (and disarming below it
+                    // re-arms send), each transition ticking a haptic so the
+                    // state change is felt without looking.
+                    guard isRecording else { return }
+                    let over = value.translation.height < -cancelSlideThreshold
+                    if over != isInCancelZone {
+                        withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.15)) {
+                            isInCancelZone = over
+                        }
+                        Haptics.selection()
+                    }
                 }
                 .onEnded { _ in
-                    if isRecording { stopRecording() }
+                    guard isRecording else { return }
+                    if isInCancelZone {
+                        cancelRecording()
+                    } else {
+                        stopRecording()
+                    }
                 }
         )
         .accessibilityLabel(Text(NSLocalizedString("voice.button", comment: "Voice input")))
@@ -124,7 +155,19 @@ public struct VoiceButton: View {
                 let secondsRemaining = Int(maxRecordingDuration) - Int(elapsed)
                 let inCountdown = elapsed >= 50 && !didAutoStop
                 VStack(spacing: 4) {
-                    if let hint = emptyHint {
+                    if isInCancelZone {
+                        // In the cancel zone the whole pill collapses to one
+                        // unambiguous "release to cancel" line — no timer, no
+                        // transcript competing with the decision.
+                        Text(NSLocalizedString("voice.recording.releaseToCancel", comment: "Release to cancel"))
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(AnyShapeStyle(CT.savedRed))
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .background(.thinMaterial, in: Capsule())
+                            .transition(reduceMotion ? .identity : .opacity)
+                            .accessibilityHidden(true)
+                    } else if let hint = emptyHint {
                         Text(hint)
                             .font(.caption)
                             .foregroundStyle(AnyShapeStyle(CT.warningText))
@@ -152,7 +195,7 @@ public struct VoiceButton: View {
                             .accessibilityHidden(true)
                     }
 
-                    if emptyHint == nil {
+                    if emptyHint == nil && !isInCancelZone {
                         let displayText = liveTranscript.isEmpty
                             ? NSLocalizedString("chat.voice.listening", comment: "Listening placeholder")
                             : liveTranscript
@@ -202,6 +245,7 @@ public struct VoiceButton: View {
             }
             do {
                 isRecording = true
+                isInCancelZone = false
                 if !reduceMotion { pulse = true }
                 liveTranscript = ""
                 elapsed = 0
@@ -282,6 +326,34 @@ public struct VoiceButton: View {
             }
         }
         liveTranscript = ""
+    }
+
+    /// Slide-up cancel: stop listening and DISCARD the transcript — the mirror
+    /// of `stopRecording`, minus the `onTranscript` callback and success haptic.
+    /// A soft impact + spoken announcement confirm the discard.
+    private func cancelRecording() {
+        voiceService.stopListening()
+        isRecording = false
+        pulse = false
+        stopElapsedTimer()
+        streamTask?.cancel()
+        streamTask = nil
+        liveTranscript = ""
+        withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.15)) {
+            isInCancelZone = false
+        }
+        recordStopEmptyGenerator.impactOccurred()
+        let hint = NSLocalizedString("voice.recording.cancelled", comment: "Recording discarded")
+        emptyHint = hint
+        if UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .announcement, argument: hint)
+        }
+        emptyHintTask?.cancel()
+        emptyHintTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(1.4))
+            guard !Task.isCancelled else { return }
+            if emptyHint == hint { emptyHint = nil }
+        }
     }
 
     private func startElapsedTimer() {


### PR DESCRIPTION
This branch carries two related iOS polish efforts.

## 1. Settings simplification (`62771990`)
Consolidates `SettingsView` from 14 sections down to 6, with a hidden
Advanced group unlocked via a 7-tap version-number gesture.

## 2. Gesture / back / haptic feel — Apple standard (`e2f8d740`)
A four-agent audit + first-hand recon found the core gesture layer
already excellent (`BottomInfoSheet` / `ChatCardStack` are reference
implementations). The defects were **consistency gaps and a few
semantic conflicts**, so this sweep converges rather than rewrites.

**Navigation & back**
- `CompanionProfileView` declared its own `NavigationStack` while always
  reached by push → double nav bar + **edge-swipe-back killed** for the
  screen. Removed; now inherits the parent stack.

**Dismiss / data-loss**
- Six edit-form sheets gained a dirty-check `interactiveDismissDisabled`
  so a stray swipe-down can't silently discard unsaved input.
- `VerifySheet` gained an explicit close so it's never a dead-end.

**Close-control consistency**
- Unified on `.cancellationAction`/`.confirmationAction` (ends the
  left/right Cancel split). Detail view `chevron.down` → standard
  `xmark`. Favorites gained a Done button.

**Gesture conflicts**
- `AvatarStack` / `DiscoverListView` buttons used a zero-distance drag
  as their action inside a scroll view (swallowed taps / phantom press).
  Now real `Button` + `PressableButtonStyle`.

**Reusable drag model**
- New `DismissibleBanner` distils `BottomInfoSheet`'s tuned model (1:1
  tracking, `predictedEndTranslation` momentum projection, velocity-
  continuous settle) into one modifier, replacing three hand-rolled
  banners that neither tracked 1:1 nor honoured a quick flick.

**Haptics**
- `PressableButtonStyle` default haptic `true`→`false`, moved to
  release; ~34 buttons no longer buzz on every touch. FAB & sort-picker
  double-buzzes removed.

**Voice button**
- Hold-to-talk gained **slide-up-to-cancel** (WeChat-style) with a red
  "release to cancel" state; a11y hint now matches the real gesture.

**Springs**
- New `Motion` semantic tokens in `DesignTokens`; press df 0.6→0.82,
  six over-bouncy df-0.45 springs → 0.7.

## Verification
`** BUILD SUCCEEDED **` on iPhone 17 (iOS 26.1); 37 tests across the
affected suites pass (the `PressableButtonStyle` guard was updated to
assert the new invariants — release-edge haptic, default-off).

https://claude.ai/code/session_01RWTk6BFar8UqAQGn7Kg89F