### PR TITLE
fix(ios): restore MapViewModel.routeCandidates() — unbreak main TestFlight archive

### DIFF
--- a/apps/ios/SoloCompass/Tests/FavoriteFilterTests.swift
+++ b/apps/ios/SoloCompass/Tests/FavoriteFilterTests.swift
@@ -138,3 +138,109 @@ final class FavoriteFilterTests: XCTestCase {
         XCTAssertFalse(vm.isFavoriteFilter, "clearFilters clears the Saved filter")
     }
 }
+
+/// Regression guards for the create-route candidate pool (UX audit 2026-07-16:
+/// "選擇地點 list empty + AI button dead").
+///
+/// Root cause: the create-route sheet was fed `viewModel.visibleExperiences`,
+/// but its entry cards live in the Now section — so the pool arrived
+/// pre-filtered by `isBestNow()` and was routinely empty. Both flows died at
+/// once: a blank manual picker and a permanently `.disabled` ✨ button (which,
+/// with explicit colors and `.plain` style, didn't even LOOK disabled).
+/// `routeCandidates()` must ignore the transient map filters.
+@MainActor
+final class RouteCandidatesPoolTests: XCTestCase {
+
+    private func makeExperience(id: String, cityCode: String, lon: Double, lat: Double) -> Experience {
+        let now = Date()
+        return Experience(
+            id: id,
+            title: "Fixture \(id)",
+            oneLiner: "Fixture \(id)",
+            whyItMatters: "Route candidates fixture",
+            category: .food,
+            location: ExperienceLocation(coordinates: [lon, lat], cityCode: cityCode),
+            // No bestTimes → `isBestNow()` is false → the Now filter drops
+            // every fixture, reproducing the audit's empty-pool scenario.
+            bestTimes: [],
+            durationMinutes: .init(min: 30, max: 60),
+            howTo: [],
+            realInconveniences: [],
+            soloScore: SoloScore(
+                overall: 5,
+                breakdown: .init(
+                    seatingFriendly: 7, soloPatronRatio: 7, staffPressure: 7,
+                    soloPortioning: 7, ambianceFit: 7, safety: 7
+                ),
+                basedOnCount: 1
+            ),
+            sources: [InformationSource(type: .user, attribution: "test", verifiedAt: now)],
+            confidence: Confidence(
+                level: 3,
+                lastVerifiedAt: now,
+                reason: "Test fixture",
+                signals: .init(aiScrapeAgeDays: 1, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)
+            ),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .active,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    private func makeViewModel() -> MapViewModel {
+        let suite = "route.candidates.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let prefs = UserPreferences(defaults: defaults)
+        prefs.lastSelectedCity = "cmi"
+        let seed = [
+            makeExperience(id: "cmi_1", cityCode: "cmi", lon: 98.9938, lat: 18.7877),
+            makeExperience(id: "cmi_2", cityCode: "cmi", lon: 98.9940, lat: 18.7880),
+            makeExperience(id: "cmi_3", cityCode: "cmi", lon: 98.9942, lat: 18.7882)
+        ]
+        return MapViewModel(
+            locationService: LocationService(),
+            experienceService: ExperienceService(seed: seed),
+            aiService: AIService(),
+            preferences: prefs
+        )
+    }
+
+    /// The audit scenario: Now filter active, zero visible experiences — the
+    /// route builder must still see the full nearby pool.
+    func testRouteCandidatesIgnoreNowFilter() {
+        let vm = makeViewModel()
+        vm.selectNowFilter()
+        XCTAssertTrue(vm.visibleExperiences.isEmpty,
+                      "precondition: fixtures have no bestTimes, so Now filters everything out")
+        XCTAssertEqual(vm.routeCandidates().count, 3,
+                       "routeCandidates must ignore the transient Now filter — an empty pool kills both the manual picker and the AI button")
+    }
+
+    func testRouteCandidatesIgnoreCategoryFilter() {
+        let vm = makeViewModel()
+        vm.selectCategory(.culture) // fixtures are .food → visible = 0
+        XCTAssertEqual(vm.routeCandidates().count, 3,
+                       "routeCandidates must ignore the transient category filter")
+    }
+
+    /// Structural pin on the CompassMapView wiring: the create sheet must be
+    /// fed `routeCandidates()`, and the Now placeholder (whose copy promises
+    /// "Solo picks 3 stops") must open with `autoGenerate: true`.
+    func testCreateRouteSheetWiring() throws {
+        let here = URL(fileURLWithPath: #filePath)
+        let url = here
+            .deletingLastPathComponent()   // Tests/
+            .deletingLastPathComponent()   // SoloCompass/
+            .appendingPathComponent("Views/Map/CompassMapView.swift")
+        let source = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertFalse(source.contains("candidates: viewModel.visibleExperiences"),
+                       "CreateRouteView must not be fed the Now-filtered visibleExperiences (empty-pool dead end)")
+        XCTAssertTrue(source.contains("candidates: viewModel.routeCandidates()"),
+                      "CreateRouteView must draw from the unfiltered routeCandidates() pool")
+        XCTAssertTrue(source.contains(".create(autoGenerate: true)"),
+                      "the Now placeholder promises Solo picks the stops — it must open with autoGenerate: true")
+    }
+}

--- a/apps/ios/SoloCompass/Tests/FilterBarViewTests.swift
+++ b/apps/ios/SoloCompass/Tests/FilterBarViewTests.swift
@@ -75,3 +75,61 @@ final class FilterBarViewTests: XCTestCase {
                        "Tapping an inactive pill must not resolve to clear")
     }
 }
+
+/// Regression guard for the "Ask Solo" pill's tap action (P2.5 #250).
+///
+/// History: commit 7a255c3b wired `onSoloAgentTap` to a placeholder —
+/// `viewModel.selectNowFilter()` — instead of opening the ChatSheet. With the
+/// Now filter already active (the app's common resting state) the tap was a
+/// complete no-op: the most prominent AI entry point on the home screen was a
+/// dead button. The real action must route through the parent's chat
+/// presenter (`ensureOrchestrator`) with the suggest-now seed prompt.
+///
+/// SwiftUI closures can't be introspected from XCTest, so this scans the
+/// source the same way `BottomSheetUnifiedScrollGuardTest` and
+/// `NeverInventPOIRedLineTests` do, asserting the structural wiring.
+final class AskSoloPillWiringGuardTest: XCTestCase {
+
+    private func mapViewSource() throws -> String {
+        let here = URL(fileURLWithPath: #filePath)
+        let url = here
+            .deletingLastPathComponent()   // Tests/
+            .deletingLastPathComponent()   // SoloCompass/
+            .appendingPathComponent("Views/Map/CompassMapView.swift")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// The FilterBar hook must forward the parent-supplied closure — never a
+    /// filter mutation. `selectNowFilter()` next to `onSoloAgentTap:` is the
+    /// exact dead-button regression.
+    func testSoloAgentTapDoesNotDegradeToNowFilter() throws {
+        let source = try mapViewSource()
+        XCTAssertFalse(
+            source.contains("onSoloAgentTap: { viewModel.selectNowFilter() }"),
+            "Ask Solo pill must open the chat, not silently re-select the Now filter (dead button when Now is already active)"
+        )
+        XCTAssertTrue(
+            source.contains("onSoloAgentTap: onAskSolo"),
+            "FilterBarView's onSoloAgentTap must forward MapOverlayView.onAskSolo (the parent's open-chat closure)"
+        )
+    }
+
+    /// The parent's `onAskSolo` closure must actually present the chat: it
+    /// needs both the orchestrator bring-up and the seed prompt that fires
+    /// the suggest_now_action shortcut the pill promises.
+    func testOnAskSoloOpensChatWithSeedPrompt() throws {
+        let source = try mapViewSource()
+        guard let range = source.range(of: "onAskSolo: {") else {
+            return XCTFail("CompassMapContentView must pass an onAskSolo closure to MapOverlayView")
+        }
+        let body = String(source[range.upperBound...].prefix(600))
+        XCTAssertTrue(
+            body.contains("ensureOrchestrator(viewModel: viewModel)"),
+            "onAskSolo must bring up the chat orchestrator (this is what presents the ChatSheet)"
+        )
+        XCTAssertTrue(
+            body.contains("filter.solo.agent.seed"),
+            "onAskSolo must seed the suggest-now prompt so the agent answers immediately"
+        )
+    }
+}

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -1521,6 +1521,28 @@ public final class MapViewModel {
         }
     }
 
+    /// Candidate pool for the route builder: every nearby experience in the
+    /// selected city, ignoring the *transient* map filters (Now / category /
+    /// tag / favorite). The create-route sheet used to be fed
+    /// `visibleExperiences` — but its entry card lives in the Now section, so
+    /// the pool arrived pre-filtered by `isBestNow()` and was routinely empty:
+    /// a blank "選擇地點" list and a permanently disabled AI button.
+    /// Standing preferences (disliked categories) still apply.
+    public func routeCandidates() -> [Experience] {
+        var nearby = experienceService.getExperiences(
+            near: nearbyQueryOrigin,
+            radiusKm: max(1.0, preferences.maxDistanceKm)
+        )
+        if let cityCode = selectedCity, !cityCode.hasPrefix("custom_") {
+            nearby = nearby.filter { Self.cityCodeMatches($0.location.cityCode, selected: cityCode) }
+        }
+        if !preferences.dislikedCategories.isEmpty {
+            let disliked = Set(preferences.dislikedCategories)
+            nearby = nearby.filter { !disliked.contains($0.category) }
+        }
+        return nearby
+    }
+
     private func applyFilters(near coordinate: CLLocationCoordinate2D, radiusKm: Double) -> [Experience] {
         var nearby = experienceService.getExperiences(near: coordinate, radiusKm: radiusKm)
         #if DEBUG


### PR DESCRIPTION
## 问题

TestFlight 部署在 `main` 上持续失败（[run 29628390087](https://github.com/getyak/solo-compass/actions/runs/29628390087/job/88037230880)），`** ARCHIVE FAILED **`。

## 根因：一次分裂的合并（split merge）

PR #606 把**调用方**合进了 main：

```
CompassMapView.swift:1177 → viewModel.routeCandidates()
```

但**方法定义没进 main** —— 它当时只存在于本地未提交的工作树改动里。Release archive 编译于是报：

```
CompassMapView.swift:1177: value of type 'MapViewModel'
  has no dynamic member 'routeCandidates'
** ARCHIVE FAILED **
```

（日志里前面全是 Swift 6 warning 噪声，真正的 `::error` 被 xcbeautify 埋在 ARCHIVE FAILED 之前几行。）

## 修复

补回 `routeCandidates()`：create-route 的候选池，忽略瞬时地图过滤器（Now / 分类 / 标签 / 收藏），但保留常驻偏好（不喜欢的分类）。缺了它，create-route sheet 被喂了 Now 预过滤后的空池 —— 就是 UX 审计里「選擇地點列表空 + ✨ 按钮死掉」的死胡同。

附带 `RouteCandidatesPoolTests` 回归防护。

## 验证

`xcodebuild build` → **BUILD SUCCEEDED**（iPhone 17 / OS 26.1），`routeCandidates` 报错 0 次。

https://claude.ai/code/session_01RWTk6BFar8UqAQGn7Kg89F