### PR TITLE
feat(ios): personal-data export + first-launch/UX fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ apps/ios/SoloCompass/Resources/JSON/seed_experiences.json.backup
 # Scratch skill directories (sc-evaluator/sc-executor/sc-loop) that live
 # alongside the shipping code but aren't part of the app build.
 .agents/skills/
+.gstack/

--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		0C0580E1BF61F5C02C2EE640 /* BottomSheetUnifiedScrollGuardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E41DCA29798B5D8E49B7CA /* BottomSheetUnifiedScrollGuardTest.swift */; };
 		0C910AC3F463BC15AE61B602 /* ComplianceBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0059E8B90B93210D7C505BFD /* ComplianceBanner.swift */; };
 		0CAAE3EBA0298FD3E1AD9485 /* V1_9SchemaRecordsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F99B043981C964178CBECE0 /* V1_9SchemaRecordsTests.swift */; };
+		0CE94AE9F347F0B2A828B2F5 /* PersonalDataExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AE495A63DA78B732B08AE3 /* PersonalDataExporterTests.swift */; };
 		0DE8ECCE242F2FDFFD69C199 /* VoiceInterruptionToastTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E7AFBAAF6E42AE8043F476D /* VoiceInterruptionToastTest.swift */; };
 		0EAA3D2EEA89D212150A6B57 /* ExploreConsentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8B58A4F608F9951CBDF3C /* ExploreConsentSheet.swift */; };
 		0FAE1C75A6BDB6308934D19D /* SoonestUpcomingExperienceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EA228DD5B2378433757999E /* SoonestUpcomingExperienceTests.swift */; };
@@ -252,6 +253,7 @@
 		6FAA75544A1755C5712F30BA /* AddFriendSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB22C08A558D35B83043C83E /* AddFriendSheet.swift */; };
 		700914E5F9C7DD558D08B8C2 /* VoiceButtonHapticTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E0D46949612D8FCC41696B /* VoiceButtonHapticTests.swift */; };
 		70C4E4355FB1E0D911A54C11 /* BestNowBadgeClockTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93DEF5BFE055F0EC12FC21A /* BestNowBadgeClockTest.swift */; };
+		70F46182950CC4B3AC880396 /* PersonalDataExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26AE72CB438C5225086E7CB /* PersonalDataExporter.swift */; };
 		718A05DB2A42CB24354B8950 /* RouteCompanionRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60647FA4E64B48E215B9D2F /* RouteCompanionRemote.swift */; };
 		71A3C13162E62CA1D13E5EB6 /* RequestInboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F86CFA31CA2B66F6AA221ECB /* RequestInboxView.swift */; };
 		71B9FD2F300F42A5197FFA15 /* RouteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF871B84DDAAD8453B8258D /* RouteStoreTests.swift */; };
@@ -794,6 +796,7 @@
 		578C4C68A74AB74E0D2C6288 /* BestNowChipStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BestNowChipStateTests.swift; sourceTree = "<group>"; };
 		5851D15E5E0C0A25A014F186 /* LiveActivityLockScreenPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityLockScreenPreview.swift; sourceTree = "<group>"; };
 		5895B058A34A2634E816A72F /* ShareCardModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareCardModel.swift; sourceTree = "<group>"; };
+		58AE495A63DA78B732B08AE3 /* PersonalDataExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalDataExporterTests.swift; sourceTree = "<group>"; };
 		58FFFD31320F43361B9E91D4 /* ProvisionalCardUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvisionalCardUITests.swift; sourceTree = "<group>"; };
 		5933575E731D8AC09356AB9F /* GlassmorphismCapsule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassmorphismCapsule.swift; sourceTree = "<group>"; };
 		5AB8B58A4F608F9951CBDF3C /* ExploreConsentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreConsentSheet.swift; sourceTree = "<group>"; };
@@ -1145,6 +1148,7 @@
 		F1B30F2AF51F41DB5DA21899 /* ImminenceProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImminenceProgressTests.swift; sourceTree = "<group>"; };
 		F1D68F42114231582501CB90 /* NowCountCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowCountCacheTests.swift; sourceTree = "<group>"; };
 		F22DFB53BF47FEF26D9441BE /* InviteFriendsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteFriendsSheet.swift; sourceTree = "<group>"; };
+		F26AE72CB438C5225086E7CB /* PersonalDataExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalDataExporter.swift; sourceTree = "<group>"; };
 		F28FE205E7AA6068F6E0C837 /* ExperienceImageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceImageServiceTests.swift; sourceTree = "<group>"; };
 		F2DE4C5AA1D5F99E927D5C14 /* DeveloperOptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperOptionsView.swift; sourceTree = "<group>"; };
 		F336099C48E0B04CD7612E4C /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
@@ -1465,6 +1469,7 @@
 				710E82F0D31AB629848EA729 /* PeekSummarySelectionTests.swift */,
 				D26F2087E12E63A73B812D7E /* PendingCheckInBannerTests.swift */,
 				70AF2705AB2F24B69DE8CB4F /* PerformanceTests.swift */,
+				58AE495A63DA78B732B08AE3 /* PersonalDataExporterTests.swift */,
 				2EFE48683692E4C00E0A2DC5 /* PressableButtonStyleHapticTest.swift */,
 				02AED8B43F4C4059CD005C0A /* PreviewCardLifecycleTests.swift */,
 				1537012DBA238501E4DEDACE /* PrintFulfillmentClientTests.swift */,
@@ -1784,6 +1789,7 @@
 				C215AE07BA32182A887226F9 /* NotificationService.swift */,
 				422D002D531AF8AD7F4B8A5D /* OmenComposeService.swift */,
 				67173C74F1A76C3CE5C38C0A /* OverpassService.swift */,
+				F26AE72CB438C5225086E7CB /* PersonalDataExporter.swift */,
 				D2F55E299C99F8D9916E0BA1 /* PlacePhotoStore.swift */,
 				565FEEE2744AFE1F200FFA1C /* POIMerger.swift */,
 				9FBC142634F5D448F7B85875 /* POISource.swift */,
@@ -2440,6 +2446,7 @@
 				D8A9D1CB20E6D46FD5EE373C /* PeekSummarySelectionTests.swift in Sources */,
 				045740DB5060EBE8D6D2EEA0 /* PendingCheckInBannerTests.swift in Sources */,
 				D7ABC99B7839B64FF014D344 /* PerformanceTests.swift in Sources */,
+				0CE94AE9F347F0B2A828B2F5 /* PersonalDataExporterTests.swift in Sources */,
 				7ACAAE18D2EFA3E880AD6744 /* PressableButtonStyleHapticTest.swift in Sources */,
 				9BEDEF446F2D554A7F1ABA6F /* PreviewCardLifecycleTests.swift in Sources */,
 				3E8A3193039955B8A62EBC15 /* PrintFulfillmentClientTests.swift in Sources */,
@@ -2760,6 +2767,7 @@
 				ACBA4CEE6B78AA04DBD26709 /* PendingCheckInRecord.swift in Sources */,
 				641D80BD116D6F255A9ED26A /* PendingSyncRecord.swift in Sources */,
 				905A93A872B2942AE13B7F08 /* PersistenceDecoding.swift in Sources */,
+				70F46182950CC4B3AC880396 /* PersonalDataExporter.swift in Sources */,
 				3F74295066332816AAE7FD1C /* PlaceCorrectionRecord.swift in Sources */,
 				50495257AD65A0507DD43D41 /* PlacePhotoStore.swift in Sources */,
 				60FA57D3A56ED061C1F9B899 /* PresenceService.swift in Sources */,

--- a/apps/ios/SoloCompass/App/SoloCompassApp.swift
+++ b/apps/ios/SoloCompass/App/SoloCompassApp.swift
@@ -306,7 +306,16 @@ struct SoloCompassApp: App {
         // to the system asynchronously.
         locationService.preferences = preferences
         locationService.notificationService = notificationService
-        locationService.requestPermission()
+        // P0 (UX audit 2026-07-16 #1): only fire the location prompt once
+        // onboarding is also done. Bootstrap is terms-gated (the legal line),
+        // but a warm re-entry where terms were accepted yet onboarding never
+        // finished would otherwise pop the system location alert *above* the
+        // re-presented onboarding cover — the exact stacking the audit flagged.
+        // CompassMapView's `onChange(of: hasCompletedOnboarding)` still fires
+        // the request the moment onboarding completes, so nothing is lost.
+        if preferences.hasCompletedOnboarding {
+            locationService.requestPermission()
+        }
 
         // P1.1 #110: passive visit recorder. Chains onto LocationService's
         // region enter/exit callbacks; the model container injection lets it
@@ -326,6 +335,12 @@ struct SoloCompassApp: App {
         // (region enter matcher), and ProactiveNudgeScheduler (#244 year
         // end review).
         CapsuleStore.shared.setModelContainer(SoloCompassModelContainer.shared)
+
+        // Data-sovereignty export twin of ForgetMeService. Same
+        // setModelContainer pattern; lets Settings render the four
+        // high-stickiness personal assets (visits / capsules / notes /
+        // taste) to shareable files so they survive device migration.
+        PersonalDataExporter.shared.setModelContainer(SoloCompassModelContainer.shared)
 
         // US-020: cold-start TTI must not block on a serial main-thread
         // init chain. Each piece of bootstrap below is independent — no

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -1632,20 +1632,20 @@
 "route.duration.hoursMinutes" = "%dh %dmin";
 "route.duration.minutes" = "%dmin";
 "route.create.title" = "Create Route";
-"route.create.ai" = "✨ 讓 AI 幫我串成路線";
-"route.create.titleLabel" = "路線名稱";
-"route.create.titlePlaceholder" = "例如：湄公河日落散步";
-"route.create.paceLabel" = "節奏";
-"route.create.pickLabel" = "選擇地點（按點選順序串聯）";
-"route.create.selectedCount" = "已選 %d";
-"route.create.save" = "保存";
+"route.create.ai" = "✨ Let AI string one together";
+"route.create.titleLabel" = "Route name";
+"route.create.titlePlaceholder" = "e.g. Mekong sunset walk";
+"route.create.paceLabel" = "Pace";
+"route.create.pickLabel" = "Pick stops (linked in tap order)";
+"route.create.selectedCount" = "%d selected";
+"route.create.save" = "Save";
 "route.create.empty" = "No nearby places to build from yet — try Explore first, or widen your distance in Settings.";
 "route.create.ai.error" = "Couldn't build the route this time — check your connection and try again.";
 
 /* Active route drawn on the map (start route) */
-"route.active.stops" = "%d 站 · 路線中";
+"route.active.stops" = "%d stops · on route";
 "route.active.stop.a11y" = "Stop %d";
-"route.active.end" = "結束路線";
+"route.active.end" = "End route";
 "route.active.skip" = "Skip this stop";
 "route.active.pause" = "Pause route";
 "filter.tip.title" = "Browse by mood";
@@ -1668,11 +1668,11 @@
 "nearby.chip.closingNow" = "Closing now";
 
 /* US-058 — RouteCard walked-by row (CompareCanvas A-003) */
-"route.card.walkedBy" = "%d 位旅人走过";
+"route.card.walkedBy" = "Walked by %d travelers";
 
 /* US-030 — Companion Profile walked routes section */
-"profile.walkedRoutes.header" = "走过的路线 (%d)";
-"profile.walkedRoutes.viewAll" = "查看全部 ->";
+"profile.walkedRoutes.header" = "Walked routes (%d)";
+"profile.walkedRoutes.viewAll" = "View all ->";
 
 /* Empty state for MyWalkedRoutesListView */
 "profile.walkedRoutes.empty.title" = "No routes walked yet";
@@ -1682,12 +1682,12 @@
 "profile.walkedRoutes.count" = "%d routes walked";
 
 /* US-032 — DiscoverRecruitingRoutesView */
-"discover.recruiting.title" = "发现招募路线";
+"discover.recruiting.title" = "Discover recruiting routes";
 "discover.recruiting.chip" = "%d/%d · %@";
 "discover.recruiting.chip.a11y" = "%d of %d members · %@";
-"discover.recruiting.empty.title" = "目前没有招募中的路线";
-"discover.recruiting.empty.description" = "附近还没有开放加入的路线。";
-"discover.recruiting.empty.create" = "开一个你自己的路线";
+"discover.recruiting.empty.title" = "No routes recruiting right now";
+"discover.recruiting.empty.description" = "No routes open to join nearby yet.";
+"discover.recruiting.empty.create" = "Open one of your own";
 
 /* US-033 — MyRequestsListView */
 "my.requests.empty" = "You have not requested to join any routes yet.";
@@ -1703,33 +1703,33 @@
 "my.requests.count" = "%1$d requests · %2$d pending";
 
 /* US-031 — JoinRouteRequestSheet */
-"join.sheet.title" = "申请加入";
-"join.pace.label" = "配速匹配";
-"join.pace.placeholder" = "请选择";
-"join.pace.slower" = "慢于宿主";
-"join.pace.matching" = "匹配";
-"join.pace.faster" = "快于宿主";
-"join.message.label" = "自我介绍";
-"join.message.placeholder" = "向主理人介绍自己...";
-"join.submit" = "提交申请";
-"join.error.pace.missing" = "请选择配速匹配";
-"join.error.message.missing" = "请填写自我介绍";
+"join.sheet.title" = "Request to join";
+"join.pace.label" = "Pace match";
+"join.pace.placeholder" = "Please select";
+"join.pace.slower" = "Slower than host";
+"join.pace.matching" = "Matching";
+"join.pace.faster" = "Faster than host";
+"join.message.label" = "About you";
+"join.message.placeholder" = "Introduce yourself to the host...";
+"join.submit" = "Send request";
+"join.error.pace.missing" = "Please choose a pace match";
+"join.error.message.missing" = "Please add a short intro";
 
 /* US-034 — ApprovalQueueView */
-"approval.queue.title" = "待审批申请";
-"approval.queue.trust.line" = "已走过 %d 条 · 拼团 %d 次";
+"approval.queue.title" = "Pending requests";
+"approval.queue.trust.line" = "Walked %d routes · %d group trips";
 /* US-032 — per-requester trust micro-stats */
 "approval.queue.signal.optin.yes" = "Opted in";
 "approval.queue.signal.optin.no" = "Not opted in";
 "approval.queue.signal.optin.a11y" = "Companion opt-in: %@";
 "approval.queue.signal.walked.a11y" = "Walked %@ routes";
 "approval.queue.signal.group.a11y" = "%@ group trips";
-"approval.queue.decline" = "拒绝";
-"approval.queue.accept" = "接受";
+"approval.queue.decline" = "Decline";
+"approval.queue.accept" = "Accept";
 "approval.queue.empty" = "No pending requests for this route.";
 
 /* US-034 — MyHostedRoutesListView */
-"my.hosted.routes.title" = "我主理的路线";
+"my.hosted.routes.title" = "Routes I host";
 "my.hosted.routes.empty" = "You are not hosting any routes yet.";
 "my.hosted.routes.empty.title" = "No hosted routes yet";
 "my.hosted.routes.empty.hint" = "Create a route and invite companions to join you on your journey.";
@@ -1737,14 +1737,14 @@
 "settings.companion.hosted.routes" = "My hosted routes";
 
 /* US-038 — CompletionMoment */
-"completion.mark.done" = "标记完成";
-"completion.stat.walked" = "走过";
-"completion.stat.travelers" = "旅人";
-"completion.tagline" = "这条路线现在为下一批旅人发光";
+"completion.mark.done" = "Mark done";
+"completion.stat.walked" = "Walked";
+"completion.stat.travelers" = "Travelers";
+"completion.tagline" = "This route now shines for the next traveler";
 "completion.a11y" = "Route complete — walked by %d travelers, %d companions joined";
 
 /* US-039 — OpenForCompanionsSheet */
-"openForCompanions.button" = "开为招募路线 ->";
+"openForCompanions.button" = "Open for companions ->";
 "openForCompanions.sheet.title" = "Create Recruiting Route";
 "openForCompanions.departure.header" = "Departure Window";
 "openForCompanions.departureFrom" = "From";
@@ -2098,6 +2098,9 @@
 "settings.forgetMe.confirm.action" = "Forget me";
 "settings.forgetMe.toast.success" = "Done — the agent will start fresh next time you chat.";
 "settings.forgetMe.toast.failure" = "Couldn't clear right now. Try again in a moment.";
+"settings.exportData" = "Export my data";
+"settings.exportData.toast.empty" = "Nothing to export yet — your visits, capsules, and notes will show up here once you start using the app.";
+"settings.exportData.toast.failure" = "Couldn't prepare the export. Try again in a moment.";
 
 /* Startup self-diagnostics (StartupDiagnosticsService + SoloAgentBubble) */
 "diagnostics.anthropic.missing.title" = "AI brain isn't wired up";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -2108,6 +2108,9 @@
 "settings.forgetMe.confirm.action" = "忘记我";
 "settings.forgetMe.toast.success" = "已清空——下次开聊时,Agent 会重新认识你。";
 "settings.forgetMe.toast.failure" = "暂时无法清空,请稍后再试。";
+"settings.exportData" = "导出我的数据";
+"settings.exportData.toast.empty" = "暂无可导出的数据——开始使用后,你的到访、时空胶囊和笔记会在这里出现。";
+"settings.exportData.toast.failure" = "导出准备失败,请稍后再试。";
 
 /* 启动自检 (StartupDiagnosticsService + SoloAgentBubble) */
 "diagnostics.anthropic.missing.title" = "AI 大脑没接上";

--- a/apps/ios/SoloCompass/Services/PersonalDataExporter.swift
+++ b/apps/ios/SoloCompass/Services/PersonalDataExporter.swift
@@ -1,0 +1,335 @@
+import Foundation
+import SwiftData
+import os
+
+/// One-tap "Export my data" — the read-side twin of `ForgetMeService`.
+///
+/// The four highest-stickiness user assets (visit history, time capsules,
+/// traveler notes, taste profile) live in on-device SwiftData with **no cloud
+/// sync**. That is a deliberate privacy stance (PRIVACY.md on-device
+/// commitment), but until this exporter existed it had a fatal side effect:
+/// a user who accrued a year of location history and buried capsules lost all
+/// of it on device migration. `MarkdownExporter` only ever exported a single
+/// `Experience` card — never the user's own accumulated assets.
+///
+/// This service closes the data-sovereignty loop: `ForgetMeService` lets the
+/// user *erase* those four tables; `PersonalDataExporter` lets them *take the
+/// data with them*. It scopes to exactly the same tables so the two are
+/// symmetric (what you can wipe, you can also carry out).
+///
+/// Format per asset — chosen for the asset's real consumer, not uniformity:
+/// - `VisitRecord`         → CSV  (tabular; opens in Excel / hands to an accountant)
+/// - `TimeCapsule`         → Markdown (text capsules inline; voice/photo noted as binary)
+/// - `TravelerNoteRecord`  → Markdown (only `isMine` notes — seeded demo notes are
+///                            NOT the user's asset and are excluded)
+/// - `TasteProfile`        → Markdown (human-readable descriptors + confidence;
+///                            the raw embedding vector is an internal representation,
+///                            not a user-legible asset, so it is omitted)
+///
+/// Design mirrors `ForgetMeService`: a `ModelContainer` injected once at
+/// bootstrap, all reads through `ModelContext(container)`, never throws (a
+/// Settings button must never hang), and returns a `Result` so the UI can
+/// report exactly what was written rather than a silent success.
+@MainActor
+public final class PersonalDataExporter {
+
+    public static let shared = PersonalDataExporter()
+
+    private static let log = OSLog(subsystem: "com.solocompass.app", category: "PersonalDataExport")
+
+    private var modelContainer: ModelContainer?
+
+    private init() {}
+
+    /// Injected once at app bootstrap (mirrors `ForgetMeService.setModelContainer`).
+    public func setModelContainer(_ container: ModelContainer) {
+        self.modelContainer = container
+    }
+
+    /// Test-only overload: bind a specific container without the shared singleton.
+    /// Test-only overload. `nil` binds no container, exercising the
+    /// missing-container guard exactly as production hits it when bootstrap
+    /// hasn't run yet.
+    #if DEBUG
+    public convenience init(modelContainer: ModelContainer?) {
+        self.init()
+        self.modelContainer = modelContainer
+    }
+    #endif
+
+    // MARK: - Result
+
+    /// One exported file: a suggested filename + its UTF-8 text payload. The
+    /// caller (a Settings share sheet) writes these to temp URLs and hands them
+    /// to `UIActivityViewController`.
+    public struct File: Equatable, Sendable {
+        public let filename: String
+        public let contents: String
+
+        public init(filename: String, contents: String) {
+            self.filename = filename
+            self.contents = contents
+        }
+    }
+
+    /// What the export produced, so the UI reports counts (not a silent success)
+    /// and a `forgetEverything()`-style caller can assert on the numbers.
+    public struct Result: Equatable, Sendable {
+        public var files: [File]
+        public var visitRecordsExported: Int
+        public var timeCapsulesExported: Int
+        public var travelerNotesExported: Int
+        public var tasteProfileExported: Bool
+
+        public var totalAssets: Int {
+            visitRecordsExported + timeCapsulesExported +
+            travelerNotesExported + (tasteProfileExported ? 1 : 0)
+        }
+
+        public var isEmpty: Bool { totalAssets == 0 }
+    }
+
+    // MARK: - Export
+
+    /// Read all four personal-asset tables and render each to its file format.
+    ///
+    /// - Parameter now: injected clock so the export header timestamp is
+    ///   deterministic in tests. Defaults to `Date()`.
+    /// - Returns: the rendered files + per-table counts. When the
+    ///   `ModelContainer` is missing, returns an empty result and logs — never
+    ///   throws, so a Settings button never hangs on an alert.
+    @discardableResult
+    public func exportEverything(now: Date = Date()) -> Result {
+        guard let container = modelContainer else {
+            os_log("PersonalDataExport skipped — no ModelContainer bound",
+                   log: Self.log, type: .error)
+            return Result(files: [], visitRecordsExported: 0,
+                          timeCapsulesExported: 0, travelerNotesExported: 0,
+                          tasteProfileExported: false)
+        }
+        let context = ModelContext(container)
+
+        // A single id→title lookup shared by every renderer, so we hit the
+        // Experience table once instead of once per visit/capsule/note. A
+        // visit whose experience has been pruned still exports — it just shows
+        // the raw id rather than a name (never drop a user's own row).
+        let titles = experienceTitleLookup(in: context)
+
+        let (visitFile, visitCount) = exportVisits(in: context, titles: titles, now: now)
+        let (capsuleFile, capsuleCount) = exportCapsules(in: context, titles: titles, now: now)
+        let (noteFile, noteCount) = exportTravelerNotes(in: context, titles: titles, now: now)
+        let (tasteFile, hasTaste) = exportTasteProfile(in: context, now: now)
+
+        var files: [File] = []
+        if let visitFile { files.append(visitFile) }
+        if let capsuleFile { files.append(capsuleFile) }
+        if let noteFile { files.append(noteFile) }
+        if let tasteFile { files.append(tasteFile) }
+
+        os_log("PersonalDataExport v=%d c=%d n=%d taste=%{public}@ files=%d",
+               log: Self.log, type: .info, visitCount, capsuleCount, noteCount,
+               hasTaste ? "true" : "false", files.count)
+
+        return Result(
+            files: files,
+            visitRecordsExported: visitCount,
+            timeCapsulesExported: capsuleCount,
+            travelerNotesExported: noteCount,
+            tasteProfileExported: hasTaste
+        )
+    }
+
+    // MARK: - Experience title lookup
+
+    /// Build `experienceId → title` once. Missing rows simply aren't in the
+    /// map, and renderers fall back to the raw id — a pruned Experience must
+    /// never cause the user's visit/capsule/note to be dropped from the export.
+    private func experienceTitleLookup(in context: ModelContext) -> [String: String] {
+        let rows = (try? context.fetch(FetchDescriptor<ExperienceRecord>())) ?? []
+        return Dictionary(rows.map { ($0.id, $0.title) }, uniquingKeysWith: { first, _ in first })
+    }
+
+    private func placeName(for experienceId: String, titles: [String: String]) -> String {
+        titles[experienceId] ?? experienceId
+    }
+
+    // MARK: - Visits → CSV
+
+    private func exportVisits(
+        in context: ModelContext,
+        titles: [String: String],
+        now: Date
+    ) -> (File?, Int) {
+        let descriptor = FetchDescriptor<VisitRecord>(
+            sortBy: [SortDescriptor(\.visitedAt, order: .forward)]
+        )
+        guard let rows = try? context.fetch(descriptor), !rows.isEmpty else {
+            return (nil, 0)
+        }
+
+        let iso = ISO8601DateFormatter()
+        var lines = ["visited_at,place,experience_id,dwell_minutes,longitude,latitude,weather"]
+        for row in rows {
+            let place = placeName(for: row.experienceId, titles: titles)
+            let dwellMinutes = String(format: "%.1f", Double(row.dwellSeconds) / 60.0)
+            let coords = row.coords
+            let lon = coords.map { String($0[0]) } ?? ""
+            let lat = coords.map { String($0[1]) } ?? ""
+            let cells = [
+                iso.string(from: row.visitedAt),
+                place,
+                row.experienceId,
+                dwellMinutes,
+                lon,
+                lat,
+                row.weatherCode ?? "",
+            ].map(Self.csvEscape)
+            lines.append(cells.joined(separator: ","))
+        }
+
+        let filename = "solo-compass-visits-\(Self.dateStamp(now)).csv"
+        return (File(filename: filename, contents: lines.joined(separator: "\n") + "\n"), rows.count)
+    }
+
+    // MARK: - Capsules → Markdown
+
+    private func exportCapsules(
+        in context: ModelContext,
+        titles: [String: String],
+        now: Date
+    ) -> (File?, Int) {
+        let descriptor = FetchDescriptor<TimeCapsule>(
+            sortBy: [SortDescriptor(\.createdAt, order: .forward)]
+        )
+        guard let rows = try? context.fetch(descriptor), !rows.isEmpty else {
+            return (nil, 0)
+        }
+
+        let iso = ISO8601DateFormatter()
+        var body = "# Solo Compass — Time Capsules\n\n"
+        body += "Exported \(iso.string(from: now)) · \(rows.count) capsule(s)\n\n"
+
+        for row in rows {
+            let place = placeName(for: row.experienceId, titles: titles)
+            body += "## \(place)\n\n"
+            body += "- Buried: \(iso.string(from: row.createdAt))\n"
+            body += "- Opens: \(iso.string(from: row.scheduledFor))\n"
+            body += "- Status: \(row.opened ? "opened" : "sealed")\n"
+
+            switch row.contentType {
+            case TimeCapsule.ContentType.text:
+                let message = String(data: row.contentBlob, encoding: .utf8) ?? "(unreadable text)"
+                body += "\n\(message)\n"
+            case TimeCapsule.ContentType.voice:
+                body += "\n_Voice note — \(row.contentBlob.count) bytes of audio, not inlined._\n"
+            case TimeCapsule.ContentType.photo:
+                body += "\n_Photo — \(row.contentBlob.count) bytes of image, not inlined._\n"
+            default:
+                body += "\n_\(row.contentType) content — \(row.contentBlob.count) bytes, not inlined._\n"
+            }
+
+            if let ctx = CapsuleContext.decode(from: row.contextBlob) {
+                var bits: [String] = []
+                if let mood = ctx.moodEmoji { bits.append("mood \(mood)") }
+                if let weather = ctx.weatherCode { bits.append("weather \(weather)") }
+                if let desc = ctx.tasteDescriptors, !desc.isEmpty {
+                    bits.append("vibe " + desc.joined(separator: "/"))
+                }
+                if !bits.isEmpty {
+                    body += "\n> _\(bits.joined(separator: " · "))_\n"
+                }
+            }
+            body += "\n---\n\n"
+        }
+
+        let filename = "solo-compass-capsules-\(Self.dateStamp(now)).md"
+        return (File(filename: filename, contents: body), rows.count)
+    }
+
+    // MARK: - Traveler notes → Markdown (only the user's own)
+
+    private func exportTravelerNotes(
+        in context: ModelContext,
+        titles: [String: String],
+        now: Date
+    ) -> (File?, Int) {
+        // Only `isMine` notes are the user's asset. Seeded demo notes
+        // (`seedBank` in TravelerNoteStore) belong to the content layer, not
+        // the user, and must not leak into a "your data" export.
+        let descriptor = FetchDescriptor<TravelerNoteRecord>(
+            predicate: #Predicate { $0.isMine == true },
+            sortBy: [SortDescriptor(\.createdAt, order: .forward)]
+        )
+        guard let rows = try? context.fetch(descriptor), !rows.isEmpty else {
+            return (nil, 0)
+        }
+
+        let iso = ISO8601DateFormatter()
+        var body = "# Solo Compass — My Traveler Notes\n\n"
+        body += "Exported \(iso.string(from: now)) · \(rows.count) note(s)\n\n"
+
+        for row in rows {
+            let place = placeName(for: row.experienceId, titles: titles)
+            let kind = row.kind == TravelerNote.Kind.correction.rawValue ? "correction" : "note"
+            body += "## \(place)\n\n"
+            body += "- \(kind) · \(row.createdAt)"
+            if row.confirms > 0 { body += " · \(row.confirms) confirmed" }
+            if row.aiAdopted { body += " · adopted by AI" }
+            body += "\n\n\(row.text)\n\n---\n\n"
+        }
+
+        let filename = "solo-compass-notes-\(Self.dateStamp(now)).md"
+        return (File(filename: filename, contents: body), rows.count)
+    }
+
+    // MARK: - Taste profile → Markdown
+
+    private func exportTasteProfile(in context: ModelContext, now: Date) -> (File?, Bool) {
+        // Singleton table — 0 or 1 row. The raw embedding vector is an internal
+        // model representation, not a user-legible asset, so we export only the
+        // human-readable descriptors + calibrated confidence.
+        guard let row = try? context.fetch(FetchDescriptor<TasteProfile>()).first else {
+            return (nil, false)
+        }
+
+        let iso = ISO8601DateFormatter()
+        var body = "# Solo Compass — My Taste Profile\n\n"
+        body += "Exported \(iso.string(from: now))\n\n"
+        body += "- Last updated: \(iso.string(from: row.updatedAt))\n"
+        body += "- Confidence: \(String(format: "%.0f%%", row.confidence * 100))\n\n"
+
+        let descriptors = row.descriptors
+        if descriptors.isEmpty {
+            body += "_No descriptors recorded yet._\n"
+        } else {
+            body += "## Vibe\n\n"
+            for d in descriptors { body += "- \(d)\n" }
+            body += "\n"
+        }
+
+        let filename = "solo-compass-taste-\(Self.dateStamp(now)).md"
+        return (File(filename: filename, contents: body), true)
+    }
+
+    // MARK: - Helpers
+
+    /// RFC 4180 CSV escaping: wrap in double quotes and double any embedded
+    /// quote whenever the cell contains a comma, quote, or newline. A place
+    /// name like `Café "Central", Lisbon` must not shift columns.
+    static func csvEscape(_ value: String) -> String {
+        guard value.contains(",") || value.contains("\"") || value.contains("\n") else {
+            return value
+        }
+        return "\"" + value.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+    }
+
+    /// `yyyy-MM-dd` stamp for filenames, in the device's local calendar. Uses a
+    /// fixed-format `DateFormatter` (not ISO8601) so the filename has no colons,
+    /// which some file systems and share targets dislike.
+    static func dateStamp(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f.string(from: date)
+    }
+}

--- a/apps/ios/SoloCompass/Tests/PersonalDataExporterTests.swift
+++ b/apps/ios/SoloCompass/Tests/PersonalDataExporterTests.swift
@@ -1,0 +1,236 @@
+import XCTest
+import SwiftData
+@testable import SoloCompass
+
+/// Exercises `PersonalDataExporter` — the read-side twin of `ForgetMeService`.
+/// Each test builds a fresh in-memory ModelContainer holding the five tables
+/// the exporter touches, seeds rows, runs `exportEverything`, and asserts on
+/// the rendered file contents + per-table counts.
+@MainActor
+final class PersonalDataExporterTests: XCTestCase {
+
+    private let clock = Date(timeIntervalSince1970: 1_760_000_000)  // fixed for deterministic stamps
+
+    private func makeContainer() throws -> ModelContainer {
+        let config = ModelConfiguration("PersonalDataExportTests", isStoredInMemoryOnly: true)
+        return try ModelContainer(
+            for: VisitRecord.self, TimeCapsule.self, TravelerNoteRecord.self,
+            TasteProfile.self, ExperienceRecord.self,
+            configurations: config
+        )
+    }
+
+    private func makeExporter(_ container: ModelContainer) -> PersonalDataExporter {
+        PersonalDataExporter(modelContainer: container)
+    }
+
+    /// Minimal `ExperienceRecord` — the exporter only reads `id` + `title`, but
+    /// the blob fields must hold *legal* JSON encodings (empty arrays / neutral
+    /// values), not bare `Data()`. A bare empty blob makes the persistence codec
+    /// log a `decode field … failed` error on every fetch, flooding test output.
+    private func makeExperience(id: String, title: String) -> ExperienceRecord {
+        let enc = JSONEncoder.iso8601Encoder
+        let emptyArray = Data("[]".utf8)
+        let soloScore = (try? enc.encode(ExperienceRecord.neutralSoloScore)) ?? Data("{}".utf8)
+        let confidence = (try? enc.encode(ExperienceRecord.neutralConfidence)) ?? Data("{}".utf8)
+        let stats = (try? enc.encode(ExperienceRecord.neutralStats)) ?? Data("{}".utf8)
+        return ExperienceRecord(
+            id: id, title: title, oneLiner: "", whyItMatters: "",
+            category: "cafe", longitude: 0, latitude: 0, cityCode: "LIS",
+            addressHint: nil, placeNameLocal: nil, placeNameRomanized: nil,
+            durationMin: 30, durationMax: 60, status: "candidate",
+            createdAt: clock, updatedAt: clock,
+            bestTimesBlob: emptyArray, howToBlob: emptyArray,
+            realInconveniencesBlob: emptyArray, sourcesBlob: emptyArray,
+            soloScoreBlob: soloScore, confidenceBlob: confidence,
+            statsBlob: stats, nearbyExperienceIdsBlob: emptyArray
+        )
+    }
+
+    // MARK: - Empty / missing-container safety
+
+    func testMissingModelContainerReturnsEmptyAndDoesNotCrash() {
+        let exporter = PersonalDataExporter(modelContainer: nil)  // no container bound
+        let result = exporter.exportEverything(now: clock)
+        XCTAssertTrue(result.files.isEmpty)
+        XCTAssertTrue(result.isEmpty)
+        XCTAssertEqual(result.totalAssets, 0)
+    }
+
+    func testEmptyDatabaseProducesNoFiles() throws {
+        let container = try makeContainer()
+        let result = makeExporter(container).exportEverything(now: clock)
+        XCTAssertTrue(result.files.isEmpty)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Visits → CSV
+
+    func testVisitsExportedAsCSVWithReadablePlaceName() throws {
+        let container = try makeContainer()
+        let ctx = ModelContext(container)
+        ctx.insert(makeExperience(id: "exp_1", title: "Hidden Café"))
+        ctx.insert(VisitRecord(
+            experienceId: "exp_1",
+            visitedAt: Date(timeIntervalSince1970: 1_759_000_000),
+            dwellSeconds: 1800,  // 30.0 min
+            weatherCode: "rain",
+            coordSnapBlob: VisitRecord.encodeCoords([-9.1393, 38.7223])
+        ))
+        try ctx.save()
+
+        let result = makeExporter(container).exportEverything(now: clock)
+        XCTAssertEqual(result.visitRecordsExported, 1)
+
+        let csv = try XCTUnwrap(result.files.first { $0.filename.contains("visits") })
+        XCTAssertTrue(csv.filename.hasSuffix(".csv"))
+        XCTAssertTrue(csv.contents.contains("visited_at,place,experience_id,dwell_minutes"))
+        XCTAssertTrue(csv.contents.contains("Hidden Café"))
+        XCTAssertTrue(csv.contents.contains("30.0"))
+        XCTAssertTrue(csv.contents.contains("-9.1393"))
+        XCTAssertTrue(csv.contents.contains("rain"))
+    }
+
+    func testVisitWithCommaInPlaceNameIsCSVEscaped() throws {
+        let container = try makeContainer()
+        let ctx = ModelContext(container)
+        ctx.insert(makeExperience(id: "exp_2", title: "Café \"Central\", Lisbon"))
+        ctx.insert(VisitRecord(experienceId: "exp_2", dwellSeconds: 600))
+        try ctx.save()
+
+        let csv = try XCTUnwrap(
+            makeExporter(container).exportEverything(now: clock).files.first { $0.filename.contains("visits") }
+        )
+        // The comma-and-quote place name must be RFC4180-escaped so it stays one column.
+        XCTAssertTrue(csv.contents.contains("\"Café \"\"Central\"\", Lisbon\""))
+    }
+
+    func testVisitWithPrunedExperienceFallsBackToRawId() throws {
+        let container = try makeContainer()
+        let ctx = ModelContext(container)
+        // No ExperienceRecord for this id — the visit must still export.
+        ctx.insert(VisitRecord(experienceId: "exp_gone", dwellSeconds: 300))
+        try ctx.save()
+
+        let result = makeExporter(container).exportEverything(now: clock)
+        XCTAssertEqual(result.visitRecordsExported, 1)
+        let csv = try XCTUnwrap(result.files.first { $0.filename.contains("visits") })
+        XCTAssertTrue(csv.contents.contains("exp_gone"))
+    }
+
+    // MARK: - Capsules → Markdown
+
+    func testTextCapsuleInlinesMessage() throws {
+        let container = try makeContainer()
+        let ctx = ModelContext(container)
+        ctx.insert(makeExperience(id: "exp_3", title: "Rooftop Bar"))
+        ctx.insert(TimeCapsule(
+            experienceId: "exp_3",
+            scheduledFor: Date(timeIntervalSince1970: 1_800_000_000),
+            contentType: TimeCapsule.ContentType.text,
+            contentBlob: Data("Come back here in a year.".utf8)
+        ))
+        try ctx.save()
+
+        let result = makeExporter(container).exportEverything(now: clock)
+        XCTAssertEqual(result.timeCapsulesExported, 1)
+        let md = try XCTUnwrap(result.files.first { $0.filename.contains("capsules") })
+        XCTAssertTrue(md.contents.contains("Rooftop Bar"))
+        XCTAssertTrue(md.contents.contains("Come back here in a year."))
+        XCTAssertTrue(md.contents.contains("sealed"))
+    }
+
+    func testVoiceCapsuleNotedAsBinaryNotInlined() throws {
+        let container = try makeContainer()
+        let ctx = ModelContext(container)
+        ctx.insert(TimeCapsule(
+            experienceId: "exp_4",
+            scheduledFor: clock,
+            contentType: TimeCapsule.ContentType.voice,
+            contentBlob: Data(count: 4096)
+        ))
+        try ctx.save()
+
+        let md = try XCTUnwrap(
+            makeExporter(container).exportEverything(now: clock).files.first { $0.filename.contains("capsules") }
+        )
+        XCTAssertTrue(md.contents.contains("Voice note"))
+        XCTAssertTrue(md.contents.contains("4096 bytes"))
+    }
+
+    // MARK: - Traveler notes → only isMine
+
+    func testOnlyMyTravelerNotesAreExported() throws {
+        let container = try makeContainer()
+        let ctx = ModelContext(container)
+        ctx.insert(makeExperience(id: "exp_5", title: "Quiet Park"))
+        // Seeded demo note — must NOT be exported.
+        ctx.insert(TravelerNoteRecord(
+            id: "seed_1", experienceId: "exp_5", authorInitial: "J", authorColor: nil,
+            text: "Seeded demo note", kind: "experience",
+            createdAt: "2026-06-01T00:00:00Z", confirms: 3, aiAdopted: false, isMine: false
+        ))
+        // The user's own note — must be exported.
+        ctx.insert(TravelerNoteRecord(
+            id: "mine_1", experienceId: "exp_5", authorInitial: "你", authorColor: nil,
+            text: "Tuesday afternoon was dead quiet", kind: "experience",
+            createdAt: "2026-06-10T00:00:00Z", confirms: 0, aiAdopted: false, isMine: true
+        ))
+        try ctx.save()
+
+        let result = makeExporter(container).exportEverything(now: clock)
+        XCTAssertEqual(result.travelerNotesExported, 1)
+        let md = try XCTUnwrap(result.files.first { $0.filename.contains("notes") })
+        XCTAssertTrue(md.contents.contains("Tuesday afternoon was dead quiet"))
+        XCTAssertFalse(md.contents.contains("Seeded demo note"))
+    }
+
+    // MARK: - Taste profile → descriptors, no raw vector
+
+    func testTasteProfileExportsDescriptorsNotEmbedding() throws {
+        let container = try makeContainer()
+        let ctx = ModelContext(container)
+        ctx.insert(TasteProfile(
+            embedding: TasteProfile.encodeEmbedding([0.11, 0.22, 0.33]),
+            descriptorsBlob: try TasteProfile.encodeDescriptors(["arty", "quiet", "sunlit"]),
+            confidence: 0.85
+        ))
+        try ctx.save()
+
+        let result = makeExporter(container).exportEverything(now: clock)
+        XCTAssertTrue(result.tasteProfileExported)
+        let md = try XCTUnwrap(result.files.first { $0.filename.contains("taste") })
+        XCTAssertTrue(md.contents.contains("arty"))
+        XCTAssertTrue(md.contents.contains("quiet"))
+        XCTAssertTrue(md.contents.contains("85%"))
+        // The raw embedding floats must never appear in a user-legible export.
+        XCTAssertFalse(md.contents.contains("0.11"))
+    }
+
+    // MARK: - Full mixed export
+
+    func testAllFourAssetTypesProduceFourFiles() throws {
+        let container = try makeContainer()
+        let ctx = ModelContext(container)
+        ctx.insert(VisitRecord(experienceId: "e", dwellSeconds: 600))
+        ctx.insert(TimeCapsule(
+            experienceId: "e", scheduledFor: clock,
+            contentType: TimeCapsule.ContentType.text, contentBlob: Data("hi".utf8)
+        ))
+        ctx.insert(TravelerNoteRecord(
+            id: "m", experienceId: "e", authorInitial: "你", authorColor: nil,
+            text: "mine", kind: "experience", createdAt: "2026-06-10T00:00:00Z",
+            confirms: 0, aiAdopted: false, isMine: true
+        ))
+        ctx.insert(TasteProfile(
+            embedding: Data(), descriptorsBlob: try TasteProfile.encodeDescriptors(["arty"]),
+            confidence: 0.5
+        ))
+        try ctx.save()
+
+        let result = makeExporter(container).exportEverything(now: clock)
+        XCTAssertEqual(result.files.count, 4)
+        XCTAssertEqual(result.totalAssets, 4)
+        XCTAssertFalse(result.isEmpty)
+    }
+}

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -289,6 +289,21 @@ struct CompassMapContentView: View {
     // "prompt only once" behaviour across repeat onAppear fires.
     @State private var hasRunFirstAppear: Bool = false
 
+    // P0 (UX audit 2026-07-16 #1): the terms + onboarding `fullScreenCover`
+    // lives in `SoloCompassApp`, but this map still enters the hierarchy and
+    // fires its own `onAppear` side effects *underneath* that cover on a fresh
+    // install. Two of them — `locationService.requestPermission()` and the
+    // auto-opened city picker — surface a system alert / modal that iOS renders
+    // ABOVE the SwiftUI cover, visually burying the consent screen. This mirrors
+    // the exact state SoloCompassApp uses to decide the cover, so we can hold
+    // those side effects until consent + onboarding are both done. `hasAccepted`
+    // and `hasCompletedOnboarding` are the same persisted flags the cover reads;
+    // the DEBUG `-devSkipOnboarding` path sets both, so screenshot harnesses stay
+    // unaffected.
+    private var firstLaunchGateActive: Bool {
+        !(TermsConsentSheet.hasAccepted && preferences.hasCompletedOnboarding)
+    }
+
     /// Startup self-diagnostics — runs once per calendar day 1.5s after first
     /// paint. Findings drive a `SoloAgentBubble` shown just above the Solo
     /// mascot FAB; tapping the CTA seeds the findings into ChatSheet as the
@@ -809,7 +824,14 @@ struct CompassMapContentView: View {
                     ensureOrchestrator(viewModel: viewModel)
                 }
                 #endif
-                locationService.requestPermission()
+                // P0 #1: only ask for location once the consent + onboarding
+                // gate is clear. While the `fullScreenCover` is up, the system
+                // location alert would render above it and bury the terms
+                // screen. The `onChange(of: preferences.hasCompletedOnboarding)`
+                // below re-fires this the moment onboarding finishes.
+                if !firstLaunchGateActive {
+                    locationService.requestPermission()
+                }
                 // US-021: `viewModel` is built eagerly in `init`, so there is no
                 // lazy-creation block here anymore. We only run the one-shot
                 // first-launch side effects that used to live behind the
@@ -825,8 +847,15 @@ struct CompassMapContentView: View {
                     // unexpectedly opens the picker over the consent gate.
                     // DEBUG: screenshot harness can pass -skipLocationPicker to keep
                     // the home view clean (no modal sheet covering peek/pins/FAB).
+                    // P0 #1: don't auto-open the picker while the consent /
+                    // onboarding cover is still up — it would stack a modal over
+                    // (and iOS renders it above) the terms screen. Onboarding's
+                    // final step usually resolves a starting city anyway; if it
+                    // doesn't, `maybePromptCityPicker()` re-evaluates once the
+                    // gate clears.
                     let skipPicker = ProcessInfo.processInfo.arguments.contains("-skipLocationPicker")
                     if !skipPicker
+                        && !firstLaunchGateActive
                         && viewModel.selectedCity == nil
                         && preferences.lastSelectedCity == nil
                         && locationService.currentLocation == nil {
@@ -959,6 +988,19 @@ struct CompassMapContentView: View {
                 // light up on first render — without waiting for the next
                 // VisitRecord write to trigger the onChange below.
                 viewModel.attachVisitedExperienceIds(Set(visitRecords.map(\.experienceId)))
+            }
+            // P0 #1: bridge the consent/onboarding gate → deferred cold-start
+            // side effects. The map's `onAppear` fires *underneath* the terms
+            // cover on a fresh install, so it holds off on the location prompt
+            // and city picker (they'd surface a system alert / modal above the
+            // cover and bury consent). When onboarding completes the cover
+            // dismisses and this fires, running those side effects now that the
+            // screen belongs to the map. Idempotent: `requestPermission()` no-ops
+            // once decided, and `maybePromptCityPicker()` self-guards.
+            .onChange(of: preferences.hasCompletedOnboarding) { _, completed in
+                guard completed, TermsConsentSheet.hasAccepted else { return }
+                locationService.requestPermission()
+                maybePromptCityPicker()
             }
             .onChange(of: locationService.currentLocation) { _, _ in
                 viewModel.bindToLocation()
@@ -2375,6 +2417,21 @@ struct CompassMapContentView: View {
     /// DEBUG `-forceDiagnosticsBubble` launch arg: injects a synthetic finding
     /// so screenshot / e2e harnesses can always exercise the bubble without
     /// depending on the current sim's authorization / key state.
+    /// P0 #1 helper: open the city picker only when there's genuinely no city
+    /// to land on. Called both from the first-appear block and from the
+    /// onboarding-complete bridge so a fresh install that finished onboarding
+    /// without resolving a city still gets prompted — just *after* the consent
+    /// cover is gone, never stacked underneath it.
+    private func maybePromptCityPicker() {
+        let skipPicker = ProcessInfo.processInfo.arguments.contains("-skipLocationPicker")
+        guard !skipPicker,
+              !firstLaunchGateActive,
+              viewModel.selectedCity == nil,
+              preferences.lastSelectedCity == nil,
+              locationService.currentLocation == nil else { return }
+        isShowingCityPicker = true
+    }
+
     private func kickoffStartupDiagnostics() {
         let svc = diagnostics ?? StartupDiagnosticsService(
             preferences: preferences,

--- a/apps/ios/SoloCompass/Views/Map/NearbyExperienceRow.swift
+++ b/apps/ios/SoloCompass/Views/Map/NearbyExperienceRow.swift
@@ -745,7 +745,13 @@ struct NearbyExperienceRow: View {
                 cityDisplayName
             )
         }
-        return Self.distanceFormatter.string(from: Measurement(value: meters, unit: UnitLength.meters))
+        // Floor the reading at 50 m before formatting. `MeasurementFormatter`'s
+        // `.naturalScale` auto-downgrades near-zero distances to centimetres or
+        // millimetres — a GPS fix a few metres off the pin rendered a nonsense
+        // "0mm" next to the "Almost there" label. Mirrors the existing guard in
+        // `ExperienceDetailView.formatDistance` (`max(50, rounded)`).
+        let floored = max(50, meters)
+        return Self.distanceFormatter.string(from: Measurement(value: floored, unit: UnitLength.meters))
     }
 }
 

--- a/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
+++ b/apps/ios/SoloCompass/Views/Settings/SettingsView.swift
@@ -38,6 +38,14 @@ public struct SettingsView: View {
     // favorites / preferences.
     @State private var showingForgetMeConfirm = false
     @State private var forgetMeToast: String?
+    // Data-sovereignty export twin of "Forget me". Renders the four
+    // high-stickiness personal assets (visits / capsules / notes / taste) to
+    // temp files and hands them to a share sheet so they survive device
+    // migration. `exportedFileURLs` non-empty drives the share sheet; the toast
+    // covers the empty-data case (nothing accrued yet → no files to share).
+    @State private var exportedFileURLs: [URL] = []
+    @State private var showingExportShare = false
+    @State private var exportToast: String?
     @State private var restoreToast: String?
     @State private var restoreInFlight = false
     @State private var showingLanguageRestartAlert = false
@@ -526,6 +534,37 @@ public struct SettingsView: View {
                 Text(NSLocalizedString("settings.clearData.confirm.message", comment: "Clear all data message"))
             }
 
+            // Data-sovereignty export — the read-side twin of "Forget me".
+            // Non-destructive, so it sits BEFORE the two nukes: offer the user
+            // a way to carry their data out before offering ways to erase it.
+            Button {
+                let result = PersonalDataExporter.shared.exportEverything()
+                if result.isEmpty {
+                    exportToast = NSLocalizedString(
+                        "settings.exportData.toast.empty",
+                        comment: "Export empty (nothing accrued yet)"
+                    )
+                    return
+                }
+                exportedFileURLs = Self.writeExportFiles(result.files)
+                if exportedFileURLs.isEmpty {
+                    exportToast = NSLocalizedString(
+                        "settings.exportData.toast.failure",
+                        comment: "Export write failed"
+                    )
+                } else {
+                    showingExportShare = true
+                }
+            } label: {
+                settingsIconLabel(
+                    icon: "square.and.arrow.up", color: .blue,
+                    label: NSLocalizedString("settings.exportData", comment: "Export my data")
+                )
+            }
+            .sheet(isPresented: $showingExportShare) {
+                DataExportActivitySheet(items: exportedFileURLs)
+            }
+
             // P2.0 #204: "Forget me" — narrower than Clear All Data. Wipes
             // the AgentMemorySnapshot + TasteProfile singletons so the
             // Chat Agent forgets any accumulated personalisation. Routes,
@@ -586,12 +625,54 @@ public struct SettingsView: View {
                 }
             }
         )
+        // Data-export result toast — covers the empty-data and write-failure
+        // cases (success opens the share sheet instead of a toast). Same
+        // writable-binding pattern as the two alerts above.
+        .alert(
+            exportToast ?? "",
+            isPresented: Binding(
+                get: { exportToast != nil },
+                set: { if !$0 { exportToast = nil } }
+            ),
+            actions: {
+                Button(NSLocalizedString("common.ok", comment: "OK")) {
+                    exportToast = nil
+                }
+            }
+        )
     }
 
     private var appVersion: String {
         let v = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
         let b = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
         return "\(v) (\(b))"
+    }
+
+    /// Write each exported `File` to a uniquely-scoped temp directory and
+    /// return the URLs for the share sheet. A per-export subdirectory keeps
+    /// filenames stable (the share target shows `solo-compass-visits-….csv`,
+    /// not a UUID) while still avoiding collisions across repeat exports. A
+    /// file that fails to write is skipped rather than aborting the whole
+    /// export — the user still gets whatever assets serialized cleanly.
+    private static func writeExportFiles(_ files: [PersonalDataExporter.File]) -> [URL] {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("data-export-\(UUID().uuidString)", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        } catch {
+            return []
+        }
+        var urls: [URL] = []
+        for file in files {
+            let url = dir.appendingPathComponent(file.filename)
+            do {
+                try file.contents.write(to: url, atomically: true, encoding: .utf8)
+                urls.append(url)
+            } catch {
+                continue
+            }
+        }
+        return urls
     }
 
     private func handleVersionTap() {
@@ -1297,4 +1378,18 @@ struct CustomTagsView: View {
         CustomTagsView()
             .environment(UserPreferences())
     }
+}
+
+/// Wraps `UIActivityViewController` so the Settings data-export button can hand
+/// the rendered files to the system share sheet. Mirrors the private wrapper in
+/// `ShareSheet.swift`; kept file-private here to avoid coupling Settings to the
+/// Experience share module.
+private struct DataExportActivitySheet: UIViewControllerRepresentable {
+    let items: [URL]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }


### PR DESCRIPTION
## Summary

Bundles the **data-sovereignty export** feature with two pre-existing working-tree fixes that were unstaged on this branch.

**Personal data export (new — this session's work):**
- `PersonalDataExporter` — the read-side twin of `ForgetMeService`. Renders the four highest-stickiness on-device assets (visit history, time capsules, traveler notes, taste profile) to shareable files so they survive device migration. Previously these were local-only with **no export path** — a user lost a year of accrued data on device switch.
  - Visits → **CSV** (opens in Excel / hands to an accountant)
  - Capsules / notes / taste → **Markdown**
  - Only the user's *real* assets export: seeded demo notes and the raw taste embedding vector are deliberately excluded.
- Settings **"Export my data"** button → system share sheet. Placed *before* the destructive "Forget me" (carry out before erase). Localized in en + zh-Hans.

**Pre-existing fixes carried along (NOT authored this session):**
- `CompassMapView` — first-launch gate holds `requestPermission()` and the auto city picker until consent + onboarding complete, so a system alert no longer buries the consent cover on fresh install (UX audit 2026-07-16 #1).
- `en.lproj/Localizable.strings` — `route.*` strings were mistakenly filled with Traditional Chinese values in the English table; corrected to English.
- `NearbyExperienceRow` — floors distance at 50 m before formatting so a near-zero GPS fix no longer renders a nonsense "0mm".

## Test Coverage

`PersonalDataExporter`: 10 unit tests, all passing (`Executed 10 tests, 0 failures`). Covers: empty/missing-container safety, CSV escaping (comma+quote place names), pruned-Experience fallback to raw id, text vs voice capsule handling, seeded-note exclusion, embedding-not-leaked.

The pre-existing fixes (CompassMapView / strings / NearbyExperienceRow) were not authored this session and carry no new tests.

## Pre-Landing Review

Reviewed the diff. Export code covered by tests. Carried-along fixes read cleanly: `firstLaunchGateActive` gate is idempotent (`requestPermission()` no-ops once decided, city picker self-guards); strings change corrects 37 mistranslated values with no net key deletion.

## Verification

- `xcodebuild build`: **BUILD SUCCEEDED**
- `PersonalDataExporterTests`: **Executed 10 tests, 0 failures**
- Full test suite not run: iOS test runner hung-before-connection is a known environment flake on this machine; verified new code via isolated `test-without-building`.

## Notes

PR intentionally covers four themes (export feature + 3 unrelated fixes) at the author's request to avoid losing the pre-existing working-tree fixes. Not single-purpose by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)