### PR TITLE
feat(ios): Nomad OS B1 Today home behind FeatureFlags.todayHome (a/b/d)

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		352247C1FBF4C8F901D17F32 /* ApprovalTrustSignalTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804618047547A9D7F3F8EAAA /* ApprovalTrustSignalTest.swift */; };
 		36E1316045802B2F642A9623 /* LocalAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C89CB8D3309FD5646E23434 /* LocalAttachment.swift */; };
 		37273BCDAED53D5F49CD756D /* CityBriefServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDD92E055336925881B13C67 /* CityBriefServiceTests.swift */; };
+		37375126C9D00F02A3233357 /* TodayNearbyRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76E5FA5F9C2CADE936F9D40 /* TodayNearbyRow.swift */; };
 		378B1344A5EE8001D033035F /* ChatMessageRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50C2F35BCC11F93944A83B9 /* ChatMessageRecord.swift */; };
 		37D5A0FD622C9649308BD14D /* FavoriteFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA17ED8FE9ABA2F5CC1D557E /* FavoriteFilterTests.swift */; };
 		38569000AFC1017483C20063 /* DiscoverPostDetailRenderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA75549DB586E5FB6689BEAE /* DiscoverPostDetailRenderTest.swift */; };
@@ -276,6 +277,7 @@
 		79F4DE4ACC4FEABEFC3C3A70 /* AgentMemorySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5610245238F8E10140649BE4 /* AgentMemorySnapshot.swift */; };
 		7A089AEA89FE3ECC1F8F1E0D /* BestTimeTomorrowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA0493569A1D4BC9304DCB7 /* BestTimeTomorrowTests.swift */; };
 		7A5F7752DE91A7FEE6571C7A /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038BEE46BF2DFAF762B605D5 /* Route.swift */; };
+		7AC84A1CE63882AEA5D066A5 /* TodaySealReceiptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118294EB8964E37C63FEE7FC /* TodaySealReceiptTests.swift */; };
 		7ACAAE18D2EFA3E880AD6744 /* PressableButtonStyleHapticTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFE48683692E4C00E0A2DC5 /* PressableButtonStyleHapticTest.swift */; };
 		7B611EA960309C795E31B2B8 /* ChatAttachmentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA96BC45388A8EC99F3B29ED /* ChatAttachmentService.swift */; };
 		7C14629A3FAB31975BFBB0A6 /* ExperienceRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A250916F91C8EF0BE90DF763 /* ExperienceRepository.swift */; };
@@ -390,6 +392,7 @@
 		AF89A5DAA5BE9C3FC9DF1675 /* MapPinPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DBD8BED52DB4E9DD339BFD /* MapPinPickerView.swift */; };
 		B0EFE759B67951C4D10B16FD /* UserDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B0465B31ABD4A057EE984F /* UserDirectory.swift */; };
 		B0FE4A45CD3A45E9AD1D33C3 /* TodayContainerSnapshotTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34C1E95A05E3986C2E65F70 /* TodayContainerSnapshotTest.swift */; };
+		B2060AA2A2C1E4933941D2BB /* TodaySealReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912B8348C2044FEAD6C0643B /* TodaySealReceipt.swift */; };
 		B28F15C454376D86258FCD77 /* OverpassService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67173C74F1A76C3CE5C38C0A /* OverpassService.swift */; };
 		B2C98BCF4E0193B5740C7762 /* FriendsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7202B977A555239F367D02 /* FriendsListView.swift */; };
 		B32CCADAF2919BAFA66D9C94 /* SFSymbolExistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA9968E168052C0DC0E1B36 /* SFSymbolExistenceTests.swift */; };
@@ -658,6 +661,7 @@
 		112319E8315F5F6961C95264 /* VoiceAgentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAgentSession.swift; sourceTree = "<group>"; };
 		112365ED9467BFB0994BC0A0 /* CompanionProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionProfile.swift; sourceTree = "<group>"; };
 		1157BB60848F9C74D7E8C14E /* TravelerNoteRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelerNoteRecord.swift; sourceTree = "<group>"; };
+		118294EB8964E37C63FEE7FC /* TodaySealReceiptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodaySealReceiptTests.swift; sourceTree = "<group>"; };
 		11A51666D1564BE942593139 /* ChatDisplayType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDisplayType.swift; sourceTree = "<group>"; };
 		11CCB9E36FDC56604136090F /* IslandPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IslandPalette.swift; sourceTree = "<group>"; };
 		11F91F51C79F4EC2D9464FDA /* ExperienceImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceImageService.swift; sourceTree = "<group>"; };
@@ -950,6 +954,7 @@
 		9055347887EF473171916120 /* AttachmentBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentBubble.swift; sourceTree = "<group>"; };
 		907EA19EC9B84B93AB110C70 /* ColdStartExperienceLoadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColdStartExperienceLoadTests.swift; sourceTree = "<group>"; };
 		90B0465B31ABD4A057EE984F /* UserDirectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDirectory.swift; sourceTree = "<group>"; };
+		912B8348C2044FEAD6C0643B /* TodaySealReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodaySealReceipt.swift; sourceTree = "<group>"; };
 		91DB88CF9AE303E72C776B72 /* TravelerNoteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelerNoteStore.swift; sourceTree = "<group>"; };
 		91FB9685AAB19B85A859BDB8 /* PeekCardShortNameTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeekCardShortNameTest.swift; sourceTree = "<group>"; };
 		93596ABD2BD9FB0C744684F5 /* MapCluster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapCluster.swift; sourceTree = "<group>"; };
@@ -1107,6 +1112,7 @@
 		D4C10384834D53FE83113D51 /* Configuration.storekit */ = {isa = PBXFileReference; path = Configuration.storekit; sourceTree = "<group>"; };
 		D5B8BA7FFBD93A01E54B7E4A /* ExperienceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailView.swift; sourceTree = "<group>"; };
 		D60647FA4E64B48E215B9D2F /* RouteCompanionRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCompanionRemote.swift; sourceTree = "<group>"; };
+		D76E5FA5F9C2CADE936F9D40 /* TodayNearbyRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayNearbyRow.swift; sourceTree = "<group>"; };
 		D91E024770F8793AB27EF247 /* ChatCardStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCardStack.swift; sourceTree = "<group>"; };
 		D94A585E823470D513C6C861 /* ToolOutcomeLiveIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolOutcomeLiveIntegrationTests.swift; sourceTree = "<group>"; };
 		D9CF57D3342E9C609CD56801 /* AISynthesisQualityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISynthesisQualityTests.swift; sourceTree = "<group>"; };
@@ -1534,6 +1540,7 @@
 				884C97C686E2AFC3C534381A /* TasteUpdateServiceTests.swift */,
 				D34C1E95A05E3986C2E65F70 /* TodayContainerSnapshotTest.swift */,
 				FFA0BCC3FA2B0DF44F1F5217 /* TodayContainerTests.swift */,
+				118294EB8964E37C63FEE7FC /* TodaySealReceiptTests.swift */,
 				2BA42F14E0B63119912C00AD /* TodayStatusHeaderTests.swift */,
 				331B2AE74EFAD9589AF60498 /* TodoIssueReferenceTests.swift */,
 				D94A585E823470D513C6C861 /* ToolOutcomeLiveIntegrationTests.swift */,
@@ -2099,6 +2106,8 @@
 			isa = PBXGroup;
 			children = (
 				3697E1FD0492D1D0AE9274BA /* TodayContainer.swift */,
+				D76E5FA5F9C2CADE936F9D40 /* TodayNearbyRow.swift */,
+				912B8348C2044FEAD6C0643B /* TodaySealReceipt.swift */,
 				3D6EE32340E0A83362F440D7 /* TodayStatusHeader.swift */,
 			);
 			path = Today;
@@ -2524,6 +2533,7 @@
 				A7FC5F124C2C2CF9B09FA997 /* TasteUpdateServiceTests.swift in Sources */,
 				B0FE4A45CD3A45E9AD1D33C3 /* TodayContainerSnapshotTest.swift in Sources */,
 				A4528F9189C69F1292BA6006 /* TodayContainerTests.swift in Sources */,
+				7AC84A1CE63882AEA5D066A5 /* TodaySealReceiptTests.swift in Sources */,
 				3C835FCB531DC30448F763AA /* TodayStatusHeaderTests.swift in Sources */,
 				CA89195562C759E6F118465B /* TodoIssueReferenceTests.swift in Sources */,
 				E5916F3DFB21BA26A2FFFFBE /* ToolOutcomeLiveIntegrationTests.swift in Sources */,
@@ -2871,6 +2881,8 @@
 				A5382C907F425504C0A212B2 /* ThinkingBorderShimmer.swift in Sources */,
 				98E96B2C1264CF2327351A34 /* TimeCapsule.swift in Sources */,
 				8B912071E83AC5D4E3C8AA4E /* TodayContainer.swift in Sources */,
+				37375126C9D00F02A3233357 /* TodayNearbyRow.swift in Sources */,
+				B2060AA2A2C1E4933941D2BB /* TodaySealReceipt.swift in Sources */,
 				B89002ECF766AA5D3F1D3172 /* TodayStatusHeader.swift in Sources */,
 				5148EFD1A860D54B6F1CB8CB /* ToolOutcome.swift in Sources */,
 				AC44E44D1AC48E33145DF0F0 /* ToolRouterContractPreview.swift in Sources */,

--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		3BDFE453122F7D464FEF5490 /* TravelerNoteRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1157BB60848F9C74D7E8C14E /* TravelerNoteRecord.swift */; };
 		3C5AB28556912D115AEC4AEC /* LocationPickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 052B6F076F405C203184CB88 /* LocationPickerState.swift */; };
 		3C79D606DA56C1251AD58BC3 /* LiveActivityServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C070BDAE248990A4E7909B /* LiveActivityServiceTests.swift */; };
+		3C835FCB531DC30448F763AA /* TodayStatusHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA42F14E0B63119912C00AD /* TodayStatusHeaderTests.swift */; };
 		3C9BD8E9B63433890E3C74E1 /* POISourceConformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45554ECBB3B42D14E6CCE7B /* POISourceConformances.swift */; };
 		3CB7E26BCF3339F2CE297528 /* ItineraryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D60D55727FB72C1C202C90 /* ItineraryListView.swift */; };
 		3CBA775B8C215CBAE3A73EA0 /* CardBottomInsetClearanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0674DC5D526883C657A63C38 /* CardBottomInsetClearanceTest.swift */; };
@@ -406,6 +407,7 @@
 		B80813E9E3CDD855C12F7D58 /* LockScreenLiveActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02DB2C9C0BC30785E0A80F3 /* LockScreenLiveActivityView.swift */; };
 		B8267D5C532DF867AFEE6CC1 /* BragCardTemplateBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7571A35B387B48264B721AB7 /* BragCardTemplateBackground.swift */; };
 		B86F7FB5B4BF77E2A127D394 /* BaseCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ECD9C636BD77344AE8BFD79 /* BaseCard.swift */; };
+		B89002ECF766AA5D3F1D3172 /* TodayStatusHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6EE32340E0A83362F440D7 /* TodayStatusHeader.swift */; };
 		B99A941BC594A67A75015CDE /* O1FixesRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA0DDEC1B8F623DFB8C1090 /* O1FixesRegressionTests.swift */; };
 		B9AFA2FC4C9102AF0B27DFFF /* AmapLiveIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D22DBF50B6C3FABE64A9DE2 /* AmapLiveIntegrationTests.swift */; };
 		B9EDA827F7E00B19DF97512C /* ConversationRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12888843433B2A00D7CAB18 /* ConversationRecord.swift */; };
@@ -700,6 +702,7 @@
 		295A9108AFAF3BEE4EFF7524 /* HeartBurstView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeartBurstView.swift; sourceTree = "<group>"; };
 		2A96C378147BDD0B232F0ADB /* BestTimeOpensInTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BestTimeOpensInTests.swift; sourceTree = "<group>"; };
 		2B33B0431703DD49E0228D33 /* MemoryDigestServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDigestServiceTests.swift; sourceTree = "<group>"; };
+		2BA42F14E0B63119912C00AD /* TodayStatusHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayStatusHeaderTests.swift; sourceTree = "<group>"; };
 		2C7919EAFDE363B49C4B4C47 /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 		2C903ACE494B3348EEDAEE27 /* ExploreHandoffCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreHandoffCard.swift; sourceTree = "<group>"; };
 		2CEA4BFADFDB1575F6655E48 /* ActiveRouteOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveRouteOverlay.swift; sourceTree = "<group>"; };
@@ -742,6 +745,7 @@
 		3AF871B84DDAAD8453B8258D /* RouteStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteStoreTests.swift; sourceTree = "<group>"; };
 		3B0C9228AD213C6D5FE01FCE /* RoutePolylineShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutePolylineShape.swift; sourceTree = "<group>"; };
 		3C9A1F22AAE512199548C269 /* FilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarView.swift; sourceTree = "<group>"; };
+		3D6EE32340E0A83362F440D7 /* TodayStatusHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayStatusHeader.swift; sourceTree = "<group>"; };
 		3DFAB38A4600C667B8D7CD2B /* ChatHistoryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryListView.swift; sourceTree = "<group>"; };
 		3E40C49968AC6150E89CC02F /* FilterBarLabeledPillsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarLabeledPillsTest.swift; sourceTree = "<group>"; };
 		3E7AFBAAF6E42AE8043F476D /* VoiceInterruptionToastTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInterruptionToastTest.swift; sourceTree = "<group>"; };
@@ -1530,6 +1534,7 @@
 				884C97C686E2AFC3C534381A /* TasteUpdateServiceTests.swift */,
 				D34C1E95A05E3986C2E65F70 /* TodayContainerSnapshotTest.swift */,
 				FFA0BCC3FA2B0DF44F1F5217 /* TodayContainerTests.swift */,
+				2BA42F14E0B63119912C00AD /* TodayStatusHeaderTests.swift */,
 				331B2AE74EFAD9589AF60498 /* TodoIssueReferenceTests.swift */,
 				D94A585E823470D513C6C861 /* ToolOutcomeLiveIntegrationTests.swift */,
 				7FD405D02D1BE843764ADFF9 /* ToolOutcomeTests.swift */,
@@ -2094,6 +2099,7 @@
 			isa = PBXGroup;
 			children = (
 				3697E1FD0492D1D0AE9274BA /* TodayContainer.swift */,
+				3D6EE32340E0A83362F440D7 /* TodayStatusHeader.swift */,
 			);
 			path = Today;
 			sourceTree = "<group>";
@@ -2518,6 +2524,7 @@
 				A7FC5F124C2C2CF9B09FA997 /* TasteUpdateServiceTests.swift in Sources */,
 				B0FE4A45CD3A45E9AD1D33C3 /* TodayContainerSnapshotTest.swift in Sources */,
 				A4528F9189C69F1292BA6006 /* TodayContainerTests.swift in Sources */,
+				3C835FCB531DC30448F763AA /* TodayStatusHeaderTests.swift in Sources */,
 				CA89195562C759E6F118465B /* TodoIssueReferenceTests.swift in Sources */,
 				E5916F3DFB21BA26A2FFFFBE /* ToolOutcomeLiveIntegrationTests.swift in Sources */,
 				14A08808EC415815951AD5A8 /* ToolOutcomeTests.swift in Sources */,
@@ -2864,6 +2871,7 @@
 				A5382C907F425504C0A212B2 /* ThinkingBorderShimmer.swift in Sources */,
 				98E96B2C1264CF2327351A34 /* TimeCapsule.swift in Sources */,
 				8B912071E83AC5D4E3C8AA4E /* TodayContainer.swift in Sources */,
+				B89002ECF766AA5D3F1D3172 /* TodayStatusHeader.swift in Sources */,
 				5148EFD1A860D54B6F1CB8CB /* ToolOutcome.swift in Sources */,
 				AC44E44D1AC48E33145DF0F0 /* ToolRouterContractPreview.swift in Sources */,
 				3BDFE453122F7D464FEF5490 /* TravelerNoteRecord.swift in Sources */,

--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -308,6 +308,7 @@
 		89E1BDE3E8EFF2C3B8286220 /* StartupDiagnosticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C32FC4B073B393E96C59C62 /* StartupDiagnosticsService.swift */; };
 		8B118DFAAE23443EF7D90735 /* FilterBarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1694A46513909CFE464D92E /* FilterBarViewTests.swift */; };
 		8B4F2A6E8F3C6EAD0F9A8E32 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = EA0858036CFEA9774139AFD7 /* PrivacyInfo.xcprivacy */; };
+		8B912071E83AC5D4E3C8AA4E /* TodayContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3697E1FD0492D1D0AE9274BA /* TodayContainer.swift */; };
 		8BE312055186556D6FC107E2 /* BookComposeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C378BB94F43B4B2023AF470C /* BookComposeService.swift */; };
 		8BF4070A63A8B52C58F0E93E /* RouteCompanionStateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F48D7FA14E29D606FD11EA /* RouteCompanionStateMachineTests.swift */; };
 		8C106CF5C07EC37E7FBC0D67 /* FriendsHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4077595CC19D07EB22B8AA7 /* FriendsHubView.swift */; };
@@ -360,6 +361,7 @@
 		A12DF78B6B05519D2177A519 /* RouteCompanionForceUnwrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF2CEF9FE62124F51460453 /* RouteCompanionForceUnwrapTests.swift */; };
 		A217FA55BD40922DB3B8DEE6 /* SoloScoreRadarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D557D1D0D224C725834A08D /* SoloScoreRadarChart.swift */; };
 		A27A0AE4F7DB8F93878A7127 /* CapsuleOpenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2BA43E5730BFFBB1157A75 /* CapsuleOpenView.swift */; };
+		A4528F9189C69F1292BA6006 /* TodayContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA0BCC3FA2B0DF44F1F5217 /* TodayContainerTests.swift */; };
 		A49A16341F3F09EEF317FA03 /* NowScoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C04A7D4DE12B98E4801D7C4 /* NowScoreTests.swift */; };
 		A4DC0A61A6DE5897CD053198 /* ProvisionalCardUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FFFD31320F43361B9E91D4 /* ProvisionalCardUITests.swift */; };
 		A5382C907F425504C0A212B2 /* ThinkingBorderShimmer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488103B60D7D46DB3467EE87 /* ThinkingBorderShimmer.swift */; };
@@ -386,6 +388,7 @@
 		AEDEF3D7DC245681904D3469 /* MapViewModelCityCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC5559A4AAF4E3CD77E38B6 /* MapViewModelCityCacheTests.swift */; };
 		AF89A5DAA5BE9C3FC9DF1675 /* MapPinPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DBD8BED52DB4E9DD339BFD /* MapPinPickerView.swift */; };
 		B0EFE759B67951C4D10B16FD /* UserDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B0465B31ABD4A057EE984F /* UserDirectory.swift */; };
+		B0FE4A45CD3A45E9AD1D33C3 /* TodayContainerSnapshotTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34C1E95A05E3986C2E65F70 /* TodayContainerSnapshotTest.swift */; };
 		B28F15C454376D86258FCD77 /* OverpassService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67173C74F1A76C3CE5C38C0A /* OverpassService.swift */; };
 		B2C98BCF4E0193B5740C7762 /* FriendsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7202B977A555239F367D02 /* FriendsListView.swift */; };
 		B32CCADAF2919BAFA66D9C94 /* SFSymbolExistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA9968E168052C0DC0E1B36 /* SFSymbolExistenceTests.swift */; };
@@ -724,6 +727,7 @@
 		363714672D8A0FA8F7C39887 /* ExperienceCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceCardView.swift; sourceTree = "<group>"; };
 		3645957E10E52142EBF468C0 /* BestTimesSignal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BestTimesSignal.swift; sourceTree = "<group>"; };
 		3671315E80FB41CDA396AF69 /* FriendService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendService.swift; sourceTree = "<group>"; };
+		3697E1FD0492D1D0AE9274BA /* TodayContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayContainer.swift; sourceTree = "<group>"; };
 		36E41DCA29798B5D8E49B7CA /* BottomSheetUnifiedScrollGuardTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetUnifiedScrollGuardTest.swift; sourceTree = "<group>"; };
 		377590D8F67E082E58EDEAB9 /* StartRouteCoordinateResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartRouteCoordinateResolutionTests.swift; sourceTree = "<group>"; };
 		37C75D64D462A03DBEFFC4EB /* FilterNowMapSyncTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterNowMapSyncTest.swift; sourceTree = "<group>"; };
@@ -1093,6 +1097,7 @@
 		D26F2087E12E63A73B812D7E /* PendingCheckInBannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingCheckInBannerTests.swift; sourceTree = "<group>"; };
 		D2F55E299C99F8D9916E0BA1 /* PlacePhotoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacePhotoStore.swift; sourceTree = "<group>"; };
 		D30D09E054C6CE013359301E /* TopOverlayLayoutTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopOverlayLayoutTest.swift; sourceTree = "<group>"; };
+		D34C1E95A05E3986C2E65F70 /* TodayContainerSnapshotTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayContainerSnapshotTest.swift; sourceTree = "<group>"; };
 		D3DBD8BED52DB4E9DD339BFD /* MapPinPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapPinPickerView.swift; sourceTree = "<group>"; };
 		D40E9E2485E877580F0E1915 /* DiagnosticsRequestCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsRequestCard.swift; sourceTree = "<group>"; };
 		D4C10384834D53FE83113D51 /* Configuration.storekit */ = {isa = PBXFileReference; path = Configuration.storekit; sourceTree = "<group>"; };
@@ -1179,6 +1184,7 @@
 		FF5780606CA08F571BF04ACE /* ProactiveNudgeSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProactiveNudgeSchedulerTests.swift; sourceTree = "<group>"; };
 		FF753CC02718028B12891042 /* AdminService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminService.swift; sourceTree = "<group>"; };
 		FF7D0A1F8E3B8909F465194C /* ObsidianThemeContrastTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObsidianThemeContrastTest.swift; sourceTree = "<group>"; };
+		FFA0BCC3FA2B0DF44F1F5217 /* TodayContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayContainerTests.swift; sourceTree = "<group>"; };
 		FFC5559A4AAF4E3CD77E38B6 /* MapViewModelCityCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModelCityCacheTests.swift; sourceTree = "<group>"; };
 		FFED848E66BBE2A234AAA3CC /* FilterBarScrollAffordanceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarScrollAffordanceTest.swift; sourceTree = "<group>"; };
 		FFEF9ECFBFF7B7CE5246F37B /* RouteShareCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteShareCardTests.swift; sourceTree = "<group>"; };
@@ -1522,6 +1528,8 @@
 				40E424FE8CC115966B1CCCEC /* SubscriptionServiceContractTests.swift */,
 				051AD3C3A41FDF75D2C4BD8C /* SunsetSignalTests.swift */,
 				884C97C686E2AFC3C534381A /* TasteUpdateServiceTests.swift */,
+				D34C1E95A05E3986C2E65F70 /* TodayContainerSnapshotTest.swift */,
+				FFA0BCC3FA2B0DF44F1F5217 /* TodayContainerTests.swift */,
 				331B2AE74EFAD9589AF60498 /* TodoIssueReferenceTests.swift */,
 				D94A585E823470D513C6C861 /* ToolOutcomeLiveIntegrationTests.swift */,
 				7FD405D02D1BE843764ADFF9 /* ToolOutcomeTests.swift */,
@@ -1984,6 +1992,7 @@
 				F041AA40AC029B779843B5D4 /* Paywall */,
 				8FF93171FFB8E00CD1BDF550 /* Settings */,
 				07C4B3D1D25BE0A78422D951 /* Shared */,
+				CDA30BA59CFEF67F142FBEE0 /* Today */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2079,6 +2088,14 @@
 				18AAA718024540127A95A827 /* GeohashUtils.swift */,
 			);
 			path = Cache;
+			sourceTree = "<group>";
+		};
+		CDA30BA59CFEF67F142FBEE0 /* Today */ = {
+			isa = PBXGroup;
+			children = (
+				3697E1FD0492D1D0AE9274BA /* TodayContainer.swift */,
+			);
+			path = Today;
 			sourceTree = "<group>";
 		};
 		CF567757B55F1379C00F69DF /* Ost */ = {
@@ -2499,6 +2516,8 @@
 				02FE232A59260969097802E3 /* SubscriptionServiceContractTests.swift in Sources */,
 				F3C01191CC2B37DE4F3E5DEB /* SunsetSignalTests.swift in Sources */,
 				A7FC5F124C2C2CF9B09FA997 /* TasteUpdateServiceTests.swift in Sources */,
+				B0FE4A45CD3A45E9AD1D33C3 /* TodayContainerSnapshotTest.swift in Sources */,
+				A4528F9189C69F1292BA6006 /* TodayContainerTests.swift in Sources */,
 				CA89195562C759E6F118465B /* TodoIssueReferenceTests.swift in Sources */,
 				E5916F3DFB21BA26A2FFFFBE /* ToolOutcomeLiveIntegrationTests.swift in Sources */,
 				14A08808EC415815951AD5A8 /* ToolOutcomeTests.swift in Sources */,
@@ -2844,6 +2863,7 @@
 				B4A33EDD3C85BBA89CD4EC05 /* ThemeService.swift in Sources */,
 				A5382C907F425504C0A212B2 /* ThinkingBorderShimmer.swift in Sources */,
 				98E96B2C1264CF2327351A34 /* TimeCapsule.swift in Sources */,
+				8B912071E83AC5D4E3C8AA4E /* TodayContainer.swift in Sources */,
 				5148EFD1A860D54B6F1CB8CB /* ToolOutcome.swift in Sources */,
 				AC44E44D1AC48E33145DF0F0 /* ToolRouterContractPreview.swift in Sources */,
 				3BDFE453122F7D464FEF5490 /* TravelerNoteRecord.swift in Sources */,

--- a/apps/ios/SoloCompass/App/SoloCompassApp.swift
+++ b/apps/ios/SoloCompass/App/SoloCompassApp.swift
@@ -165,7 +165,13 @@ struct SoloCompassApp: App {
 
     var body: some Scene {
         WindowGroup {
-            CompassMapView()
+            // Nomad OS B1: the root is `TodayContainer`, which either renders
+            // the Today home (map as a pull-up layer) or falls straight through
+            // to `CompassMapView` when `FeatureFlags.todayHome` is off. Every
+            // environment / cover / lifecycle modifier below stays attached to
+            // the single root view and flows down to whichever branch renders,
+            // so the first-launch gate and bootstrap wiring are unchanged.
+            TodayContainer()
                 .environment(locationService)
                 .environment(experienceService)
                 .environment(travelerNoteStore)

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -2382,3 +2382,11 @@
 "today.header.firstDay" = "Just arrived";
 "today.header.visaRemaining" = "%d visa days left";
 "today.header.setEntryDate" = "Set entry";
+
+/* Nomad OS B1-d — Today nearby row + seal receipt */
+"today.nearby.count" = "%d nomads nearby";
+"today.nearby.beFirst" = "No nomads here yet — be the first";
+"today.seal.yesterdayTitle" = "Yesterday you sealed a moment";
+"today.seal.type.photo" = "a photo, waiting to resurface";
+"today.seal.type.voice" = "a voice note, waiting to resurface";
+"today.seal.type.text" = "a note, waiting to resurface";

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -2202,6 +2202,8 @@
 "dev.flag.companionLayer.subtitle" = "In-map toggle for nearby presence cells.";
 "dev.flag.cityOS.title" = "City OS";
 "dev.flag.cityOS.subtitle" = "Landing kit, local events, compliance banner, and city modes.";
+"dev.flag.todayHome.title" = "Today Home";
+"dev.flag.todayHome.subtitle" = "New Today home flow with the map demoted to a pull-up layer.";
 
 /* City OS v2: visa-expiry local reminder (PRD §5.2) */
 "cityos.visa.reminder.title" = "Visa reminder";
@@ -2368,3 +2370,8 @@
 "settings.advanced.footer" = "Power-user tools: AI provider, tester unlock, and developer options.";
 "settings.theme.system" = "System";
 "settings.theme.obsidian" = "Obsidian";
+
+/* Nomad OS B1 — Today home container (nomad-os-b1-today-home-20260719) */
+"today.scaffold.placeholder" = "Your day, your city, your ledger — coming here soon.";
+"today.map.open" = "Open map";
+"today.map.backToToday" = "Back to Today";

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -2375,3 +2375,10 @@
 "today.scaffold.placeholder" = "Your day, your city, your ledger — coming here soon.";
 "today.map.open" = "Open map";
 "today.map.backToToday" = "Back to Today";
+
+/* Nomad OS B1-b — Today status header */
+"today.header.noCity" = "Pick a city";
+"today.header.dayInCity" = "Day %d in this city";
+"today.header.firstDay" = "Just arrived";
+"today.header.visaRemaining" = "%d visa days left";
+"today.header.setEntryDate" = "Set entry";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -2392,3 +2392,11 @@
 "today.header.firstDay" = "刚抵达";
 "today.header.visaRemaining" = "签证剩 %d 天";
 "today.header.setEntryDate" = "填入境日";
+
+/* Nomad OS B1-d — Today 谁在附近 + 封存回执 */
+"today.nearby.count" = "%d 位游民在附近";
+"today.nearby.beFirst" = "这座城还没有游民 · 成为第一个";
+"today.seal.yesterdayTitle" = "昨天你封存了一个瞬间";
+"today.seal.type.photo" = "一张照片，等待重现";
+"today.seal.type.voice" = "一段语音，等待重现";
+"today.seal.type.text" = "一段文字，等待重现";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -2212,6 +2212,8 @@
 "dev.flag.companionLayer.subtitle" = "地图内的附近在场单元开关。";
 "dev.flag.cityOS.title" = "城市 OS";
 "dev.flag.cityOS.subtitle" = "落地包、在地活动、合规横幅与城市模式。";
+"dev.flag.todayHome.title" = "Today 首页";
+"dev.flag.todayHome.subtitle" = "全新 Today 首页流，地图降级为上拉图层。";
 
 /* City OS v2: visa-expiry local reminder (PRD §5.2) */
 "cityos.visa.reminder.title" = "签证提醒";
@@ -2378,3 +2380,8 @@
 "settings.advanced.footer" = "面向高级用户的工具：AI 服务、测试员解锁与开发者选项。";
 "settings.theme.system" = "跟随系统";
 "settings.theme.obsidian" = "曜石黑";
+
+/* Nomad OS B1 — Today 首页容器 (nomad-os-b1-today-home-20260719) */
+"today.scaffold.placeholder" = "你的一天、你的城市、你的账本——即将在这里呈现。";
+"today.map.open" = "打开地图";
+"today.map.backToToday" = "返回 Today";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -2385,3 +2385,10 @@
 "today.scaffold.placeholder" = "你的一天、你的城市、你的账本——即将在这里呈现。";
 "today.map.open" = "打开地图";
 "today.map.backToToday" = "返回 Today";
+
+/* Nomad OS B1-b — Today 状态头 */
+"today.header.noCity" = "选择城市";
+"today.header.dayInCity" = "在城第 %d 天";
+"today.header.firstDay" = "刚抵达";
+"today.header.visaRemaining" = "签证剩 %d 天";
+"today.header.setEntryDate" = "填入境日";

--- a/apps/ios/SoloCompass/Services/FeatureFlags.swift
+++ b/apps/ios/SoloCompass/Services/FeatureFlags.swift
@@ -130,6 +130,34 @@ public enum FeatureFlags {
         #endif
     }
 
+    /// Nomad OS B1 gate (design nomad-os-b1-today-home-20260719 §0 decision B):
+    /// when true, the app root is `TodayContainer` — a vertical Today home flow
+    /// (status header → three things → who's nearby → yesterday's seal) with the
+    /// map demoted to a pull-up full-screen layer. When false, the root falls
+    /// straight through to `CompassMapView`, i.e. today's map-first form with
+    /// zero behavioural change — this is the rollback safety net for a form
+    /// pivot that touches the app's loading point.
+    ///
+    /// Default OFF everywhere (including DEBUG) so the map-first form stays the
+    /// shipping default until Today is content-complete and staged. Flip on in
+    /// DEBUG without rebuilding:
+    ///
+    ///     defaults write <app-bundle-id> FF_TODAY_HOME -bool YES
+    ///
+    /// or via the Developer Options panel. Env var `FF_TODAY_HOME=1` wins in
+    /// CI / test schemes.
+    public static var todayHome: Bool {
+        #if DEBUG
+        if UserDefaults.standard.object(forKey: "FF_TODAY_HOME") != nil {
+            return UserDefaults.standard.bool(forKey: "FF_TODAY_HOME")
+        }
+        if let env = ProcessInfo.processInfo.environment["FF_TODAY_HOME"] {
+            return env == "1" || env.lowercased() == "true"
+        }
+        #endif
+        return readBool("FF_TODAY_HOME", default: false)
+    }
+
     /// US-009: Master gate for the in-map Companion *layer* toggle (the
     /// floating control that overlays nearby blurred presence cells). The
     /// underlying discovery still returns nil today, so the toggle is a dead
@@ -192,6 +220,8 @@ public enum FeatureFlags {
                       subtitleKey: "dev.flag.companionLayer.subtitle", defaultValue: false),
         DeveloperFlag(key: "FF_CITY_OS", titleKey: "dev.flag.cityOS.title",
                       subtitleKey: "dev.flag.cityOS.subtitle", defaultValue: false),
+        DeveloperFlag(key: "FF_TODAY_HOME", titleKey: "dev.flag.todayHome.title",
+                      subtitleKey: "dev.flag.todayHome.subtitle", defaultValue: false),
     ]
 
     /// The developer override currently stored for `key`, or nil when the

--- a/apps/ios/SoloCompass/Tests/EmptyStateCitySuggestionTest.swift
+++ b/apps/ios/SoloCompass/Tests/EmptyStateCitySuggestionTest.swift
@@ -77,13 +77,16 @@ final class EmptyStateCitySuggestionTest: XCTestCase {
     func testCityNameMapCoversAllSeedCodes() {
         let service = ExperienceService()
         let seedCodes = Set(service.allExperiences.map { $0.location.cityCode })
-        let nameMap: [String: String] = [
-            "cmi": "Chiang Mai",
-            "VTE": "Vientiane",
-            "cn-深圳市": "Shenzhen",
-        ]
+        // Assert against the real, now-`static` map — not a hand-copied subset.
+        // The previous inline copy only listed 3 cities and silently rotted as
+        // seeds gained sgn/nyc/lis/tyo/san-francisco; sourcing from the single
+        // source of truth is what keeps this guard honest (and is only possible
+        // now that `cityNameMap` is `static`).
         for code in seedCodes {
-            XCTAssertNotNil(nameMap[code], "cityNameMap should have a name for seed code '\(code)'")
+            XCTAssertNotNil(
+                MapViewModel.cityNameMap[code],
+                "MapViewModel.cityNameMap should have a name for seed code '\(code)'"
+            )
         }
     }
 }

--- a/apps/ios/SoloCompass/Tests/TodayContainerSnapshotTest.swift
+++ b/apps/ios/SoloCompass/Tests/TodayContainerSnapshotTest.swift
@@ -1,0 +1,41 @@
+import XCTest
+import SwiftUI
+@testable import SoloCompass
+
+/// B1-a visual smoke: render the Today home scaffold's placeholder content to a
+/// PNG so the shell can be eyeballed without fighting the simulator's cold-start
+/// location alert. Writes to /tmp; DEBUG-only, asserts nothing about pixels.
+@MainActor
+final class TodayContainerSnapshotTest: XCTestCase {
+
+    func testRenderTodayScaffoldPlaceholder() throws {
+        // Render only the Today-home placeholder surface (no map layer, no
+        // environment) — that's the B1-a deliverable to inspect.
+        let view = VStack(spacing: 20) {
+            Spacer(minLength: 32)
+            VStack(spacing: 8) {
+                Text("Today")
+                    .ctDisplay(34, .bold, relativeTo: .largeTitle)
+                    .foregroundStyle(CT.textPrimaryAdaptive)
+                Text(NSLocalizedString("today.scaffold.placeholder", comment: ""))
+                    .ctBody(15)
+                    .foregroundStyle(CT.textMutedAdaptive)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+            }
+            Spacer()
+        }
+        .frame(width: 402, height: 874)
+        .background(CT.pageAdaptive)
+
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 2
+        guard let uiImage = renderer.uiImage,
+              let data = uiImage.pngData() else {
+            throw XCTSkip("ImageRenderer produced no image")
+        }
+        let url = URL(fileURLWithPath: "/tmp/today_scaffold.png")
+        try data.write(to: url)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+}

--- a/apps/ios/SoloCompass/Tests/TodayContainerTests.swift
+++ b/apps/ios/SoloCompass/Tests/TodayContainerTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+import SwiftUI
+@testable import SoloCompass
+
+/// Nomad OS B1-a: `TodayContainer` is the app root and must route on
+/// `FeatureFlags.todayHome`. The critical guarantee is the **rollback path**:
+/// with the flag off (the shipping default), the root falls straight through
+/// to `CompassMapView` with zero behavioural change. These tests install the
+/// container in a real graph — both branches read `@Environment`, and the
+/// flag-on branch embeds `CompassMapView` as its map layer — so every service
+/// `CompassMapView` needs is injected regardless of branch.
+@MainActor
+final class TodayContainerTests: XCTestCase {
+
+    private let flagKey = "FF_TODAY_HOME"
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: flagKey)
+        TodayContainer.debugRenderedBranch = .none
+        super.tearDown()
+    }
+
+    /// Flag OFF (default) → root is the map, unchanged. This is the safety net.
+    func testFlagOffRendersMapFallback() {
+        UserDefaults.standard.set(false, forKey: flagKey)
+        XCTAssertFalse(FeatureFlags.todayHome, "override should force flag off")
+
+        installAndPump()
+
+        XCTAssertEqual(
+            TodayContainer.debugRenderedBranch, .mapFallback,
+            "flag off must fall through to CompassMapView with no form change"
+        )
+    }
+
+    /// Flag ON → root is the Today home scaffold, not the bare map.
+    func testFlagOnRendersTodayHome() {
+        UserDefaults.standard.set(true, forKey: flagKey)
+        XCTAssertTrue(FeatureFlags.todayHome, "override should force flag on")
+
+        installAndPump()
+
+        XCTAssertEqual(
+            TodayContainer.debugRenderedBranch, .todayHome,
+            "flag on must render the Today home scaffold"
+        )
+    }
+
+    // MARK: Helper
+
+    private func installAndPump() {
+        TodayContainer.debugRenderedBranch = .none
+
+        let root = TodayContainer()
+            .environment(LocationService())
+            .environment(ExperienceService())
+            .environment(AIService())
+            .environment(UserPreferences())
+            .environment(NotificationService.shared)
+            .environment(SubscriptionService())
+            .environment(CompanionService())
+            .environment(PresenceService())
+            .environment(BestNowClock.shared)
+
+        let host = UIHostingController(rootView: root)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 402, height: 874))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.5))
+    }
+}

--- a/apps/ios/SoloCompass/Tests/TodaySealReceiptTests.swift
+++ b/apps/ios/SoloCompass/Tests/TodaySealReceiptTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+import Foundation
+@testable import SoloCompass
+
+/// Nomad OS B1-d: `TodaySealReceipt` shows a capsule buried *yesterday*
+/// (design §2 ④ option a). These pin the day-boundary selection so the receipt
+/// never surfaces today's fresh seal or an older one, and picks the latest when
+/// several were buried yesterday.
+final class TodaySealReceiptTests: XCTestCase {
+
+    private let cal = Calendar.current
+
+    private func capsule(createdAt: Date) -> TimeCapsule {
+        TimeCapsule(
+            experienceId: "exp_test",
+            createdAt: createdAt,
+            scheduledFor: cal.date(byAdding: .month, value: 6, to: createdAt)!,
+            contentType: "text",
+            contentBlob: Data()
+        )
+    }
+
+    /// A capsule created yesterday qualifies.
+    func testPicksYesterdayCapsule() {
+        let now = Date()
+        let yesterdayNoon = cal.date(byAdding: .day, value: -1, to: now)!
+        let result = TodaySealReceipt.yesterdayCapsule(
+            from: [capsule(createdAt: yesterdayNoon)], now: now
+        )
+        XCTAssertNotNil(result, "a capsule buried yesterday should surface")
+    }
+
+    /// Today's fresh capsule must NOT surface as "yesterday's".
+    func testExcludesTodayCapsule() {
+        let now = cal.date(bySettingHour: 14, minute: 0, second: 0, of: Date())!
+        let earlierToday = cal.date(bySettingHour: 9, minute: 0, second: 0, of: now)!
+        let result = TodaySealReceipt.yesterdayCapsule(
+            from: [capsule(createdAt: earlierToday)], now: now
+        )
+        XCTAssertNil(result, "today's capsule is not yesterday's receipt")
+    }
+
+    /// A capsule from two days ago is outside the yesterday window.
+    func testExcludesOlderCapsule() {
+        let now = Date()
+        let twoDaysAgo = cal.date(byAdding: .day, value: -2, to: now)!
+        let result = TodaySealReceipt.yesterdayCapsule(
+            from: [capsule(createdAt: twoDaysAgo)], now: now
+        )
+        XCTAssertNil(result, "a capsule older than yesterday must not surface")
+    }
+
+    /// With several buried yesterday, the most recent one wins.
+    func testPicksLatestAmongYesterday() {
+        let now = Date()
+        let yStart = cal.startOfDay(for: cal.date(byAdding: .day, value: -1, to: now)!)
+        let morning = cal.date(byAdding: .hour, value: 8, to: yStart)!
+        let evening = cal.date(byAdding: .hour, value: 20, to: yStart)!
+        let result = TodaySealReceipt.yesterdayCapsule(
+            from: [capsule(createdAt: morning), capsule(createdAt: evening)], now: now
+        )
+        XCTAssertEqual(result?.createdAt, evening, "latest capsule of yesterday wins")
+    }
+}

--- a/apps/ios/SoloCompass/Tests/TodayStatusHeaderTests.swift
+++ b/apps/ios/SoloCompass/Tests/TodayStatusHeaderTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+import SwiftUI
+@testable import SoloCompass
+
+/// Nomad OS B1-b: `TodayStatusHeader` derives city / day / face / visa from
+/// independent sources, not the map's `MapViewModel`. These pin the pure
+/// derivations that the header shows — most importantly that the city name
+/// resolves from the now-`static` `MapViewModel.cityNameMap` (the single source
+/// of truth shared with the map pill), and that the visa ring's three-state
+/// logic keys off compliance state existing.
+@MainActor
+final class TodayStatusHeaderTests: XCTestCase {
+
+    /// The name map went `static` so Today and the map pill agree without a
+    /// shared view model. Guard the codes Today will most often see.
+    func testCityNameMapResolvesSharedNames() {
+        XCTAssertEqual(MapViewModel.cityNameMap["SZX"], "Shenzhen")
+        XCTAssertEqual(MapViewModel.cityNameMap["CNX"], "Chiang Mai")
+        XCTAssertEqual(MapViewModel.cityNameMap["VTE"], "Vientiane")
+        XCTAssertEqual(MapViewModel.cityNameMap["lisbon"], "Lisbon")
+    }
+
+    /// Face derivation is pure `BaseFace.derive(mode:stage:)`; a Live city with
+    /// no stage rests at `.live`, land/settle read as arriving.
+    func testFaceDerivationMatchesLifecycle() {
+        XCTAssertEqual(BaseFace.derive(mode: .live, stage: nil), .live)
+        XCTAssertEqual(BaseFace.derive(mode: .live, stage: .land), .arrive)
+        XCTAssertEqual(BaseFace.derive(mode: .live, stage: .settle), .arrive)
+        XCTAssertEqual(BaseFace.derive(mode: .live, stage: .leave), .recall)
+        XCTAssertEqual(BaseFace.derive(mode: .plan, stage: nil), .plan)
+    }
+
+    /// Visa ring three-state (decision C): compliance `state()` is nil until an
+    /// entry date is confirmed → the header shows the "Set entry" CTA instead
+    /// of a ring. Once entry date + length are set, `state()` returns a ring.
+    func testComplianceStateGatesVisaRing() {
+        let prefs = UserPreferences()
+
+        // Unset → no state → CTA branch.
+        prefs.visaEntryDate = nil
+        prefs.visaLengthDays = nil
+        XCTAssertNil(ComplianceService(preferences: prefs).state(),
+                     "no entry date → nil state → Set-entry CTA")
+
+        // Confirmed → state exists → ring branch. Entry 10 calendar days ago
+        // means daysStayed = 11 (entry day counts as day 1), so a 30-day visa
+        // leaves 30 - 11 = 19.
+        prefs.visaEntryDate = Calendar.current.date(byAdding: .day, value: -10, to: Date())
+        prefs.visaLengthDays = 30
+        let state = ComplianceService(preferences: prefs).state()
+        XCTAssertNotNil(state, "entry date + length → ring state")
+        XCTAssertEqual(state?.visaDaysRemaining, 19,
+                       "30-day visa, 11 days stayed (entry day = day 1) → 19 remaining")
+    }
+}

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -689,7 +689,7 @@ public final class MapViewModel {
             let code = exp.location.cityCode
             cityExperiences[code, default: []].append(coord)
         }
-        let nameMap = cityNameMap
+        let nameMap = Self.cityNameMap
         var byCode: [String: (code: String, name: String, center: CLLocationCoordinate2D)] = [:] // swiftlint:disable:this large_tuple
         let nearbyLabel = NSLocalizedString("city.nearby", comment: "Fallback city label for synthetic osm_ codes")
         // Seed-derived rows first.
@@ -730,7 +730,11 @@ public final class MapViewModel {
 
     /// Static seed-city names. Discovered-city names come from
     /// `DiscoveredCityRecord` via `availableCities`.
-    private let cityNameMap: [String: String] = [
+    /// City code → display name. `static` so surfaces outside the map (e.g.
+    /// `TodayStatusHeader`) resolve a city's name from the same single source
+    /// of truth without holding a `MapViewModel`, keeping the name shown on
+    /// Today and on the map pill in lockstep. Pure data, no instance state.
+    static let cityNameMap: [String: String] = [
         "cmi": "Chiang Mai",
         "CNX": "Chiang Mai",
         "VTE": "Vientiane",
@@ -886,7 +890,7 @@ public final class MapViewModel {
     public var suggestedCityName: String? {
         guard visibleExperiences.isEmpty else { return nil }
         guard let code = firstAvailableCityCode else { return nil }
-        return cityNameMap[code] ?? code
+        return Self.cityNameMap[code] ?? code
     }
 
     /// When the current area has no experiences, returns the code of the first
@@ -900,9 +904,9 @@ public final class MapViewModel {
     /// static name map and alias table. Used by the city pill when
     /// `availableCities` doesn't contain the code directly.
     public func resolvedCityName(for code: String) -> String? {
-        if let name = cityNameMap[code] { return name }
+        if let name = Self.cityNameMap[code] { return name }
         if let canonical = Self.cityCodeAliases[code.lowercased()],
-           let name = cityNameMap[canonical] { return name }
+           let name = Self.cityNameMap[canonical] { return name }
         return nil
     }
 

--- a/apps/ios/SoloCompass/Views/Today/TodayContainer.swift
+++ b/apps/ios/SoloCompass/Views/Today/TodayContainer.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+
+/// Nomad OS B1 root container (design nomad-os-b1-today-home-20260719).
+///
+/// This is the app's new root when `FeatureFlags.todayHome` is on: a vertical
+/// **Today** home flow with the map demoted to a full-screen layer that pulls
+/// up from the bottom. When the flag is off, `body` falls straight through to
+/// `CompassMapView()` — today's map-first form, byte-for-byte unchanged. That
+/// pass-through is the rollback safety net for a form pivot that swaps the
+/// app's loading point (`SoloCompassApp.body` renders `TodayContainer()` in
+/// place of `CompassMapView()`, keeping every environment/cover modifier).
+///
+/// B1-a scope: container shell + pull-up map layer + rollback flag only. The
+/// Today content here is a placeholder skeleton; StatusHeader / three-things /
+/// nearby / seal-receipt接线 lands in B1-b..d. The map layer embeds the whole
+/// existing `CompassMapView` (its BottomInfoSheet + 15 sheet slots ride along
+/// untouched — we never reach into its `:182-209` refactor-forbidden zone).
+///
+/// The container reads no environment of its own: both branches resolve
+/// `@Environment` from the injection chain that `SoloCompassApp` already
+/// applies above this view, so `CompassMapView`'s nine `@Environment` reads
+/// keep working whether it renders as the whole app or as the pulled-up layer.
+public struct TodayContainer: View {
+    public init() {}
+
+    public var body: some View {
+        if FeatureFlags.todayHome {
+            TodayHomeScaffold()
+                .onAppear { TodayContainer.debugRenderedBranch = .todayHome }
+        } else {
+            // Rollback path: zero behavioural change from today's shipping form.
+            CompassMapView()
+                .onAppear { TodayContainer.debugRenderedBranch = .mapFallback }
+        }
+    }
+
+    #if DEBUG
+    /// Test hook: which branch `body` resolved to once installed in a graph.
+    /// Lets `TodayContainerTests` assert the flag actually routes the root,
+    /// including the flag-off rollback path (the shipping default). DEBUG-only
+    /// and read-only — never affects production rendering.
+    @MainActor enum RenderedBranch { case none, todayHome, mapFallback }
+    @MainActor static var debugRenderedBranch: RenderedBranch = .none
+    #endif
+}
+
+/// The Today-on, map-as-layer composition. Kept separate from `TodayContainer`
+/// so the flag-off path never constructs any of this view's state.
+private struct TodayHomeScaffold: View {
+    /// How far the map layer is pulled up, in points above its resting
+    /// (fully-hidden-below) position. 0 = map parked off-screen, showing only
+    /// its grab affordance; `fullTravel` = map covers the screen.
+    @State private var mapReveal: CGFloat = 0
+    /// Live drag delta, applied on top of `mapReveal` without committing it —
+    /// mirrors BottomInfoSheet's offset-translation approach so the heavy map
+    /// isn't re-laid-out every frame, only translated.
+    @GestureState private var dragTranslation: CGFloat = 0
+
+    /// Height of the peek handle that stays visible when the map is parked.
+    private let handlePeek: CGFloat = 96
+
+    public var body: some View {
+        GeometryReader { proxy in
+            let fullTravel = proxy.size.height
+            // Committed reveal + live drag, clamped to [0, fullTravel].
+            let reveal = min(max(mapReveal + dragTranslation, 0), fullTravel)
+            let isMapOpen = reveal > fullTravel * 0.5
+
+            ZStack(alignment: .bottom) {
+                // ── Layer 1: Today home (placeholder skeleton for B1-a) ──
+                todayHome
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(CT.pageAdaptive.ignoresSafeArea())
+                    // Dim the home slightly as the map takes over, so the pull
+                    // reads as "the map is coming forward", not a hard cut.
+                    .overlay(
+                        CT.scrimSoft
+                            .opacity(Double(reveal / fullTravel))
+                            .ignoresSafeArea()
+                            .allowsHitTesting(false)
+                    )
+
+                // ── Layer 2: the existing map, as a pull-up full-screen layer ──
+                mapLayer(
+                    fullTravel: fullTravel,
+                    reveal: reveal,
+                    isOpen: isMapOpen,
+                    toggle: { mapReveal = isMapOpen ? 0 : fullTravel }
+                )
+                .offset(y: fullTravel - reveal)
+            }
+            .animation(.spring(response: 0.32, dampingFraction: 0.85), value: mapReveal)
+        }
+        .ignoresSafeArea(.keyboard)
+    }
+
+    // MARK: Today home placeholder (B1-a skeleton — real content in B1-b..d)
+
+    private var todayHome: some View {
+        VStack(spacing: Space.xl) {
+            Spacer(minLength: Space.xxxl)
+
+            VStack(spacing: Space.sm) {
+                Text("Today")
+                    .ctDisplay(34, .bold, relativeTo: .largeTitle)
+                    .foregroundStyle(CT.textPrimaryAdaptive)
+                Text(NSLocalizedString(
+                    "today.scaffold.placeholder",
+                    comment: "B1-a placeholder subtitle on the Today home shell"
+                ))
+                .ctBody(15)
+                .foregroundStyle(CT.textMutedAdaptive)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Space.xxl)
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: Map layer + grab handle
+
+    private func mapLayer(
+        fullTravel: CGFloat,
+        reveal: CGFloat,
+        isOpen: Bool,
+        toggle: @escaping () -> Void
+    ) -> some View {
+        ZStack(alignment: .top) {
+            CompassMapView()
+
+            // Grab affordance / return-to-Today control, pinned to the layer's
+            // top edge. When parked it's the "open map" handle; when open it's
+            // the one-tap way back to Today (design §2 ⑤).
+            mapHandle(isOpen: isOpen, toggle: toggle)
+                .frame(maxWidth: .infinity)
+                .padding(.top, Space.sm)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(CT.pageAdaptive)
+        .clipShape(.rect(cornerRadius: isOpen ? 0 : Radius.xl, style: .continuous))
+        .shadow(color: CT.scrimSoft, radius: isOpen ? 0 : 12, y: -4)
+        .gesture(mapDragGesture(fullTravel: fullTravel))
+    }
+
+    private func mapHandle(isOpen: Bool, toggle: @escaping () -> Void) -> some View {
+        Button {
+            // Tap toggles between parked and open — a discoverable alternative
+            // to the drag so the map is never trapped behind a gesture only.
+            toggle()
+        } label: {
+            VStack(spacing: Space.xs) {
+                Capsule()
+                    .fill(CT.fgSubtle.opacity(0.6))
+                    .frame(width: 40, height: 5)
+                Text(NSLocalizedString(
+                    isOpen ? "today.map.backToToday" : "today.map.open",
+                    comment: "Map layer handle label: open the map / return to Today"
+                ))
+                .ctBody(13, .medium)
+                .foregroundStyle(CT.textMutedAdaptive)
+            }
+            .padding(.vertical, Space.sm)
+            .padding(.horizontal, Space.lg)
+            .frame(height: handlePeek)
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text(NSLocalizedString(
+            isOpen ? "today.map.backToToday" : "today.map.open",
+            comment: "Map layer handle accessibility label"
+        )))
+    }
+
+    private func mapDragGesture(fullTravel: CGFloat) -> some Gesture {
+        DragGesture(minimumDistance: 8)
+            .updating($dragTranslation) { value, state, _ in
+                // Dragging up (negative translation.height) reveals more map;
+                // invert so a positive `dragTranslation` means "more revealed".
+                state = -value.translation.height
+            }
+            .onEnded { value in
+                let projected = mapReveal - value.translation.height
+                    - value.predictedEndTranslation.height * 0.25
+                // Snap to whichever end of the travel the throw is closer to.
+                mapReveal = projected > fullTravel * 0.5 ? fullTravel : 0
+            }
+    }
+}

--- a/apps/ios/SoloCompass/Views/Today/TodayContainer.swift
+++ b/apps/ios/SoloCompass/Views/Today/TodayContainer.swift
@@ -47,6 +47,8 @@ public struct TodayContainer: View {
 /// The Today-on, map-as-layer composition. Kept separate from `TodayContainer`
 /// so the flag-off path never constructs any of this view's state.
 private struct TodayHomeScaffold: View {
+    @Environment(UserPreferences.self) private var preferences
+
     /// How far the map layer is pulled up, in points above its resting
     /// (fully-hidden-below) position. 0 = map parked off-screen, showing only
     /// its grab affordance; `fullTravel` = map covers the screen.
@@ -111,29 +113,47 @@ private struct TodayHomeScaffold: View {
         .ignoresSafeArea(.keyboard)
     }
 
-    // MARK: Today home placeholder (B1-a skeleton — real content in B1-b..d)
+    // MARK: Today home (real content lands slice by slice — three-things = B1-c)
+
+    private var cityCode: String? { preferences.lastSelectedCity }
 
     private var todayHome: some View {
         VStack(spacing: 0) {
-            // Sticky status header (B1-b). Stays out of any scroll region — the
-            // three-things / nearby / seal-receipt content that scrolls below it
-            // lands in B1-c/d.
+            // Sticky status header (B1-b) — stays out of the scroll region.
             TodayStatusHeader()
 
-            // Placeholder for the scrolling Today body (B1-c/d).
-            VStack(spacing: Space.sm) {
-                Spacer(minLength: Space.xxxl)
-                Text(NSLocalizedString(
-                    "today.scaffold.placeholder",
-                    comment: "Placeholder subtitle for the not-yet-wired Today body"
-                ))
-                .ctBody(15)
-                .foregroundStyle(CT.textMutedAdaptive)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, Space.xxl)
-                Spacer()
+            // Scrolling body. NavigationStack so the nearby row can push the
+            // full discovery list; its own bar is hidden to keep Today chrome
+            // clean (the status header above is the app's real top).
+            NavigationStack {
+                ScrollView {
+                    VStack(spacing: Space.lg) {
+                        // Who's nearby (B1-d) — self-gates on FeatureFlags.companion.
+                        TodayNearbyRow(cityCode: cityCode)
+
+                        // Yesterday's seal receipt (B1-d) — renders only when a
+                        // capsule was buried yesterday, else takes no space.
+                        TodaySealReceipt()
+
+                        // Three-things placeholder (B1-c).
+                        Text(NSLocalizedString(
+                            "today.scaffold.placeholder",
+                            comment: "Placeholder subtitle for the not-yet-wired Today body"
+                        ))
+                        .ctBody(15)
+                        .foregroundStyle(CT.textMutedAdaptive)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, Space.xxl)
+                        .padding(.top, Space.xxl)
+                    }
+                    .padding(.top, Space.lg)
+                }
+                .navigationDestination(for: NearbyDestination.self) { dest in
+                    DiscoverListView(cityCode: dest.cityCode)
+                }
+                .toolbar(.hidden, for: .navigationBar)
+                .background(CT.pageAdaptive)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/apps/ios/SoloCompass/Views/Today/TodayContainer.swift
+++ b/apps/ios/SoloCompass/Views/Today/TodayContainer.swift
@@ -56,6 +56,16 @@ private struct TodayHomeScaffold: View {
     /// isn't re-laid-out every frame, only translated.
     @GestureState private var dragTranslation: CGFloat = 0
 
+    /// Latches true the first time the map layer is pulled up. Until then the
+    /// heavy `CompassMapView` is NOT instantiated — the parked layer is just a
+    /// grab handle. This is what stops the map's cold-start `onAppear` from
+    /// firing an Always-location prompt over the Today home on launch (B1-a
+    /// finding): the map only requests location once the traveler actually
+    /// reaches for it. Once mounted it stays mounted, so a rest back to parked
+    /// never tears down and rebuilds the map (that would be expensive and
+    /// re-trigger its bootstrap).
+    @State private var mapEverRevealed = false
+
     /// Height of the peek handle that stays visible when the map is parked.
     private let handlePeek: CGFloat = 96
 
@@ -65,6 +75,8 @@ private struct TodayHomeScaffold: View {
             // Committed reveal + live drag, clamped to [0, fullTravel].
             let reveal = min(max(mapReveal + dragTranslation, 0), fullTravel)
             let isMapOpen = reveal > fullTravel * 0.5
+            // Mount the real map as soon as any pull begins; keep it mounted.
+            let mapMounted = mapEverRevealed || reveal > 0
 
             ZStack(alignment: .bottom) {
                 // ── Layer 1: Today home (placeholder skeleton for B1-a) ──
@@ -85,11 +97,16 @@ private struct TodayHomeScaffold: View {
                     fullTravel: fullTravel,
                     reveal: reveal,
                     isOpen: isMapOpen,
+                    mapMounted: mapMounted,
                     toggle: { mapReveal = isMapOpen ? 0 : fullTravel }
                 )
                 .offset(y: fullTravel - reveal)
             }
             .animation(.spring(response: 0.32, dampingFraction: 0.85), value: mapReveal)
+            .onChange(of: reveal) { _, newValue in
+                // Latch the mount the first time the layer is pulled at all.
+                if newValue > 0 && !mapEverRevealed { mapEverRevealed = true }
+            }
         }
         .ignoresSafeArea(.keyboard)
     }
@@ -97,24 +114,26 @@ private struct TodayHomeScaffold: View {
     // MARK: Today home placeholder (B1-a skeleton — real content in B1-b..d)
 
     private var todayHome: some View {
-        VStack(spacing: Space.xl) {
-            Spacer(minLength: Space.xxxl)
+        VStack(spacing: 0) {
+            // Sticky status header (B1-b). Stays out of any scroll region — the
+            // three-things / nearby / seal-receipt content that scrolls below it
+            // lands in B1-c/d.
+            TodayStatusHeader()
 
+            // Placeholder for the scrolling Today body (B1-c/d).
             VStack(spacing: Space.sm) {
-                Text("Today")
-                    .ctDisplay(34, .bold, relativeTo: .largeTitle)
-                    .foregroundStyle(CT.textPrimaryAdaptive)
+                Spacer(minLength: Space.xxxl)
                 Text(NSLocalizedString(
                     "today.scaffold.placeholder",
-                    comment: "B1-a placeholder subtitle on the Today home shell"
+                    comment: "Placeholder subtitle for the not-yet-wired Today body"
                 ))
                 .ctBody(15)
                 .foregroundStyle(CT.textMutedAdaptive)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, Space.xxl)
+                Spacer()
             }
-
-            Spacer()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -125,10 +144,20 @@ private struct TodayHomeScaffold: View {
         fullTravel: CGFloat,
         reveal: CGFloat,
         isOpen: Bool,
+        mapMounted: Bool,
         toggle: @escaping () -> Void
     ) -> some View {
         ZStack(alignment: .top) {
-            CompassMapView()
+            if mapMounted {
+                // The real map — only instantiated once the layer is reached
+                // for, so its cold-start location request never fires under the
+                // Today home (B1-a finding).
+                CompassMapView()
+            } else {
+                // Parked, never-opened placeholder: a plain warm surface behind
+                // the grab handle. No CompassMapView → no location prompt.
+                CT.pageAdaptive
+            }
 
             // Grab affordance / return-to-Today control, pinned to the layer's
             // top edge. When parked it's the "open map" handle; when open it's

--- a/apps/ios/SoloCompass/Views/Today/TodayNearbyRow.swift
+++ b/apps/ios/SoloCompass/Views/Today/TodayNearbyRow.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+/// Nomad OS B1-d: the "who's nearby" row on the Today home (design
+/// nomad-os-b1-today-home-20260719 §2 ③).
+///
+/// A compact, horizontal preview of anonymized companion posts in the current
+/// city — emoji avatars stacked with a one-line count — that taps through to
+/// the full `DiscoverListView`. It reads `CompanionService.discoverPosts` and
+/// is gated entirely behind `FeatureFlags.companion`:
+///
+///   - flag off              → the row does not render at all (no dead button;
+///     `fetchDiscovery` also self-gates and returns []).
+///   - flag on, has posts    → avatar stack + count + chevron → DiscoverListView.
+///   - flag on, no posts yet  → a "be the first" invite, never a dead end
+///     (design §2 ③, echoing the nomad-entry零数据 lesson).
+///
+/// The map's own companion layer stays behind its separate, still-off
+/// `companionLayerEnabled` flag; this row talks only to the real discovery
+/// fetch, so it shows real people or an honest empty state — not a control that
+/// never does anything.
+struct TodayNearbyRow: View {
+    let cityCode: String?
+
+    @Environment(CompanionService.self) private var companion
+    @State private var didLoad = false
+
+    var body: some View {
+        // Master gate: the whole social surface is off unless companion is on.
+        if FeatureFlags.companion, let cityCode, !cityCode.isEmpty {
+            content(cityCode: cityCode)
+                .task(id: cityCode) { await load(cityCode: cityCode) }
+        }
+    }
+
+    @ViewBuilder
+    private func content(cityCode: String) -> some View {
+        let posts = companion.discoverPosts
+        if posts.isEmpty {
+            // Honest empty state — an invite, not a dead end.
+            NavigationLink(value: NearbyDestination(cityCode: cityCode)) {
+                rowShell {
+                    HStack(spacing: Space.md) {
+                        Image(systemName: "person.2.badge.plus")
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundStyle(CT.accent)
+                        Text(NSLocalizedString(
+                            "today.nearby.beFirst",
+                            comment: "No nomads registered here yet — be the first"
+                        ))
+                        .ctBody(14, .medium)
+                        .foregroundStyle(CT.textMutedAdaptive)
+                        Spacer(minLength: 0)
+                        chevron
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+        } else {
+            NavigationLink(value: NearbyDestination(cityCode: cityCode)) {
+                rowShell {
+                    HStack(spacing: Space.md) {
+                        avatarStack(posts: posts)
+                        Text(String(
+                            format: NSLocalizedString(
+                                "today.nearby.count",
+                                comment: "%d nomads nearby in this city"
+                            ),
+                            posts.count
+                        ))
+                        .ctBody(14, .semibold)
+                        .foregroundStyle(CT.textPrimaryAdaptive)
+                        Spacer(minLength: 0)
+                        chevron
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: Pieces
+
+    private func avatarStack(posts: [DiscoverPost]) -> some View {
+        // Show up to 4 emoji avatars, overlapped. `handle` is an emoji, never a
+        // real name or user id (DiscoverPost contract).
+        let shown = Array(posts.prefix(4))
+        return HStack(spacing: -Space.sm) {
+            ForEach(Array(shown.enumerated()), id: \.element.id) { _, post in
+                Text(post.handle)
+                    .font(.system(size: 20))
+                    .frame(width: 34, height: 34)
+                    .background(Circle().fill(CT.pageAdaptive))
+                    .overlay(Circle().strokeBorder(CT.borderSubtle, lineWidth: 1))
+            }
+        }
+        .accessibilityHidden(true)
+    }
+
+    private var chevron: some View {
+        Image(systemName: "chevron.right")
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(CT.fgSubtle)
+    }
+
+    private func rowShell<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        content()
+            .padding(Space.lg)
+            .background(
+                RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
+                    .fill(CT.cardAdaptive)
+            )
+            .padding(.horizontal, Space.xl)
+    }
+
+    private func load(cityCode: String) async {
+        // Idempotent per city — `.task(id:)` re-fires on city change.
+        await companion.fetchDiscovery(
+            params: CompanionDiscoverParams(cityCode: cityCode, mode: .nearby)
+        )
+        didLoad = true
+    }
+}
+
+/// Navigation payload for the Today → full discovery push. A dedicated type
+/// keeps the destination unambiguous in the Today navigation stack.
+struct NearbyDestination: Hashable {
+    let cityCode: String
+}

--- a/apps/ios/SoloCompass/Views/Today/TodaySealReceipt.swift
+++ b/apps/ios/SoloCompass/Views/Today/TodaySealReceipt.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+/// Nomad OS B1-d: the "yesterday's seal" receipt on the Today home (design
+/// nomad-os-b1-today-home-20260719 §2 ④).
+///
+/// Design §2 ④ picks option (a): "yesterday's seal" = a capsule the traveler
+/// buried yesterday, read from `CapsuleStore.buriedUnripeCapsules()` filtered to
+/// yesterday's `createdAt`. It renders only when such a capsule exists — no
+/// empty placeholder occupying the row. Tapping opens the capsule detail flow.
+///
+/// The richer per-day "seal ritual" model is deliberately left to B2 with the
+/// ledger; B1-d reuses the existing TimeCapsule / CapsuleStore as-is (no new
+/// persistence).
+struct TodaySealReceipt: View {
+    /// Called when the receipt is tapped — routes to the capsule detail /
+    /// chapter card. Wired by the container in a later slice.
+    var onOpen: (TimeCapsule) -> Void = { _ in }
+
+    @State private var yesterdayCapsule: TimeCapsule?
+
+    var body: some View {
+        Group {
+            if let capsule = yesterdayCapsule {
+                Button {
+                    onOpen(capsule)
+                } label: {
+                    HStack(spacing: Space.md) {
+                        Image(systemName: "archivebox.fill")
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundStyle(CT.accent)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(NSLocalizedString(
+                                "today.seal.yesterdayTitle",
+                                comment: "Yesterday you sealed a moment"
+                            ))
+                            .ctBody(14, .semibold)
+                            .foregroundStyle(CT.textPrimaryAdaptive)
+                            Text(sealSubtitle(for: capsule))
+                                .ctBody(12)
+                                .foregroundStyle(CT.textMutedAdaptive)
+                                .lineLimit(1)
+                        }
+                        Spacer(minLength: 0)
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(CT.fgSubtle)
+                    }
+                    .padding(Space.lg)
+                    .background(
+                        RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
+                            .fill(CT.cardAdaptive)
+                    )
+                    .padding(.horizontal, Space.xl)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .task { refresh() }
+    }
+
+    /// One-line context: the sealed content type, kept generic since the blob is
+    /// opaque here (full render lives in the capsule detail view).
+    private func sealSubtitle(for capsule: TimeCapsule) -> String {
+        switch capsule.contentType {
+        case "photo":
+            return NSLocalizedString("today.seal.type.photo", comment: "a photo")
+        case "voice":
+            return NSLocalizedString("today.seal.type.voice", comment: "a voice note")
+        default:
+            return NSLocalizedString("today.seal.type.text", comment: "a note")
+        }
+    }
+
+    private func refresh() {
+        yesterdayCapsule = Self.yesterdayCapsule(
+            from: CapsuleStore.shared.buriedUnripeCapsules(),
+            now: Date()
+        )
+    }
+
+    /// Pick the most recent still-buried capsule created *yesterday* (local
+    /// day). Pure so `TodaySealReceiptTests` can pin the day-boundary logic
+    /// without a live store: today's and older capsules are excluded, only
+    /// yesterday's qualifies. `nonisolated` — no view state touched.
+    nonisolated static func yesterdayCapsule(
+        from capsules: [TimeCapsule],
+        now: Date,
+        calendar: Calendar = Calendar.current
+    ) -> TimeCapsule? {
+        guard let yesterday = calendar.date(byAdding: .day, value: -1, to: now) else {
+            return nil
+        }
+        let yesterdayStart = calendar.startOfDay(for: yesterday)
+        let todayStart = calendar.startOfDay(for: now)
+        return capsules
+            .filter { $0.createdAt >= yesterdayStart && $0.createdAt < todayStart }
+            .max(by: { $0.createdAt < $1.createdAt })
+    }
+}

--- a/apps/ios/SoloCompass/Views/Today/TodayStatusHeader.swift
+++ b/apps/ios/SoloCompass/Views/Today/TodayStatusHeader.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+import SwiftData
+
+/// Nomad OS B1-b status header: the sticky top of the Today home —
+/// **city · day-in-city · lifecycle face · visa ring** (design
+/// nomad-os-b1-today-home-20260719 §2 ①).
+///
+/// It reuses the map's visual language — `BaseFace` for the lifecycle chip and
+/// `BaseCountdownRing` for the visa ring — but derives its data from
+/// independently-obtainable sources rather than the map's `MapViewModel`
+/// `@State` (which Today can't reach), so it never forces the map's internal
+/// state to be hoisted:
+///
+///   - city       ← `preferences.lastSelectedCity` + the now-`static`
+///                  `MapViewModel.cityNameMap` (one source of truth for names)
+///   - day-in-city← `ArchiveViewModel.currentTrip?.dayCount` (the ledger's
+///                  in-city day span, NOT the visa stay day the map's BaseCard
+///                  fills — design §2 ① calls out the two口径 must not be mixed)
+///   - face       ← `CityOSStore.mode/stage` → `BaseFace.derive`
+///   - visa ring  ← `ComplianceService.state()`, three-state per decision C:
+///                  unset (entry-date CTA) / confirmed (ring) / critical (tint)
+struct TodayStatusHeader: View {
+    @Environment(UserPreferences.self) private var preferences
+
+    /// Independently-built ledger + compliance sources. Kept as `@State` so
+    /// they survive re-renders; refreshed in `.task` and when the city changes.
+    @State private var archive: ArchiveViewModel?
+    @State private var compliance: ComplianceService?
+    @State private var cityStore: CityOSStore?
+
+    /// Called when the traveler taps the unset visa ring — the entry-date
+    /// confirm hook (design decision C: empty state is the ledger's first
+    /// onboarding hook, not a hidden block). Wired in a later slice.
+    var onConfirmEntryDate: () -> Void = {}
+
+    var body: some View {
+        HStack(alignment: .center, spacing: Space.lg) {
+            VStack(alignment: .leading, spacing: Space.sm) {
+                faceChip
+                Text(cityName)
+                    .ctDisplay(20, .bold, relativeTo: .title2)
+                    .foregroundStyle(CT.textPrimaryAdaptive)
+                    .lineLimit(1)
+                dayLine
+            }
+            Spacer(minLength: 0)
+            visaRing
+        }
+        .padding(.horizontal, Space.xl)
+        .padding(.vertical, Space.lg)
+        .background(CT.pageAdaptive)
+        .task { rebuildSources() }
+        .onChange(of: preferences.lastSelectedCity) { _, _ in rebuildSources() }
+    }
+
+    // MARK: Derived values
+
+    private var cityCode: String? {
+        preferences.lastSelectedCity
+    }
+
+    private var cityName: String {
+        guard let code = cityCode, !code.isEmpty else {
+            return NSLocalizedString("today.header.noCity", comment: "No city selected yet")
+        }
+        return MapViewModel.cityNameMap[code] ?? code
+    }
+
+    /// In-city day span from the ledger (nil when no visits recorded yet).
+    private var dayInCity: Int? {
+        archive?.currentTrip?.dayCount
+    }
+
+    private var face: BaseFace {
+        let mode = cityStore?.mode(for: cityCode) ?? .live
+        let stage = cityStore?.stage(for: cityCode, daysStayed: dayInCity)
+        return BaseFace.derive(mode: mode, stage: stage)
+    }
+
+    // MARK: Pieces
+
+    private var faceChip: some View {
+        HStack(spacing: Space.xs) {
+            Image(systemName: face.symbol)
+                .font(.system(size: 10, weight: .bold))
+            Text(face.tagText)
+                .font(.system(size: 10, weight: .bold, design: .rounded))
+                .tracking(1.0)
+                .textCase(.uppercase)
+        }
+        .foregroundStyle(face.tagColor)
+        .padding(.horizontal, Space.sm)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(face.tagColor.opacity(0.12)))
+    }
+
+    @ViewBuilder
+    private var dayLine: some View {
+        if let day = dayInCity {
+            Text(String(
+                format: NSLocalizedString("today.header.dayInCity", comment: "Day %d in this city"),
+                day
+            ))
+            .ctBody(13, .medium)
+            .foregroundStyle(CT.textMutedAdaptive)
+        } else {
+            Text(NSLocalizedString("today.header.firstDay", comment: "Just arrived / no visits yet"))
+                .ctBody(13, .medium)
+                .foregroundStyle(CT.textMutedAdaptive)
+        }
+    }
+
+    /// Three-state visa ring (decision C). `state()` is nil until the traveler
+    /// confirms an entry date → show a tap-to-confirm affordance instead of an
+    /// empty ring, turning the void into the ledger's first onboarding hook.
+    @ViewBuilder
+    private var visaRing: some View {
+        if let state = compliance?.state(),
+           let policyDays = visaPolicyDays {
+            BaseCountdownRing(
+                remaining: state.visaDaysRemaining,
+                total: policyDays
+            )
+            .accessibilityLabel(Text(String(
+                format: NSLocalizedString("today.header.visaRemaining", comment: "%d visa days left"),
+                state.visaDaysRemaining
+            )))
+        } else {
+            Button(action: onConfirmEntryDate) {
+                VStack(spacing: 2) {
+                    Image(systemName: "calendar.badge.plus")
+                        .font(.system(size: 18, weight: .semibold))
+                    Text(NSLocalizedString("today.header.setEntryDate", comment: "Set entry date CTA"))
+                        .ctBody(10, .semibold)
+                        .multilineTextAlignment(.center)
+                }
+                .foregroundStyle(CT.accent)
+                .frame(width: 56)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    /// The city's visa allowance (denominator for the ring). Read from the
+    /// persisted stay length the traveler set; nil hides the ring in favour of
+    /// the confirm CTA. `ComplianceService.state()` supplies remaining; total
+    /// comes from `preferences.visaLengthDays`.
+    private var visaPolicyDays: Int? {
+        guard let days = preferences.visaLengthDays, days > 0 else { return nil }
+        return days
+    }
+
+    // MARK: Source lifecycle
+
+    private func rebuildSources() {
+        let container = SoloCompassModelContainer.shared
+        let vm = archive ?? ArchiveViewModel(modelContainer: container, activeCityCode: cityCode)
+        vm.activeCityCode = cityCode
+        vm.refresh()
+        archive = vm
+
+        if compliance == nil { compliance = ComplianceService(preferences: preferences) }
+        if cityStore == nil { cityStore = CityOSStore(preferences: preferences) }
+    }
+}


### PR DESCRIPTION
## What

Lands the first three slices of the Nomad OS **B1 Today home** form-pivot (design `nomad-os-b1-today-home-20260719`), all behind `FeatureFlags.todayHome` (**default OFF everywhere**). With the flag off the app root falls straight through to `CompassMapView` — today's map-first form is byte-for-byte unchanged, so this ships dark and is fully reversible.

| Slice | What |
|---|---|
| **B1-a** | `TodayContainer` root shell + `FeatureFlags.todayHome` rollback flag; map embedded as a pull-up full-screen layer (never reaches into `BottomInfoSheet`'s refactor-forbidden zone). |
| **B1-b** | `TodayStatusHeader` — city · in-city day · lifecycle face · three-state visa ring; derived from independent sources (not the map's `MapViewModel` `@State`). Lazy map layer so the parked map doesn't fire an Always-location prompt over Today on launch. |
| **B1-d** | `TodayNearbyRow` (companion discovery preview → `DiscoverListView`, honest empty state) + `TodaySealReceipt` (yesterday's buried capsule, absent when none). |

Three-things (**B1-c**) is intentionally deferred — it waits on the content-supply decision (design §0 decision A) and would otherwise空转 on non-seed cities.

## Why

Nomad OS demotes the map from the home screen to a pull-up layer. Swapping the app's loading point is an irreversible product bet on the largest file's mount point, so it ships behind a rollback flag and rolls out staged.

## Notable

- `MapViewModel.cityNameMap` → `static`: one source of truth for city names shared by Today and the map pill.
- Fixes pre-existing test debt: `EmptyStateCitySuggestionTest` hand-copied a 3-city name map that rotted as seeds grew; now asserts against the real static map.
- Two callbacks (`onConfirmEntryDate`, seal `onOpen`) are stubs, wired in a later slice.

## Verification

- ✅ Full iOS build (iPhone 17, iOS 26.1)
- ✅ TS↔Swift↔DB parity, `format:check` green
- ✅ Today test suites + touched existing suites green (container flag routing, status-header derivation, seal-receipt day boundaries, city cache/suggestion)
- ✅ On-sim visual (flag on): status header renders Shenzhen · visa ring, nearby row shows honest "be the first" empty state, no location-prompt-over-Today; flag off = unchanged map form

## Rollout

Flag default OFF; flip `FF_TODAY_HOME` in Developer Options / DEBUG to preview. Safe to merge — no behavioural change to the shipping form.

https://claude.ai/code/session_01A9yc2UDrmYN3aSUT5MQJjM