### PR TITLE
feat(ios): capture nomad cohort in onboarding (Nomad OS B1-e)

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		344AA4D02D20133A5BC7562D /* TasteUpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D194A2740848FA0C9D4BA3D /* TasteUpdateService.swift */; };
 		34F2006B922A8F29F62B7317 /* FarAwayDistanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA7C71C5E9C16456C7A65D2 /* FarAwayDistanceTest.swift */; };
 		352247C1FBF4C8F901D17F32 /* ApprovalTrustSignalTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804618047547A9D7F3F8EAAA /* ApprovalTrustSignalTest.swift */; };
+		3596C0741E576CFBBB50FDF7 /* NomadCohortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E478564C50AFC377D036375E /* NomadCohortTests.swift */; };
 		36E1316045802B2F642A9623 /* LocalAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C89CB8D3309FD5646E23434 /* LocalAttachment.swift */; };
 		37273BCDAED53D5F49CD756D /* CityBriefServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDD92E055336925881B13C67 /* CityBriefServiceTests.swift */; };
 		37375126C9D00F02A3233357 /* TodayNearbyRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76E5FA5F9C2CADE936F9D40 /* TodayNearbyRow.swift */; };
@@ -583,6 +584,7 @@
 		FD8F94BFC5C298D62943FFF3 /* MarkerStatePerformanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658C2890F90C08A686F501BA /* MarkerStatePerformanceTest.swift */; };
 		FDF6502B0962A7AD161E1067 /* ChatCardRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A54294FE114979C2230686E /* ChatCardRecord.swift */; };
 		FEC4BF6E3C7FA92D982C0B4F /* ChatCardRenderVisualTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C504FA7911B469792541F323 /* ChatCardRenderVisualTest.swift */; };
+		FF03726AF1497D01D665620B /* OnboardingCohortStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762C398E4512C7B1809CD866 /* OnboardingCohortStep.swift */; };
 		FF880C11C06B7673E5C728D7 /* MemoryDigestServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B33B0431703DD49E0228D33 /* MemoryDigestServiceTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -879,6 +881,7 @@
 		741295168A3FC1A94FBDDA45 /* ItineraryRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItineraryRecord.swift; sourceTree = "<group>"; };
 		746139AC01A1D37CE002BFCF /* ReviewsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsService.swift; sourceTree = "<group>"; };
 		7571A35B387B48264B721AB7 /* BragCardTemplateBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BragCardTemplateBackground.swift; sourceTree = "<group>"; };
+		762C398E4512C7B1809CD866 /* OnboardingCohortStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCohortStep.swift; sourceTree = "<group>"; };
 		763DF01F638C99097DD5FE20 /* EmptyStateAnnouncementTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateAnnouncementTest.swift; sourceTree = "<group>"; };
 		76D60D55727FB72C1C202C90 /* ItineraryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItineraryListView.swift; sourceTree = "<group>"; };
 		76DB99E393326334CEAD0309 /* DataSourceSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSourceSettingsTests.swift; sourceTree = "<group>"; };
@@ -1133,6 +1136,7 @@
 		E212233396693C6264237B11 /* SoloScoreBadgeScaleTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloScoreBadgeScaleTest.swift; sourceTree = "<group>"; };
 		E406C379247653B4AA5A3E0E /* SupabaseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseClient.swift; sourceTree = "<group>"; };
 		E4486B29C6268AB3905D4E0F /* FriendshipStateMachineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendshipStateMachineTests.swift; sourceTree = "<group>"; };
+		E478564C50AFC377D036375E /* NomadCohortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NomadCohortTests.swift; sourceTree = "<group>"; };
 		E4E0D46949612D8FCC41696B /* VoiceButtonHapticTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceButtonHapticTests.swift; sourceTree = "<group>"; };
 		E536D4CFF44CF4CEFD1EFF4F /* WeatherCacheTTLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherCacheTTLTests.swift; sourceTree = "<group>"; };
 		E575898B14533C58035EFC79 /* ConversationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStore.swift; sourceTree = "<group>"; };
@@ -1468,6 +1472,7 @@
 				994CE03CD59A3B638A7570AD /* NearbySkeletonRenderTest.swift */,
 				DE1E1FC2007C2AFC681D322A /* NeverInventPOIRedLineTests.swift */,
 				D08AFC181DB143A21E97A2ED /* NextBestExperienceClockTest.swift */,
+				E478564C50AFC377D036375E /* NomadCohortTests.swift */,
 				CE95C3399C8616CBDE8B44BE /* NoProductionPrintTests.swift */,
 				49F36F9AC9ED0AE7E3F0E5EA /* NotificationServiceHandleURLTests.swift */,
 				F1D68F42114231582501CB90 /* NowCountCacheTests.swift */,
@@ -2063,6 +2068,7 @@
 			isa = PBXGroup;
 			children = (
 				7D3D7AE265D80F76BA9BB28B /* OnboardingCityStep.swift */,
+				762C398E4512C7B1809CD866 /* OnboardingCohortStep.swift */,
 				D0123E9112C29BF44DBF525B /* OnboardingVibeStep.swift */,
 				C660F7996B1E4387C37720B3 /* OnboardingView.swift */,
 				0364599CF5416C94D9711120 /* TermsConsentSheet.swift */,
@@ -2462,6 +2468,7 @@
 				62F1F72C563FF41389050CEB /* NeverInventPOIRedLineTests.swift in Sources */,
 				FC1E25FED02B767FBFB5EFE2 /* NextBestExperienceClockTest.swift in Sources */,
 				B42207A02271655D3498B723 /* NoProductionPrintTests.swift in Sources */,
+				3596C0741E576CFBBB50FDF7 /* NomadCohortTests.swift in Sources */,
 				2FDE17BACDABCE85552A022B /* NotificationServiceHandleURLTests.swift in Sources */,
 				C3A87993F509B921A9F7FE06 /* NowCountCacheTests.swift in Sources */,
 				98CE98CA3A71C84641FBC39D /* NowEmptyStateTest.swift in Sources */,
@@ -2786,6 +2793,7 @@
 				81C19176806829BBF820D0C2 /* OmenCardView.swift in Sources */,
 				E61ADD9CE38B917026123DEE /* OmenComposeService.swift in Sources */,
 				D3D09BE396ED9D2DF5FE91B9 /* OnboardingCityStep.swift in Sources */,
+				FF03726AF1497D01D665620B /* OnboardingCohortStep.swift in Sources */,
 				0AB319F3D38506DF9EA6F7D5 /* OnboardingVibeStep.swift in Sources */,
 				C81007F6A39364D0872736B2 /* OnboardingView.swift in Sources */,
 				CD73E1A29E0D2EB8D8AC93AC /* OpenForCompanionsSheet.swift in Sources */,

--- a/apps/ios/SoloCompass/Models/UserPreferences.swift
+++ b/apps/ios/SoloCompass/Models/UserPreferences.swift
@@ -20,11 +20,42 @@ public final class UserPreferences {
         public var id: String { rawValue }
     }
 
+    /// Nomad OS B1-e: how often the traveler changes cities in a year. The
+    /// data floor for the digital-nomad convergence strategy — a higher band
+    /// maps directly to a sharper visa / 90-180-day compliance pain point, and
+    /// so to a higher willingness to pay for the B2 ledger. Captured once in
+    /// onboarding (the cohort step, after style); `.unset` until then so a
+    /// returning user who predates the step is never mis-bucketed.
+    public enum NomadCohort: String, Codable, CaseIterable, Identifiable {
+        /// Not yet asked (returning users pre-B1-e) — treated as "no signal".
+        case unset
+        /// 1-2 cities a year — settled travel, one long base.
+        case settled
+        /// 3-5 — slow travel, a season per city.
+        case slow
+        /// 6-11 — active nomad, roughly monthly hops.
+        case active
+        /// 12+ — high-frequency, a city or less per month.
+        case frequent
+
+        public var id: String { rawValue }
+
+        /// The four bands the onboarding step offers (everything except the
+        /// `.unset` sentinel, which is never a user-selectable option).
+        public static var selectableCases: [NomadCohort] {
+            allCases.filter { $0 != .unset }
+        }
+    }
+
     /// Snapshot used for Codable persistence. Mirrors the @Observable surface.
     private struct Snapshot: Codable {
         var preferredCategories: [ExperienceCategory] = []
         var dislikedCategories: [ExperienceCategory] = []
         var soloTravelStyle: SoloTravelStyle = .explorer
+        // Nomad OS B1-e: city-change frequency band. Raw string so adding a
+        // future band never breaks an older client's decode. `.unset` until
+        // the onboarding cohort step captures it.
+        var nomadCohortRaw: String = NomadCohort.unset.rawValue
         // First-launch default raised 5 → 8 km so a cold start in a seeded city
         // (e.g. Chiang Mai, where Doi Suthep sits at ~7.8 km from the centroid)
         // surfaces all curated Experiences instead of showing an "empty within
@@ -104,7 +135,7 @@ public final class UserPreferences {
 
         // swiftlint:disable:next nesting
         enum CodingKeys: String, CodingKey {
-            case preferredCategories, dislikedCategories, soloTravelStyle, maxDistanceKm
+            case preferredCategories, dislikedCategories, soloTravelStyle, nomadCohortRaw, maxDistanceKm
             case visitHistory, completedExperiences, favoritedExperiences, favoritedAt, pendingCheckIns
             case lastSelectedCity, hasCompletedOnboarding, notificationsEnabled
             case quietHoursStart, quietHoursEnd, seedImported, swiftDataMirrored
@@ -129,6 +160,7 @@ public final class UserPreferences {
             preferredCategories: [ExperienceCategory],
             dislikedCategories: [ExperienceCategory],
             soloTravelStyle: SoloTravelStyle,
+            nomadCohortRaw: String = NomadCohort.unset.rawValue,
             maxDistanceKm: Double,
             visitHistory: [String: Date],
             completedExperiences: Set<String>,
@@ -175,6 +207,7 @@ public final class UserPreferences {
             self.preferredCategories = preferredCategories
             self.dislikedCategories = dislikedCategories
             self.soloTravelStyle = soloTravelStyle
+            self.nomadCohortRaw = nomadCohortRaw
             self.maxDistanceKm = maxDistanceKm
             self.visitHistory = visitHistory
             self.completedExperiences = completedExperiences
@@ -224,6 +257,7 @@ public final class UserPreferences {
             self.preferredCategories = try container.decodeIfPresent([ExperienceCategory].self, forKey: .preferredCategories) ?? []
             self.dislikedCategories = try container.decodeIfPresent([ExperienceCategory].self, forKey: .dislikedCategories) ?? []
             self.soloTravelStyle = try container.decodeIfPresent(SoloTravelStyle.self, forKey: .soloTravelStyle) ?? .explorer
+            self.nomadCohortRaw = try container.decodeIfPresent(String.self, forKey: .nomadCohortRaw) ?? NomadCohort.unset.rawValue
             self.maxDistanceKm = try container.decodeIfPresent(Double.self, forKey: .maxDistanceKm) ?? 8.0
             self.visitHistory = try container.decodeIfPresent([String: Date].self, forKey: .visitHistory) ?? [:]
             self.completedExperiences = try container.decodeIfPresent(Set<String>.self, forKey: .completedExperiences) ?? []
@@ -273,6 +307,16 @@ public final class UserPreferences {
     public var preferredCategories: [ExperienceCategory] { didSet { persist() } }
     public var dislikedCategories: [ExperienceCategory] { didSet { persist() } }
     public var soloTravelStyle: SoloTravelStyle { didSet { persist() } }
+    /// Nomad OS B1-e: raw string backing for `nomadCohort`. Stored so a new
+    /// band added later still decodes on older clients. Default `.unset`.
+    public var nomadCohortRaw: String { didSet { persist() } }
+    /// Nomad OS B1-e: typed access to the traveler's city-change frequency
+    /// band. Reads/writes `nomadCohortRaw`; an unknown stored value degrades
+    /// to `.unset` rather than crashing.
+    public var nomadCohort: NomadCohort {
+        get { NomadCohort(rawValue: nomadCohortRaw) ?? .unset }
+        set { nomadCohortRaw = newValue.rawValue }
+    }
     public var maxDistanceKm: Double { didSet { persist() } }
     public var visitHistory: [String: Date] { didSet { persist() } }
     public var completedExperiences: Set<String> { didSet { persist() } }
@@ -432,6 +476,7 @@ public final class UserPreferences {
         self.preferredCategories = snapshot.preferredCategories
         self.dislikedCategories = snapshot.dislikedCategories
         self.soloTravelStyle = snapshot.soloTravelStyle
+        self.nomadCohortRaw = snapshot.nomadCohortRaw
         self.maxDistanceKm = snapshot.maxDistanceKm
         self.visitHistory = snapshot.visitHistory
         self.completedExperiences = snapshot.completedExperiences
@@ -506,6 +551,7 @@ public final class UserPreferences {
             preferredCategories: preferredCategories,
             dislikedCategories: dislikedCategories,
             soloTravelStyle: soloTravelStyle,
+            nomadCohortRaw: nomadCohortRaw,
             maxDistanceKm: maxDistanceKm,
             visitHistory: visitHistory,
             completedExperiences: completedExperiences,

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -562,6 +562,22 @@
 "onboarding.scoring.cta" = "Makes sense";
 "onboarding.style.cta" = "Start exploring";
 "onboarding.style.skip" = "Decide later";
+
+/* Onboarding cohort step (Nomad OS B1-e) — city-change frequency */
+"onboarding.cohort.title" = "How often do you move?";
+"onboarding.cohort.subtitle" = "Roughly how many cities you settle into in a year. It tunes your visa and day-count reminders.";
+"onboarding.cohort.cta" = "That's me";
+"onboarding.cohort.skip" = "Skip for now";
+"onboarding.cohort.settled.title" = "Home base";
+"onboarding.cohort.settled.desc" = "1–2 cities a year";
+"onboarding.cohort.slow.title" = "Slow travel";
+"onboarding.cohort.slow.desc" = "3–5 cities a year";
+"onboarding.cohort.active.title" = "Active nomad";
+"onboarding.cohort.active.desc" = "6–11 cities a year";
+"onboarding.cohort.frequent.title" = "Always moving";
+"onboarding.cohort.frequent.desc" = "12+ cities a year";
+"onboarding.cohort.unset.title" = "Not set";
+
 "onboarding.skip" = "Skip";
 
 /* Favorites list */

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -338,6 +338,22 @@
 "onboarding.scoring.cta" = "明白了";
 "onboarding.style.cta" = "开始探索";
 "onboarding.style.skip" = "稍后决定";
+
+/* Onboarding cohort step (Nomad OS B1-e) — 换城频率 */
+"onboarding.cohort.title" = "你多久换一座城？";
+"onboarding.cohort.subtitle" = "一年大概在几座城市住下来。它会调校你的签证与天数提醒。";
+"onboarding.cohort.cta" = "就是我";
+"onboarding.cohort.skip" = "暂时跳过";
+"onboarding.cohort.settled.title" = "定居旅行";
+"onboarding.cohort.settled.desc" = "一年 1–2 座城";
+"onboarding.cohort.slow.title" = "慢游";
+"onboarding.cohort.slow.desc" = "一年 3–5 座城";
+"onboarding.cohort.active.title" = "活跃游民";
+"onboarding.cohort.active.desc" = "一年 6–11 座城";
+"onboarding.cohort.frequent.title" = "常在路上";
+"onboarding.cohort.frequent.desc" = "一年 12 座城以上";
+"onboarding.cohort.unset.title" = "未设置";
+
 "onboarding.skip" = "跳过";
 
 /* Favorites list */

--- a/apps/ios/SoloCompass/Tests/NomadCohortTests.swift
+++ b/apps/ios/SoloCompass/Tests/NomadCohortTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import SoloCompass
+
+/// Nomad OS B1-e: the onboarding cohort step captures the traveler's
+/// city-change frequency band into `UserPreferences.nomadCohort`. These tests
+/// pin the persistence round-trip, the raw-string degrade path, the
+/// selectable-cases contract the step relies on, and the two-localization
+/// coverage of the step's strings.
+final class NomadCohortTests: XCTestCase {
+
+    // MARK: Persistence
+
+    /// Selecting a band writes through `persist()` and survives a reload — the
+    /// signal must not be lost if the user force-quits before finishing.
+    @MainActor
+    func testCohortPersistsAcrossLaunches() {
+        let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+        let preferences = UserPreferences(defaults: defaults)
+
+        XCTAssertEqual(preferences.nomadCohort, .unset,
+                       "A fresh user must start with no cohort signal")
+
+        preferences.nomadCohort = .active
+
+        let reloaded = UserPreferences(defaults: defaults)
+        XCTAssertEqual(reloaded.nomadCohort, .active,
+                       "The selected cohort must persist across launches")
+    }
+
+    /// The typed accessor writes back into the raw string, and reading an
+    /// unknown stored value degrades to `.unset` rather than trapping — this is
+    /// what lets a future band ship without breaking older clients.
+    @MainActor
+    func testUnknownRawDegradesToUnset() {
+        let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+        let preferences = UserPreferences(defaults: defaults)
+
+        preferences.nomadCohortRaw = "some-band-added-in-2027"
+        XCTAssertEqual(preferences.nomadCohort, .unset,
+                       "An unrecognized raw band must read back as .unset")
+
+        preferences.nomadCohort = .frequent
+        XCTAssertEqual(preferences.nomadCohortRaw, "frequent",
+                       "The typed setter must write the raw rawValue")
+    }
+
+    // MARK: Selectable cases contract
+
+    /// The step renders `selectableCases`, which must be exactly the four real
+    /// bands — never the `.unset` sentinel (there is no "not set" row to tap).
+    func testSelectableCasesExcludeUnset() {
+        let selectable = UserPreferences.NomadCohort.selectableCases
+        XCTAssertEqual(selectable, [.settled, .slow, .active, .frequent],
+                       "The onboarding step must offer exactly the four real bands, in ascending order")
+        XCTAssertFalse(selectable.contains(.unset),
+                       ".unset is a sentinel, never a selectable row")
+    }
+
+    /// Every selectable band must resolve a non-empty title + description +
+    /// symbol so no row renders blank.
+    func testEverySelectableBandHasDisplay() {
+        for cohort in UserPreferences.NomadCohort.selectableCases {
+            XCTAssertFalse(cohort.localizedTitle.isEmpty,
+                           "\(cohort) must have a non-empty title")
+            XCTAssertFalse(cohort.localizedDescription.isEmpty,
+                           "\(cohort) must have a non-empty description")
+            XCTAssertFalse(cohort.symbol.isEmpty,
+                           "\(cohort) must have an SF Symbol")
+        }
+    }
+
+    // MARK: Localization
+
+    /// The cohort step's user-facing keys must exist in both shipped
+    /// localizations — the en/zh split that a past regression polluted.
+    func testCohortStringsLocalizedInBothLanguages() throws {
+        let searchBundles = [Bundle.main, Bundle(for: NomadCohortTests.self)]
+        let requiredKeys = [
+            "onboarding.cohort.title",
+            "onboarding.cohort.subtitle",
+            "onboarding.cohort.cta",
+            "onboarding.cohort.settled.title",
+            "onboarding.cohort.settled.desc",
+            "onboarding.cohort.slow.title",
+            "onboarding.cohort.active.title",
+            "onboarding.cohort.frequent.title",
+        ]
+        for localization in ["en", "zh-Hans"] {
+            var found: [String: String]?
+            for bundle in searchBundles {
+                if let url = bundle.url(forResource: "Localizable",
+                                        withExtension: "strings",
+                                        subdirectory: nil,
+                                        localization: localization),
+                   let dict = NSDictionary(contentsOf: url) as? [String: String] {
+                    found = dict
+                    break
+                }
+            }
+            guard let dict = found else {
+                throw XCTSkip("Localizable.strings (\(localization)) not found in test host bundle")
+            }
+            for key in requiredKeys {
+                XCTAssertNotNil(dict[key],
+                                "\(localization).lproj must define \(key)")
+            }
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Views/Onboarding/OnboardingCohortStep.swift
+++ b/apps/ios/SoloCompass/Views/Onboarding/OnboardingCohortStep.swift
@@ -1,0 +1,189 @@
+import SwiftUI
+
+/// Nomad OS B1-e onboarding step: how often does the traveler change cities?
+///
+/// This is the data floor for the digital-nomad convergence strategy — the
+/// selected band (`UserPreferences.NomadCohort`) maps directly to the sharpness
+/// of the visa / 90-180-day compliance pain point, and so to willingness to pay
+/// for the B2 ledger. It sits right after the travel-style step: both answer
+/// "who is this traveler", so they read as one identity beat.
+///
+/// Mirrors `OnboardingCityStep`'s shape — a standalone view driven by an
+/// `onContinue` callback, embedded inside the shared step chrome by
+/// `OnboardingView`. Selecting a band writes `preferences.nomadCohort`
+/// immediately (a tap is a commit), so there is no separate save action and the
+/// signal survives even if the user force-quits before finishing onboarding.
+public struct OnboardingCohortStep: View {
+
+    /// Called when the user confirms a band (or taps continue after selecting).
+    public let onContinue: () -> Void
+
+    @Environment(UserPreferences.self) private var preferences
+
+    public init(onContinue: @escaping () -> Void) {
+        self.onContinue = onContinue
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+
+            VStack(spacing: 24) {
+                header
+
+                VStack(spacing: 10) {
+                    ForEach(UserPreferences.NomadCohort.selectableCases) { cohort in
+                        cohortRow(cohort)
+                    }
+                }
+                .padding(.horizontal, 24)
+            }
+
+            Spacer(minLength: 0)
+            Spacer(minLength: 0)
+
+            actions
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: - Subviews
+
+    private var header: some View {
+        VStack(spacing: 24) {
+            Text(NSLocalizedString("onboarding.cohort.title", comment: "Cohort step title"))
+                .font(.title.bold())
+                .multilineTextAlignment(.center)
+
+            Text(NSLocalizedString("onboarding.cohort.subtitle", comment: "Cohort step subtitle"))
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+        }
+    }
+
+    private func cohortRow(_ cohort: UserPreferences.NomadCohort) -> some View {
+        let selected = preferences.nomadCohort == cohort
+        return Button {
+            Haptics.selection()
+            preferences.nomadCohort = cohort
+        } label: {
+            HStack(spacing: 14) {
+                Image(systemName: cohort.symbol)
+                    .font(.title3)
+                    .foregroundStyle(selected ? Color.white : CT.accent)
+                    .frame(width: 36, height: 36)
+                    .background(
+                        Circle().fill(selected ? CT.accent : CT.accent.opacity(0.12))
+                    )
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(cohort.localizedTitle)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.primary)
+                    Text(cohort.localizedDescription)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                if selected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(CT.accent)
+                }
+            }
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(selected ? CT.accent.opacity(0.08) : Color(.secondarySystemBackground))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(selected ? CT.accent : Color.clear, lineWidth: 1.5)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text("\(cohort.localizedTitle), \(cohort.localizedDescription)"))
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+
+    private var actions: some View {
+        VStack(spacing: 12) {
+            Button {
+                onContinue()
+            } label: {
+                Text(NSLocalizedString("onboarding.cohort.cta", comment: "Continue after picking a frequency"))
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .background(CT.accent, in: RoundedRectangle(cornerRadius: 14))
+                    .foregroundStyle(.white)
+            }
+
+            Button {
+                onContinue()
+            } label: {
+                Text(NSLocalizedString("onboarding.cohort.skip", comment: "Skip picking a frequency"))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.bottom, 48)
+    }
+}
+
+// MARK: - NomadCohort display
+
+extension UserPreferences.NomadCohort {
+    /// SF Symbol for each band — a rising cadence from a single anchor
+    /// (settled) to a globe (frequent). `.unset` is never rendered as a row.
+    var symbol: String {
+        switch self {
+        case .unset:    return "questionmark"
+        case .settled:  return "house"
+        case .slow:     return "leaf"
+        case .active:   return "airplane"
+        case .frequent: return "globe"
+        }
+    }
+
+    var localizedTitle: String {
+        switch self {
+        case .unset:
+            return NSLocalizedString("onboarding.cohort.unset.title", comment: "Cohort: not set")
+        case .settled:
+            return NSLocalizedString("onboarding.cohort.settled.title", comment: "Cohort: settled")
+        case .slow:
+            return NSLocalizedString("onboarding.cohort.slow.title", comment: "Cohort: slow travel")
+        case .active:
+            return NSLocalizedString("onboarding.cohort.active.title", comment: "Cohort: active nomad")
+        case .frequent:
+            return NSLocalizedString("onboarding.cohort.frequent.title", comment: "Cohort: high frequency")
+        }
+    }
+
+    var localizedDescription: String {
+        switch self {
+        case .unset:
+            return ""
+        case .settled:
+            return NSLocalizedString("onboarding.cohort.settled.desc", comment: "1-2 cities a year")
+        case .slow:
+            return NSLocalizedString("onboarding.cohort.slow.desc", comment: "3-5 cities a year")
+        case .active:
+            return NSLocalizedString("onboarding.cohort.active.desc", comment: "6-11 cities a year")
+        case .frequent:
+            return NSLocalizedString("onboarding.cohort.frequent.desc", comment: "12+ cities a year")
+        }
+    }
+}
+
+#Preview {
+    OnboardingCohortStep(onContinue: {})
+        .environment(UserPreferences())
+}

--- a/apps/ios/SoloCompass/Views/Onboarding/OnboardingView.swift
+++ b/apps/ios/SoloCompass/Views/Onboarding/OnboardingView.swift
@@ -37,13 +37,13 @@ public struct OnboardingView: View {
 
     @State private var step: Int = {
         #if DEBUG
-        // Goal-audit entry point: `-onboardingStep <n>` (0…6) skips to the
+        // Goal-audit entry point: `-onboardingStep <n>` (0…7) skips to the
         // requested step on first appear so simctl screenshot can capture
         // the vibe / city surfaces without touching the flow.
         if let idx = ProcessInfo.processInfo.arguments.firstIndex(of: "-onboardingStep"),
            idx + 1 < ProcessInfo.processInfo.arguments.count,
            let n = Int(ProcessInfo.processInfo.arguments[idx + 1]),
-           (0...6).contains(n) {
+           (0...7).contains(n) {
             return n
         }
         #endif
@@ -58,9 +58,10 @@ public struct OnboardingView: View {
     /// non-modal post-onboarding paywall, not repeated wall-of-trial popups).
     private static let onboardingPaywallSeenKey = "hasSeenOnboardingPaywall"
 
-    // P1.2: added two new steps after styleStep — vibe (#120) at index 4
-    // and city (#121) at index 5 — so the paywall step now sits at index 6.
-    private static let totalSteps = 7
+    // P1.2: added two steps after styleStep — vibe (#120) and city (#121).
+    // Nomad OS B1-e: inserted the cohort step at index 4 (right after style),
+    // pushing vibe→5, city→6, paywall→7. The flow is now 8 steps.
+    private static let totalSteps = 8
 
     private var slideTransition: AnyTransition {
         reduceMotion
@@ -93,17 +94,21 @@ public struct OnboardingView: View {
                     .transition(slideTransition)
                     .id(3)
             case 4:
-                vibeStep
+                cohortStep
                     .transition(slideTransition)
                     .id(4)
             case 5:
-                cityStep
+                vibeStep
                     .transition(slideTransition)
                     .id(5)
+            case 6:
+                cityStep
+                    .transition(slideTransition)
+                    .id(6)
             default:
                 paywallStep
                     .transition(slideTransition)
-                    .id(6)
+                    .id(7)
             }
         }
         .overlay(alignment: .topTrailing) {
@@ -119,7 +124,7 @@ public struct OnboardingView: View {
     /// future onboarding re-entry doesn't re-pitch the trial.
     private var skipButton: some View {
         Button {
-            if step == 6 {
+            if step == 7 {
                 UserDefaults.standard.set(true, forKey: Self.onboardingPaywallSeenKey)
             }
             preferences.completeOnboarding()
@@ -412,10 +417,10 @@ public struct OnboardingView: View {
 
             VStack(spacing: 12) {
                 Button {
-                    // P1.2: vibe (step 4) + city (step 5) come BEFORE any paywall
-                    // gating now, so styleStep always advances to vibe. The
-                    // "skip the paywall pitch" gate is consulted later, in the
-                    // city step's onContinue handler.
+                    // Nomad OS B1-e: style now advances to the cohort step
+                    // (index 4). Vibe/city/paywall all shifted down one. The
+                    // "skip the paywall pitch" gate is still consulted later,
+                    // in the city step's onContinue handler.
                     withAnimation { step = 4 }
                 } label: {
                     Text(NSLocalizedString("onboarding.style.cta", comment: "Start exploring"))
@@ -442,7 +447,7 @@ public struct OnboardingView: View {
         .accessibilityElement(children: .contain)
     }
 
-    // MARK: - Step 4: Paywall (1-month free trial via StoreKit)
+    // MARK: - Step 7: Paywall (1-month free trial via StoreKit)
 
     /// True if we should bypass the onboarding paywall and finish immediately.
     /// Covers three cases that all share the same UX rule: the user has
@@ -470,7 +475,22 @@ public struct OnboardingView: View {
         onComplete()
     }
 
-    // MARK: - Step 4: Vibe (P1.2 #120)
+    // MARK: - Step 4: Cohort — city-change frequency (Nomad OS B1-e)
+
+    /// Embed the standalone `OnboardingCohortStep` inside the shared step
+    /// chrome. The selected band writes `preferences.nomadCohort` on tap; the
+    /// CTA just advances to the vibe step (index 5).
+    private var cohortStep: some View {
+        VStack(spacing: 0) {
+            stepIndicator
+                .padding(.top, 24)
+            OnboardingCohortStep {
+                withAnimation { step = 5 }
+            }
+        }
+    }
+
+    // MARK: - Step 5: Vibe (P1.2 #120)
 
     /// Embed the standalone OnboardingVibeStep view inside the same step
     /// chrome the rest of the flow uses. The step indicator runs at the
@@ -480,12 +500,12 @@ public struct OnboardingView: View {
             stepIndicator
                 .padding(.top, 24)
             OnboardingVibeStep {
-                withAnimation { step = 5 }
+                withAnimation { step = 6 }
             }
         }
     }
 
-    // MARK: - Step 5: City + afternoon (P1.2 #121)
+    // MARK: - Step 6: City + afternoon (P1.2 #121)
 
     /// After city is picked, the user either lands on the paywall or — if the
     /// onboarding paywall has already been seen this device — finishes the
@@ -499,7 +519,7 @@ public struct OnboardingView: View {
                     preferences.completeOnboarding()
                     onComplete()
                 } else {
-                    withAnimation { step = 6 }
+                    withAnimation { step = 7 }
                 }
             }
         }


### PR DESCRIPTION
## What

Adds a **city-change-frequency** step to onboarding — the data floor for the digital-nomad convergence strategy (Nomad OS B1-e). The selected band maps directly to the sharpness of the visa / 90-180-day compliance pain point, and so to willingness to pay for the B2 ledger.

## Changes

- **`UserPreferences.NomadCohort`** — `unset / settled / slow / active / frequent`, stored as a raw string with a typed accessor (same pattern as `companionVisibilityRaw`) so a future band never breaks an older client's decode. `.unset` until captured → returning users who predate the step are never mis-bucketed.
- **`OnboardingCohortStep`** — inserted at index 4, right after the travel-style step (both answer "who is this traveler"). Flow is now **8 steps**; vibe/city/paywall shifted down one, with every step index, `.id`, skip guard and the `-onboardingStep` debug range updated to match.
- **en + zh-Hans strings** for the step and the four bands, kept symmetric (13 keys each side, no language pollution).
- **`NomadCohortTests`** — persistence round-trip, unknown-raw degrade to `.unset`, `selectableCases` excludes the sentinel, both-language string coverage.

## Cohort → band mapping

| Band | Cities / year |
|---|---|
| Home base | 1–2 |
| Slow travel | 3–5 |
| Active nomad | 6–11 |
| Always moving | 12+ |

## Verification

- **Debug + Release builds both `BUILD SUCCEEDED`** (iPhone 17, iOS 26.1).
- `UserPreferences` is iOS-local (not in the TS↔Swift parity set), so **no `packages/core` change**.
- The XCTest host hits the known simulator **bootstrap ANR** (`project_ios_test_runner_hung`) — an environment issue unrelated to this change; the cohort unit tests touch only `UserPreferences` and are pure. iOS CI builds (not tests), matching this.

## Scope / rollback

Onboarding-only, additive. No behavioural change to existing steps beyond their index shift. The captured cohort is a stored signal not yet read by any surface — B2 ledger + B1-c will consume it.

https://claude.ai/code/session_01A9yc2UDrmYN3aSUT5MQJjM