### PR TITLE
feat(ios): read a city's synthesized experiences from the backend (Nomad OS A2)

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		0EAA3D2EEA89D212150A6B57 /* ExploreConsentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8B58A4F608F9951CBDF3C /* ExploreConsentSheet.swift */; };
 		0FAE1C75A6BDB6308934D19D /* SoonestUpcomingExperienceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EA228DD5B2378433757999E /* SoonestUpcomingExperienceTests.swift */; };
 		0FCFC050B8070B75AC86A0C9 /* BestNowChipStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578C4C68A74AB74E0D2C6288 /* BestNowChipStateTests.swift */; };
+		0FE5929DA97BDB8049CF4641 /* CityExperienceFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5878CFB62925A4FC8B25D40 /* CityExperienceFetcher.swift */; };
 		111BB3E172B85E65E430C093 /* DesignTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC45C610C546626FABA9F7 /* DesignTokens.swift */; };
 		1130F4E1887551F856FCB9DB /* CompletionMomentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649ECD409B685D38E30527FD /* CompletionMomentTests.swift */; };
 		116FF0278F882D45402B0E78 /* ExperienceRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03076AD221F78BBDE981C3A /* ExperienceRecord.swift */; };
@@ -242,6 +243,7 @@
 		67D784ECDFE24AE5384975D2 /* Friendship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531D01560A12EAE904126D15 /* Friendship.swift */; };
 		680774109C2AD675E26ADA18 /* CreateRouteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0782F4AA0496B97DDAAA380 /* CreateRouteView.swift */; };
 		6838D33C7C53FC3854A3CF10 /* DeveloperOptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2DE4C5AA1D5F99E927D5C14 /* DeveloperOptionsView.swift */; };
+		68BD5A7F506A8B8260DACC99 /* CityExperienceFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE8A044F952385E2990D48F /* CityExperienceFetcherTests.swift */; };
 		690ED25AA3EDA8529E915850 /* MyWalkedRoutesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F48906724062C4636DE947 /* MyWalkedRoutesListView.swift */; };
 		6AA87132BC6ACDDDC6D98735 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF007DB5F72E30021CADA555 /* NetworkMonitor.swift */; };
 		6B06E0141358CBC81CB3ADB2 /* EmptyStateCitySuggestionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE4DB6455FBF5257A3709D9 /* EmptyStateCitySuggestionTest.swift */; };
@@ -295,7 +297,6 @@
 		83BF31EF553028D19D695105 /* RouteSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C6C906BAD8DBC107491B7F /* RouteSharePayload.swift */; };
 		842E955B0ED4DC5255816199 /* NowScore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75D6A32EAF01F792AFAE15E /* NowScore.swift */; };
 		84832AC481CB3E19977A07BA /* CapsuleComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9523A96A3D4F48D1670E0590 /* CapsuleComposeView.swift */; };
-		84C7525626CF30AF8AD92C19 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 154BDAAACF2DDCFE0953E722 /* Secrets.plist */; };
 		8592C07C234EA6B55619D0D1 /* RouteShareRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A453FDDE85569DCA8FF70A8A /* RouteShareRenderer.swift */; };
 		85B238721EB01B78DDC078F0 /* RouteCompanionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA9EA4E29955D78499E3AAC /* RouteCompanionTests.swift */; };
 		85C233AB7998521788B2BB5F /* WeatherCacheTTLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E536D4CFF44CF4CEFD1EFF4F /* WeatherCacheTTLTests.swift */; };
@@ -488,7 +489,6 @@
 		D2E9B20230FDE14CB1029DC3 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535B5FA4ADF216CEC74FE056 /* RouteTests.swift */; };
 		D391728579EB266152984A30 /* SoloCompassLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6982D2F9E150319AA0E1000F /* SoloCompassLiveActivity.swift */; };
 		D3D09BE396ED9D2DF5FE91B9 /* OnboardingCityStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3D7AE265D80F76BA9BB28B /* OnboardingCityStep.swift */; };
-		D3D6DD13C4BE1230C9A5F5E5 /* seed_experiences.json.backup in Resources */ = {isa = PBXBuildFile; fileRef = 88C4087271547E494464570E /* seed_experiences.json.backup */; };
 		D3F1DBFF74F227E5390736C6 /* POISource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FBC142634F5D448F7B85875 /* POISource.swift */; };
 		D4193263CDA544D0995749B0 /* NavigationLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FB43528F45882868CCC203 /* NavigationLauncherTests.swift */; };
 		D50CC44D67F686293769FE4C /* ExploreModeOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C7F1FDCCF3B2D5BCA451974 /* ExploreModeOverlay.swift */; };
@@ -676,7 +676,6 @@
 		143FF1379DE02FC9B0D637CA /* ToolRouterOutcomeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolRouterOutcomeTests.swift; sourceTree = "<group>"; };
 		14A2953D1F2B46AFC9F85D42 /* AddToItinerarySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToItinerarySheet.swift; sourceTree = "<group>"; };
 		1537012DBA238501E4DEDACE /* PrintFulfillmentClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintFulfillmentClientTests.swift; sourceTree = "<group>"; };
-		154BDAAACF2DDCFE0953E722 /* Secrets.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Secrets.plist; sourceTree = "<group>"; };
 		15720012D06D8C0F34FAF77B /* AppClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppClock.swift; sourceTree = "<group>"; };
 		15C512E1C0A5CFFE798CEEEA /* AppLaunchPerformanceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchPerformanceTest.swift; sourceTree = "<group>"; };
 		176E799668057C7DD5C559AD /* RoutesSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutesSectionView.swift; sourceTree = "<group>"; };
@@ -784,6 +783,7 @@
 		4EAB2E028C69B7C63DCAF860 /* RouteCardRecruitMiniTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCardRecruitMiniTest.swift; sourceTree = "<group>"; };
 		4F7202B977A555239F367D02 /* FriendsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsListView.swift; sourceTree = "<group>"; };
 		4F7AE422ACCFA23FCA7DF90D /* ChatSessionRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSessionRecord.swift; sourceTree = "<group>"; };
+		4FE8A044F952385E2990D48F /* CityExperienceFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityExperienceFetcherTests.swift; sourceTree = "<group>"; };
 		4FE945F792AFD68B33B7E8B5 /* UserDirectoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDirectoryTests.swift; sourceTree = "<group>"; };
 		503E5BFE7687F3B79FDB2838 /* TrustBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrustBadge.swift; sourceTree = "<group>"; };
 		511EDFCCBC74626702DDCE8C /* PersistenceDecoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceDecoding.swift; sourceTree = "<group>"; };
@@ -928,7 +928,6 @@
 		88553B5578C07FA890183A0D /* BottomInfoSheetHandleHitTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomInfoSheetHandleHitTargetTests.swift; sourceTree = "<group>"; };
 		88805BD09F10F37A334CE2F0 /* ChatAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentTests.swift; sourceTree = "<group>"; };
 		88863482E2CD46BBE315B59D /* LocationErrorSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationErrorSurfaceTests.swift; sourceTree = "<group>"; };
-		88C4087271547E494464570E /* seed_experiences.json.backup */ = {isa = PBXFileReference; path = seed_experiences.json.backup; sourceTree = "<group>"; };
 		88DFC61CD1B433E92301FB18 /* AddFriendSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFriendSheetTests.swift; sourceTree = "<group>"; };
 		88E54A903B58582BCBF1C904 /* ExploreModeOverlayRenderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreModeOverlayRenderTest.swift; sourceTree = "<group>"; };
 		892E8A5180374C97B894E71F /* VisitTrackingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitTrackingServiceTests.swift; sourceTree = "<group>"; };
@@ -1041,6 +1040,7 @@
 		B418AD0352AC3402D6609E4C /* SkeletonBadgeViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonBadgeViewTests.swift; sourceTree = "<group>"; };
 		B431F5042572370E6726FF82 /* GenerateTasteProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateTasteProfileTests.swift; sourceTree = "<group>"; };
 		B45554ECBB3B42D14E6CCE7B /* POISourceConformances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POISourceConformances.swift; sourceTree = "<group>"; };
+		B5878CFB62925A4FC8B25D40 /* CityExperienceFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityExperienceFetcher.swift; sourceTree = "<group>"; };
 		B5C6E142FB1F81390D163CC2 /* TravelerNotesSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelerNotesSection.swift; sourceTree = "<group>"; };
 		B5C80E55217939455A2F41E1 /* ProvisionalCardLedgerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvisionalCardLedgerTests.swift; sourceTree = "<group>"; };
 		B5E620A87D721B6282E6C298 /* RubricReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RubricReport.swift; sourceTree = "<group>"; };
@@ -1390,6 +1390,7 @@
 				CB511F86191D72DBCBCB5A01 /* ChatRedesignVisualTest.swift */,
 				953772A59B51A407DC0D305C /* CityBriefHealthTests.swift */,
 				FDD92E055336925881B13C67 /* CityBriefServiceTests.swift */,
+				4FE8A044F952385E2990D48F /* CityExperienceFetcherTests.swift */,
 				B07765108DFDB705B49FAD8D /* CityOSInterruptionBudgetTests.swift */,
 				13607F78187BF3ABDD080DC7 /* CityOSStoreTests.swift */,
 				F7A43265755D995975812D62 /* CityOSToolRouterTests.swift */,
@@ -1586,7 +1587,6 @@
 			children = (
 				FB52A67C323F1302895C0C67 /* seed_city_brief_vte.json */,
 				61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */,
-				88C4087271547E494464570E /* seed_experiences.json.backup */,
 				1F39081CF797874064A33814 /* seed_routes.json */,
 				8C8D88BCFAC97E436BE97274 /* seed_users.json */,
 			);
@@ -1771,6 +1771,7 @@
 				AA96BC45388A8EC99F3B29ED /* ChatAttachmentService.swift */,
 				A7E8E3F1E2D1A0382CC5D9A6 /* ChatService.swift */,
 				9052079680AA5EA57B014D93 /* CityBriefService.swift */,
+				B5878CFB62925A4FC8B25D40 /* CityExperienceFetcher.swift */,
 				AF58E512BB0C51F4C5887108 /* CityOSInterruptionBudget.swift */,
 				016B15E49242CF08822EF3DF /* CityOSStore.swift */,
 				1A8062A7E6BA3EE88C6DAF02 /* CompanionService.swift */,
@@ -2025,7 +2026,6 @@
 				409FB4B0922C4A1D8AAEB1D1 /* FeatureFlags.plist */,
 				BC185539C95D5D940693BCB7 /* Info.plist */,
 				EA0858036CFEA9774139AFD7 /* PrivacyInfo.xcprivacy */,
-				154BDAAACF2DDCFE0953E722 /* Secrets.plist */,
 				AB46D6F6F8942CD390A5CCF4 /* SoloCompass.entitlements */,
 				349E26E71AF3FA04CA5CC24C /* JSON */,
 				80020844C0A45A5993333741 /* Localizable.strings */,
@@ -2300,10 +2300,8 @@
 				BAC775E6105DD571F71ACBC1 /* Localizable.strings in Resources */,
 				F3461FC7F38900F40A880255 /* Localizable.stringsdict in Resources */,
 				8B4F2A6E8F3C6EAD0F9A8E32 /* PrivacyInfo.xcprivacy in Resources */,
-				84C7525626CF30AF8AD92C19 /* Secrets.plist in Resources */,
 				BB34E346EFB5F570DED6B039 /* seed_city_brief_vte.json in Resources */,
 				D7CC906B358ED5337880A942 /* seed_experiences.json in Resources */,
-				D3D6DD13C4BE1230C9A5F5E5 /* seed_experiences.json.backup in Resources */,
 				EAFABF90D77B4D5E00D6BDFC /* seed_routes.json in Resources */,
 				2A4A75FDB09E99452C161048 /* seed_users.json in Resources */,
 			);
@@ -2383,6 +2381,7 @@
 				2F00F874A1B50C113AC8CA55 /* ChatRedesignVisualTest.swift in Sources */,
 				4FEA8F9301FFC1427DE6A223 /* CityBriefHealthTests.swift in Sources */,
 				37273BCDAED53D5F49CD756D /* CityBriefServiceTests.swift in Sources */,
+				68BD5A7F506A8B8260DACC99 /* CityExperienceFetcherTests.swift in Sources */,
 				5B7BA2C36A50D7B1D44D1B4A /* CityOSInterruptionBudgetTests.swift in Sources */,
 				C4529604A378FA8EABBF6EF5 /* CityOSStoreTests.swift in Sources */,
 				4927CDD0A8222F7510DFD8B9 /* CityOSToolRouterTests.swift in Sources */,
@@ -2633,6 +2632,7 @@
 				B44FE0FADDB12E8EA6A3083C /* CityBriefCacheRecord.swift in Sources */,
 				216BA52386A50FF740EED857 /* CityBriefService.swift in Sources */,
 				A0C1702CF2CB823849D31BE0 /* CityCodexView.swift in Sources */,
+				0FE5929DA97BDB8049CF4641 /* CityExperienceFetcher.swift in Sources */,
 				76049112A5F17F05AA50D6A8 /* CityOSComponents.swift in Sources */,
 				54941425223B5EBAC714ADE9 /* CityOSInterruptionBudget.swift in Sources */,
 				AC96592EE251F5FD659D5B54 /* CityOSStore.swift in Sources */,

--- a/apps/ios/SoloCompass/Services/CityExperienceFetcher.swift
+++ b/apps/ios/SoloCompass/Services/CityExperienceFetcher.swift
@@ -1,0 +1,244 @@
+import Foundation
+
+/// Nomad OS A2: pulls a city's already-synthesized experiences from the backend
+/// so a traveler in a non-seed city isn't stuck with an empty map.
+///
+/// The gap this closes: `synthesize-experiences` writes every batch it compiles
+/// into the public-read `synthesized_experiences` table, keyed by `city_code` —
+/// but the client never read it. Seed ships 8 cities; everywhere else stayed
+/// empty unless the user personally ran Explore. This fetcher is the missing
+/// read side: any city another traveler has already synthesized becomes
+/// available to the next person who opens it.
+///
+/// ## Why two tables
+/// The stored `payload` is the raw AI item array (title / category / soloOverall
+/// …) — it carries `osmId` but **no coordinates or place name**. The write path
+/// (`AIService.synthesizeViaEdge`) backfills those from the Overpass POI batch it
+/// holds in memory; a pure read has no such batch. So we join the equally
+/// public-read `osm_pois` table by `osm_id` to recover lat/lon, names, and the
+/// `source` tag. Without the join the experiences would have no coordinate and
+/// could neither be pinned on the map nor feed the Today three-things
+/// (`workReadySpots` / `nowScore` both need a location).
+///
+/// The item→Experience mapping mirrors `AIService.synthesizeViaEdge` exactly
+/// (same clamps, same flat solo-score breakdown, `status: .candidate`,
+/// `confidence.level: 1`, `id: "exp_osm_<osmId>"`) so a synthesized experience
+/// read here is byte-identical to one produced by Explore — they share the
+/// `appendGenerated` id-dedup and never diverge.
+@MainActor
+final class CityExperienceFetcher {
+    private let supabase: SupabaseClientProtocol
+
+    init(supabase: SupabaseClientProtocol = SupabaseClient.shared) {
+        self.supabase = supabase
+    }
+
+    /// One `synthesized_experiences` row's `payload`: the raw AI item array the
+    /// Edge function stored. Field-for-field identical to `AIService`'s private
+    /// `EdgeItem`; only `osmId` links back to a place.
+    struct SynthItem: Decodable, Sendable {
+        let osmId: Int64
+        let title: String
+        let oneLiner: String
+        let whyItMatters: String
+        let category: String
+        let bestStartHour: Int?
+        let bestEndHour: Int?
+        let durationMinMinutes: Int?
+        let durationMaxMinutes: Int?
+        let howTo: [String]?
+        let soloHint: String?
+        let soloOverall: Double?
+    }
+
+    /// One `synthesized_experiences` row — we only select `payload`.
+    private struct SynthRow: Decodable {
+        let payload: [SynthItem]
+    }
+
+    /// One `osm_pois` row: the place facts the payload lacks.
+    private struct PoiRow: Decodable {
+        let osmId: Int64
+        let name: String
+        let nameEn: String?
+        let lat: Double
+        let lon: Double
+        let tags: [String: String]
+
+        enum CodingKeys: String, CodingKey {
+            case osmId = "osm_id"
+            case name
+            case nameEn = "name_en"
+            case lat, lon, tags
+        }
+    }
+
+    /// Fetch and assemble the full `[Experience]` for a city, or `[]` on any
+    /// miss (backend off, no session, offline, empty city, or the POI join
+    /// coming up dry). Never throws — a read failure is "nothing to add", never
+    /// a reason to disturb what's already on the map (mirrors
+    /// `CityBriefService`'s "failure = no update" invariant).
+    func fetchCityExperiences(cityCode: String) async -> [Experience] {
+        let code = cityCode.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !code.isEmpty else { return [] }
+
+        // 1. Pull every synthesized row for the city; flatten the per-batch
+        //    payload arrays into one item list, de-duped by osmId (later
+        //    batches win — an id re-synthesized keeps its newest copy).
+        guard let synthData = await get(
+            table: "synthesized_experiences",
+            query: [
+                URLQueryItem(name: "city_code", value: "eq.\(code)"),
+                URLQueryItem(name: "select", value: "payload"),
+            ]
+        ), !synthData.isEmpty else {
+            return []
+        }
+        guard let rows = await Self.decode([SynthRow].self, from: synthData) else {
+            return []
+        }
+        var itemByOsmId: [Int64: SynthItem] = [:]
+        for row in rows {
+            for item in row.payload {
+                itemByOsmId[item.osmId] = item
+            }
+        }
+        guard !itemByOsmId.isEmpty else { return [] }
+
+        // 2. Recover coordinates + names from osm_pois for exactly those ids.
+        let poiById = await fetchPois(osmIds: Array(itemByOsmId.keys))
+        guard !poiById.isEmpty else { return [] }
+
+        // 3. Join. An item whose POI didn't come back is dropped — without a
+        //    coordinate it can't be pinned or ranked, so a half-experience is
+        //    worse than absence.
+        let now = Date()
+        return itemByOsmId.values.compactMap { item -> Experience? in
+            guard let poi = poiById[item.osmId] else { return nil }
+            return Self.makeExperience(item: item, poi: poi, cityCode: code, now: now)
+        }
+    }
+
+    // MARK: - osm_pois join
+
+    /// Read `osm_pois` for the given ids via a single `osm_id=in.(...)` query.
+    /// PostgREST caps URL length, so we chunk the id list to stay well under it.
+    private func fetchPois(osmIds: [Int64]) async -> [Int64: PoiRow] {
+        var result: [Int64: PoiRow] = [:]
+        // 100 bigints ≈ under 2 KB of query — comfortably within limits.
+        for chunk in osmIds.chunked(into: 100) {
+            let list = chunk.map(String.init).joined(separator: ",")
+            guard let data = await get(
+                table: "osm_pois",
+                query: [
+                    URLQueryItem(name: "osm_id", value: "in.(\(list))"),
+                    URLQueryItem(name: "select", value: "osm_id,name,name_en,lat,lon,tags"),
+                ]
+            ), !data.isEmpty else {
+                continue
+            }
+            guard let poiRows = await Self.decode([PoiRow].self, from: data) else { continue }
+            for poi in poiRows {
+                result[poi.osmId] = poi
+            }
+        }
+        return result
+    }
+
+    // MARK: - Mapping (parity with AIService.synthesizeViaEdge)
+
+    /// Build one `Experience` from a synthesized item + its POI facts, using the
+    /// identical rules the write path applies (clamps, flat breakdown, provenance
+    /// source, candidate/level-1 defaults). Kept in lockstep so read and write
+    /// produce the same shape.
+    private static func makeExperience(
+        item: SynthItem,
+        poi: PoiRow,
+        cityCode: String,
+        now: Date
+    ) -> Experience {
+        let category = ExperienceCategory(rawValue: item.category)
+            ?? OverpassService.category(for: poi.tags)
+        let startHour = item.bestStartHour.map { max(0, min(23, $0)) } ?? 9
+        let endHour = item.bestEndHour.map { max(0, min(23, $0)) } ?? 21
+        let dMin = item.durationMinMinutes ?? 30
+        let dMax = max(dMin, item.durationMaxMinutes ?? 90)
+        let overall = max(6.0, min(9.5, item.soloOverall ?? 7.0))
+        let breakdown = SoloScore.Breakdown(
+            seatingFriendly: overall, soloPatronRatio: overall, staffPressure: overall,
+            soloPortioning: overall, ambianceFit: overall, safety: overall
+        )
+        let howTo = (item.howTo ?? []).enumerated().map { HowToStep(order: $0.offset + 1, text: $0.element) }
+        let isAmap = poi.tags["source"] == "amap"
+        return Experience(
+            id: "exp_osm_\(poi.osmId)",
+            title: item.title,
+            oneLiner: item.oneLiner,
+            whyItMatters: item.whyItMatters,
+            category: category,
+            location: ExperienceLocation(
+                coordinates: [poi.lon, poi.lat],
+                cityCode: cityCode,
+                addressHint: nil,
+                placeNameLocal: poi.name,
+                placeNameRomanized: poi.nameEn
+            ),
+            bestTimes: [TimeWindow(startHour: startHour, endHour: endHour)],
+            durationMinutes: .init(min: dMin, max: dMax),
+            howTo: howTo,
+            realInconveniences: [],
+            soloScore: SoloScore(overall: overall, breakdown: breakdown, hint: item.soloHint, basedOnCount: 0),
+            sources: [
+                InformationSource(
+                    type: isAmap ? .amap : .user,
+                    url: isAmap ? nil : URL(string: "https://www.openstreetmap.org/node/\(poi.osmId)"),
+                    attribution: isAmap ? "© AutoNavi (Amap) + AI" : "© OpenStreetMap contributors + AI",
+                    verifiedAt: now
+                )
+            ],
+            confidence: Confidence(
+                level: 1,
+                lastVerifiedAt: now,
+                reason: "AI-synthesized via Edge Function, unverified",
+                signals: .init(aiScrapeAgeDays: 0, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)
+            ),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .candidate,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    // MARK: - Plumbing
+
+    private func get(table: String, query: [URLQueryItem]) async -> Data? {
+        switch await supabase.get(table: table, query: query) {
+        case .success(let data):
+            return data
+        case .failure:
+            return nil
+        }
+    }
+
+    /// Decode off the main actor so a large city's payload doesn't hitch the UI.
+    nonisolated static func decode<T: Decodable & Sendable>(
+        _ type: T.Type,
+        from data: Data
+    ) async -> T? {
+        await Task.detached(priority: .userInitiated) {
+            try? JSONDecoder().decode(type, from: data)
+        }.value
+    }
+}
+
+private extension Array {
+    /// Split into fixed-size chunks (last may be shorter). Used to keep the
+    /// `osm_id=in.(...)` query under PostgREST's URL length ceiling.
+    func chunked(into size: Int) -> [[Element]] {
+        guard size > 0 else { return [self] }
+        return stride(from: 0, to: count, by: size).map {
+            Array(self[$0 ..< Swift.min($0 + size, count)])
+        }
+    }
+}

--- a/apps/ios/SoloCompass/Tests/CityExperienceFetcherTests.swift
+++ b/apps/ios/SoloCompass/Tests/CityExperienceFetcherTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+@testable import SoloCompass
+
+/// Nomad OS A2: `CityExperienceFetcher` reads a city's synthesized experiences
+/// from `synthesized_experiences` and joins `osm_pois` for the coordinates the
+/// payload lacks. These tests pin the join, the drop-on-missing-POI rule, and
+/// the empty-return contract, with a stub Supabase client keyed by table name.
+final class CityExperienceFetcherTests: XCTestCase {
+
+    /// Returns canned JSON per table so the fetcher's two reads (synthesized
+    /// payload, then osm_pois) can be driven independently.
+    private final class StubSupabaseClient: SupabaseClientProtocol {
+        var synthJSON: String = "[]"
+        var poisJSON: String = "[]"
+        /// When true, every `get` returns `.success(Data())` — the backend-off /
+        /// offline shape the real client produces behind the flag gate.
+        var returnsEmpty = false
+
+        var currentSession: SupabaseClient.Session? {
+            SupabaseClient.Session(
+                userId: "u", accessToken: "at", refreshToken: "rt",
+                expiresAt: Date().addingTimeInterval(3600)
+            )
+        }
+
+        func get(table: String, query: [URLQueryItem]) async -> Result<Data, SupabaseClient.SupabaseError> {
+            if returnsEmpty { return .success(Data()) }
+            let json: String
+            switch table {
+            case "synthesized_experiences": json = synthJSON
+            case "osm_pois": json = poisJSON
+            default: json = "[]"
+            }
+            return .success(Data(json.utf8))
+        }
+
+        func signInAnonymously() async -> Result<SupabaseClient.Session, SupabaseClient.SupabaseError> { .failure(.notSignedIn) }
+        func refreshSession() async -> Result<SupabaseClient.Session, SupabaseClient.SupabaseError> { .failure(.notSignedIn) }
+        func invoke(function: String, body: Data) async -> Result<Data, SupabaseClient.SupabaseError> { .success(Data()) }
+        func linkAppleIdentity(identityToken: String, nonce: String) async -> Result<SupabaseClient.Session, SupabaseClient.SupabaseError> { .failure(.notSignedIn) }
+        var isAnonymous: Bool { get async { false } }
+        func post(table: String, body: Data) async -> Result<Data, SupabaseClient.SupabaseError> { .success(Data()) }
+        func delete(table: String, id: String) async -> Result<Void, SupabaseClient.SupabaseError> { .success(()) }
+    }
+
+    @MainActor
+    private func makeFetcher(_ stub: StubSupabaseClient) -> CityExperienceFetcher {
+        CityExperienceFetcher(supabase: stub)
+    }
+
+    // MARK: - Happy path
+
+    /// A synthesized item whose osmId resolves in osm_pois becomes a complete
+    /// Experience: coordinates ([lon, lat]) and names come from the POI, copy
+    /// and score from the payload, and the id follows `exp_osm_<osmId>`.
+    @MainActor
+    func testJoinsPayloadWithPoiCoordinates() async {
+        let stub = StubSupabaseClient()
+        stub.synthJSON = """
+        [{"payload":[
+          {"osmId":111,"title":"Counter seat at Kinn","oneLiner":"Solo ramen","whyItMatters":"quiet","category":"food","bestStartHour":18,"bestEndHour":21,"soloOverall":8.5,"howTo":["walk in"],"soloHint":"sit at the bar"}
+        ]}]
+        """
+        stub.poisJSON = """
+        [{"osm_id":111,"name":"Kinn Ramen","name_en":"Kinn Ramen","lat":13.75,"lon":100.5,"tags":{}}]
+        """
+        let fetched = await makeFetcher(stub).fetchCityExperiences(cityCode: "bkk")
+
+        XCTAssertEqual(fetched.count, 1)
+        let exp = try! XCTUnwrap(fetched.first)
+        XCTAssertEqual(exp.id, "exp_osm_111")
+        XCTAssertEqual(exp.title, "Counter seat at Kinn")
+        XCTAssertEqual(exp.location.coordinates, [100.5, 13.75], "coordinates must be [lon, lat] from the POI")
+        XCTAssertEqual(exp.location.placeNameLocal, "Kinn Ramen")
+        XCTAssertEqual(exp.location.cityCode, "bkk")
+        XCTAssertEqual(exp.soloScore.overall, 8.5, accuracy: 0.001)
+        XCTAssertEqual(exp.status, .candidate)
+    }
+
+    /// An item whose osmId is absent from osm_pois is dropped — a
+    /// coordinate-less experience can't be pinned or ranked, so absence beats a
+    /// half-record.
+    @MainActor
+    func testDropsItemsMissingFromPoiTable() async {
+        let stub = StubSupabaseClient()
+        stub.synthJSON = """
+        [{"payload":[
+          {"osmId":1,"title":"Has POI","oneLiner":"a","whyItMatters":"b","category":"coffee","soloOverall":7.0},
+          {"osmId":2,"title":"No POI","oneLiner":"a","whyItMatters":"b","category":"coffee","soloOverall":7.0}
+        ]}]
+        """
+        stub.poisJSON = """
+        [{"osm_id":1,"name":"Only One","name_en":null,"lat":1.0,"lon":2.0,"tags":{}}]
+        """
+        let fetched = await makeFetcher(stub).fetchCityExperiences(cityCode: "bkk")
+
+        XCTAssertEqual(fetched.count, 1, "the item with no matching POI must be dropped")
+        XCTAssertEqual(fetched.first?.id, "exp_osm_1")
+    }
+
+    /// The amap `source` tag flips provenance to `.amap` with the AutoNavi
+    /// attribution and no OSM url — parity with the write path.
+    @MainActor
+    func testAmapSourceTagSetsProvenance() async {
+        let stub = StubSupabaseClient()
+        stub.synthJSON = """
+        [{"payload":[{"osmId":9,"title":"T","oneLiner":"a","whyItMatters":"b","category":"food","soloOverall":7.0}]}]
+        """
+        stub.poisJSON = """
+        [{"osm_id":9,"name":"店","name_en":null,"lat":22.5,"lon":114.0,"tags":{"source":"amap"}}]
+        """
+        let fetched = await makeFetcher(stub).fetchCityExperiences(cityCode: "szx")
+
+        let source = try! XCTUnwrap(fetched.first?.sources.first)
+        XCTAssertEqual(source.type, .amap)
+        XCTAssertNil(source.url, "amap places carry no OSM node url")
+    }
+
+    // MARK: - Empty / failure contract
+
+    /// No synthesized rows → empty result, and osm_pois is never queried.
+    @MainActor
+    func testEmptySynthReturnsEmpty() async {
+        let stub = StubSupabaseClient()
+        stub.synthJSON = "[]"
+        let fetched = await makeFetcher(stub).fetchCityExperiences(cityCode: "bkk")
+        XCTAssertTrue(fetched.isEmpty)
+    }
+
+    /// Synthesized items present but osm_pois comes back empty (e.g. POI rows
+    /// evicted) → empty, never coordinate-less experiences.
+    @MainActor
+    func testNoPoisReturnsEmpty() async {
+        let stub = StubSupabaseClient()
+        stub.synthJSON = """
+        [{"payload":[{"osmId":5,"title":"T","oneLiner":"a","whyItMatters":"b","category":"food","soloOverall":7.0}]}]
+        """
+        stub.poisJSON = "[]"
+        let fetched = await makeFetcher(stub).fetchCityExperiences(cityCode: "bkk")
+        XCTAssertTrue(fetched.isEmpty)
+    }
+
+    /// The backend-off / offline shape (empty Data) yields an empty result, not
+    /// a decode crash.
+    @MainActor
+    func testBackendOffReturnsEmpty() async {
+        let stub = StubSupabaseClient()
+        stub.returnsEmpty = true
+        let fetched = await makeFetcher(stub).fetchCityExperiences(cityCode: "bkk")
+        XCTAssertTrue(fetched.isEmpty)
+    }
+
+    /// A blank city code short-circuits before any network read.
+    @MainActor
+    func testBlankCityCodeReturnsEmpty() async {
+        let stub = StubSupabaseClient()
+        stub.synthJSON = """
+        [{"payload":[{"osmId":1,"title":"T","oneLiner":"a","whyItMatters":"b","category":"food","soloOverall":7.0}]}]
+        """
+        let fetched = await makeFetcher(stub).fetchCityExperiences(cityCode: "   ")
+        XCTAssertTrue(fetched.isEmpty)
+    }
+}

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -55,6 +55,17 @@ public final class MapViewModel {
     /// environment in `CompassMapView` (Epic D US-024).
     private weak var subscriptionService: SubscriptionService?
 
+    /// Nomad OS A2: pulls a city's already-synthesized experiences from the
+    /// backend when the local store has none, so non-seed cities aren't empty.
+    /// `@ObservationIgnored lazy` mirrors `enrichmentAgent` — no init-signature
+    /// change, no cost on paths that never trigger a hydrate, still injectable.
+    @ObservationIgnored
+    private lazy var cityExperienceFetcher = CityExperienceFetcher()
+    /// Cities already hydrated from the backend this session, so a repeated
+    /// `selectCity` (e.g. GPS re-follow) fires at most one network read per city.
+    @ObservationIgnored
+    private var backendHydratedCities: Set<String> = []
+
     /// Wire the subscription service after init (called from
     /// CompassMapView.onAppear). Free tier gating only applies after
     /// this is set; pre-attach treats every caller as Pro to keep the
@@ -880,6 +891,38 @@ public final class MapViewModel {
         ))
         loadNearbyExperiences()
         updateBottomInfo()
+        hydrateCityFromBackendIfNeeded(cityCode)
+    }
+
+    /// Nomad OS A2: if the freshly-selected city has no local experiences, pull
+    /// whatever another traveler already synthesized for it from the backend and
+    /// merge it in. Fire-and-forget and self-gating so it never blocks the map:
+    ///
+    ///  - skips seed / already-populated cities (a non-empty local set means
+    ///    the map is fine as-is — this only rescues the empty case);
+    ///  - runs at most once per city per session (`backendHydratedCities`);
+    ///  - a fetch miss (backend off, offline, or nobody has synthesized this
+    ///    city yet) leaves the empty state exactly as it was — the honest
+    ///    "no experiences here" is a valid outcome, never an error.
+    ///
+    /// On a real merge it re-runs `loadNearbyExperiences()` so the new pins
+    /// reach `visibleExperiences` (append alone doesn't refresh the map).
+    private func hydrateCityFromBackendIfNeeded(_ cityCode: String?) {
+        guard let cityCode, !cityCode.isEmpty else { return }
+        // Only rescue the empty case; a populated city needs no network read.
+        guard visibleExperiences.isEmpty else { return }
+        guard !backendHydratedCities.contains(cityCode) else { return }
+        backendHydratedCities.insert(cityCode)
+
+        Task { [weak self] in
+            guard let self else { return }
+            let fetched = await self.cityExperienceFetcher.fetchCityExperiences(cityCode: cityCode)
+            guard !fetched.isEmpty else { return }
+            let added = self.experienceService.appendGenerated(fetched)
+            // Only refresh if this is still the active city and something landed.
+            guard added > 0, self.selectedCity == cityCode else { return }
+            self.loadNearbyExperiences()
+        }
     }
 
     /// When the current area has no experiences, returns the name of the first


### PR DESCRIPTION
## Problem

Non-seed cities are empty on the map. `synthesize-experiences` already writes every batch it compiles into the **public-read `synthesized_experiences`** table keyed by `city_code` — but **the client never read it**. Seed ships 8 cities; everywhere else stays blank unless the user personally ran Explore. Another traveler's synthesized city was invisible to the next person.

This adds the missing **read side** — the minimal step that unlocks non-seed cities (Nomad OS decision A2).

## What

- **`CityExperienceFetcher`** — pulls a city's synthesized rows, then joins the equally public-read **`osm_pois`** table by `osm_id` to recover the **coordinates + names the payload lacks** (the stored `payload` is the raw AI item array — it carries only `osmId`). Without the join the experiences would have no coordinate → couldn't be pinned or ranked, so an item whose POI doesn't resolve is **dropped** rather than surfaced half-built.
- The item→Experience mapping **mirrors `AIService.synthesizeViaEdge` field-for-field** (same clamps, flat solo-score breakdown, `status:.candidate`, `confidence.level:1`, `id "exp_osm_<osmId>"`) so a read experience is byte-identical to an Explore-produced one and shares `appendGenerated`'s id-dedup.
- **`MapViewModel.hydrateCityFromBackendIfNeeded`** fires from `selectCity`'s tail, self-gating: only the **empty-city** case, **at most once per city per session**, on a detached `Task`, refreshing via `loadNearbyExperiences` **only if** rows landed and the city is still active. The core load path is untouched.
- A read miss (backend off, offline, nobody synthesized this city yet) leaves the empty state exactly as it was — mirrors `CityBriefService`'s **"failure = no update"** invariant.

## Why two tables

`synthesized_experiences.payload` is the raw AI item array (title / category / soloOverall …) — it has `osmId` but **no coordinates or place name**. The write path backfills those from the Overpass POI batch it holds; a pure read has none, so it joins `osm_pois` (lat/lon/name/tags, also public-read).

## Verification

- **Debug + Release builds both `BUILD SUCCEEDED`** (Release verified because this touches the core `MapViewModel` and ships to TestFlight).
- `CityExperienceFetcherTests` — join, drop-on-missing-POI, amap provenance, empty-synth / empty-POI / backend-off / blank-code all return empty. (XCTest host hits the known simulator bootstrap ANR `project_ios_test_runner_hung`, unrelated — the fetcher tests use a stub Supabase client and never boot the app.)

## Scope / follow-ups

Additive; gated behind `FeatureFlags.backendSync` + an anonymous session (both required for the `get` to reach the network). Deliberately does **not** build city-level pre-generation scheduling — that's a separate effort that should align with `docs/PLAN_living_experience_data.md` (which proposes unifying experience storage onto `packages/db`).

https://claude.ai/code/session_01A9yc2UDrmYN3aSUT5MQJjM