### PR TITLE
feat(ios): wire Today's three things — work / now / tonight (Nomad OS B1-c)

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -295,7 +295,6 @@
 		83BF31EF553028D19D695105 /* RouteSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C6C906BAD8DBC107491B7F /* RouteSharePayload.swift */; };
 		842E955B0ED4DC5255816199 /* NowScore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75D6A32EAF01F792AFAE15E /* NowScore.swift */; };
 		84832AC481CB3E19977A07BA /* CapsuleComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9523A96A3D4F48D1670E0590 /* CapsuleComposeView.swift */; };
-		84C7525626CF30AF8AD92C19 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 154BDAAACF2DDCFE0953E722 /* Secrets.plist */; };
 		8592C07C234EA6B55619D0D1 /* RouteShareRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A453FDDE85569DCA8FF70A8A /* RouteShareRenderer.swift */; };
 		85B238721EB01B78DDC078F0 /* RouteCompanionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA9EA4E29955D78499E3AAC /* RouteCompanionTests.swift */; };
 		85C233AB7998521788B2BB5F /* WeatherCacheTTLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E536D4CFF44CF4CEFD1EFF4F /* WeatherCacheTTLTests.swift */; };
@@ -327,6 +326,7 @@
 		915E4532026427BA9F00B39D /* ModerationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71031524B916484E4C152E6 /* ModerationView.swift */; };
 		9260A79D1F643E59A55A4401 /* CityBrief.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05F48898F445A18234B6979 /* CityBrief.swift */; };
 		92C0C68AE15DFE4AF0DFE012 /* UndoPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C03A30AB5CD426978E8C72 /* UndoPill.swift */; };
+		952E35DC8914A2F0384962BF /* TodayThreeThings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D6CA0AEDFCE1422EA4A1D2 /* TodayThreeThings.swift */; };
 		95389B7D23017957CB6C69E0 /* RouteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66273C940FD90B51EBCD97BC /* RouteBuilder.swift */; };
 		953C7BD48AF4AF55608145A6 /* LanguageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87002BB6D344B384A3FDFBFD /* LanguageService.swift */; };
 		95960204376DC82FBC3EBB9D /* WeatherSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B922F9040238050C82A5F312 /* WeatherSignal.swift */; };
@@ -488,7 +488,6 @@
 		D2E9B20230FDE14CB1029DC3 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535B5FA4ADF216CEC74FE056 /* RouteTests.swift */; };
 		D391728579EB266152984A30 /* SoloCompassLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6982D2F9E150319AA0E1000F /* SoloCompassLiveActivity.swift */; };
 		D3D09BE396ED9D2DF5FE91B9 /* OnboardingCityStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3D7AE265D80F76BA9BB28B /* OnboardingCityStep.swift */; };
-		D3D6DD13C4BE1230C9A5F5E5 /* seed_experiences.json.backup in Resources */ = {isa = PBXBuildFile; fileRef = 88C4087271547E494464570E /* seed_experiences.json.backup */; };
 		D3F1DBFF74F227E5390736C6 /* POISource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FBC142634F5D448F7B85875 /* POISource.swift */; };
 		D4193263CDA544D0995749B0 /* NavigationLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FB43528F45882868CCC203 /* NavigationLauncherTests.swift */; };
 		D50CC44D67F686293769FE4C /* ExploreModeOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C7F1FDCCF3B2D5BCA451974 /* ExploreModeOverlay.swift */; };
@@ -571,6 +570,7 @@
 		F89696722D9A0A3C85B8C7BC /* PeekCardShortNameTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FB9685AAB19B85A859BDB8 /* PeekCardShortNameTest.swift */; };
 		FA1137B32C1B39D8340DD42F /* ForgetMeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF401E3F554B9E2948A64ABC /* ForgetMeService.swift */; };
 		FA8584E1511404B374B57E66 /* ExploreProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0997D8150E77F70A4B8C64 /* ExploreProgressBar.swift */; };
+		FA9632525DA89F235F69B7F8 /* TodayThreeThingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CEEAF462B119E54E9340766 /* TodayThreeThingsTests.swift */; };
 		FB18E501DE07BA0D80A7F3C5 /* NearbySkeletonRenderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994CE03CD59A3B638A7570AD /* NearbySkeletonRenderTest.swift */; };
 		FB6C7D275F3072ACE07C371E /* ProvisionalCardWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271284A1F632E444E85EF589 /* ProvisionalCardWiringTests.swift */; };
 		FB7EEAB898783B82525C324D /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF04600907C1137CC70AFFC /* AnalyticsService.swift */; };
@@ -676,7 +676,6 @@
 		143FF1379DE02FC9B0D637CA /* ToolRouterOutcomeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolRouterOutcomeTests.swift; sourceTree = "<group>"; };
 		14A2953D1F2B46AFC9F85D42 /* AddToItinerarySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToItinerarySheet.swift; sourceTree = "<group>"; };
 		1537012DBA238501E4DEDACE /* PrintFulfillmentClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintFulfillmentClientTests.swift; sourceTree = "<group>"; };
-		154BDAAACF2DDCFE0953E722 /* Secrets.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Secrets.plist; sourceTree = "<group>"; };
 		15720012D06D8C0F34FAF77B /* AppClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppClock.swift; sourceTree = "<group>"; };
 		15C512E1C0A5CFFE798CEEEA /* AppLaunchPerformanceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchPerformanceTest.swift; sourceTree = "<group>"; };
 		176E799668057C7DD5C559AD /* RoutesSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutesSectionView.swift; sourceTree = "<group>"; };
@@ -836,6 +835,7 @@
 		6163572F4644BF852B35FDA4 /* SyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncService.swift; sourceTree = "<group>"; };
 		61C0472D19B6973CF720ADBD /* SortButtonA11yValueTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortButtonA11yValueTest.swift; sourceTree = "<group>"; };
 		61D000D2E41CDD0DBF2B54C1 /* OnboardingA11yOrderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingA11yOrderTest.swift; sourceTree = "<group>"; };
+		61D6CA0AEDFCE1422EA4A1D2 /* TodayThreeThings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayThreeThings.swift; sourceTree = "<group>"; };
 		61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = seed_experiences.json; sourceTree = "<group>"; };
 		62C03A30AB5CD426978E8C72 /* UndoPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UndoPill.swift; sourceTree = "<group>"; };
 		62E28B094263860A9B4657A2 /* UIAuditSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAuditSnapshotTests.swift; sourceTree = "<group>"; };
@@ -861,6 +861,7 @@
 		6C5CA5533D846B39EF16CDFA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6CA38159B41E3E998455E922 /* MusicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicService.swift; sourceTree = "<group>"; };
 		6CE165B6335EEBF5DDED2C47 /* AmapPOIServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmapPOIServiceTests.swift; sourceTree = "<group>"; };
+		6CEEAF462B119E54E9340766 /* TodayThreeThingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayThreeThingsTests.swift; sourceTree = "<group>"; };
 		6D22DBF50B6C3FABE64A9DE2 /* AmapLiveIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmapLiveIntegrationTests.swift; sourceTree = "<group>"; };
 		6D31F422914779D9228B0278 /* RouteCardNowReasonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCardNowReasonTests.swift; sourceTree = "<group>"; };
 		6DE289F1023BD3630C38364C /* TimeCapsule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeCapsule.swift; sourceTree = "<group>"; };
@@ -928,7 +929,6 @@
 		88553B5578C07FA890183A0D /* BottomInfoSheetHandleHitTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomInfoSheetHandleHitTargetTests.swift; sourceTree = "<group>"; };
 		88805BD09F10F37A334CE2F0 /* ChatAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentTests.swift; sourceTree = "<group>"; };
 		88863482E2CD46BBE315B59D /* LocationErrorSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationErrorSurfaceTests.swift; sourceTree = "<group>"; };
-		88C4087271547E494464570E /* seed_experiences.json.backup */ = {isa = PBXFileReference; path = seed_experiences.json.backup; sourceTree = "<group>"; };
 		88DFC61CD1B433E92301FB18 /* AddFriendSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFriendSheetTests.swift; sourceTree = "<group>"; };
 		88E54A903B58582BCBF1C904 /* ExploreModeOverlayRenderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreModeOverlayRenderTest.swift; sourceTree = "<group>"; };
 		892E8A5180374C97B894E71F /* VisitTrackingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitTrackingServiceTests.swift; sourceTree = "<group>"; };
@@ -1542,6 +1542,7 @@
 				FFA0BCC3FA2B0DF44F1F5217 /* TodayContainerTests.swift */,
 				118294EB8964E37C63FEE7FC /* TodaySealReceiptTests.swift */,
 				2BA42F14E0B63119912C00AD /* TodayStatusHeaderTests.swift */,
+				6CEEAF462B119E54E9340766 /* TodayThreeThingsTests.swift */,
 				331B2AE74EFAD9589AF60498 /* TodoIssueReferenceTests.swift */,
 				D94A585E823470D513C6C861 /* ToolOutcomeLiveIntegrationTests.swift */,
 				7FD405D02D1BE843764ADFF9 /* ToolOutcomeTests.swift */,
@@ -1586,7 +1587,6 @@
 			children = (
 				FB52A67C323F1302895C0C67 /* seed_city_brief_vte.json */,
 				61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */,
-				88C4087271547E494464570E /* seed_experiences.json.backup */,
 				1F39081CF797874064A33814 /* seed_routes.json */,
 				8C8D88BCFAC97E436BE97274 /* seed_users.json */,
 			);
@@ -2025,7 +2025,6 @@
 				409FB4B0922C4A1D8AAEB1D1 /* FeatureFlags.plist */,
 				BC185539C95D5D940693BCB7 /* Info.plist */,
 				EA0858036CFEA9774139AFD7 /* PrivacyInfo.xcprivacy */,
-				154BDAAACF2DDCFE0953E722 /* Secrets.plist */,
 				AB46D6F6F8942CD390A5CCF4 /* SoloCompass.entitlements */,
 				349E26E71AF3FA04CA5CC24C /* JSON */,
 				80020844C0A45A5993333741 /* Localizable.strings */,
@@ -2109,6 +2108,7 @@
 				D76E5FA5F9C2CADE936F9D40 /* TodayNearbyRow.swift */,
 				912B8348C2044FEAD6C0643B /* TodaySealReceipt.swift */,
 				3D6EE32340E0A83362F440D7 /* TodayStatusHeader.swift */,
+				61D6CA0AEDFCE1422EA4A1D2 /* TodayThreeThings.swift */,
 			);
 			path = Today;
 			sourceTree = "<group>";
@@ -2300,10 +2300,8 @@
 				BAC775E6105DD571F71ACBC1 /* Localizable.strings in Resources */,
 				F3461FC7F38900F40A880255 /* Localizable.stringsdict in Resources */,
 				8B4F2A6E8F3C6EAD0F9A8E32 /* PrivacyInfo.xcprivacy in Resources */,
-				84C7525626CF30AF8AD92C19 /* Secrets.plist in Resources */,
 				BB34E346EFB5F570DED6B039 /* seed_city_brief_vte.json in Resources */,
 				D7CC906B358ED5337880A942 /* seed_experiences.json in Resources */,
-				D3D6DD13C4BE1230C9A5F5E5 /* seed_experiences.json.backup in Resources */,
 				EAFABF90D77B4D5E00D6BDFC /* seed_routes.json in Resources */,
 				2A4A75FDB09E99452C161048 /* seed_users.json in Resources */,
 			);
@@ -2535,6 +2533,7 @@
 				A4528F9189C69F1292BA6006 /* TodayContainerTests.swift in Sources */,
 				7AC84A1CE63882AEA5D066A5 /* TodaySealReceiptTests.swift in Sources */,
 				3C835FCB531DC30448F763AA /* TodayStatusHeaderTests.swift in Sources */,
+				FA9632525DA89F235F69B7F8 /* TodayThreeThingsTests.swift in Sources */,
 				CA89195562C759E6F118465B /* TodoIssueReferenceTests.swift in Sources */,
 				E5916F3DFB21BA26A2FFFFBE /* ToolOutcomeLiveIntegrationTests.swift in Sources */,
 				14A08808EC415815951AD5A8 /* ToolOutcomeTests.swift in Sources */,
@@ -2884,6 +2883,7 @@
 				37375126C9D00F02A3233357 /* TodayNearbyRow.swift in Sources */,
 				B2060AA2A2C1E4933941D2BB /* TodaySealReceipt.swift in Sources */,
 				B89002ECF766AA5D3F1D3172 /* TodayStatusHeader.swift in Sources */,
+				952E35DC8914A2F0384962BF /* TodayThreeThings.swift in Sources */,
 				5148EFD1A860D54B6F1CB8CB /* ToolOutcome.swift in Sources */,
 				AC44E44D1AC48E33145DF0F0 /* ToolRouterContractPreview.swift in Sources */,
 				3BDFE453122F7D464FEF5490 /* TravelerNoteRecord.swift in Sources */,

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -2376,6 +2376,12 @@
 "today.map.open" = "Open map";
 "today.map.backToToday" = "Back to Today";
 
+/* B1-c — today's three things */
+"today.threeThings.empty" = "Nothing to surface here yet — open the map and explore to fill this in.";
+"today.card.work.eyebrow" = "Work today";
+"today.card.now.eyebrow" = "Worth it now";
+"today.card.tonight.eyebrow" = "Tonight";
+
 /* Nomad OS B1-b — Today status header */
 "today.header.noCity" = "Pick a city";
 "today.header.dayInCity" = "Day %d in this city";

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -2386,6 +2386,12 @@
 "today.map.open" = "打开地图";
 "today.map.backToToday" = "返回 Today";
 
+/* B1-c — 今日三件事 */
+"today.threeThings.empty" = "这里还没有可呈现的内容——打开地图探索一下来填满它。";
+"today.card.work.eyebrow" = "今日办公";
+"today.card.now.eyebrow" = "此刻最值得";
+"today.card.tonight.eyebrow" = "今晚";
+
 /* Nomad OS B1-b — Today 状态头 */
 "today.header.noCity" = "选择城市";
 "today.header.dayInCity" = "在城第 %d 天";

--- a/apps/ios/SoloCompass/Tests/TodayThreeThingsTests.swift
+++ b/apps/ios/SoloCompass/Tests/TodayThreeThingsTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+@testable import SoloCompass
+
+/// Nomad OS B1-c: `TodayThreeThings.pick` chooses the work / now / tonight
+/// cards from a city's experiences. These tests pin each lens, the cross-card
+/// de-dup, and the empty-city contract — all against the pure `pick` function,
+/// no view or store.
+@MainActor
+final class TodayThreeThingsTests: XCTestCase {
+
+    // A fixed clock at 14:00 so "now" and "tonight" windows are deterministic.
+    private var twoPM: Date {
+        var c = DateComponents()
+        c.year = 2026; c.month = 7; c.day = 19; c.hour = 14; c.minute = 0
+        return Calendar.current.date(from: c)!
+    }
+
+    private func window(_ start: Int, _ end: Int) -> TimeWindow {
+        TimeWindow(startHour: start, endHour: end, dayOfWeek: nil, season: nil, note: nil)
+    }
+
+    private func wifi() -> CategoryHighlight {
+        CategoryHighlight(kind: .wifi, label: "Wi-Fi", value: "fast")
+    }
+
+    private func make(
+        id: String,
+        cityCode: String = "cmi",
+        category: ExperienceCategory,
+        score: Double = 5,
+        bestTimes: [TimeWindow] = [],
+        highlights: [CategoryHighlight] = []
+    ) -> Experience {
+        let now = Date()
+        return Experience(
+            id: id,
+            title: "Fixture \(id)",
+            oneLiner: "One liner \(id)",
+            whyItMatters: "Why \(id).",
+            category: category,
+            location: ExperienceLocation(coordinates: [98.99, 18.78], cityCode: cityCode),
+            bestTimes: bestTimes,
+            durationMinutes: .init(min: 30, max: 60),
+            howTo: [],
+            realInconveniences: [],
+            soloScore: SoloScore(
+                overall: score,
+                breakdown: .init(
+                    seatingFriendly: 7, soloPatronRatio: 7, staffPressure: 7,
+                    soloPortioning: 7, ambianceFit: 7, safety: 7
+                ),
+                basedOnCount: 1
+            ),
+            sources: [InformationSource(type: .user, attribution: "test", verifiedAt: now)],
+            confidence: Confidence(
+                level: 3, lastVerifiedAt: now, reason: "fixture",
+                signals: .init(aiScrapeAgeDays: 1, passiveGpsHits30d: 0, activeReports30d: 0, trustedVerifications: 0)
+            ),
+            nearbyExperienceIds: [],
+            stats: .init(completionCount: 0, averageRating: 0),
+            status: .active,
+            createdAt: now, updatedAt: now,
+            categoryHighlights: highlights.isEmpty ? nil : highlights
+        )
+    }
+
+    // MARK: Work lens
+
+    /// The work card takes the highest-solo-score work-ready spot (a `.work`
+    /// place, or a `.coffee` with wifi/power). A plain café without wifi is not
+    /// work-ready.
+    func testWorkPicksHighestScoringWorkReady() {
+        let all = [
+            make(id: "cowork-lo", category: .work, score: 7),
+            make(id: "cowork-hi", category: .work, score: 9),
+            make(id: "cafe-wifi", category: .coffee, score: 8, highlights: [wifi()]),
+            make(id: "cafe-plain", category: .coffee, score: 9.5), // not work-ready
+        ]
+        let picks = TodayThreeThings.pick(from: all, cityCode: "cmi", now: twoPM)
+        XCTAssertEqual(picks.work?.id, "cowork-hi",
+                       "work must be the top-scoring work-ready spot, not the plain café")
+    }
+
+    // MARK: Now lens
+
+    /// The now card takes the highest nowScore. An experience whose bestTimes
+    /// contain the current hour scores highly; one that doesn't lags.
+    func testNowPicksBestScoringForCurrentHour() {
+        let all = [
+            make(id: "open-now", category: .food, score: 8, bestTimes: [window(12, 16)]),  // covers 14:00
+            make(id: "closed-now", category: .food, score: 8, bestTimes: [window(6, 9)]),  // morning only
+        ]
+        let picks = TodayThreeThings.pick(from: all, cityCode: "cmi", now: twoPM)
+        XCTAssertEqual(picks.now?.id, "open-now",
+                       "now must favour the experience whose best window covers the current hour")
+    }
+
+    // MARK: Tonight lens
+
+    /// The tonight card requires an evening window (opens ≥18:00).
+    func testTonightRequiresEveningWindow() {
+        let all = [
+            make(id: "daytime", category: .culture, score: 9, bestTimes: [window(9, 17)]),
+            make(id: "evening", category: .nightlife, score: 7, bestTimes: [window(19, 23)]),
+        ]
+        let picks = TodayThreeThings.pick(from: all, cityCode: "cmi", now: twoPM)
+        XCTAssertEqual(picks.tonight?.id, "evening",
+                       "tonight must require a window opening at or after 18:00")
+    }
+
+    // MARK: De-dup
+
+    /// One experience can win two lenses; the earlier lens (work→now→tonight)
+    /// keeps it and the later lens falls to its runner-up, so no card repeats.
+    func testNoDuplicateAcrossCards() {
+        // A single evening work café that's also open now would otherwise win
+        // all three; give each later lens a distinct runner-up.
+        let all = [
+            make(id: "super", category: .work, score: 9, bestTimes: [window(12, 23)], highlights: [wifi()]),
+            make(id: "now-alt", category: .food, score: 8, bestTimes: [window(12, 16)]),
+            make(id: "night-alt", category: .nightlife, score: 8, bestTimes: [window(20, 23)]),
+        ]
+        let picks = TodayThreeThings.pick(from: all, cityCode: "cmi", now: twoPM)
+        XCTAssertEqual(picks.work?.id, "super", "work claims the super spot first")
+        XCTAssertNotEqual(picks.now?.id, "super", "now must not repeat the work pick")
+        XCTAssertNotEqual(picks.tonight?.id, "super", "tonight must not repeat the work pick")
+        let ids = [picks.work?.id, picks.now?.id, picks.tonight?.id].compactMap { $0 }
+        XCTAssertEqual(Set(ids).count, ids.count, "no experience may appear on two cards")
+    }
+
+    // MARK: City / empty contract
+
+    /// Experiences in another city are ignored.
+    func testFiltersToSelectedCity() {
+        let all = [
+            make(id: "here", category: .work, score: 9, highlights: [wifi()]),
+            make(id: "elsewhere", cityCode: "lis", category: .work, score: 9.5, highlights: [wifi()]),
+        ]
+        let picks = TodayThreeThings.pick(from: all, cityCode: "cmi", now: twoPM)
+        XCTAssertEqual(picks.work?.id, "here")
+    }
+
+    /// No city, empty list, or a city with no experiences → empty picks.
+    func testEmptyContracts() {
+        let some = [make(id: "x", category: .work, score: 9, highlights: [wifi()])]
+        XCTAssertTrue(TodayThreeThings.pick(from: some, cityCode: nil, now: twoPM).isEmpty)
+        XCTAssertTrue(TodayThreeThings.pick(from: [], cityCode: "cmi", now: twoPM).isEmpty)
+        XCTAssertTrue(TodayThreeThings.pick(from: some, cityCode: "tyo", now: twoPM).isEmpty,
+                      "a city with no matching experiences yields empty picks")
+    }
+}

--- a/apps/ios/SoloCompass/Views/Today/TodayContainer.swift
+++ b/apps/ios/SoloCompass/Views/Today/TodayContainer.swift
@@ -157,16 +157,9 @@ private struct TodayHomeScaffold: View {
                         // capsule was buried yesterday, else takes no space.
                         TodaySealReceipt()
 
-                        // Three-things placeholder (B1-c).
-                        Text(NSLocalizedString(
-                            "today.scaffold.placeholder",
-                            comment: "Placeholder subtitle for the not-yet-wired Today body"
-                        ))
-                        .ctBody(15)
-                        .foregroundStyle(CT.textMutedAdaptive)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, Space.xxl)
-                        .padding(.top, Space.xxl)
+                        // Today's three things (B1-c): work / now / tonight,
+                        // picked from the current city's experiences.
+                        TodayThreeThings()
                     }
                     .padding(.top, Space.lg)
                 }

--- a/apps/ios/SoloCompass/Views/Today/TodayThreeThings.swift
+++ b/apps/ios/SoloCompass/Views/Today/TodayThreeThings.swift
@@ -1,0 +1,238 @@
+import SwiftUI
+
+/// Nomad OS B1-c: the "today's three things" block on the Today home — the
+/// north-star content (design nomad-os-b1-today-home-20260719 §2 ②).
+///
+/// Three cards in a fixed order — **work → now → tonight** — each picked from
+/// the current city's experiences by a distinct lens:
+///
+///   - ☕ work    : the best work-ready spot (`isWorkReady`, solo-score ranked)
+///   - ✨ now     : what's most worth it *right now* (`nowScore` ranked)
+///   - 🌙 tonight : something whose best window opens this evening (≥18:00)
+///
+/// The selection is a pure function (`pick`) so it's unit-testable without a
+/// view. Data comes from the same independent sources the other Today
+/// components use — `ExperienceService.allExperiences` filtered to
+/// `preferences.lastSelectedCity` — never the map's `MapViewModel` @State
+/// (which Today can't reach). A city with nothing to show renders an honest
+/// empty line rather than three blank cards; non-seed cities are filled by the
+/// A2 backend hydrate, and a truly empty city says so plainly.
+struct TodayThreeThings: View {
+    @Environment(ExperienceService.self) private var experienceService
+    @Environment(UserPreferences.self) private var preferences
+
+    /// Recomputed on appear and when the city changes. `nowScore` depends on the
+    /// wall clock, but a per-render re-pick would thrash; a snapshot on appear is
+    /// the right granularity for a home screen (the map is where live "now"
+    /// browsing happens).
+    @State private var picks: Picks = .empty
+
+    var body: some View {
+        VStack(spacing: Space.md) {
+            if picks.isEmpty {
+                emptyState
+            } else {
+                if let work = picks.work {
+                    TodayCard(kind: .work, experience: work)
+                }
+                if let now = picks.now {
+                    TodayCard(kind: .now, experience: now)
+                }
+                if let tonight = picks.tonight {
+                    TodayCard(kind: .tonight, experience: tonight)
+                }
+            }
+        }
+        .task(id: preferences.lastSelectedCity) { refresh() }
+    }
+
+    private var emptyState: some View {
+        Text(NSLocalizedString(
+            "today.threeThings.empty",
+            comment: "No experiences to build today's three things from yet"
+        ))
+        .ctBody(15)
+        .foregroundStyle(CT.textMutedAdaptive)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, Space.xxl)
+        .padding(.top, Space.xxl)
+    }
+
+    private func refresh() {
+        picks = Self.pick(
+            from: experienceService.allExperiences,
+            cityCode: preferences.lastSelectedCity,
+            now: Date()
+        )
+    }
+
+    // MARK: - Selection (pure, testable)
+
+    /// The three chosen experiences, any of which may be nil when the city has
+    /// nothing that fits that lens.
+    struct Picks: Equatable {
+        var work: Experience?
+        var now: Experience?
+        var tonight: Experience?
+
+        static let empty = Picks(work: nil, now: nil, tonight: nil)
+        var isEmpty: Bool { work == nil && now == nil && tonight == nil }
+    }
+
+    /// Pick the three cards from a full experience list. Pure so
+    /// `TodayThreeThingsTests` can pin the lenses without a view or a store.
+    /// `@MainActor` because it calls `MapViewModel`'s main-actor-isolated
+    /// `cityCodeMatches` / `isWorkReady` statics — and `pick` only ever runs on
+    /// the main thread (the view's `refresh`) anyway.
+    ///
+    /// De-dupes across cards: if the same experience wins two lenses (a great
+    /// evening work café that's also best-now), the earlier lens in
+    /// work→now→tonight order keeps it and the later lens takes its runner-up,
+    /// so the block never shows the same place twice.
+    @MainActor
+    static func pick(
+        from all: [Experience],
+        cityCode: String?,
+        now: Date
+    ) -> Picks {
+        guard let cityCode, !cityCode.isEmpty else { return .empty }
+        let inCity = all.filter {
+            MapViewModel.cityCodeMatches($0.location.cityCode, selected: cityCode)
+        }
+        guard !inCity.isEmpty else { return .empty }
+
+        var used = Set<String>()
+
+        // ☕ Work: work-ready, solo-score ranked (mirrors workReadySpots).
+        let workReady = inCity
+            .filter { MapViewModel.isWorkReady($0) }
+            .sorted(by: soloDescendingTitleAscending)
+        let work = workReady.first { used.insert($0.id).inserted }
+
+        // ✨ Now: highest nowScore, only if it's genuinely a good time (≥0.5 —
+        // below that we'd be celebrating a mediocre moment; the map is where
+        // marginal now-browsing belongs). Scored first, then sorted, in
+        // separate steps so the type-checker doesn't choke on one long chain.
+        let scored: [(exp: Experience, score: Double)] = inCity
+            .map { (exp: $0, score: $0.nowScore(at: now).value) }
+            .filter { $0.score >= 0.5 }
+        let nowRanked = scored
+            .sorted { $0.score != $1.score ? $0.score > $1.score : $0.exp.title < $1.exp.title }
+            .map(\.exp)
+        let nowPick = nowRanked.first { used.insert($0.id).inserted }
+
+        // 🌙 Tonight: has an evening window (opens ≥18:00), solo-score ranked.
+        let evening = inCity
+            .filter { exp in exp.bestTimes.contains { $0.startHour >= 18 } }
+            .sorted(by: soloDescendingTitleAscending)
+        let tonight = evening.first { used.insert($0.id).inserted }
+
+        return Picks(work: work, now: nowPick, tonight: tonight)
+    }
+
+    private static func soloDescendingTitleAscending(_ a: Experience, _ b: Experience) -> Bool {
+        if a.soloScore.overall != b.soloScore.overall {
+            return a.soloScore.overall > b.soloScore.overall
+        }
+        return a.title < b.title
+    }
+}
+
+/// One of the three Today cards. A single container that differs by `kind` — the
+/// icon, accent, and eyebrow label change; the body (place name + a warm,
+/// self-written subtitle + solo score) is shared. Visual token set matches the
+/// other Today rows (`Radius.lg` / `CT.cardAdaptive` / `Space.lg`).
+struct TodayCard: View {
+    enum Kind {
+        case work, now, tonight
+
+        var symbol: String {
+            switch self {
+            case .work:    return "cup.and.saucer.fill"
+            case .now:     return "sparkles"
+            case .tonight: return "moon.stars.fill"
+            }
+        }
+
+        var eyebrowKey: String {
+            switch self {
+            case .work:    return "today.card.work.eyebrow"
+            case .now:     return "today.card.now.eyebrow"
+            case .tonight: return "today.card.tonight.eyebrow"
+            }
+        }
+    }
+
+    let kind: Kind
+    let experience: Experience
+
+    var body: some View {
+        HStack(spacing: Space.md) {
+            Image(systemName: kind.symbol)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(CT.accent)
+                .frame(width: 34, height: 34)
+                .background(Circle().fill(CT.accent.opacity(0.12)))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(NSLocalizedString(kind.eyebrowKey, comment: "Today card eyebrow label"))
+                    .font(.system(size: 10, weight: .bold, design: .rounded))
+                    .tracking(1.0)
+                    .textCase(.uppercase)
+                    .foregroundStyle(CT.accent)
+                Text(experience.shortName)
+                    .ctBody(15, .semibold)
+                    .foregroundStyle(CT.textPrimaryAdaptive)
+                    .lineLimit(1)
+                if let subtitle = warmSubtitle {
+                    Text(subtitle)
+                        .ctBody(12)
+                        .foregroundStyle(CT.textMutedAdaptive)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(CT.fgSubtle)
+        }
+        .padding(Space.lg)
+        .background(
+            RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
+                .fill(CT.cardAdaptive)
+        )
+        .padding(.horizontal, Space.xl)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(accessibilityLabel))
+    }
+
+    /// A warm, user-facing subtitle written here — never `NowScore.reason`,
+    /// which is a developer string. Prefers the solo-lens hint, then the AI
+    /// one-liner (if it isn't just the title again), then the first sentence of
+    /// why-it-matters. Nil when none is usable (the card still reads fine on
+    /// name + eyebrow alone).
+    private var warmSubtitle: String? {
+        if let hint = experience.soloScore.hint, !hint.isEmpty {
+            return hint
+        }
+        let oneLiner = experience.oneLiner
+        if !oneLiner.isEmpty, oneLiner != experience.title {
+            return oneLiner
+        }
+        let why = experience.whyItMatters
+        if !why.isEmpty {
+            return why.split(whereSeparator: { $0 == "." || $0 == "。" }).first.map(String.init)
+        }
+        return nil
+    }
+
+    private var accessibilityLabel: String {
+        let eyebrow = NSLocalizedString(kind.eyebrowKey, comment: "")
+        if let subtitle = warmSubtitle {
+            return "\(eyebrow): \(experience.shortName). \(subtitle)"
+        }
+        return "\(eyebrow): \(experience.shortName)"
+    }
+}


### PR DESCRIPTION
## What

Replaces the Today placeholder with the **north-star content** — three cards picked from the current city's experiences, one lens each. This is the last B1 content slice; A2 (PR #613) unblocks it by filling non-seed cities.

## The three lenses

`TodayThreeThings.pick` — a **pure, `@MainActor`, testable** selector:

| Card | Lens |
|---|---|
| ☕ **Work** | best work-ready spot (`isWorkReady`, solo-score ranked) |
| ✨ **Now** | highest `nowScore`, gated at **≥0.5** so we never celebrate a mediocre moment (the map is where marginal now-browsing lives) |
| 🌙 **Tonight** | an experience whose best window opens **this evening (≥18:00)** |

De-dupes across cards in work→now→tonight order, so one place never fills two slots — the later lens falls to its runner-up.

## Cards

- **`TodayCard`** — one container that differs by `kind`. Title uses **`shortName`** (never the long `title` sentence — it's a description, not a name). The subtitle is **written here** (`soloScore.hint` → `oneLiner` → why-it-matters first sentence), **never `NowScore.reason`**, which is a developer string (the design's copy rule).
- Data comes from the same independent sources the other Today components use (`ExperienceService.allExperiences` filtered to `preferences.lastSelectedCity` via `MapViewModel.cityCodeMatches`), **never** the map's `MapViewModel` `@State`.
- A city with nothing shows **one honest empty line**; non-seed cities are filled by the A2 backend hydrate (#613).

## Verification

- **Debug + Release builds both `BUILD SUCCEEDED`** (Release verified — this touches `TodayContainer`, which ships to TestFlight).
- `TodayThreeThingsTests` — each lens, cross-card de-dup, city filtering, empty contracts. (XCTest host hits the known simulator bootstrap ANR `project_ios_test_runner_hung`, unrelated — `pick` is pure and its tests never boot the app.)

## Scope / rollback

Behind the still-off `todayHome` flag → no change to the shipping map-first form. Additive.

https://claude.ai/code/session_01A9yc2UDrmYN3aSUT5MQJjM