### PR TITLE
fix(ios): 地图主页五处体验重构 — 定位/悬浮卡/城市模式/基地卡遮挡/上滑

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 		59A9E2DAC8378384BBCD8A57 /* RouteShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4181409CE6A219B1C07502 /* RouteShareSheet.swift */; };
 		5A0A16C0E997E1C0A8FD8BFE /* AmapPOIServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE165B6335EEBF5DDED2C47 /* AmapPOIServiceTests.swift */; };
 		5A9323A635F6E38C05E3C1D2 /* ComplianceBannerArbitrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBFA931C11A30D500343248 /* ComplianceBannerArbitrationTests.swift */; };
+		5AECC874C79EC746EB1224BA /* MapZoomLevelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD99CAC8132E200BBA0AF57 /* MapZoomLevelTests.swift */; };
 		5B22BAF4AD26B9941361351B /* CompanionCrossTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA531A7BAD8A34652BA4801 /* CompanionCrossTests.swift */; };
 		5B7BA2C36A50D7B1D44D1B4A /* CityOSInterruptionBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07765108DFDB705B49FAD8D /* CityOSInterruptionBudgetTests.swift */; };
 		5C05B87EA78458094612AC01 /* BottomInfoBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13350B81187FB64B252B8A46 /* BottomInfoBar.swift */; };
@@ -299,7 +300,6 @@
 		83BF31EF553028D19D695105 /* RouteSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C6C906BAD8DBC107491B7F /* RouteSharePayload.swift */; };
 		842E955B0ED4DC5255816199 /* NowScore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75D6A32EAF01F792AFAE15E /* NowScore.swift */; };
 		84832AC481CB3E19977A07BA /* CapsuleComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9523A96A3D4F48D1670E0590 /* CapsuleComposeView.swift */; };
-		84C7525626CF30AF8AD92C19 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 154BDAAACF2DDCFE0953E722 /* Secrets.plist */; };
 		8592C07C234EA6B55619D0D1 /* RouteShareRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A453FDDE85569DCA8FF70A8A /* RouteShareRenderer.swift */; };
 		85B238721EB01B78DDC078F0 /* RouteCompanionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA9EA4E29955D78499E3AAC /* RouteCompanionTests.swift */; };
 		85C233AB7998521788B2BB5F /* WeatherCacheTTLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E536D4CFF44CF4CEFD1EFF4F /* WeatherCacheTTLTests.swift */; };
@@ -494,7 +494,6 @@
 		D2E9B20230FDE14CB1029DC3 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535B5FA4ADF216CEC74FE056 /* RouteTests.swift */; };
 		D391728579EB266152984A30 /* SoloCompassLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6982D2F9E150319AA0E1000F /* SoloCompassLiveActivity.swift */; };
 		D3D09BE396ED9D2DF5FE91B9 /* OnboardingCityStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3D7AE265D80F76BA9BB28B /* OnboardingCityStep.swift */; };
-		D3D6DD13C4BE1230C9A5F5E5 /* seed_experiences.json.backup in Resources */ = {isa = PBXBuildFile; fileRef = 88C4087271547E494464570E /* seed_experiences.json.backup */; };
 		D3F1DBFF74F227E5390736C6 /* POISource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FBC142634F5D448F7B85875 /* POISource.swift */; };
 		D4193263CDA544D0995749B0 /* NavigationLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FB43528F45882868CCC203 /* NavigationLauncherTests.swift */; };
 		D50CC44D67F686293769FE4C /* ExploreModeOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C7F1FDCCF3B2D5BCA451974 /* ExploreModeOverlay.swift */; };
@@ -684,7 +683,6 @@
 		143FF1379DE02FC9B0D637CA /* ToolRouterOutcomeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolRouterOutcomeTests.swift; sourceTree = "<group>"; };
 		14A2953D1F2B46AFC9F85D42 /* AddToItinerarySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToItinerarySheet.swift; sourceTree = "<group>"; };
 		1537012DBA238501E4DEDACE /* PrintFulfillmentClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintFulfillmentClientTests.swift; sourceTree = "<group>"; };
-		154BDAAACF2DDCFE0953E722 /* Secrets.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Secrets.plist; sourceTree = "<group>"; };
 		15720012D06D8C0F34FAF77B /* AppClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppClock.swift; sourceTree = "<group>"; };
 		15C512E1C0A5CFFE798CEEEA /* AppLaunchPerformanceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchPerformanceTest.swift; sourceTree = "<group>"; };
 		176E799668057C7DD5C559AD /* RoutesSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutesSectionView.swift; sourceTree = "<group>"; };
@@ -941,7 +939,6 @@
 		88553B5578C07FA890183A0D /* BottomInfoSheetHandleHitTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomInfoSheetHandleHitTargetTests.swift; sourceTree = "<group>"; };
 		88805BD09F10F37A334CE2F0 /* ChatAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentTests.swift; sourceTree = "<group>"; };
 		88863482E2CD46BBE315B59D /* LocationErrorSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationErrorSurfaceTests.swift; sourceTree = "<group>"; };
-		88C4087271547E494464570E /* seed_experiences.json.backup */ = {isa = PBXFileReference; path = seed_experiences.json.backup; sourceTree = "<group>"; };
 		88DFC61CD1B433E92301FB18 /* AddFriendSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFriendSheetTests.swift; sourceTree = "<group>"; };
 		88E54A903B58582BCBF1C904 /* ExploreModeOverlayRenderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreModeOverlayRenderTest.swift; sourceTree = "<group>"; };
 		892E8A5180374C97B894E71F /* VisitTrackingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitTrackingServiceTests.swift; sourceTree = "<group>"; };
@@ -959,6 +956,7 @@
 		8D38CFDF2B9D4C92F3954DA0 /* ExperienceFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceFilter.swift; sourceTree = "<group>"; };
 		8D41862432A45DC023C96B8D /* FilterNowMapAnimationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterNowMapAnimationTest.swift; sourceTree = "<group>"; };
 		8D52416277C10558C0CD7096 /* SoloCompassActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloCompassActivityAttributes.swift; sourceTree = "<group>"; };
+		8DD99CAC8132E200BBA0AF57 /* MapZoomLevelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapZoomLevelTests.swift; sourceTree = "<group>"; };
 		8E055BAC372B75F743428920 /* MyHostedRoutesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyHostedRoutesListView.swift; sourceTree = "<group>"; };
 		8EBBF97536F80B36291DB787 /* JourneyAuditP0RegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneyAuditP0RegressionTests.swift; sourceTree = "<group>"; };
 		8F1F20B36F8441905A909DC2 /* ChatHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryStore.swift; sourceTree = "<group>"; };
@@ -1476,6 +1474,7 @@
 				48FF87CCF00DEEE87B290812 /* MapViewModelCityRegionSyncTests.swift */,
 				05D76C3B221A1223BA095ABB /* MapViewModelClassifyFailureTests.swift */,
 				774D16A741A01ECD6F878025 /* MapViewModelEagerInitTest.swift */,
+				8DD99CAC8132E200BBA0AF57 /* MapZoomLevelTests.swift */,
 				DC34BA3586B5607F63F86CC0 /* MarkerClosingSoonStyleTest.swift */,
 				658C2890F90C08A686F501BA /* MarkerStatePerformanceTest.swift */,
 				2B33B0431703DD49E0228D33 /* MemoryDigestServiceTests.swift */,
@@ -1606,7 +1605,6 @@
 			children = (
 				FB52A67C323F1302895C0C67 /* seed_city_brief_vte.json */,
 				61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */,
-				88C4087271547E494464570E /* seed_experiences.json.backup */,
 				1F39081CF797874064A33814 /* seed_routes.json */,
 				8C8D88BCFAC97E436BE97274 /* seed_users.json */,
 			);
@@ -2046,7 +2044,6 @@
 				409FB4B0922C4A1D8AAEB1D1 /* FeatureFlags.plist */,
 				BC185539C95D5D940693BCB7 /* Info.plist */,
 				EA0858036CFEA9774139AFD7 /* PrivacyInfo.xcprivacy */,
-				154BDAAACF2DDCFE0953E722 /* Secrets.plist */,
 				AB46D6F6F8942CD390A5CCF4 /* SoloCompass.entitlements */,
 				349E26E71AF3FA04CA5CC24C /* JSON */,
 				80020844C0A45A5993333741 /* Localizable.strings */,
@@ -2324,10 +2321,8 @@
 				BAC775E6105DD571F71ACBC1 /* Localizable.strings in Resources */,
 				F3461FC7F38900F40A880255 /* Localizable.stringsdict in Resources */,
 				8B4F2A6E8F3C6EAD0F9A8E32 /* PrivacyInfo.xcprivacy in Resources */,
-				84C7525626CF30AF8AD92C19 /* Secrets.plist in Resources */,
 				BB34E346EFB5F570DED6B039 /* seed_city_brief_vte.json in Resources */,
 				D7CC906B358ED5337880A942 /* seed_experiences.json in Resources */,
-				D3D6DD13C4BE1230C9A5F5E5 /* seed_experiences.json.backup in Resources */,
 				EAFABF90D77B4D5E00D6BDFC /* seed_routes.json in Resources */,
 				2A4A75FDB09E99452C161048 /* seed_users.json in Resources */,
 			);
@@ -2477,6 +2472,7 @@
 				53FB06EED514C3F3C7CB43E1 /* MapViewModelCityRegionSyncTests.swift in Sources */,
 				6EE4D64EF1B3E0F56519DA59 /* MapViewModelClassifyFailureTests.swift in Sources */,
 				C68E48A7B9D9E45647898D4C /* MapViewModelEagerInitTest.swift in Sources */,
+				5AECC874C79EC746EB1224BA /* MapZoomLevelTests.swift in Sources */,
 				BB2B54BC5A41E7956362E1CE /* MarkerClosingSoonStyleTest.swift in Sources */,
 				FD8F94BFC5C298D62943FFF3 /* MarkerStatePerformanceTest.swift in Sources */,
 				FF880C11C06B7673E5C728D7 /* MemoryDigestServiceTests.swift in Sources */,

--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -300,6 +300,7 @@
 		83BF31EF553028D19D695105 /* RouteSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C6C906BAD8DBC107491B7F /* RouteSharePayload.swift */; };
 		842E955B0ED4DC5255816199 /* NowScore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75D6A32EAF01F792AFAE15E /* NowScore.swift */; };
 		84832AC481CB3E19977A07BA /* CapsuleComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9523A96A3D4F48D1670E0590 /* CapsuleComposeView.swift */; };
+		84C7525626CF30AF8AD92C19 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 154BDAAACF2DDCFE0953E722 /* Secrets.plist */; };
 		8592C07C234EA6B55619D0D1 /* RouteShareRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A453FDDE85569DCA8FF70A8A /* RouteShareRenderer.swift */; };
 		85B238721EB01B78DDC078F0 /* RouteCompanionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA9EA4E29955D78499E3AAC /* RouteCompanionTests.swift */; };
 		85C233AB7998521788B2BB5F /* WeatherCacheTTLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E536D4CFF44CF4CEFD1EFF4F /* WeatherCacheTTLTests.swift */; };
@@ -494,6 +495,7 @@
 		D2E9B20230FDE14CB1029DC3 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535B5FA4ADF216CEC74FE056 /* RouteTests.swift */; };
 		D391728579EB266152984A30 /* SoloCompassLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6982D2F9E150319AA0E1000F /* SoloCompassLiveActivity.swift */; };
 		D3D09BE396ED9D2DF5FE91B9 /* OnboardingCityStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3D7AE265D80F76BA9BB28B /* OnboardingCityStep.swift */; };
+		D3D6DD13C4BE1230C9A5F5E5 /* seed_experiences.json.backup in Resources */ = {isa = PBXBuildFile; fileRef = 88C4087271547E494464570E /* seed_experiences.json.backup */; };
 		D3F1DBFF74F227E5390736C6 /* POISource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FBC142634F5D448F7B85875 /* POISource.swift */; };
 		D4193263CDA544D0995749B0 /* NavigationLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FB43528F45882868CCC203 /* NavigationLauncherTests.swift */; };
 		D50CC44D67F686293769FE4C /* ExploreModeOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C7F1FDCCF3B2D5BCA451974 /* ExploreModeOverlay.swift */; };
@@ -683,6 +685,7 @@
 		143FF1379DE02FC9B0D637CA /* ToolRouterOutcomeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolRouterOutcomeTests.swift; sourceTree = "<group>"; };
 		14A2953D1F2B46AFC9F85D42 /* AddToItinerarySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToItinerarySheet.swift; sourceTree = "<group>"; };
 		1537012DBA238501E4DEDACE /* PrintFulfillmentClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintFulfillmentClientTests.swift; sourceTree = "<group>"; };
+		154BDAAACF2DDCFE0953E722 /* Secrets.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Secrets.plist; sourceTree = "<group>"; };
 		15720012D06D8C0F34FAF77B /* AppClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppClock.swift; sourceTree = "<group>"; };
 		15C512E1C0A5CFFE798CEEEA /* AppLaunchPerformanceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchPerformanceTest.swift; sourceTree = "<group>"; };
 		176E799668057C7DD5C559AD /* RoutesSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutesSectionView.swift; sourceTree = "<group>"; };
@@ -939,6 +942,7 @@
 		88553B5578C07FA890183A0D /* BottomInfoSheetHandleHitTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomInfoSheetHandleHitTargetTests.swift; sourceTree = "<group>"; };
 		88805BD09F10F37A334CE2F0 /* ChatAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentTests.swift; sourceTree = "<group>"; };
 		88863482E2CD46BBE315B59D /* LocationErrorSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationErrorSurfaceTests.swift; sourceTree = "<group>"; };
+		88C4087271547E494464570E /* seed_experiences.json.backup */ = {isa = PBXFileReference; path = seed_experiences.json.backup; sourceTree = "<group>"; };
 		88DFC61CD1B433E92301FB18 /* AddFriendSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFriendSheetTests.swift; sourceTree = "<group>"; };
 		88E54A903B58582BCBF1C904 /* ExploreModeOverlayRenderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreModeOverlayRenderTest.swift; sourceTree = "<group>"; };
 		892E8A5180374C97B894E71F /* VisitTrackingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitTrackingServiceTests.swift; sourceTree = "<group>"; };
@@ -1605,6 +1609,7 @@
 			children = (
 				FB52A67C323F1302895C0C67 /* seed_city_brief_vte.json */,
 				61ED51ACFDCE6E0ED274BB60 /* seed_experiences.json */,
+				88C4087271547E494464570E /* seed_experiences.json.backup */,
 				1F39081CF797874064A33814 /* seed_routes.json */,
 				8C8D88BCFAC97E436BE97274 /* seed_users.json */,
 			);
@@ -2044,6 +2049,7 @@
 				409FB4B0922C4A1D8AAEB1D1 /* FeatureFlags.plist */,
 				BC185539C95D5D940693BCB7 /* Info.plist */,
 				EA0858036CFEA9774139AFD7 /* PrivacyInfo.xcprivacy */,
+				154BDAAACF2DDCFE0953E722 /* Secrets.plist */,
 				AB46D6F6F8942CD390A5CCF4 /* SoloCompass.entitlements */,
 				349E26E71AF3FA04CA5CC24C /* JSON */,
 				80020844C0A45A5993333741 /* Localizable.strings */,
@@ -2321,8 +2327,10 @@
 				BAC775E6105DD571F71ACBC1 /* Localizable.strings in Resources */,
 				F3461FC7F38900F40A880255 /* Localizable.stringsdict in Resources */,
 				8B4F2A6E8F3C6EAD0F9A8E32 /* PrivacyInfo.xcprivacy in Resources */,
+				84C7525626CF30AF8AD92C19 /* Secrets.plist in Resources */,
 				BB34E346EFB5F570DED6B039 /* seed_city_brief_vte.json in Resources */,
 				D7CC906B358ED5337880A942 /* seed_experiences.json in Resources */,
+				D3D6DD13C4BE1230C9A5F5E5 /* seed_experiences.json.backup in Resources */,
 				EAFABF90D77B4D5E00D6BDFC /* seed_routes.json in Resources */,
 				2A4A75FDB09E99452C161048 /* seed_users.json in Resources */,
 			);

--- a/apps/ios/SoloCompass/Services/CityOSStore.swift
+++ b/apps/ios/SoloCompass/Services/CityOSStore.swift
@@ -43,6 +43,27 @@ public final class CityOSStore {
         preferences.cityModesRaw = raw
     }
 
+    /// Infer the city's mode from signals the app already has, so the traveler
+    /// never has to flip it by hand: a stay that has ended (stage `.leave`) →
+    /// recall; a GPS fix inside the city → live; a city picked far from where we
+    /// are (no fix nearby) → plan.
+    ///
+    /// - Parameters:
+    ///   - cityCode: the city being framed (currently only used for symmetry
+    ///     with the other store APIs; the decision is driven by the signals).
+    ///   - isUserInCity: whether a GPS fix places the traveler inside this city
+    ///     (computed by the caller from distance to the city center).
+    ///   - stage: the lifecycle stage from `stage(for:daysStayed:)`; `.leave`
+    ///     means the stay has ended.
+    ///
+    /// Pure so it can be unit-tested without a live location or preferences.
+    public func inferMode(for cityCode: String?, isUserInCity: Bool, stage: CityStage?) -> CityMode {
+        // A finished stay reads as recall regardless of where the phone is now.
+        if stage == .leave { return .recall }
+        // Standing in the city → live; a far-away pick with no nearby fix → plan.
+        return isUserInCity ? .live : .plan
+    }
+
     /// Whether the landing kit has already auto-surfaced for this city.
     public func hasSeenKit(_ cityCode: String) -> Bool {
         preferences.kitSeenCities.contains(Self.normalizedCityKey(cityCode))

--- a/apps/ios/SoloCompass/Tests/CityOSStoreTests.swift
+++ b/apps/ios/SoloCompass/Tests/CityOSStoreTests.swift
@@ -128,6 +128,50 @@ final class CityOSStoreTests: XCTestCase {
         XCTAssertEqual(store.stage(for: "vte", daysStayed: 1), .land)
     }
 
+    // MARK: - inferMode (P1: automatic Live/Plan/Recall)
+
+    func testInferModeLeaveStageWinsRecall() {
+        let (store, _) = makeStore()
+        // A finished stay reads as Recall regardless of the GPS signal.
+        XCTAssertEqual(
+            store.inferMode(for: "cmi", isUserInCity: true, stage: .leave),
+            .recall,
+            "已离城 (.leave) 无论 GPS 是否在城内都应回顾"
+        )
+        XCTAssertEqual(
+            store.inferMode(for: "cmi", isUserInCity: false, stage: .leave),
+            .recall
+        )
+    }
+
+    func testInferModeInCityIsLive() {
+        let (store, _) = makeStore()
+        // A GPS fix inside the city, stay not ended → Live.
+        XCTAssertEqual(
+            store.inferMode(for: "vte", isUserInCity: true, stage: .live),
+            .live
+        )
+        XCTAssertEqual(
+            store.inferMode(for: "vte", isUserInCity: true, stage: nil),
+            .live,
+            "在城内且未离城 → 生活"
+        )
+    }
+
+    func testInferModeFarAwayIsPlan() {
+        let (store, _) = makeStore()
+        // A far-away city (no nearby fix), stay not ended → Plan.
+        XCTAssertEqual(
+            store.inferMode(for: "lpq", isUserInCity: false, stage: nil),
+            .plan
+        )
+        XCTAssertEqual(
+            store.inferMode(for: "lpq", isUserInCity: false, stage: .live),
+            .plan,
+            "选了远城、GPS 不在城内 → 计划"
+        )
+    }
+
     // MARK: - Helpers
 
     private func makeKitItem(kind: CityKitItem.Kind) -> CityKitItem {

--- a/apps/ios/SoloCompass/Tests/MapZoomLevelTests.swift
+++ b/apps/ios/SoloCompass/Tests/MapZoomLevelTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+import CoreLocation
+@testable import SoloCompass
+
+/// P5: the map used a single coarse ~10km span everywhere, so travelers
+/// couldn't read the shops underfoot. Camera spans are now two named levels:
+/// street-level when a GPS fix exists, city-level when only a city is picked.
+/// This locks the ordering (street tighter than city) and the street-level
+/// budget (well under the old 0.09 coarse span) so a future edit can't silently
+/// regress back to a district-scale zoom.
+@MainActor
+final class MapZoomLevelTests: XCTestCase {
+
+    func testStreetLevelIsTighterThanCityLevel() {
+        XCTAssertLessThan(
+            MapViewModel.MapZoom.streetLevel,
+            MapViewModel.MapZoom.cityLevel,
+            "Street-level zoom must be tighter (smaller span) than city-level."
+        )
+    }
+
+    func testStreetLevelIsStreetScaleNotDistrict() {
+        // ~0.012 deg latitude ≈ 1.3km, i.e. walkable street scale. Guard well
+        // under the old coarse 0.09 (~10km) so we don't regress.
+        XCTAssertLessThanOrEqual(MapViewModel.MapZoom.streetLevel, 0.02)
+        XCTAssertGreaterThan(MapViewModel.MapZoom.streetLevel, 0)
+    }
+
+    func testCityLevelStaysLegibleCityScale() {
+        // City-level should be wider than street but still tighter than the old
+        // coarse span, so the city outline reads without a location.
+        XCTAssertGreaterThan(MapViewModel.MapZoom.cityLevel, MapViewModel.MapZoom.streetLevel)
+        XCTAssertLessThan(MapViewModel.MapZoom.cityLevel, 0.09)
+    }
+}

--- a/apps/ios/SoloCompass/Tests/PreviewCardLifecycleTests.swift
+++ b/apps/ios/SoloCompass/Tests/PreviewCardLifecycleTests.swift
@@ -7,21 +7,22 @@ import XCTest
 ///
 ///     selectedExperience != nil && !isShowingDetail
 ///
-/// Tap-vs-long-press model (all card/pin entry points behave the same):
-///   • TAP a card/pin (`openExperienceDetail`) jumps straight to the detail
-///     sheet — `selectedExperience` is set AND `isShowingDetail = true`;
+/// Tap-vs-long-press model — the dismiss destination depends on how detail was
+/// reached (`MapViewModel.DetailEntrySource`):
+///   • TAP a card/pin (`openExperienceDetail`) jumps straight to detail as
+///     `.listTap` — `selectedExperience` is set AND `isShowingDetail = true`;
+///     backing out CLEARS the selection → clean list, no floating card left over;
 ///   • LONG-PRESS a card/pin (`selectExperience`) floats the quick preview card
-///     instead — it does NOT open detail;
-///   • the preview card's expand action opens the detail sheet
-///     (isShowingDetail = true);
-///   • backing out of detail (dismissDetail) FALLS BACK to the preview card —
-///     selection is retained, because detail is a layer above the preview;
-///   • the card's own dismiss (clearSelection) is the only thing that returns
-///     to the bare map.
+///     as `.mapPeek` — it does NOT open detail;
+///   • the preview card's expand action opens the detail sheet above the peek;
+///     backing out FALLS BACK to that preview card (selection retained), because
+///     detail is a layer above a card the user deliberately summoned;
+///   • the card's own dismiss (clearSelection) returns to the bare map and
+///     resets the entry source.
 ///
-/// Regression guard for the "退出详情后悬窗残留" report: backing out of detail
-/// lands on the preview card (selection retained), and `clearSelection` gives a
-/// clean exit to the bare map.
+/// P3 regression guard for the "退出详情后悬窗残留 / Starbucks card floating over
+/// the list" report: a list-tap dismiss must NOT leave a preview card hovering
+/// over the list, while the long-press peek fall-back stays intact.
 @MainActor
 final class PreviewCardLifecycleTests: XCTestCase {
 
@@ -72,35 +73,63 @@ final class PreviewCardLifecycleTests: XCTestCase {
                        "the preview card must NOT float on a tap — detail is up")
     }
 
-    // MARK: - Tap → back-out falls back to the preview card
+    // MARK: - List/pin tap → back-out returns to a CLEAN list (no floating card)
 
-    func testOpenDetailThenDismissFallsBackToCard() throws {
+    /// P3 regression: a Nearby/pin *tap* opens detail as `.listTap`; backing out
+    /// must clear the selection so no preview card is left hovering over the list
+    /// ("Starbucks card floating above the list" / 退出详情后悬窗残留). This is the
+    /// listTap ≠ mapPeek distinction — a tap has no card underneath to fall back
+    /// to, unlike the long-press peek path below.
+    func testListTapDetailThenDismissClearsSelection() throws {
         let vm = makeViewModel()
         let exp = try firstExperience(vm)
 
-        vm.openExperienceDetail(exp)         // tap → detail
+        vm.openExperienceDetail(exp)         // list/pin tap → detail (.listTap)
+        XCTAssertEqual(vm.detailEntrySource, .listTap,
+                       "a tap into detail must record the listTap source")
         vm.dismissDetail()                   // back out of detail
-        XCTAssertTrue(cardIsFloating(vm),
-                      "backing out of a tapped detail still lands on the card")
-        XCTAssertEqual(vm.selectedExperience?.id, exp.id,
-                       "selection retained after dismissing a tapped detail")
+        XCTAssertNil(vm.selectedExperience,
+                     "dismissing a list-tapped detail must clear selection — no floating card")
+        XCTAssertFalse(cardIsFloating(vm),
+                       "no preview card may hover over the clean list after a list-tap dismiss")
+        XCTAssertFalse(vm.isShowingDetail)
     }
 
-    // MARK: - Card → detail → back lands on the card again
+    // MARK: - Long-press peek → card → detail → back lands on the card again
 
-    func testExpandThenDismissDetailFallsBackToCard() throws {
+    /// Approach C: long-press floats the preview card (`.mapPeek`), the card's
+    /// expand opens detail *above* it, and backing out peels only the detail
+    /// layer — the deliberately-summoned card returns, selection retained.
+    func testMapPeekExpandThenDismissDetailFallsBackToCard() throws {
         let vm = makeViewModel()
         let exp = try firstExperience(vm)
 
-        vm.selectExperience(exp)             // card up
+        vm.selectExperience(exp)             // long-press peek → card up (.mapPeek)
+        XCTAssertEqual(vm.detailEntrySource, .mapPeek,
+                       "long-press peek must record the mapPeek source")
         vm.isShowingDetail = true            // onExpand → detail
         XCTAssertFalse(cardIsFloating(vm), "card hidden behind detail")
 
         vm.dismissDetail()                   // back out of detail
         XCTAssertTrue(cardIsFloating(vm),
-                      "dismissing detail must fall back to the preview card")
+                      "dismissing a peek-expanded detail must fall back to the preview card")
         XCTAssertEqual(vm.selectedExperience?.id, exp.id,
-                       "selection is retained on detail dismiss")
+                       "selection is retained on a mapPeek detail dismiss")
+    }
+
+    // MARK: - Source resets to mapPeek after a full clear
+
+    /// A subsequent long-press peek must not inherit a stale `.listTap` source
+    /// from a prior tap — `clearSelection` resets it so the peek → expand →
+    /// dismiss fall-back keeps working.
+    func testClearSelectionResetsEntrySourceToMapPeek() throws {
+        let vm = makeViewModel()
+        let exp = try firstExperience(vm)
+
+        vm.openExperienceDetail(exp)         // .listTap
+        vm.clearSelection()
+        XCTAssertEqual(vm.detailEntrySource, .mapPeek,
+                       "clearSelection must reset the entry source to the peek default")
     }
 
     // MARK: - Card dismiss is the only full exit to the bare map

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -1192,12 +1192,19 @@ public final class MapViewModel {
     /// Purely a render cue for `EventMarkerView.isHighlighted`; nil = none.
     public var highlightedEventId: String?
     public var isShowingDetail: Bool = false
-    /// True when the current detail sheet was opened *directly* by a tap (map
-    /// pin / Nearby row) with no floating preview card behind it. Backing out
-    /// of such a sheet returns to the bare map, not to a preview card the user
-    /// never summoned. A detail opened by *expanding* a preview card (long-press
-    /// → card → expand) leaves this false, so dismiss peels back to that card.
-    private var detailOpenedDirectly: Bool = false
+    /// How the currently-open detail was reached, so dismissing it can pick the
+    /// right destination: a list/nearby/pin tap returns to the clean list, while
+    /// a map-pin long-press peek falls back to the floating preview card.
+    ///
+    /// The two entry points share one `selectedExperience` but carry different
+    /// mental models. A `.listTap` is "open this, look, then back to my list" —
+    /// backing out must land on a clean list with no floating card left hovering
+    /// over it (the "退出详情后悬窗残留 / Starbucks card floating over the list"
+    /// report). A `.mapPeek` is the Approach-C long-press flow (peek card →
+    /// expand → detail): backing out deliberately falls back to that preview
+    /// card, because detail is a layer *above* the peek, not a replacement.
+    enum DetailEntrySource { case listTap, mapPeek }
+    private(set) var detailEntrySource: DetailEntrySource = .mapPeek
     public var bottomInfoText: String = ""
     public var nearbySoloCount: Int = 0
     public var aiExplanation: String?
@@ -1830,10 +1837,10 @@ public final class MapViewModel {
     public func selectExperience(_ experience: Experience) {
         Haptics.impact(.light)
         selectedExperience = experience
-        // This is the preview-card path (long-press). The detail layer, if the
-        // user later expands the card, sits *above* this card — so dismissing
+        // This is the preview-card path (long-press peek). The detail layer, if
+        // the user later expands the card, sits *above* this card — so dismissing
         // it must peel back to the card, not to the bare map.
-        detailOpenedDirectly = false
+        detailEntrySource = .mapPeek
         // isShowingDetail stays false — card shows first, detail sheet on expand
         focusOnExperience(experience)
     }
@@ -1849,9 +1856,9 @@ public final class MapViewModel {
         selectedExperience = experience
         isShowingDetail = true
         // Tap jumped straight to detail with no preview card behind it, so a
-        // back-out should land on the bare map rather than reveal a card the
-        // user never summoned (see `dismissDetail`).
-        detailOpenedDirectly = true
+        // back-out should land on the clean list / bare map rather than reveal a
+        // card the user never summoned (see `dismissDetail`).
+        detailEntrySource = .listTap
         focusOnExperience(experience)
     }
 
@@ -1891,23 +1898,20 @@ public final class MapViewModel {
         }
     }
 
-    /// Close the expanded detail sheet, falling back to the floating preview
-    /// card for the same experience.
+    /// Close the expanded detail sheet, choosing the destination by how the
+    /// detail was reached (`detailEntrySource`).
     ///
-    /// Every entry point (map pin, Nearby list row, favorites) now routes
-    /// through the preview card first — selecting an experience floats the
-    /// card, and the card's expand action opens the detail. Backing out of the
-    /// detail therefore lands back on that preview card (selectedExperience is
-    /// deliberately retained), which is the consistent mental model: detail is
-    /// a layer *above* the preview, not a replacement for it. The card is only
-    /// fully cleared when the user dismisses the card itself (`clearSelection`).
+    /// - `.listTap` (Nearby row / map pin / favorites tap): the user opened
+    ///   detail straight from a list with no preview card underneath, so a
+    ///   back-out clears the selection and lands on the clean list — nothing
+    ///   floats over it. This kills the "退出详情后悬窗残留 / Starbucks card
+    ///   hovering above the list" overlap.
+    /// - `.mapPeek` (long-press → preview card → expand): detail is a layer
+    ///   *above* the peek card the user deliberately summoned, so dismiss peels
+    ///   off only that layer and reveals the card again (selection retained).
     public func dismissDetail() {
         isShowingDetail = false
-        // A tap-opened detail has no preview card underneath — peel straight
-        // back to the bare map. A card-expanded detail keeps its selection so
-        // the dismiss reveals the preview card it sits above.
-        if detailOpenedDirectly {
-            detailOpenedDirectly = false
+        if detailEntrySource == .listTap {
             selectedExperience = nil
         }
     }
@@ -1919,7 +1923,7 @@ public final class MapViewModel {
     public func clearSelection() {
         isShowingDetail = false
         selectedExperience = nil
-        detailOpenedDirectly = false
+        detailEntrySource = .mapPeek
     }
 
     /// US-VA-03 tool `dismiss_recommendation`: hide one experience from
@@ -1932,7 +1936,7 @@ public final class MapViewModel {
         if selectedExperience?.id == id {
             selectedExperience = nil
             isShowingDetail = false
-            detailOpenedDirectly = false
+            detailEntrySource = .mapPeek
         }
     }
 

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -19,6 +19,23 @@ public final class MapViewModel {
     // Default: Chiang Mai old city center.
     public static let defaultCenter = CLLocationCoordinate2D(latitude: 18.7877, longitude: 98.9938)
 
+    // Camera spans. Street-level (~1.3km) when we have a GPS fix so the
+    // traveler can read the shops underfoot, matching Apple/高德 Maps'
+    // locate-me zoom; wider city-level (~5.5km) when only a city is picked
+    // with no fix, so the city outline stays legible. The previous single
+    // 0.09 span (~10km, big-district scale) read as "too coarse".
+    enum MapZoom {
+        static let streetLevel: CLLocationDegrees = 0.012
+        static let cityLevel: CLLocationDegrees = 0.05
+    }
+
+    /// The span an initial / city-selection camera should use: street-level
+    /// when a GPS fix is available (the traveler is somewhere concrete), else
+    /// city-level so the picked city stays legible without a location.
+    private var initialCameraSpan: CLLocationDegrees {
+        locationService.currentLocation != nil ? MapZoom.streetLevel : MapZoom.cityLevel
+    }
+
     // MARK: - Dependencies
     private let locationService: LocationService
     private let experienceService: ExperienceService
@@ -629,7 +646,7 @@ public final class MapViewModel {
         if selectedCity?.hasPrefix("custom_") == true { return }
         cameraPosition = .region(MKCoordinateRegion(
             center: defaultCenterForSelectedCity,
-            span: MKCoordinateSpan(latitudeDelta: 0.09, longitudeDelta: 0.09)
+            span: MKCoordinateSpan(latitudeDelta: initialCameraSpan, longitudeDelta: initialCameraSpan)
         ))
     }
 
@@ -658,9 +675,11 @@ public final class MapViewModel {
         customLocationLabel = label
         selectedCity = cityCode
         preferences.lastSelectedCity = nil  // don't persist custom pins across restarts
+        // A custom pin is a deliberate concrete point the user dropped, so
+        // zoom straight to street-level regardless of GPS.
         cameraPosition = .region(MKCoordinateRegion(
             center: coordinate,
-            span: MKCoordinateSpan(latitudeDelta: 0.09, longitudeDelta: 0.09)
+            span: MKCoordinateSpan(latitudeDelta: MapZoom.streetLevel, longitudeDelta: MapZoom.streetLevel)
         ))
         loadNearbyExperiences()
         updateBottomInfo()
@@ -1396,7 +1415,10 @@ public final class MapViewModel {
         }
         self._cameraPosition = .region(MKCoordinateRegion(
             center: initialCenter,
-            span: MKCoordinateSpan(latitudeDelta: 0.09, longitudeDelta: 0.09)
+            span: MKCoordinateSpan(
+                latitudeDelta: locationService.currentLocation != nil ? MapZoom.streetLevel : MapZoom.cityLevel,
+                longitudeDelta: locationService.currentLocation != nil ? MapZoom.streetLevel : MapZoom.cityLevel
+            )
         ))
         // V-002: `didSet` does not fire for the `selectedCity` set above
         // (initializer semantics), so apply the same camera↔city sync here so
@@ -1947,7 +1969,7 @@ public final class MapViewModel {
         withAnimation(Self.cameraAnimation) {
             cameraPosition = .region(MKCoordinateRegion(
                 center: coordinate,
-                span: MKCoordinateSpan(latitudeDelta: 0.04, longitudeDelta: 0.04)
+                span: MKCoordinateSpan(latitudeDelta: MapZoom.streetLevel, longitudeDelta: MapZoom.streetLevel)
             ))
         }
         // The camera was just deliberately pinned on `coordinate`; the pin

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -296,6 +296,13 @@ public struct BottomInfoSheet<Content: View>: View {
     /// peek-only floating overlays (drawer tabs / mode cards). Optional with a
     /// nil default so every existing call site is byte-identical.
     private let onDetentChange: ((BottomSheetDetent) -> Void)?
+    /// City OS: an optional header slot rendered ONLY in the peek state, between
+    /// the drag handle and the peek summary card. The City-OS 游民基地 Base card
+    /// lives here so it rides inside the sheet instead of floating over the map
+    /// (where its full-width banner occluded the right-side control column).
+    /// Optional with a nil default so every non-City-OS call site stays
+    /// byte-identical and the row simply never renders.
+    private let peekHeaderContent: (() -> AnyView)?
     private let content: (BottomSheetDetent, Binding<SortMode>) -> Content
 
     public init(
@@ -310,6 +317,7 @@ public struct BottomInfoSheet<Content: View>: View {
         onShuffle: (() -> Void)? = nil,
         onRefresh: (() async -> Void)? = nil,
         onDetentChange: ((BottomSheetDetent) -> Void)? = nil,
+        peekHeader: (() -> AnyView)? = nil,
         @ViewBuilder content: @escaping (BottomSheetDetent, Binding<SortMode>) -> Content
     ) {
         self.aiHint = aiHint
@@ -323,6 +331,7 @@ public struct BottomInfoSheet<Content: View>: View {
         self.onShuffle = onShuffle
         self.onRefresh = onRefresh
         self.onDetentChange = onDetentChange
+        self.peekHeaderContent = peekHeader
         self.content = content
     }
 
@@ -377,6 +386,15 @@ public struct BottomInfoSheet<Content: View>: View {
             // settle animates at compositor cost.
             VStack(spacing: 0) {
                 dragHandleArea(detentHeight: detentHeight, minHeight: minHeight, maxHeight: maxHeight)
+                // City OS Base card slot — only in peek. At mid/full the space
+                // yields to the list, matching the old floating card's
+                // `sheetDetent == .peek` gate. Horizontal padding matches the
+                // peek summary card below (16) so the two align.
+                if currentDetent == .peek, let peekHeaderContent {
+                    peekHeaderContent()
+                        .padding(.horizontal, 16)
+                        .padding(.top, 6)
+                }
                 peekContentArea
                     .padding(.horizontal, 16)
                     .padding(.top, 6)

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -402,18 +402,13 @@ struct CompassMapContentView: View {
     /// controls hug the sheet without crowding it.
     private var controlBarBottomInset: CGFloat {
         let controlSheetGap: CGFloat = 8
-        let base = sheetPeekClearance + controlSheetGap
-        return cityOSBottomSlotOccupied ? base + 60 : base
+        // The Base card no longer floats over the map (it now lives inside the
+        // sheet peek header), so the control bar only needs to clear the peek
+        // sheet itself — no extra lift for a bottom slot.
+        return sheetPeekClearance + controlSheetGap
     }
 
     // MARK: - City OS v2 helpers
-
-    /// Bottom inset for the City-OS Base card so it floats just above the
-    /// peek sheet. Slightly more gap than the control bar so the card reads
-    /// as its own row, not stacked on the FAB.
-    private var baseSlotBottomInset: CGFloat {
-        sheetPeekClearance + 8
-    }
 
     /// The current city's mode (Live/Plan/Recall). Live is the default.
     private var currentCityMode: CityMode {
@@ -578,18 +573,6 @@ struct CompassMapContentView: View {
             dismissed: complianceBannerDismissed,
             isLive: currentCityMode == .live
         )
-    }
-
-    /// Whether the City-OS drawer tabs should show: flag on, resting at peek,
-    /// Live mode, no experience selected, and kit content exists.
-    /// Whether the City-OS floating bottom slot (the always-on Base card) is
-    /// occupied. Centered empty-state cards consult this to shift up clear of
-    /// the slot — without it the quiet-hours card's CTA renders underneath
-    /// the Base card.
-    private var cityOSBottomSlotOccupied: Bool {
-        FeatureFlags.cityOS
-            && sheetDetent == .peek
-            && viewModel.selectedExperience == nil
     }
 
     /// Load the landing kit + local events for a city and, when `autoSurface`
@@ -1419,7 +1402,7 @@ struct CompassMapContentView: View {
                         VStack {
                             Spacer()
                             NowEmptyOverlay(viewModel: viewModel)
-                                .padding(.bottom, sheetPeekClearance + 16 + (cityOSBottomSlotOccupied ? 52 : 0))
+                                .padding(.bottom, sheetPeekClearance + 16)
                         }
                         .transition(.move(edge: .bottom).combined(with: .opacity))
                         .animation(.easeOut(duration: 0.35), value: viewModel.visibleExperiences.isEmpty)
@@ -1427,7 +1410,7 @@ struct CompassMapContentView: View {
                         VStack {
                             Spacer()
                             FilteredEmptyOverlay(viewModel: viewModel)
-                                .padding(.bottom, sheetPeekClearance + 16 + (cityOSBottomSlotOccupied ? 52 : 0))
+                                .padding(.bottom, sheetPeekClearance + 16)
                         }
                         .transition(.move(edge: .bottom).combined(with: .opacity))
                         .animation(.easeOut(duration: 0.35), value: viewModel.visibleExperiences.isEmpty)
@@ -1514,7 +1497,34 @@ struct CompassMapContentView: View {
                         },
                         onDetentChange: { detent in
                             if sheetDetent != detent { sheetDetent = detent }
-                        }
+                        },
+                        // City OS: the 游民基地 Base card rides inside the sheet's
+                        // peek header instead of floating over the map, so its
+                        // full-width banner no longer occludes the right-side
+                        // control column (AI / explore / config). Only provided
+                        // when cityOS is on; nil otherwise keeps the sheet
+                        // behaviour identical for non-City-OS users.
+                        peekHeader: FeatureFlags.cityOS ? {
+                            AnyView(
+                                BaseCard(
+                                    face: currentBaseFace,
+                                    cityName: currentCityDisplayName,
+                                    daysStayed: complianceService.state()?.daysStayed,
+                                    visaDaysRemaining: complianceService.state()?.visaDaysRemaining,
+                                    visaPolicyDays: cityBriefService.kit
+                                        .first(where: { $0.kind == .visa })?.action?.visaDays,
+                                    workReadyCount: viewModel.workReadySpots(limit: 99).count,
+                                    eventCount: cityBriefService.activeEvents().count,
+                                    kitDone: viewModel.selectedCity.map {
+                                        cityOSStore.kitTodoDoneCount(cityCode: $0, kit: cityBriefService.kit)
+                                    } ?? 0,
+                                    kitTotal: cityBriefService.kit.count,
+                                    recallVisited: recallVisited.count,
+                                    recallPending: recallPending.count,
+                                    onOpen: { isShowingBaseSheet = true }
+                                )
+                            )
+                        } : nil
                     ) { detent, sortMode in
                         if detent != .peek {
                             VStack(spacing: 0) {
@@ -1689,41 +1699,12 @@ struct CompassMapContentView: View {
                     }
                 }
 
-                // City OS: the floating slot above the peek sheet holds the one
-                // 游民基地 Base card — every mode, every stage, no data gate.
-                // Live mode used to swap in CityDrawerTabs here, but that pair
-                // was guarded by `!kit.isEmpty`, so the traveler actually IN the
-                // city lost the entry whenever the server kit hadn't loaded —
-                // the exact entry-existence-gated-by-data mistake that got v1
-                // reverted. One card, always present; the panel carries the
-                // kit / live hops the tabs used to provide (BaseFollowUp).
-                if FeatureFlags.cityOS {
-                    if sheetDetent == .peek && viewModel.selectedExperience == nil {
-                        VStack {
-                            Spacer()
-                            BaseCard(
-                                face: currentBaseFace,
-                                cityName: currentCityDisplayName,
-                                daysStayed: complianceService.state()?.daysStayed,
-                                visaDaysRemaining: complianceService.state()?.visaDaysRemaining,
-                                visaPolicyDays: cityBriefService.kit
-                                    .first(where: { $0.kind == .visa })?.action?.visaDays,
-                                workReadyCount: viewModel.workReadySpots(limit: 99).count,
-                                eventCount: cityBriefService.activeEvents().count,
-                                kitDone: viewModel.selectedCity.map {
-                                    cityOSStore.kitTodoDoneCount(cityCode: $0, kit: cityBriefService.kit)
-                                } ?? 0,
-                                kitTotal: cityBriefService.kit.count,
-                                recallVisited: recallVisited.count,
-                                recallPending: recallPending.count,
-                                onOpen: { isShowingBaseSheet = true }
-                            )
-                            .padding(.horizontal, 20)
-                            .padding(.bottom, baseSlotBottomInset)
-                        }
-                        .transition(.opacity)
-                    }
-                }
+                // City OS: the 游民基地 Base card no longer floats over the map —
+                // it rides inside the BottomInfoSheet peek header (see the
+                // `peekHeader:` argument on the BottomInfoSheet above), so its
+                // full-width banner no longer occludes the right-side control
+                // column. Still peek-only + no data gate: the sheet renders it
+                // only at `.peek`, matching the old `sheetDetent == .peek` gate.
 
                 // City OS v3 toast (印证 confirmation). Floats above the dock
                 // slot; purely informational, never intercepts touches.
@@ -1736,7 +1717,7 @@ struct CompassMapContentView: View {
                             .padding(.horizontal, 16)
                             .padding(.vertical, 10)
                             .background(Capsule().fill(CT.accent))
-                            .padding(.bottom, baseSlotBottomInset + 62)
+                            .padding(.bottom, sheetPeekClearance + 70)
                     }
                     .allowsHitTesting(false)
                     .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -429,6 +429,38 @@ struct CompassMapContentView: View {
         )
     }
 
+    /// City OS v2 · infer this city's Live / Plan / Recall mode from signals the
+    /// app already has and persist it, replacing the manual segmented control the
+    /// traveler used to flip in the location picker.
+    ///
+    /// - A GPS fix inside the city (`<50 km` from its center) → Live.
+    /// - A city picked far from where we are (no nearby fix) → Plan.
+    /// - A stay whose lifecycle stage has reached `.leave` → Recall.
+    ///
+    /// Called on cold start and on every city switch, before the city pill and
+    /// brief render, so `cityPillModeLine` reads the freshly inferred mode. Never
+    /// overrides an already-`.recall` city back to Live/Plan — a finished stay
+    /// stays a memory (the stored mode feeds `currentCityStage`, whose `.leave`
+    /// keeps `inferMode` on Recall).
+    private func inferAndPersistCityMode(for cityCode: String?) {
+        guard FeatureFlags.cityOS, let cityCode, !cityCode.isEmpty else { return }
+        // Distance from the current GPS fix to this city's center decides whether
+        // the traveler is standing in it. `defaultCenterForSelectedCity` resolves
+        // the selected city's center (this helper runs for the selected city).
+        let isUserInCity: Bool = {
+            guard let fix = locationService.currentLocation else { return false }
+            let center = viewModel.defaultCenterForSelectedCity
+            let cityLoc = CLLocation(latitude: center.latitude, longitude: center.longitude)
+            return fix.distance(from: cityLoc) < 50_000  // 50 km radius
+        }()
+        let inferred = cityOSStore.inferMode(
+            for: cityCode,
+            isUserInCity: isUserInCity,
+            stage: currentCityStage
+        )
+        cityOSStore.setMode(inferred, for: cityCode)
+    }
+
     /// City OS v3 · the city pill's second line ("第 3 天 · 生活" / "未到 · 计划"
     /// / "已离 · 回顾"). Nil keeps the pill single-line: Live with no entry date
     /// has nothing honest to say, so it says nothing.
@@ -874,6 +906,12 @@ struct CompassMapContentView: View {
                     // lands directly on a city with seeded routes shows an empty
                     // Routes section, and 开始路线 is unreachable from the map.
                     refreshNearbyRoutes(cityCode: viewModel.selectedCity)
+                    // City OS v2: infer the initial city's mode (Live/Plan/
+                    // Recall) from GPS + lifecycle stage before the pill and
+                    // brief render, so the pill's mode line is correct on cold
+                    // start without any manual flip. A DEBUG `-cityMode` override
+                    // below still wins (it runs after this).
+                    inferAndPersistCityMode(for: viewModel.selectedCity)
                     // City OS v2: load the landing kit + local events for the
                     // initial city and, on first cold start in a Live city, let
                     // the kit auto-surface once (budget-gated).
@@ -1115,6 +1153,10 @@ struct CompassMapContentView: View {
                 // City OS v3: 切城 = 切换整个聚合上下文 — active filters belong
                 // to the city they were set in, so they never carry over.
                 viewModel.clearFilters()
+                // City OS v2: re-infer the new city's mode (Live/Plan/Recall)
+                // from GPS + lifecycle stage before the pill + brief render, so
+                // switching city updates the mode line without a manual flip.
+                inferAndPersistCityMode(for: cityCode)
                 loadCityBrief(for: cityCode, autoSurface: true)
             }
             .onReceive(NotificationCenter.default.publisher(for: RouteStore.didChange)) { _ in

--- a/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/LocationPickerSheet.swift
@@ -8,9 +8,11 @@ import CoreLocation
 /// (drag-a-pin or type coordinates + save-as-city flow).
 struct LocationPickerSheet: View {
     @Bindable var viewModel: MapViewModel
-    /// City OS v2: when provided (flag on), the selected city gains a
-    /// Live/Plan/Recall mode control + rows carry a small mode tag. nil keeps
-    /// the sheet exactly as it shipped.
+    /// City OS v2: retained for call-site stability. The per-city Live / Plan /
+    /// Recall mode is now inferred automatically (see
+    /// `CompassMapView.inferAndPersistCityMode`), so the sheet no longer renders
+    /// a manual mode control — this is kept so the existing `CompassMapView`
+    /// invocation doesn't have to change.
     let cityOSStore: CityOSStore?
     let onDismiss: () -> Void
 
@@ -123,19 +125,13 @@ struct LocationPickerSheet: View {
     @ViewBuilder
     private func citiesContent(bs: Bindable<LocationPickerState>) -> some View {
         List {
-            // City OS v2: mode control for the currently selected city, so the
-            // traveler can flip Live / Plan / Recall (the aggregation context).
-            if let store = cityOSStore, let selected = viewModel.selectedCity {
-                Section(NSLocalizedString("cityos.picker.mode.section", comment: "City mode section title")) {
-                    CityModePicker(
-                        mode: store.mode(for: selected),
-                        onSelect: { newMode in
-                            commitHaptic()
-                            store.setMode(newMode, for: selected)
-                        }
-                    )
-                }
-            }
+            // City OS v2: the per-city Live / Plan / Recall mode is now inferred
+            // automatically (GPS fix inside the city → Live, a far / not-yet
+            // reached city → Plan, a stay that has ended → Recall) in
+            // `CompassMapView.inferAndPersistCityMode`, so this picker no longer
+            // carries a manual segmented control — the traveler never has to flip
+            // it by hand. `cityOSStore` is retained in the signature only to keep
+            // the call site stable.
 
             // "All Cities" row
             Button {
@@ -709,55 +705,6 @@ private struct CoordinateField: View {
                 .keyboardType(.decimalPad)
                 .monospacedDigit()
                 .autocorrectionDisabled()
-        }
-    }
-}
-
-// MARK: - CityModePicker (City OS v2)
-
-/// A compact Live / Plan / Recall segmented control for the selected city.
-/// Live = 在此城 (warm), Plan = 计划 (cool blue), Recall = 回顾 (muted). Mode is
-/// the aggregation context, not a filter — switching it re-frames the whole
-/// city surface (PRD §4.1).
-private struct CityModePicker: View {
-    let mode: CityMode
-    let onSelect: (CityMode) -> Void
-
-    var body: some View {
-        HStack(spacing: 8) {
-            ForEach(CityMode.allCases, id: \.self) { candidate in
-                Button {
-                    onSelect(candidate)
-                } label: {
-                    Text(Self.label(for: candidate))
-                        .ctBody(13, mode == candidate ? .semibold : .regular)
-                        .foregroundStyle(mode == candidate ? .white : Self.tint(for: candidate))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 8)
-                        .background(
-                            Capsule().fill(mode == candidate ? Self.tint(for: candidate) : Self.tint(for: candidate).opacity(0.12))
-                        )
-                }
-                .buttonStyle(.plain)
-                .accessibilityAddTraits(mode == candidate ? [.isButton, .isSelected] : .isButton)
-            }
-        }
-        .padding(.vertical, 2)
-    }
-
-    private static func label(for mode: CityMode) -> String {
-        switch mode {
-        case .live:   return NSLocalizedString("cityos.mode.live.tag", comment: "在此城")
-        case .plan:   return NSLocalizedString("cityos.mode.plan.tag", comment: "计划")
-        case .recall: return NSLocalizedString("cityos.mode.recall.tag", comment: "回顾")
-        }
-    }
-
-    private static func tint(for mode: CityMode) -> Color {
-        switch mode {
-        case .live:   return CT.sunGoldDeep
-        case .plan:   return CT.modePlanBlue
-        case .recall: return CT.fgMuted
         }
     }
 }

--- a/apps/ios/SoloCompass/Views/Map/UserLocationMarker.swift
+++ b/apps/ios/SoloCompass/Views/Map/UserLocationMarker.swift
@@ -4,58 +4,32 @@ import SwiftUI
 /// `UserAnnotation` blue dot, which renders too small to pick out at a glance —
 /// solo travelers kept losing "where am I" against the dense POI markers.
 ///
-/// This is the *center* marker only (a large, high-contrast dot with a white
-/// ring and a slow breathing pulse). The surrounding geographic radius circle
-/// is drawn separately by a `MapCircle` in the map layer, so the two compose:
-/// the marker stays a fixed on-screen size at any zoom, while the circle scales
-/// with the map to convey real "nearby" distance.
+/// This is the *center* marker only: a large, high-contrast accent dot with a
+/// white ring. It renders **static** — no perpetual pulse. The earlier design
+/// ran a `repeatForever` breathing halo that expanded and faded every 1.6s;
+/// against a still map that read as the marker "always flashing", so it was
+/// removed. The surrounding geographic radius circle is still drawn separately
+/// by a `MapCircle` in the map layer, so the two compose: the marker stays a
+/// fixed on-screen size at any zoom, while the circle scales with the map to
+/// convey real "nearby" distance.
 ///
-/// Motion respects `accessibilityReduceMotion`: when reduce-motion is on the
-/// pulse is suppressed and only the static dot + ring remain.
+/// The white ring is intentionally kept in the layout bounds while nothing
+/// animates, so a SwiftUI `Annotation` resolves its `.center` anchor against a
+/// constant size and the marker never drifts off its GPS coordinate.
 struct UserLocationMarker: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
-    /// Drives the breathing halo. Toggled on once in `onAppear` so the
-    /// `repeatForever` animation keeps running for the marker's lifetime.
-    @State private var pulse = false
-
     /// Diameter of the solid center dot. Comfortably larger than the system
     /// blue dot (~22pt) so it reads at a glance over POI clusters.
     private let coreDiameter: CGFloat = 22
 
-    /// Outer reach of the breathing halo at its largest, relative to the core.
-    private let haloScale: CGFloat = 2.4
-
     var body: some View {
-        // The white ring backing defines the marker's *layout bounds* — a fixed
-        // `coreDiameter + 6`. Everything that animates (the breathing halo) lives
-        // in a layout-neutral `.background`, so the reported size never changes.
-        //
-        // This matters because a SwiftUI `Annotation` re-resolves its anchor
-        // point against the content's bounds every frame. If the pulsing halo
-        // sat in a `ZStack` (participating in layout), the ZStack would breathe
-        // between 22pt and 52.8pt, MapKit would recompute the `.center` anchor
-        // against that changing frame, and the whole marker would drift back and
-        // forth on screen — decoupled from the real GPS coordinate. Keeping the
-        // animated layer out of layout pins the anchor to a constant size.
+        // The white ring backing defines the marker's fixed layout bounds
+        // (`coreDiameter + 6`). Nothing animates, so the reported size is
+        // constant and MapKit's per-frame anchor resolution has nothing to
+        // chase — the marker sits still on the real GPS coordinate.
         Circle()
             .fill(.white)
             .frame(width: coreDiameter + 6, height: coreDiameter + 6)
             .shadow(color: .black.opacity(0.25), radius: 3, y: 1)
-            // Breathing halo — a soft accent ring that expands and fades. Pure
-            // decoration in a layout-neutral background, so it carries no hit
-            // target, doesn't grow the marker's measured bounds, and is hidden
-            // from VoiceOver (the core dot owns the accessibility label).
-            .background {
-                if !reduceMotion {
-                    Circle()
-                        .fill(Color.accentColor.opacity(0.25))
-                        .frame(width: coreDiameter, height: coreDiameter)
-                        .scaleEffect(pulse ? haloScale : 1.0, anchor: .center)
-                        .opacity(pulse ? 0.0 : 0.6)
-                        .accessibilityHidden(true)
-                }
-            }
             // Solid accent core, centered over the white ring.
             .overlay {
                 Circle()
@@ -67,12 +41,6 @@ struct UserLocationMarker: View {
                 "map.userLocation.label",
                 comment: "Accessibility label for the traveler's own location marker on the map"
             )))
-            .onAppear {
-                guard !reduceMotion else { return }
-                withAnimation(.easeOut(duration: 1.6).repeatForever(autoreverses: false)) {
-                    pulse = true
-                }
-            }
     }
 }
 


### PR DESCRIPTION
基于用户地图主页实测提出的五处体验裂缝，逐一定位代码级根因后重构。四条独立实现线，全部在 \`FeatureFlags.cityOS\` 门内或纯参数/动画调整，可灰度可回滚 —— 未开 cityOS 的用户零行为变化。

## 五处修复

| # | 问题 | 修复 |
|---|------|------|
| **P5** | 定位标记一直闪烁 + 初始颗粒度太粗（旁边都是大商圈） | 删掉 `UserLocationMarker` 的 `repeatForever` 呼吸光晕（只留静态 white ring + solid core）；抽 `MapZoom.streetLevel(0.012≈1.3km)/cityLevel(0.05)`，有 GPS fix 落街区级、仅选城无 fix 保城市级，recenter 也收细到街区级（focusOnExperience 不动） |
| **P3** | 点列表卡片进详情、返回后卡片悬浮在原列表结构之上 | 把模糊的 `detailOpenedDirectly` bool 重构成 `DetailEntrySource(.listTap/.mapPeek)` 枚举，`dismissDetail` 集中分流：列表 tap 返回**清空选择回干净列表**，长按 peek 返回**保留浮卡**（Approach C 不破）。所有关闭点统一路由到 `dismissDetail`。顺手修了红 baseline 里一条自 203c5195 起就矛盾的过时断言 |
| **P1** | 城市模式「在此城/计划/回顾」手动分段控件反人性 | 删掉手动控件；新增 `CityOSStore.inferMode(for:isUserInCity:stage:)` 纯函数，由 GPS + 签证阶段**自动推断**（离城→回顾 / 在城→在此城 / 远城→计划），冷启动 + 切城两处接线 |
| **P4** | 全宽「城市·基地」卡盖在地图下部、遮挡右侧 AI/探索/配置按钮 | `BaseCard` 从地图浮层移进 `BottomInfoSheet` 的 peek 顶栏（新增可选 `peekHeader` slot，nil default 保证现有调用点 byte-identical）；回收全部避让常量（`baseSlotBottomInset`/`cityOSBottomSlotOccupied`/`+60`）。地图与右侧按钮全通透 |
| **P2** | 默认页上滑既想滑卡片、也想展开 sheet | **随 P4 自愈** —— 浮卡从 peek 上方移走后，`BottomInfoSheet` 早已实现的 co-operative drag（内容先滚到顶再拉 sheet）全程可达，无需改手势 |

## 验证

- 每条线独立 git worktree 并行实现，各自 **Debug + Release 双构建** `BUILD SUCCEEDED`
- 合并后主工作树完整 **Debug 构建 `BUILD SUCCEEDED`**，四线共存验证
- 新增 3 组测试：`MapZoomLevelTests` / `PreviewCardLifecycleTests`（重写）/ `CityOSStoreTests`（inferMode 三分支）

**改动范围：** 9 文件，+340/-229。全部 iOS 端，无 TS/后端改动。

https://claude.ai/code/session_01A9yc2UDrmYN3aSUT5MQJjM