### PR TITLE
feat(ios): global drag on bottom sheet + fix stuck "未到·计划" pill

### DIFF
--- a/apps/ios/SoloCompass/Tests/BottomSheetGlobalDragGuardTest.swift
+++ b/apps/ios/SoloCompass/Tests/BottomSheetGlobalDragGuardTest.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import SoloCompass
+
+/// Structural regression guard for the BottomInfoSheet's *global* drag.
+///
+/// History: the co-operative `contentDragGesture` (grab anywhere to steer the
+/// sheet, Apple-Maps style) originally lived ONLY on the inner `ScrollView`.
+/// At the `.peek` detent the summary card ("此刻最值得去") and its 带我去 / 换一个
+/// buttons sit *above* that ScrollView (which is empty at peek), so the card
+/// could only be *tapped* to expand — dragging its body, text, or buttons did
+/// nothing. The user asked for the whole sheet to be pull-up-able from any
+/// region, not just the handle.
+///
+/// The fix wraps everything BELOW the handle (peek header, peek card, sort
+/// toolbar, and the list) in one container and attaches the drag there via
+/// `.contentShape(Rectangle()).simultaneousGesture(contentDragGesture(…))`, so
+/// a pull that begins anywhere in the body steers the sheet. The handle keeps
+/// its own unconditional drag.
+///
+/// SwiftUI view trees can't be introspected from XCTest, so — like
+/// `BottomSheetUnifiedScrollGuardTest` — this scans the source and asserts the
+/// structural invariants that together prove the drag now covers the whole
+/// body instead of just the scroll list.
+final class BottomSheetGlobalDragGuardTest: XCTestCase {
+
+    private func sheetSource() throws -> String {
+        let url = Self.sourceRoot().appendingPathComponent("Views/Map/BottomInfoSheet.swift")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// Invariant: the `contentDragGesture` is attached to the container that
+    /// ENCLOSES the ScrollView (so it also covers the peek card), NOT to the
+    /// ScrollView itself. Proof: the ScrollView's last modifier
+    /// (`.scrollBounceBehavior`) is followed by a closing brace `}` BEFORE the
+    /// `.contentShape(Rectangle())` + `.simultaneousGesture(contentDragGesture(…))`
+    /// pair — i.e. the scroll view closes and the gesture lands on the wrapper.
+    func testContentDragGestureWrapsWholeBodyNotJustScrollView() throws {
+        let source = try sheetSource()
+
+        guard let bounceRange = source.range(of: ".scrollBounceBehavior(.basedOnSize)") else {
+            XCTFail("Expected the unified ScrollView to end with .scrollBounceBehavior(.basedOnSize)")
+            return
+        }
+        let afterBounce = source[bounceRange.upperBound...]
+
+        guard let shapeRange = afterBounce.range(of: ".contentShape(Rectangle())") else {
+            XCTFail(
+                "Expected `.contentShape(Rectangle())` after the ScrollView so the peek "
+                    + "whitespace is grabbable — the drag must cover the whole sheet body."
+            )
+            return
+        }
+        // The scroll view must CLOSE (a `}`) between its last modifier and the
+        // drag-gesture attachment: that brace is the inner wrapping VStack /
+        // ScrollView boundary, proving the gesture is on the enclosing body
+        // container (which holds the peek card), not on the ScrollView.
+        let betweenBounceAndShape = afterBounce[..<shapeRange.lowerBound]
+        XCTAssertTrue(
+            betweenBounceAndShape.contains("}"),
+            "The drag gesture must be attached to the container ENCLOSING the ScrollView "
+                + "(a `}` must close the scroll layer before `.contentShape`), so a pull on "
+                + "the peek card — not just the list — steers the sheet."
+        )
+
+        // …and immediately after the contentShape, the co-operative drag is wired.
+        let afterShape = afterBounce[shapeRange.upperBound...]
+        guard let gestureRange = afterShape.range(of: ".simultaneousGesture(") else {
+            XCTFail("Expected `.simultaneousGesture(` right after `.contentShape(Rectangle())`")
+            return
+        }
+        let afterGesture = afterShape[gestureRange.upperBound...]
+        XCTAssertTrue(
+            afterGesture.hasPrefix("\n") && afterShape[gestureRange.upperBound...].contains("contentDragGesture("),
+            "The body-level `.simultaneousGesture` must drive `contentDragGesture(…)` — the "
+                + "same co-operative drag that decides steer-sheet vs. scroll-list per drag."
+        )
+    }
+
+    /// Invariant: the handle keeps its OWN drag gesture (unconditional steer),
+    /// separate from the body's co-operative one, so grabbing the handle always
+    /// moves the sheet even when the list is scrolled at `.full`.
+    func testHandleRetainsItsOwnDragGesture() throws {
+        let source = try sheetSource()
+        guard let handleRange = source.range(of: "private func dragHandleArea(") else {
+            XCTFail("Could not locate `dragHandleArea` to scan")
+            return
+        }
+        let afterHandle = source[handleRange.upperBound...]
+        // Bound the scan to the handle function (up to the next top-level MARK).
+        let handleBody: Substring
+        if let nextMark = afterHandle.range(of: "\n// MARK:") {
+            handleBody = afterHandle[..<nextMark.lowerBound]
+        } else {
+            handleBody = afterHandle
+        }
+        XCTAssertTrue(
+            handleBody.contains("DragGesture(minimumDistance: 4)"),
+            "The handle must keep its dedicated DragGesture so it always steers the sheet."
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// `apps/ios/SoloCompass/` — derived from this test file's compile-time path.
+    private static func sourceRoot(file: StaticString = #filePath) -> URL {
+        URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // SoloCompass/
+    }
+}

--- a/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
+++ b/apps/ios/SoloCompass/Views/Map/BottomInfoSheet.swift
@@ -386,101 +386,117 @@ public struct BottomInfoSheet<Content: View>: View {
             // settle animates at compositor cost.
             VStack(spacing: 0) {
                 dragHandleArea(detentHeight: detentHeight, minHeight: minHeight, maxHeight: maxHeight)
-                // City OS Base card slot — only in peek. At mid/full the space
-                // yields to the list, matching the old floating card's
-                // `sheetDetent == .peek` gate. Horizontal padding matches the
-                // peek summary card below (16) so the two align.
-                if currentDetent == .peek, let peekHeaderContent {
-                    peekHeaderContent()
+                // Everything BELOW the handle shares ONE co-operative drag so a
+                // pull that begins ANYWHERE in the sheet body — the peek summary
+                // card, its text and its 带我去 / 换一个 buttons, the sort toolbar,
+                // or the list — moves the sheet, exactly like Apple Maps / Find My.
+                // Previously the drag lived only on the inner ScrollView, so at
+                // peek (where the card sits *above* an empty ScrollView) the card
+                // could only be *tapped*, never dragged up. `contentShape` makes
+                // the padding and whitespace grabbable too, and the DragGesture's
+                // `minimumDistance: 8` still lets taps and button presses through.
+                VStack(spacing: 0) {
+                    // City OS Base card slot — only in peek. At mid/full the space
+                    // yields to the list, matching the old floating card's
+                    // `sheetDetent == .peek` gate. Horizontal padding matches the
+                    // peek summary card below (16) so the two align.
+                    if currentDetent == .peek, let peekHeaderContent {
+                        peekHeaderContent()
+                            .padding(.horizontal, 16)
+                            .padding(.top, 6)
+                    }
+                    peekContentArea
                         .padding(.horizontal, 16)
                         .padding(.top, 6)
-                }
-                peekContentArea
-                    .padding(.horizontal, 16)
-                    .padding(.top, 6)
-                // The sort/count toolbar only belongs above the *list*; in the
-                // peek state the summary card stands alone, so it is gated out.
-                if currentDetent != .peek {
-                    SortCountToolbar(count: count, isNowMode: isNowMode, sortMode: $sortMode)
-                        .padding(.horizontal, 16)
-                        .padding(.top, 8)
-                }
-                // Single unified scroll layer for every sheet section (Routes →
-                // Create-route → Nearby). The sheet header rows above (handle,
-                // peek/now-hint, toolbar) stay pinned; only the content closure
-                // scrolls. Previously this was a bare `content + Spacer`, so the
-                // Routes + Create-route rows were non-scrollable and only Nearby
-                // carried its own inner ScrollView — a long Routes list pushed
-                // Nearby off-screen with no way to scroll it back, and dragging up
-                // to mid left the route cards stuck (the user's "滑不动"). Hosting
-                // the whole closure in one ScrollView makes the sections a
-                // continuous, naturally scrollable stream (like Apple Maps / Find
-                // My) at *any* detent — mid scrolls the full list, no need to first
-                // expand to full. At .peek the closure is empty, so this is a cheap
-                // no-op.
-                ScrollView {
-                    // iOS 17-compatible scroll-offset probe. A zero-height anchor
-                    // pinned to the content top reports its minY within the
-                    // ScrollView's coordinate space: 0 when the list is at its
-                    // top, negative once scrolled down. (`onScrollGeometryChange`
-                    // would be cleaner but is iOS 18+, and the target is 17.0.)
-                    // We negate it into `listScrollOffset` so "> 0 = scrolled
-                    // down", matching the co-operative-drag ownership rule.
-                    GeometryReader { geo in
-                        Color.clear
-                            .frame(height: 0)
-                            .preference(
-                                key: ListScrollOffsetKey.self,
-                                value: geo.frame(in: .named(Self.listScrollSpace)).minY
-                            )
+                    // The sort/count toolbar only belongs above the *list*; in the
+                    // peek state the summary card stands alone, so it is gated out.
+                    if currentDetent != .peek {
+                        SortCountToolbar(count: count, isNowMode: isNowMode, sortMode: $sortMode)
+                            .padding(.horizontal, 16)
+                            .padding(.top, 8)
                     }
-                    .frame(height: 0)
+                    // Single unified scroll layer for every sheet section (Routes →
+                    // Create-route → Nearby). The sheet header rows above (handle,
+                    // peek/now-hint, toolbar) stay pinned; only the content closure
+                    // scrolls. Previously this was a bare `content + Spacer`, so the
+                    // Routes + Create-route rows were non-scrollable and only Nearby
+                    // carried its own inner ScrollView — a long Routes list pushed
+                    // Nearby off-screen with no way to scroll it back, and dragging up
+                    // to mid left the route cards stuck (the user's "滑不动"). Hosting
+                    // the whole closure in one ScrollView makes the sections a
+                    // continuous, naturally scrollable stream (like Apple Maps / Find
+                    // My) at *any* detent — mid scrolls the full list, no need to first
+                    // expand to full. At .peek the closure is empty, so this is a cheap
+                    // no-op.
+                    ScrollView {
+                        // iOS 17-compatible scroll-offset probe. A zero-height anchor
+                        // pinned to the content top reports its minY within the
+                        // ScrollView's coordinate space: 0 when the list is at its
+                        // top, negative once scrolled down. (`onScrollGeometryChange`
+                        // would be cleaner but is iOS 18+, and the target is 17.0.)
+                        // We negate it into `listScrollOffset` so "> 0 = scrolled
+                        // down", matching the co-operative-drag ownership rule.
+                        GeometryReader { geo in
+                            Color.clear
+                                .frame(height: 0)
+                                .preference(
+                                    key: ListScrollOffsetKey.self,
+                                    value: geo.frame(in: .named(Self.listScrollSpace)).minY
+                                )
+                        }
+                        .frame(height: 0)
 
-                    content(contentDetent, $sortMode)
-                        // Pin content to the top so the column never re-centres
-                        // against the viewport — without this the rows visibly
-                        // jump frame-to-frame, reading as a flicker.
-                        .frame(maxWidth: .infinity, alignment: .top)
-                        .padding(.bottom, 28 * scale)
+                        content(contentDetent, $sortMode)
+                            // Pin content to the top so the column never re-centres
+                            // against the viewport — without this the rows visibly
+                            // jump frame-to-frame, reading as a flicker.
+                            .frame(maxWidth: .infinity, alignment: .top)
+                            .padding(.bottom, 28 * scale)
+                    }
+                    .coordinateSpace(name: Self.listScrollSpace)
+                    .onPreferenceChange(ListScrollOffsetKey.self) { minY in
+                        // minY: 0 at top, negative when scrolled down. Flip sign so
+                        // `listScrollOffset > 0` means "the list has scrolled down".
+                        listScrollOffset = -minY
+                    }
+                    // With the fixed-height + offset layout, the bottom
+                    // `maxHeight − detentHeight` points of the viewport sit below
+                    // the screen edge at peek/mid. This margin extends the
+                    // scrollable range by exactly that amount so the last row can
+                    // still be scrolled up into the visible region. It changes only
+                    // on a detent settle (never per drag frame).
+                    .contentMargins(.bottom, max(0, maxHeight - detentHeight), for: .scrollContent)
+                    // Down-pull-to-refresh removed: the refresh re-ran the full
+                    // nearby POI reload + AI recompile, which the user found
+                    // meaningless during normal browsing (and it stole the downward
+                    // gesture from sheet-collapse). Downward drag now collapses the
+                    // sheet (Apple Maps behaviour) via `contentDragGesture`. The
+                    // `onRefresh` closure is retained on the API for a future
+                    // explicit refresh affordance but is no longer bound to a pull.
+                    //
+                    // Disable native scrolling while EITHER the handle is dragging or
+                    // a content-area drag has claimed the sheet, so the ScrollView
+                    // doesn't re-clamp its offset against the moving sheet and fight
+                    // the drag (flicker). Re-enabled the instant the drag ends.
+                    .scrollDisabled(isDragging || contentDragOwnsSheet == true)
+                    .scrollDismissesKeyboard(.interactively)
+                    // Show the indicator at mid/full as an affordance that more
+                    // content lies below; peek has no scroll content so it stays clean.
+                    .scrollIndicators(currentDetent == .peek ? .hidden : .automatic)
+                    // Suppress the empty bottom rubber-band when content is shorter
+                    // than the viewport, so a short list doesn't feel "loose".
+                    .scrollBounceBehavior(.basedOnSize)
                 }
-                .coordinateSpace(name: Self.listScrollSpace)
-                .onPreferenceChange(ListScrollOffsetKey.self) { minY in
-                    // minY: 0 at top, negative when scrolled down. Flip sign so
-                    // `listScrollOffset > 0` means "the list has scrolled down".
-                    listScrollOffset = -minY
-                }
-                // With the fixed-height + offset layout, the bottom
-                // `maxHeight − detentHeight` points of the viewport sit below
-                // the screen edge at peek/mid. This margin extends the
-                // scrollable range by exactly that amount so the last row can
-                // still be scrolled up into the visible region. It changes only
-                // on a detent settle (never per drag frame).
-                .contentMargins(.bottom, max(0, maxHeight - detentHeight), for: .scrollContent)
-                // Down-pull-to-refresh removed: the refresh re-ran the full
-                // nearby POI reload + AI recompile, which the user found
-                // meaningless during normal browsing (and it stole the downward
-                // gesture from sheet-collapse). Downward drag now collapses the
-                // sheet (Apple Maps behaviour) via `contentDragGesture`. The
-                // `onRefresh` closure is retained on the API for a future
-                // explicit refresh affordance but is no longer bound to a pull.
-                //
-                // Disable native scrolling while EITHER the handle is dragging or
-                // a content-area drag has claimed the sheet, so the ScrollView
-                // doesn't re-clamp its offset against the moving sheet and fight
-                // the drag (flicker). Re-enabled the instant the drag ends.
-                .scrollDisabled(isDragging || contentDragOwnsSheet == true)
-                .scrollDismissesKeyboard(.interactively)
-                // Show the indicator at mid/full as an affordance that more
-                // content lies below; peek has no scroll content so it stays clean.
-                .scrollIndicators(currentDetent == .peek ? .hidden : .automatic)
-                // Suppress the empty bottom rubber-band when content is shorter
-                // than the viewport, so a short list doesn't feel "loose".
-                .scrollBounceBehavior(.basedOnSize)
-                // Apple-Maps-style co-operative drag over the whole list area:
-                // grabbing anywhere in the content can steer the sheet, not just
-                // the handle. `simultaneousGesture` lets it coexist with the
-                // ScrollView — the ownership decision (steer sheet vs. let the
-                // list scroll) is made once per drag in `contentDragGesture`.
+                // Apple-Maps-style co-operative drag over the ENTIRE sheet body —
+                // the peek summary card, its text and buttons, the sort toolbar,
+                // AND the list — so a pull that begins anywhere steers the sheet,
+                // not just the handle. `contentShape(Rectangle())` makes the peek
+                // whitespace grabbable; `simultaneousGesture` lets the drag coexist
+                // with the inner ScrollView — the ownership decision (steer sheet
+                // vs. let the list scroll) is made once per drag in
+                // `contentDragGesture`, and its `minimumDistance: 8` still lets
+                // taps and button presses through untouched.
+                .contentShape(Rectangle())
                 .simultaneousGesture(
                     contentDragGesture(
                         detentHeight: detentHeight,

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -453,6 +453,12 @@ struct CompassMapContentView: View {
             isUserInCity: isUserInCity,
             stage: currentCityStage
         )
+        // Only write when the inference actually changes the stored mode. This
+        // runs on cold start, on every city switch, AND on every GPS fix (see
+        // the `locationService.currentLocation` onChange) — an unconditional
+        // write would churn the Observable preferences blob on every location
+        // tick, and re-render the pill + brief needlessly.
+        guard inferred != cityOSStore.mode(for: cityCode) else { return }
         cityOSStore.setMode(inferred, for: cityCode)
     }
 
@@ -1025,6 +1031,17 @@ struct CompassMapContentView: View {
             }
             .onChange(of: locationService.currentLocation) { _, _ in
                 viewModel.bindToLocation()
+                // City OS v2: the first GPS fix almost always lands AFTER
+                // cold-start inference already ran with no location — and no
+                // location resolves to Plan ("未到 · 计划"). Re-infer now that we
+                // know where the traveler actually is, so someone standing in
+                // their selected city flips Plan → Live instead of staying stuck
+                // on "未到" (the user's "我明明在广州却显示未到"). The inference is
+                // keyed off the *selected* city's centre vs. the fix, so a city
+                // deliberately picked to plan a future trip (far from the fix)
+                // correctly stays Plan; only a fix inside the selected city
+                // promotes it to Live. A finished stay stays Recall (stage gate).
+                inferAndPersistCityMode(for: viewModel.selectedCity)
             }
             // "Entering the app" isn't only a cold launch: when the process
             // survives a trip to another city, returning to the foreground


### PR DESCRIPTION
## What

Make the bottom sheet pull-up-able from **anywhere** in its body (not just the drag handle), and fix the city pill being stuck on "未到 · 计划" while the traveler is physically standing in the city.

## Why

Two issues surfaced from the attached screenshot (standing in central Guangzhou):

1. **Drag only worked on the handle / the list.** The co-operative `contentDragGesture` lived only on the inner `ScrollView`. At the `.peek` detent the summary card (此刻最值得去) and its 带我去 / 换一个 buttons sit *above* an empty `ScrollView`, so the card could only be **tapped** to expand — dragging its body, text, or buttons did nothing. The user wanted an Apple-Maps / Find-My style sheet where a pull that begins anywhere steers the sheet up to full.

2. **Pill stuck on "未到 · 计划" while in the city.** `inferAndPersistCityMode` runs on cold start, but the first GPS fix almost always lands *after* it — and no-fix resolves to `.plan`. Nothing re-inferred once the fix arrived (`onChange(of: currentLocation)` only rebound the camera), so the pill stayed "未到" even though the user was in Guangzhou.

Fixes:
- Wrap everything below the handle (peek header, peek card, sort toolbar, list) in one container and attach the drag there via `.contentShape(Rectangle()).simultaneousGesture(contentDragGesture(…))`. `minimumDistance: 8` keeps taps and button presses working; the handle keeps its own unconditional drag; the co-operative ownership rule (steer sheet vs. scroll list) is unchanged.
- Re-infer the city mode on the `currentLocation` change so `.plan` flips to `.live` when a fix places the user inside the *selected* city. Keyed off the selected city's centre, so a deliberately-planned far city stays `.plan`, and a finished stay stays `.recall`. A guard skips the write when the mode is unchanged, so the per-tick re-inference doesn't churn the persisted blob.

Closes #

## Three-pillar check

- [x] **Map-First** — sheet + pill are on the map home screen; no navigation away
- [x] **Experience-as-Unit** — no "place" / "POI" concepts introduced
- [x] **AI doesn't decide** — peek card still presents options + reasons

## Schema impact

- [x] No schema change

## Testing

- Added `BottomSheetGlobalDragGuardTest` — source-scan structural guards (SwiftUI trees can't be introspected in XCTest, matching `BottomSheetUnifiedScrollGuardTest`) asserting the drag now wraps the whole body (a `}` closes the scroll layer before `.contentShape` + `.simultaneousGesture(contentDragGesture(…))`) and that the handle keeps its own dedicated `DragGesture`.
- Existing `CityOSStoreTests` cover the unchanged pure `inferMode` logic (Live/Plan/Recall). The persist guard is a view-level no-op-on-equal change.
- Full XCTest / build run happens in `ios-ci` (macOS) after `xcodegen generate`.

## Screenshots / video

Behavioural change (drag + pill) — verify on the map home screen: drag the peek card body/text/buttons up to expand; confirm the pill reads Live once a GPS fix lands inside the selected city.

---
_Generated by [Claude Code](https://claude.ai/code/session_0199X1anCMM61Wcxy12gCoy2)_