### PR TITLE
feat(ios): live web search in chat + deep cross-compile feed + online POI search

### DIFF
--- a/apps/ios/SoloCompass.xcodeproj/project.pbxproj
+++ b/apps/ios/SoloCompass.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		03FDD2032C0B0D8B59A1EE8E /* POILoadingBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C23113554E651AA08FD2430 /* POILoadingBanner.swift */; };
 		045740DB5060EBE8D6D2EEA0 /* PendingCheckInBannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26F2087E12E63A73B812D7E /* PendingCheckInBannerTests.swift */; };
 		066FE809A43C937B7EFA7609 /* VoiceToastA11yTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A3AF5B9538F583142315C2 /* VoiceToastA11yTests.swift */; };
+		0795433F1CAF00991D18134B /* CompileProgressEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1390AAD8D1CF7F4898F86D6 /* CompileProgressEvent.swift */; };
 		0999BCD90C799F91E7F16093 /* ProactiveNudgeScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F5ED4487949F7D636C23CA4 /* ProactiveNudgeScheduler.swift */; };
 		09D620F3F748072EBF4AD680 /* AddFriendButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6435C36695377646C7ED8FC2 /* AddFriendButton.swift */; };
 		0A830B26D4A18948D16F3A42 /* Experience.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C97F8159A6FA7953D28DAB /* Experience.swift */; };
@@ -139,6 +140,7 @@
 		3B2C16B114CAAADE0862AF7B /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AF76F1B505EF8AF6EF2470 /* ShareSheet.swift */; };
 		3B98DDD4F8F717C605273209 /* AIModelRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94528EF9FE097A4F46EAA62A /* AIModelRouter.swift */; };
 		3BDFE453122F7D464FEF5490 /* TravelerNoteRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1157BB60848F9C74D7E8C14E /* TravelerNoteRecord.swift */; };
+		3BE3D3EDDE77FF7F359CCE10 /* WebSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B443064A303A430365531106 /* WebSearchService.swift */; };
 		3C5AB28556912D115AEC4AEC /* LocationPickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 052B6F076F405C203184CB88 /* LocationPickerState.swift */; };
 		3C79D606DA56C1251AD58BC3 /* LiveActivityServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C070BDAE248990A4E7909B /* LiveActivityServiceTests.swift */; };
 		3C835FCB531DC30448F763AA /* TodayStatusHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA42F14E0B63119912C00AD /* TodayStatusHeaderTests.swift */; };
@@ -189,12 +191,14 @@
 		4F85ADCAE47D7654A6A91068 /* MyRequestsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98E594C5575B41E32382209 /* MyRequestsListView.swift */; };
 		4FEA8F9301FFC1427DE6A223 /* CityBriefHealthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953772A59B51A407DC0D305C /* CityBriefHealthTests.swift */; };
 		50140E7D5FFAC2588C141A3F /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = EE5F70FDF5F3A929496EC981 /* Supabase */; };
+		50490622772219848C210D8B /* RecompileProgressStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A807E7983F3BF9461F529B6 /* RecompileProgressStoreTests.swift */; };
 		50495257AD65A0507DD43D41 /* PlacePhotoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F55E299C99F8D9916E0BA1 /* PlacePhotoStore.swift */; };
 		5148EFD1A860D54B6F1CB8CB /* ToolOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EF938F0BC8381E7CC299E57 /* ToolOutcome.swift */; };
 		51C24A88B584979BC4D534F6 /* SolarEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B922F1B566195E79BD671D85 /* SolarEventsTests.swift */; };
 		51C722DEC34CF7FD0078BC5F /* ItineraryRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741295168A3FC1A94FBDDA45 /* ItineraryRecord.swift */; };
 		520074EB0E4747FC9F2EF12B /* ChatReasoningRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E15D735F5BB23210B7753FA /* ChatReasoningRecord.swift */; };
 		52B53BDA14EBACE5242FC016 /* StopsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C6279345E826F9B01AE41C /* StopsList.swift */; };
+		530F93680E4B5E7636DF77EF /* RecompileProgressStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123F398ACF02F1B20A51EF2D /* RecompileProgressStore.swift */; };
 		533F5021295C5791D0DC9ACF /* HandleRouteStopEnteredContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3958C2A95962D2B1E731052C /* HandleRouteStopEnteredContractTests.swift */; };
 		535A676AB1ADAD1F5B525E0E /* DataSourceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89A27720E54E9354EFAE82B /* DataSourceSettingsView.swift */; };
 		53C4F7B11856CF3D1313A228 /* ColorExtensionScopeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00295FF044E4D732D1EB2EA /* ColorExtensionScopeTest.swift */; };
@@ -368,6 +372,7 @@
 		A068F103E60F3CD258FA4EE0 /* VisitTrackingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E68DE604B89070192A69118 /* VisitTrackingService.swift */; };
 		A0C1702CF2CB823849D31BE0 /* CityCodexView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7E5C099EA3546AC77EB7F1 /* CityCodexView.swift */; };
 		A12DF78B6B05519D2177A519 /* RouteCompanionForceUnwrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF2CEF9FE62124F51460453 /* RouteCompanionForceUnwrapTests.swift */; };
+		A14A300F066F16643CCE7260 /* MapKitSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7B9A4D4C5882C6C74B4AA6 /* MapKitSearchTests.swift */; };
 		A217FA55BD40922DB3B8DEE6 /* SoloScoreRadarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D557D1D0D224C725834A08D /* SoloScoreRadarChart.swift */; };
 		A27A0AE4F7DB8F93878A7127 /* CapsuleOpenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2BA43E5730BFFBB1157A75 /* CapsuleOpenView.swift */; };
 		A4528F9189C69F1292BA6006 /* TodayContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA0BCC3FA2B0DF44F1F5217 /* TodayContainerTests.swift */; };
@@ -473,6 +478,7 @@
 		C9DAF262896CB6CFBA6F97D3 /* IOS18AvailabilityGuardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFF9ECB175F4D2219406952 /* IOS18AvailabilityGuardTest.swift */; };
 		CA06289D4E0D0C24C2079B40 /* VoiceWaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0CBFD5114CC6728D6AA876 /* VoiceWaveformView.swift */; };
 		CA5A2B58111A59382070CA09 /* ClusterAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07F40CCC54EAA1037C567AF /* ClusterAnnotationView.swift */; };
+		CA8149C048484AA65178402B /* WebSearchServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29D5C0DB9E2A92A269A8A8F /* WebSearchServiceTests.swift */; };
 		CA89195562C759E6F118465B /* TodoIssueReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331B2AE74EFAD9589AF60498 /* TodoIssueReferenceTests.swift */; };
 		CB2B1A4103C7C88169CC289C /* StartupDiagnosticsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D67877E313C474E4624F0E2 /* StartupDiagnosticsServiceTests.swift */; };
 		CB7524D681F638DFD45BA1FA /* RouteShareStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EB8B6538D85C6E3641D778 /* RouteShareStyle.swift */; };
@@ -550,6 +556,7 @@
 		EDBD7B0E715165E71BC0C17D /* DiscoveredCityRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE05EF69960CBB73431A6F2F /* DiscoveredCityRecord.swift */; };
 		EE525A0C11B87F4A9E0681F3 /* TurnPlannerHeuristicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3906916B4E1FC9899BFD6916 /* TurnPlannerHeuristicTests.swift */; };
 		EE798F063BB1E59F9FB6C827 /* VoiceButtonAutoStopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31343F698EBC4D2410F48A6 /* VoiceButtonAutoStopTests.swift */; };
+		EE9FEE688D81142DC6819CFC /* RecompileFeedSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7671C3EC875C1CA145ACEA /* RecompileFeedSheet.swift */; };
 		EEDACDFBDD234C27FB186358 /* CoordinateConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC8ABD20EA5E73CF7B449B /* CoordinateConverter.swift */; };
 		EEEA71095A413286D8282F1C /* TravelerNoteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E595A6B9324B26C7FB2DBF55 /* TravelerNoteStoreTests.swift */; };
 		EF2003CC07F7787C25847BDF /* ReportIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576B08910782A58C3597E596 /* ReportIssueSheet.swift */; };
@@ -659,6 +666,7 @@
 		0BE431CB74D7AB2703998BA4 /* ComplianceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplianceService.swift; sourceTree = "<group>"; };
 		0C04A7D4DE12B98E4801D7C4 /* NowScoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowScoreTests.swift; sourceTree = "<group>"; };
 		0C6FC4A3B60FA8D9DC3A4779 /* SoloScoreRadarA11yTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloScoreRadarA11yTest.swift; sourceTree = "<group>"; };
+		0C7B9A4D4C5882C6C74B4AA6 /* MapKitSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapKitSearchTests.swift; sourceTree = "<group>"; };
 		0CB5FD37267074EF4015F95D /* ConversationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListView.swift; sourceTree = "<group>"; };
 		0E0157D30FF53B21FF31D519 /* MarkerIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerIconView.swift; sourceTree = "<group>"; };
 		0EBFA931C11A30D500343248 /* ComplianceBannerArbitrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplianceBannerArbitrationTests.swift; sourceTree = "<group>"; };
@@ -675,6 +683,7 @@
 		11CCB9E36FDC56604136090F /* IslandPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IslandPalette.swift; sourceTree = "<group>"; };
 		11F91F51C79F4EC2D9464FDA /* ExperienceImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceImageService.swift; sourceTree = "<group>"; };
 		120FC7465285714C5FA8F96D /* VoiceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceService.swift; sourceTree = "<group>"; };
+		123F398ACF02F1B20A51EF2D /* RecompileProgressStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecompileProgressStore.swift; sourceTree = "<group>"; };
 		12F087E4FA7161529378098C /* ExperienceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceService.swift; sourceTree = "<group>"; };
 		130B51007552B26F3C1D1AE0 /* PendingCheckInBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingCheckInBanner.swift; sourceTree = "<group>"; };
 		13350B81187FB64B252B8A46 /* BottomInfoBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomInfoBar.swift; sourceTree = "<group>"; };
@@ -762,6 +771,7 @@
 		3DFAB38A4600C667B8D7CD2B /* ChatHistoryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryListView.swift; sourceTree = "<group>"; };
 		3E40C49968AC6150E89CC02F /* FilterBarLabeledPillsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarLabeledPillsTest.swift; sourceTree = "<group>"; };
 		3E7AFBAAF6E42AE8043F476D /* VoiceInterruptionToastTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInterruptionToastTest.swift; sourceTree = "<group>"; };
+		3F7671C3EC875C1CA145ACEA /* RecompileFeedSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecompileFeedSheet.swift; sourceTree = "<group>"; };
 		402644EEDBCD7DD3658E6DD5 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		405A56207920EA0DDADF8FC5 /* CompanionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionRequest.swift; sourceTree = "<group>"; };
 		409FB4B0922C4A1D8AAEB1D1 /* FeatureFlags.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = FeatureFlags.plist; sourceTree = "<group>"; };
@@ -904,6 +914,7 @@
 		7989FA184B0EFCE68C961241 /* ChatCardViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCardViews.swift; sourceTree = "<group>"; };
 		79B73212B8F704EABD27EF5B /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
 		7A6F9AAA8749FA23B91F7C93 /* ReviewsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsServiceTests.swift; sourceTree = "<group>"; };
+		7A807E7983F3BF9461F529B6 /* RecompileProgressStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecompileProgressStoreTests.swift; sourceTree = "<group>"; };
 		7AB6DC54C82CAD121880FE2D /* UrgencyPulse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrgencyPulse.swift; sourceTree = "<group>"; };
 		7B2B85A119750C65697903E0 /* CustomCityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCityStore.swift; sourceTree = "<group>"; };
 		7B88A8CA4BEE6CDF6D7C5DEF /* RouteCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCard.swift; sourceTree = "<group>"; };
@@ -1010,11 +1021,13 @@
 		A00295FF044E4D732D1EB2EA /* ColorExtensionScopeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtensionScopeTest.swift; sourceTree = "<group>"; };
 		A023CA792B79697E2C3AC068 /* TodayNewHomeBannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayNewHomeBannerTests.swift; sourceTree = "<group>"; };
 		A02DB2C9C0BC30785E0A80F3 /* LockScreenLiveActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenLiveActivityView.swift; sourceTree = "<group>"; };
+		A1390AAD8D1CF7F4898F86D6 /* CompileProgressEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompileProgressEvent.swift; sourceTree = "<group>"; };
 		A1F76E8EBB87A2F70FEA1BB0 /* ExploreCacheRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreCacheRecord.swift; sourceTree = "<group>"; };
 		A2385BA37D345462C9E216F0 /* InteractionTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionTracker.swift; sourceTree = "<group>"; };
 		A250916F91C8EF0BE90DF763 /* ExperienceRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceRepository.swift; sourceTree = "<group>"; };
 		A25BADDFAE88472DEA796890 /* BlindboxLaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlindboxLaunchView.swift; sourceTree = "<group>"; };
 		A267CD0DA0A8053B0AB072BC /* PrivacyAcknowledgementSheetSnapshotTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyAcknowledgementSheetSnapshotTest.swift; sourceTree = "<group>"; };
+		A29D5C0DB9E2A92A269A8A8F /* WebSearchServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchServiceTests.swift; sourceTree = "<group>"; };
 		A2BE90CD51D94B3FEE2F5AFA /* CompanionReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionReport.swift; sourceTree = "<group>"; };
 		A3735B2091D64BD44C91D277 /* user_stories.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = user_stories.json; sourceTree = "<group>"; };
 		A3CCA6D836F4636724C8E31C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -1056,6 +1069,7 @@
 		B3F5D58C93D87AC9205148CC /* Itinerary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Itinerary.swift; sourceTree = "<group>"; };
 		B418AD0352AC3402D6609E4C /* SkeletonBadgeViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonBadgeViewTests.swift; sourceTree = "<group>"; };
 		B431F5042572370E6726FF82 /* GenerateTasteProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateTasteProfileTests.swift; sourceTree = "<group>"; };
+		B443064A303A430365531106 /* WebSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchService.swift; sourceTree = "<group>"; };
 		B45554ECBB3B42D14E6CCE7B /* POISourceConformances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POISourceConformances.swift; sourceTree = "<group>"; };
 		B5878CFB62925A4FC8B25D40 /* CityExperienceFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityExperienceFetcher.swift; sourceTree = "<group>"; };
 		B5C6E142FB1F81390D163CC2 /* TravelerNotesSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelerNotesSection.swift; sourceTree = "<group>"; };
@@ -1281,6 +1295,7 @@
 				8509E525DD268E88ED3AD4FD /* LocationCard.swift */,
 				85591C678C692990339095E9 /* MarkdownShareSheet.swift */,
 				2DA6E405C780A5A12A9FC1D6 /* MicroSurveySheet.swift */,
+				3F7671C3EC875C1CA145ACEA /* RecompileFeedSheet.swift */,
 				576B08910782A58C3597E596 /* ReportIssueSheet.swift */,
 				B5C6E142FB1F81390D163CC2 /* TravelerNotesSection.swift */,
 				B99BC58510B4AF3E9B9E8377 /* Share */,
@@ -1473,6 +1488,7 @@
 				88863482E2CD46BBE315B59D /* LocationErrorSurfaceTests.swift */,
 				340D914D24038F4A380B008C /* LocationServiceTests.swift */,
 				F494ACF8BB53CF5EEB1D4FB8 /* MapDensityLODTests.swift */,
+				0C7B9A4D4C5882C6C74B4AA6 /* MapKitSearchTests.swift */,
 				792E683DA00FBA63A77161A3 /* MapTopOverlayRenderTest.swift */,
 				FFC5559A4AAF4E3CD77E38B6 /* MapViewModelCityCacheTests.swift */,
 				48FF87CCF00DEEE87B290812 /* MapViewModelCityRegionSyncTests.swift */,
@@ -1519,6 +1535,7 @@
 				14392FEFAE7F1E9596DCCA53 /* PushTokenServiceTests.swift */,
 				BBC81B5C5F0F7BD46D31483F /* RecallMemoryLiveIntegrationTests.swift */,
 				AEFAE8B83CF381DAF5FF64E0 /* RecallMemoryToolTests.swift */,
+				7A807E7983F3BF9461F529B6 /* RecompileProgressStoreTests.swift */,
 				7A6F9AAA8749FA23B91F7C93 /* ReviewsServiceTests.swift */,
 				07C8EE9D6C64872261609DEF /* RouteBuilderTests.swift */,
 				6D31F422914779D9228B0278 /* RouteCardNowReasonTests.swift */,
@@ -1589,6 +1606,7 @@
 				E536D4CFF44CF4CEFD1EFF4F /* WeatherCacheTTLTests.swift */,
 				C0F20A91F36C7CA4041BEEC9 /* WeatherServiceTests.swift */,
 				672C97E1FBA4FEF7EE87D59B /* WeatherSignalTests.swift */,
+				A29D5C0DB9E2A92A269A8A8F /* WebSearchServiceTests.swift */,
 				F9BD2D777F3A487C7C211E7E /* ZhHansPunctuationTest.swift */,
 				31C755D99D3C5CA318357B6C /* fixtures */,
 			);
@@ -1740,6 +1758,7 @@
 				A2BE90CD51D94B3FEE2F5AFA /* CompanionReport.swift */,
 				405A56207920EA0DDADF8FC5 /* CompanionRequest.swift */,
 				8C1DD2BA0AF4E693B9E36F90 /* CompiledPlace.swift */,
+				A1390AAD8D1CF7F4898F86D6 /* CompileProgressEvent.swift */,
 				B9864D3AA45FA7D5ADC4D2ED /* Conversation.swift */,
 				C1C97F8159A6FA7953D28DAB /* Experience.swift */,
 				8D38CFDF2B9D4C92F3954DA0 /* ExperienceFilter.swift */,
@@ -1843,6 +1862,7 @@
 				7F5ED4487949F7D636C23CA4 /* ProactiveNudgeScheduler.swift */,
 				A582931FC4E74C77DA1DEEA2 /* ProvisionalCardLedger.swift */,
 				A6F061EC88D5CC60CDEE2515 /* PushTokenService.swift */,
+				123F398ACF02F1B20A51EF2D /* RecompileProgressStore.swift */,
 				64BDF8B4B7CC82F3845C5068 /* ReverseGeocodeService.swift */,
 				746139AC01A1D37CE002BFCF /* ReviewsService.swift */,
 				D60647FA4E64B48E215B9D2F /* RouteCompanionRemote.swift */,
@@ -1869,6 +1889,7 @@
 				20208D92E4F564C474E8AEED /* VoiceAgentToolRouter.swift */,
 				120FC7465285714C5FA8F96D /* VoiceService.swift */,
 				78404BD902D3A518F5C8730D /* WeatherService.swift */,
+				B443064A303A430365531106 /* WebSearchService.swift */,
 				7A49D3BA616DE54B8E6F4B7C /* Agents */,
 				CD349A8744520E6EB084B41A /* Cache */,
 				4889864C3C5478D1001C73B3 /* Context */,
@@ -2475,6 +2496,7 @@
 				A58C50A2BB9BDBD2919E9D2F /* LocationErrorSurfaceTests.swift in Sources */,
 				AABC7AE2FEE9FD5C2ABC41BB /* LocationServiceTests.swift in Sources */,
 				22DC23D3CB176D63BC30DA01 /* MapDensityLODTests.swift in Sources */,
+				A14A300F066F16643CCE7260 /* MapKitSearchTests.swift in Sources */,
 				E5A671C7D6965762EEE8A93A /* MapTopOverlayRenderTest.swift in Sources */,
 				AEDEF3D7DC245681904D3469 /* MapViewModelCityCacheTests.swift in Sources */,
 				53FB06EED514C3F3C7CB43E1 /* MapViewModelCityRegionSyncTests.swift in Sources */,
@@ -2521,6 +2543,7 @@
 				7DBE0CBB02CBB7565A230BA4 /* PushTokenServiceTests.swift in Sources */,
 				EA1A96639D6FE4B3BAACC547 /* RecallMemoryLiveIntegrationTests.swift in Sources */,
 				38D2C70BD257E87E3A874202 /* RecallMemoryToolTests.swift in Sources */,
+				50490622772219848C210D8B /* RecompileProgressStoreTests.swift in Sources */,
 				49C48BE7027B3D172A0BD9B1 /* ReviewsServiceTests.swift in Sources */,
 				3E92704051F386C38C3A5533 /* RouteBuilderTests.swift in Sources */,
 				2EC741296992D9D0A4F3077D /* RouteCardNowReasonTests.swift in Sources */,
@@ -2591,6 +2614,7 @@
 				85C233AB7998521788B2BB5F /* WeatherCacheTTLTests.swift in Sources */,
 				CD74E5E501088F7BECA74FBC /* WeatherServiceTests.swift in Sources */,
 				D51532D17022F9004544FFF3 /* WeatherSignalTests.swift in Sources */,
+				CA8149C048484AA65178402B /* WebSearchServiceTests.swift in Sources */,
 				24A47D8F35DD718BD74601F6 /* ZhHansPunctuationTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2683,6 +2707,7 @@
 				1917588F1289C48C928ACF6C /* CompanionService.swift in Sources */,
 				337CAFC8B35CF36D175B27CF /* CompareTokens.swift in Sources */,
 				C21906307DCC96E5B2583BFE /* CompassMapView.swift in Sources */,
+				0795433F1CAF00991D18134B /* CompileProgressEvent.swift in Sources */,
 				EF7C549F31EDA5ABE2B95FE8 /* CompiledPlace.swift in Sources */,
 				A93EEDF38B969D10CC369C59 /* CompletionCelebrationView.swift in Sources */,
 				89E009AABEDECE319C331924 /* CompletionMoment.swift in Sources */,
@@ -2849,6 +2874,8 @@
 				CDFE61514D60EAC16659A119 /* PushTokenService.swift in Sources */,
 				C4FE64920461E93F76D76919 /* QRScannerView.swift in Sources */,
 				9C8CC563D33FDBB3DF57A841 /* RecentExploreRegion.swift in Sources */,
+				EE9FEE688D81142DC6819CFC /* RecompileFeedSheet.swift in Sources */,
+				530F93680E4B5E7636DF77EF /* RecompileProgressStore.swift in Sources */,
 				76F57DBD1B6F0020E8BF91E5 /* RecruitingModule.swift in Sources */,
 				6BDE2B5BBBFDFB98C3A12BE4 /* ReportBlockSheet.swift in Sources */,
 				EF2003CC07F7787C25847BDF /* ReportIssueSheet.swift in Sources */,
@@ -2950,6 +2977,7 @@
 				C985528978123590367E30EB /* WeatherService.swift in Sources */,
 				95960204376DC82FBC3EBB9D /* WeatherSignal.swift in Sources */,
 				5544DD796A2D4987A7CB9DC9 /* WebSearchEnrichmentSource.swift in Sources */,
+				3BE3D3EDDE77FF7F359CCE10 /* WebSearchService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/SoloCompass/Models/ChatCard.swift
+++ b/apps/ios/SoloCompass/Models/ChatCard.swift
@@ -25,12 +25,17 @@ public enum ChatCard: Identifiable, Equatable {
     /// Rendered as a stack of `ChatEventCard`s; tapping "在地图上看" jumps to
     /// the event on the map.
     case events(id: UUID, [CityEvent])
+    /// Live web-search sources the agent cited (via `web_search`). Rendered as
+    /// a compact list of tappable source-link cards (title + host) beneath the
+    /// grounded answer — Perplexity-style provenance. Tapping opens the URL.
+    case webSources(id: UUID, [WebSearchResult])
 
     public var id: UUID {
         switch self {
         case let .experiences(id, _): return id
         case let .route(id, _): return id
         case let .events(id, _): return id
+        case let .webSources(id, _): return id
         }
     }
 

--- a/apps/ios/SoloCompass/Models/CompileProgressEvent.swift
+++ b/apps/ios/SoloCompass/Models/CompileProgressEvent.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// One line in the deep cross-compile feed. The recompile pipeline is an AI
+/// agent loop that fans out across several POI providers, ranks, backfills, and
+/// synthesizes — but until now all of that ran behind a single spinner, so a
+/// tap that found nothing looked identical to a tap that was still working.
+///
+/// A `CompileProgressEvent` makes each stage of that loop *visible*: which
+/// source is being queried, how many signals it returned, whether it succeeded,
+/// was skipped (no key / not applicable), or failed. The feed sheet renders
+/// these in order, so the user watches the agent think instead of staring at a
+/// spinner that may or may not resolve.
+public struct CompileProgressEvent: Identifiable, Equatable, Sendable {
+    /// The distinct stages of the enrichment loop, in pipeline order. Used to
+    /// pick an icon and a human label; the `detail` string carries specifics.
+    public enum Stage: String, Sendable {
+        case start            // "Deep cross-compile started"
+        case amap             // Amap POIs (mainland China authoritative)
+        case mapKit           // Apple MapKit POIs
+        case overpass         // OpenStreetMap / Overpass
+        case foursquare       // Foursquare hard signals (rating/hours/price)
+        case ranking          // Signal-richness ranking, top-N cut
+        case address          // Reverse-geocode street-address backfill
+        case synthesis        // AI synthesis of the enriched, ranked POIs
+        case webVerify        // Web-search verification of objective fields
+        case adopt            // Quality/identity gate before replacing the card
+        case done             // Terminal success
+        case failed           // Terminal failure / no upgrade found
+    }
+
+    /// How a stage resolved. Drives the row's color and glyph in the feed:
+    /// running = spinner, success = green ✓, skipped = muted dash, failure = red ✗.
+    public enum Status: String, Sendable {
+        case running
+        case success
+        case skipped
+        case failure
+    }
+
+    public let id: UUID
+    public let stage: Stage
+    public var status: Status
+    /// Human-readable specifics for this line — a count, a provider name, or a
+    /// reason for a skip/failure. Kept short; the stage supplies the verb.
+    public var detail: String
+
+    public init(
+        id: UUID = UUID(),
+        stage: Stage,
+        status: Status,
+        detail: String = ""
+    ) {
+        self.id = id
+        self.stage = stage
+        self.status = status
+        self.detail = detail
+    }
+}

--- a/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/en.lproj/Localizable.strings
@@ -603,6 +603,7 @@
 "search.experiences.placeholder" = "Search experiences";
 "search.clear" = "Clear search";
 "search.empty.title" = "No results for \"%@\"";
+"search.web.cta" = "Search the map for \"%@\"";
 "favorites.search.noResults" = "No matches for \"%@\"";
 "favorites.search.noResults.hint" = "Try a different word, or clear your search.";
 /* VoiceOver announcement when favorites search returns results: "%d matching favorites" */
@@ -746,6 +747,37 @@
 "recompile.inProgress" = "Cross-compiling…";
 "recompile.toast.success" = "Upgraded with cross-source detail";
 "recompile.toast.noChange" = "Already as detailed as we can get this one";
+
+// Deep cross-compile live feed sheet
+"recompile.feed.title" = "Deep cross-compile";
+"recompile.feed.subtitle" = "Cross-referencing multiple sources…";
+"recompile.feed.working" = "Working…";
+"recompile.feed.upgraded" = "Upgraded with richer cross-source detail.";
+"recompile.feed.noChange" = "Nothing richer was found — the card is unchanged.";
+"recompile.feed.poiCount" = "%d places found";
+"recompile.feed.signalCount" = "%d rich signals";
+"recompile.feed.keptCount" = "Kept the top %d";
+"recompile.feed.noPOIs" = "No places found nearby";
+"recompile.feed.noKey" = "No API key — skipped";
+"recompile.feed.noAI" = "AI unavailable — used local ranking";
+"recompile.feed.noCoordinate" = "This place has no coordinate to compile around";
+"recompile.feed.pipelineError" = "Something went wrong fetching data";
+"recompile.feed.noMatch" = "No matching venue nearby";
+"recompile.feed.skeletonOnly" = "Only basic data available — not an upgrade";
+"recompile.feed.rejected" = "Closest match was a different venue or lower quality";
+// Cross-compile stage labels
+"recompile.stage.start" = "Deep cross-compile started";
+"recompile.stage.amap" = "Querying Amap (AutoNavi)";
+"recompile.stage.mapKit" = "Querying Apple Maps";
+"recompile.stage.overpass" = "Querying OpenStreetMap";
+"recompile.stage.foursquare" = "Folding in Foursquare signals";
+"recompile.stage.ranking" = "Ranking by signal richness";
+"recompile.stage.address" = "Backfilling street addresses";
+"recompile.stage.synthesis" = "Synthesizing with AI";
+"recompile.stage.webVerify" = "Verifying details on the web";
+"recompile.stage.adopt" = "Matching to this place";
+"recompile.stage.done" = "Done";
+"recompile.stage.failed" = "Finished";
 "explore.aiBadge" = "AI-generated · OpenStreetMap";
 "explore.osmBadge" = "OpenStreetMap · not enriched";
 "trustBadge.verified" = "%d sources";
@@ -910,6 +942,7 @@
 "agent.step.save" = "❤️ Saving to favorites…";
 "agent.step.dismiss" = "✕ Dismissing…";
 "agent.step.search" = "🔍 Searching places…";
+"agent.step.webSearch" = "🌐 Searching the web…";
 "agent.step.navigate" = "🗺 Opening navigation…";
 "agent.step.buildRoute" = "🧭 Stringing a route together…";
 "agent.step.executing" = "⚙️ Executing…";
@@ -918,6 +951,11 @@
 "agent.trace.foundPlaces" = "Found %d place(s) that fit";
 "agent.trace.builtRoute" = "Strung %d stops into a walk";
 "agent.trace.foundEvents" = "Found %d local event(s)";
+"agent.trace.foundSources" = "Cited %d web source(s)";
+
+/* Web-search source cards (in-chat provenance) */
+"chat.sources.title" = "Sources";
+"chat.sources.a11y" = "Source %1$d: %2$@, from %3$@";
 "chat.thinking.title" = "Thinking it through";
 "chat.thinking.a11y" = "Solo Compass is thinking";
 
@@ -1463,6 +1501,7 @@
 "action.ok" = "OK";
 "action.cancel" = "Cancel";
 "action.done" = "Done";
+"action.hide" = "Hide";
 
 /* ============================================================
  * Companion Hub — entry point on the map

--- a/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/SoloCompass/Resources/zh-Hans.lproj/Localizable.strings
@@ -417,6 +417,37 @@
 "recompile.inProgress" = "交叉编译中…";
 "recompile.toast.success" = "已用多来源信息升级";
 "recompile.toast.noChange" = "这个地点已经尽可能详细了";
+
+// 深度交叉编译实时 feed 弹窗
+"recompile.feed.title" = "深度交叉编译";
+"recompile.feed.subtitle" = "正在交叉比对多个来源…";
+"recompile.feed.working" = "处理中…";
+"recompile.feed.upgraded" = "已用更丰富的多来源信息升级。";
+"recompile.feed.noChange" = "没有找到更丰富的信息——卡片保持不变。";
+"recompile.feed.poiCount" = "找到 %d 个地点";
+"recompile.feed.signalCount" = "%d 条丰富信号";
+"recompile.feed.keptCount" = "保留信号最丰富的 %d 个";
+"recompile.feed.noPOIs" = "附近没有找到地点";
+"recompile.feed.noKey" = "未配置 API 密钥——已跳过";
+"recompile.feed.noAI" = "AI 不可用——改用本地排序";
+"recompile.feed.noCoordinate" = "这个地点没有坐标,无法交叉编译";
+"recompile.feed.pipelineError" = "获取数据时出错";
+"recompile.feed.noMatch" = "附近没有匹配的地点";
+"recompile.feed.skeletonOnly" = "只有基础数据——算不上升级";
+"recompile.feed.rejected" = "最近的匹配是另一个地点或质量更低";
+// 交叉编译各阶段标签
+"recompile.stage.start" = "深度交叉编译已开始";
+"recompile.stage.amap" = "正在查询高德地图";
+"recompile.stage.mapKit" = "正在查询苹果地图";
+"recompile.stage.overpass" = "正在查询 OpenStreetMap";
+"recompile.stage.foursquare" = "正在融合 Foursquare 信号";
+"recompile.stage.ranking" = "按信号丰富度排序";
+"recompile.stage.address" = "正在回填街道地址";
+"recompile.stage.synthesis" = "正在用 AI 合成";
+"recompile.stage.webVerify" = "正在联网核实细节";
+"recompile.stage.adopt" = "正在匹配到这个地点";
+"recompile.stage.done" = "完成";
+"recompile.stage.failed" = "已结束";
 "explore.aiBadge" = "AI 生成 · 来自 OpenStreetMap";
 "explore.osmBadge" = "来自 OpenStreetMap · 未增强";
 "trustBadge.verified" = "%d 源确认";
@@ -1037,7 +1068,12 @@
 "agent.trace.foundPlaces" = "找到 %d 个合适的地方";
 "agent.trace.builtRoute" = "把 %d 个站点串成了一条路线";
 "agent.trace.foundEvents" = "找到 %d 场在地活动";
+"agent.trace.foundSources" = "引用了 %d 个网页来源";
 "chat.thinking.title" = "正在思考";
+
+/* Web 搜索来源卡片(聊天内溯源) */
+"chat.sources.title" = "来源";
+"chat.sources.a11y" = "来源 %1$d:%2$@,来自 %3$@";
 "chat.thinking.a11y" = "Solo Compass 正在思考";
 "agent.trace.summary.steps" = "推理了 %d 步";
 "agent.trace.summary.thought" = "已想清楚";
@@ -1062,6 +1098,7 @@
 "chat.route.stops" = "%1$d 站 · %2$@";
 "agent.step.save" = "❤️ 收藏中…";
 "agent.step.search" = "🔍 搜索地点…";
+"agent.step.webSearch" = "🌐 联网搜索中…";
 "agent.step.showDetails" = "📍 查看详情…";
 "agent.step.thinking" = "思考中…";
 
@@ -1256,6 +1293,7 @@
 "search.experiences.placeholder" = "搜索体验";
 "search.clear" = "清除搜索";
 "search.empty.title" = "没有\"%@\"的结果";
+"search.web.cta" = "在地图上搜索\"%@\"";
 "favorites.search.noResults" = "没有\"%@\"的匹配结果";
 "favorites.search.noResults.hint" = "换个词试试，或清空搜索。";
 "favorites.search.prompt" = "搜索收藏";
@@ -1950,6 +1988,7 @@
 
 /* Actions */
 "action.done" = "完成";
+"action.hide" = "隐藏";
 "action.favorited" = "已收藏";
 "action.notFavorited" = "未收藏";
 

--- a/apps/ios/SoloCompass/Services/Agents/EnrichmentAgent.swift
+++ b/apps/ios/SoloCompass/Services/Agents/EnrichmentAgent.swift
@@ -25,6 +25,16 @@ import os
 public final class EnrichmentAgent {
     private static let logger = Logger(subsystem: "com.solocompass", category: "EnrichmentAgent")
 
+    /// Progress callback fired at each stage of the enrichment loop so a UI can
+    /// render a live feed instead of an opaque spinner. Always invoked on the
+    /// main actor. Optional — passing `nil` (the default) keeps the silent path
+    /// for background auto-upgrades and tests.
+    public typealias ProgressHandler = @MainActor (
+        CompileProgressEvent.Stage,
+        CompileProgressEvent.Status,
+        String
+    ) -> Void
+
     /// Default search radius. Deliberately small — the whole point is depth
     /// over breadth. Callers can widen it for a sparse area.
     public static let defaultRadiusMeters = 800
@@ -265,28 +275,48 @@ public final class EnrichmentAgent {
         category: ExperienceCategory? = nil,
         cityCode: String,
         locale: Locale = .current,
-        topN: Int = EnrichmentAgent.defaultTopN
+        topN: Int = EnrichmentAgent.defaultTopN,
+        onProgress: ProgressHandler? = nil
     ) async throws -> [Experience] {
+        // Which base provider is authoritative here — reported to the feed so
+        // the user sees "Amap" in China vs "OpenStreetMap" overseas.
+        let inCN = CoordinateConverter.isInsideChinaMainland(coordinate)
+        let baseStage: CompileProgressEvent.Stage =
+            (inCN && amapService != nil && DataSourceSettings.policy.allowsAmap) ? .amap : .overpass
+
         // 1. Base collection, routed by region: Amap inside mainland China
         //    (authoritative there), Overpass overseas / on fallback. MapKit is
         //    folded in best-effort. Returns WGS84 regardless of source.
+        onProgress?(baseStage, .running, "")
+        onProgress?(.mapKit, .running, "")
         var pois = try await basePOIs(
             near: coordinate, radiusMeters: radiusMeters, category: category
         )
-        guard !pois.isEmpty else { return [] }
+        guard !pois.isEmpty else {
+            onProgress?(baseStage, .failure, NSLocalizedString("recompile.feed.noPOIs", comment: "No POIs found nearby"))
+            onProgress?(.mapKit, .failure, "")
+            return []
+        }
+        onProgress?(baseStage, .success, String(format: NSLocalizedString("recompile.feed.poiCount", comment: "N places found"), pois.count))
+        onProgress?(.mapKit, .success, "")
 
         // 2. Fold Foursquare hard signals into the matching base POIs. One
         //    region call (with fields) covers the whole small radius. Skipped
         //    when no key is configured.
         if !Secrets.resolvedFoursquareKey.isEmpty {
+            onProgress?(.foursquare, .running, "")
             do {
                 let fsq = try await foursquareService.fetchPOIs(
                     near: coordinate, radiusMeters: radiusMeters, category: category
                 )
                 pois = FoursquareService.enrichMerge(base: pois, enrichment: fsq)
+                onProgress?(.foursquare, .success, String(format: NSLocalizedString("recompile.feed.signalCount", comment: "N signals"), fsq.count))
             } catch {
                 Self.logger.error("Foursquare enrichment failed: \(String(describing: error), privacy: .public)")
+                onProgress?(.foursquare, .failure, "")
             }
+        } else {
+            onProgress?(.foursquare, .skipped, NSLocalizedString("recompile.feed.noKey", comment: "No API key configured"))
         }
 
         // 3. Fold the ephemeral Amap enrichment channel (rating / hours /
@@ -299,17 +329,31 @@ public final class EnrichmentAgent {
         pois = foldAmapEnrichments(into: pois)
 
         // 4. Rank by signal richness (now rating-aware), keep the deepest N.
+        onProgress?(.ranking, .running, "")
         let ranked = Array(
             pois.sorted { Self.signalScore($0) > Self.signalScore($1) }.prefix(topN)
         )
+        onProgress?(.ranking, .success, String(format: NSLocalizedString("recompile.feed.keptCount", comment: "kept top N"), ranked.count))
 
         // 5. Backfill a street-level address on survivors missing one.
+        onProgress?(.address, .running, "")
         let enriched = await backfillAddresses(ranked)
+        onProgress?(.address, .success, "")
 
         // 6. Synthesize. The (already-relaxed) prompt cites the real signals.
-        return try await aiService.synthesizeExperiences(
+        onProgress?(.synthesis, .running, "")
+        let synthesized = try await aiService.synthesizeExperiences(
             from: enriched, cityCode: cityCode, locale: locale
         )
+        // Honest signal: an AI-enriched result means the model actually ran; a
+        // pure skeleton (no key / quota) leaves `isAIEnriched` false everywhere.
+        let didSynthesize = synthesized.contains { $0.isAIEnriched }
+        onProgress?(
+            .synthesis,
+            didSynthesize ? .success : .skipped,
+            didSynthesize ? "" : NSLocalizedString("recompile.feed.noAI", comment: "AI unavailable, used local ranking")
+        )
+        return synthesized
     }
 
     // MARK: - Single-entry Re-compile
@@ -327,9 +371,13 @@ public final class EnrichmentAgent {
     public func recompile(
         experience: Experience,
         radiusMeters: Int = EnrichmentAgent.recompileRadiusMeters,
-        locale: Locale = .current
+        locale: Locale = .current,
+        onProgress: ProgressHandler? = nil
     ) async -> Experience? {
-        guard let coordinate = experience.coordinate else { return nil }
+        guard let coordinate = experience.coordinate else {
+            onProgress?(.adopt, .failure, NSLocalizedString("recompile.feed.noCoordinate", comment: "Place has no coordinate"))
+            return nil
+        }
 
         let candidates: [Experience]
         do {
@@ -339,10 +387,12 @@ public final class EnrichmentAgent {
                 category: experience.category,
                 cityCode: experience.location.cityCode,
                 locale: locale,
-                topN: EnrichmentAgent.recompileTopN
+                topN: EnrichmentAgent.recompileTopN,
+                onProgress: onProgress
             )
         } catch {
             Self.logger.error("Re-compile failed for \(experience.id, privacy: .public): \(String(describing: error), privacy: .public)")
+            onProgress?(.adopt, .failure, NSLocalizedString("recompile.feed.pipelineError", comment: "Pipeline error"))
             return nil
         }
 
@@ -359,21 +409,30 @@ public final class EnrichmentAgent {
             }
             .min { $0.1 < $1.1 }
 
-        guard let (enrichedMatch, matchDistance) = best else { return nil }
+        guard let (enrichedMatch, matchDistance) = best else {
+            onProgress?(.adopt, .failure, NSLocalizedString("recompile.feed.noMatch", comment: "No matching venue nearby"))
+            return nil
+        }
 
         // Only return an upgrade if it actually went through AI synthesis with
         // real cross-source signals. A skeleton fallback is not an upgrade.
-        guard enrichedMatch.isAIEnriched else { return nil }
+        guard enrichedMatch.isAIEnriched else {
+            onProgress?(.adopt, .failure, NSLocalizedString("recompile.feed.skeletonOnly", comment: "Only skeleton data, not an upgrade"))
+            return nil
+        }
 
+        onProgress?(.adopt, .running, "")
         guard Self.shouldAdoptRecompiled(
             original: experience,
             candidate: enrichedMatch,
             distanceMeters: matchDistance
         ) else {
             Self.logger.info("Re-compile match rejected for \(experience.id, privacy: .public): different venue or lower quality")
+            onProgress?(.adopt, .failure, NSLocalizedString("recompile.feed.rejected", comment: "Different venue or lower quality"))
             return nil
         }
 
+        onProgress?(.adopt, .success, "")
         return experience.adoptingContent(of: enrichedMatch)
     }
 

--- a/apps/ios/SoloCompass/Services/MapKitPOIService.swift
+++ b/apps/ios/SoloCompass/Services/MapKitPOIService.swift
@@ -74,6 +74,59 @@ public final class MapKitPOIService {
         return response.mapItems.compactMap { Self.poi(from: $0) }
     }
 
+    /// Free-text POI search — the missing piece the local card filter can't do.
+    ///
+    /// `MKLocalPointsOfInterestRequest` (used by `fetchPOIs`) can only return
+    /// "everything of category X near a point"; it takes no query string. To
+    /// answer "find me izakayas" the user must be able to *type* — that's what
+    /// `MKLocalSearch.Request.naturalLanguageQuery` is for. We bias the results
+    /// toward the user's current map region so "coffee" surfaces nearby cafes
+    /// rather than a city across the country.
+    ///
+    /// Best-effort: an empty MapKit result (which surfaces as an `MKError` on
+    /// some OS versions) degrades to `[]` rather than throwing, so the caller
+    /// can render an honest "no results" state instead of an error banner.
+    ///
+    /// - Parameters:
+    ///   - query: The raw, user-typed search string. Whitespace-trimmed here;
+    ///     an empty query short-circuits to `[]` (no wasted network call).
+    ///   - coordinate: Center of the region to bias results toward.
+    ///   - radiusMeters: Half-span of the search region (default 20 km — wide
+    ///     enough to cover a city, tight enough to stay locally relevant).
+    public func search(
+        query: String,
+        near coordinate: CLLocationCoordinate2D,
+        radiusMeters: Int = 20_000
+    ) async throws -> [OverpassService.POI] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        isFetching = true
+        defer { isFetching = false }
+
+        let request = MKLocalSearch.Request()
+        request.naturalLanguageQuery = trimmed
+        request.region = MKCoordinateRegion(
+            center: coordinate,
+            latitudinalMeters: CLLocationDistance(radiusMeters * 2),
+            longitudinalMeters: CLLocationDistance(radiusMeters * 2)
+        )
+
+        let search = MKLocalSearch(request: request)
+        let response: MKLocalSearch.Response
+        do {
+            response = try await search.start()
+        } catch {
+            let ns = error as NSError
+            if ns.domain == MKError.errorDomain {
+                return []
+            }
+            throw MapKitPOIError.searchFailed(String(describing: error))
+        }
+
+        return response.mapItems.compactMap { Self.poi(from: $0) }
+    }
+
     // MARK: - Mapping
 
     /// Convert an `MKMapItem` into an `OverpassService.POI`. Returns nil when

--- a/apps/ios/SoloCompass/Services/RecompileProgressStore.swift
+++ b/apps/ios/SoloCompass/Services/RecompileProgressStore.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Observation
+
+/// Live feed backing the deep cross-compile sheet. The `EnrichmentAgent` emits
+/// `CompileProgressEvent`s as it walks the loop; this store collects them so the
+/// SwiftUI sheet can render the running trace and its terminal outcome.
+///
+/// One store instance drives one sheet presentation. `MapViewModel` owns it and
+/// hands the agent a `@MainActor` callback that appends here. Because both the
+/// callback and the UI live on the main actor, no synchronization is needed.
+@MainActor
+@Observable
+public final class RecompileProgressStore {
+    /// The ordered feed. Newest events are appended to the end; the sheet
+    /// scrolls to follow the tail.
+    public private(set) var events: [CompileProgressEvent] = []
+
+    /// The place being compiled — drives the sheet's title. Set when a run
+    /// begins so the sheet can show "Compiling <name>" before any event lands.
+    public private(set) var placeName: String = ""
+
+    /// True while the loop is still running. The sheet keeps its dismiss button
+    /// disabled-looking (but never traps the user) and shows the tail spinner
+    /// only while this holds.
+    public private(set) var isRunning: Bool = false
+
+    /// Set once the loop reaches a terminal stage. `nil` while running.
+    /// `true` = the card was upgraded; `false` = finished with no richer result.
+    public private(set) var didUpgrade: Bool?
+
+    public init() {}
+
+    /// Begin a fresh run for `placeName`, clearing any prior feed. Idempotent
+    /// per presentation — callers reset before each recompile.
+    public func begin(placeName: String) {
+        self.placeName = placeName
+        events = [CompileProgressEvent(stage: .start, status: .running)]
+        isRunning = true
+        didUpgrade = nil
+    }
+
+    /// Append a new event to the feed. This is the entry point the agent's
+    /// progress callback funnels into.
+    public func emit(_ event: CompileProgressEvent) {
+        events.append(event)
+    }
+
+    /// Convenience wrapper matching the agent callback signature.
+    public func emit(_ stage: CompileProgressEvent.Stage,
+                     _ status: CompileProgressEvent.Status,
+                     _ detail: String = "") {
+        events.append(CompileProgressEvent(stage: stage, status: status, detail: detail))
+    }
+
+    /// Mark the run finished. Appends a terminal `done`/`failed` line and flips
+    /// `isRunning` off so the sheet stops its tail spinner.
+    public func finish(upgraded: Bool, detail: String = "") {
+        // Flip the leading `start` row from running → success now that the loop
+        // has terminated, so a completed feed shows no orphaned spinner up top.
+        if let first = events.first, first.stage == .start, first.status == .running {
+            events[0].status = .success
+        }
+        events.append(
+            CompileProgressEvent(
+                stage: upgraded ? .done : .failed,
+                status: upgraded ? .success : .failure,
+                detail: detail
+            )
+        )
+        didUpgrade = upgraded
+        isRunning = false
+    }
+}

--- a/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentOrchestrator.swift
@@ -791,6 +791,16 @@ public final class VoiceAgentOrchestrator: Identifiable {
                     list.count
                 )
             ))
+        case let .webSources(list):
+            guard !list.isEmpty else { return }
+            card = .webSources(id: UUID(), list)
+            reasoningTrace.append(ReasoningStep(
+                kind: .insight,
+                label: String(
+                    format: NSLocalizedString("agent.trace.foundSources", comment: "Cited N web sources"),
+                    list.count
+                )
+            ))
         }
         provisionalCards.append(card: card, to: messageId, at: Date())
         syncCardsSnapshot()
@@ -1028,6 +1038,8 @@ public final class VoiceAgentOrchestrator: Identifiable {
             return NSLocalizedString("agent.step.dismiss", comment: "✕ Dismissing…")
         case "search_places":
             return NSLocalizedString("agent.step.search", comment: "🔍 Searching places…")
+        case "web_search":
+            return NSLocalizedString("agent.step.webSearch", comment: "🌐 Searching the web…")
         case "navigate_to":
             return NSLocalizedString("agent.step.navigate", comment: "🗺 Opening navigation…")
         case "build_route":
@@ -1118,6 +1130,7 @@ public final class VoiceAgentOrchestrator: Identifiable {
         8. build_route(experience_ids?) — String nearby places into ONE walkable route, ordered into a sensible walk, with a "why now" line reflecting the time, weather, and which places the user has or hasn't visited. The route appears as a card the user can adopt — it is NOT saved until they tap adopt. Use when the user asks you to plan a walk or string places together.
         9. get_city_kit(city_code?, kinds?) — Return the 落地包 landing-kit essentials for the current city: connectivity, money, visa/tax, safety. Use for "how do I get online / get cash / visa rules / days left / emergency numbers". Visa day counts come from the user's own stored data — if `visa_setup_needed` is returned, tell them to set their entry date in the 落地包; NEVER invent day counts.
         10. find_local_events(city_code?, within_days?, solo_score_min?, query?) — Find 在地 local happenings this week with a solo-friendliness score and a "good to go alone?" note. Results appear as tappable cards the user can jump to on the map. Use for "what's on this weekend / anything happening / something to do alone".
+        11. web_search(query, topic?, days?) — Search the LIVE web for current, real-world facts you don't reliably know or that change over time: opening hours, this week's exhibitions/events, recent news, prices, whether a place still exists, travel advisories. Returns real pages that appear to the user as source-link cards. ALWAYS prefer this over guessing from memory when a question is time-sensitive or about a specific real place/event, and CITE what you find ("according to …"). Use topic="news" (with optional days) for recent happenings. This does NOT touch the map — for on-map discovery use explore_nearby / search_places.
 
         PLAN BLOCKS (① plan-execute-reflect):
         - Some turns will be preceded by a `<plan>...</plan>` system block containing a JSON plan with an ordered `steps` array.

--- a/apps/ios/SoloCompass/Services/VoiceAgentToolRouter.swift
+++ b/apps/ios/SoloCompass/Services/VoiceAgentToolRouter.swift
@@ -86,6 +86,10 @@ public final class VoiceAgentToolRouter {
         /// City OS v2: 在地 events surfaced by `find_local_events`, rendered as
         /// `ChatEventCard`s the user can tap to jump to on the map.
         case events([CityEvent])
+        /// Live web-search sources surfaced by `web_search`, rendered as
+        /// tappable source-link cards (Perplexity-style provenance) beneath the
+        /// agent's grounded answer.
+        case webSources([WebSearchResult])
     }
     public private(set) var lastEffect: ToolEffect?
 
@@ -97,18 +101,24 @@ public final class VoiceAgentToolRouter {
     /// the model never invents day counts.
     private weak var complianceService: ComplianceService?
 
+    /// Live web search backing the `web_search` tool. Defaults to the shared
+    /// instance; injectable so tests can stub the network.
+    private let webSearchService: WebSearchService
+
     public init(
         mapViewModel: MapViewModel,
         preferences: UserPreferences,
         aiService: AIService? = nil,
         cityBriefService: CityBriefService? = nil,
-        complianceService: ComplianceService? = nil
+        complianceService: ComplianceService? = nil,
+        webSearchService: WebSearchService? = nil
     ) {
         self.mapViewModel = mapViewModel
         self.preferences = preferences
         self.aiService = aiService
         self.cityBriefService = cityBriefService
         self.complianceService = complianceService
+        self.webSearchService = webSearchService ?? WebSearchService.shared
     }
 
     // MARK: - Tool catalog
@@ -132,6 +142,21 @@ public final class VoiceAgentToolRouter {
                 "rating_min":     {"type": "number", "minimum": 0, "maximum": 10, "description": "Minimum provider rating"},
                 "ambiance_min":   {"type": "number", "minimum": 0, "maximum": 10, "description": "Minimum ambiance fit score"},
                 "progressive":    {"type": "boolean", "default": true, "description": "When true, use progressive multi-ring explore (recommended)"}
+              }
+            }
+            """#
+        ),
+        .init(
+            name: "web_search",
+            description: "Search the live web for current, real-world information you don't already know or that changes over time — opening hours, this week's events/exhibitions, recent news, prices, whether a place still exists, travel advisories. Returns real web pages (title, url, snippet) to ground your answer; cite them. Use this instead of guessing from training knowledge whenever the question is time-sensitive or asks about a specific real place/event. Do NOT use it for on-map actions (use explore_nearby / search_places for those).",
+            parametersJSON: #"""
+            {
+              "type": "object",
+              "required": ["query"],
+              "properties": {
+                "query": {"type": "string", "description": "The natural-language search query, e.g. 'exhibitions in Shenzhen this week' or 'Giang Cafe Hanoi opening hours'"},
+                "topic": {"type": "string", "enum": ["general", "news"], "default": "general", "description": "Use 'news' for time-sensitive/recent-events queries; 'general' otherwise"},
+                "days": {"type": "integer", "minimum": 1, "maximum": 30, "description": "For topic=news only: how many days back to search"}
               }
             }
             """#
@@ -444,6 +469,8 @@ public final class VoiceAgentToolRouter {
                 return try executeDismissRecommendation(args: call.argumentsJSON)
             case "search_places":
                 return try await executeSearchPlaces(args: call.argumentsJSON)
+            case "web_search":
+                return try await executeWebSearch(args: call.argumentsJSON)
             case "navigate_to":
                 return try executeNavigateTo(args: call.argumentsJSON)
             case "filter_visible":
@@ -700,6 +727,47 @@ public final class VoiceAgentToolRouter {
             "progressive": useProgressive,
             "auto_expanded_stages": stagesExpanded,
             "search_exhausted": ladderExhausted,
+        ])
+    }
+
+    // MARK: - web_search (live web search via Tavily)
+
+    private struct WebSearchArgs: Decodable {
+        let query: String
+        let topic: String?
+        let days: Int?
+    }
+
+    /// Run a live web search and hand the model back real pages to ground its
+    /// answer. The result envelope includes the snippets (so the model can cite
+    /// them) and sets `lastEffect = .webSources` (so the UI can render tappable
+    /// source cards). Best-effort: an empty result set is a valid, non-error
+    /// outcome — the model then answers from its own knowledge and says so.
+    private func executeWebSearch(args: String) async throws -> String {
+        let parsed: WebSearchArgs = try Self.decode(args, tool: "web_search")
+        let query = parsed.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else {
+            throw RouterError.invalidArguments(tool: "web_search", reason: "query must not be empty")
+        }
+
+        let topic: WebSearchService.Topic = (parsed.topic == "news") ? .news : .general
+        let results = await webSearchService.search(query: query, topic: topic, days: parsed.days)
+
+        // Surface source cards to the UI only when the search actually returned
+        // pages — an empty result leaves the chat clean.
+        if !results.isEmpty {
+            lastEffect = .webSources(results)
+        }
+
+        // Model-facing envelope: the snippets are what it summarizes. Keep it
+        // compact — title, url, and the bounded content per source.
+        let sources: [[String: Any]] = results.map { r in
+            ["title": r.title, "url": r.url, "content": r.content]
+        }
+        return Self.successJSON([
+            "query": query,
+            "result_count": results.count,
+            "sources": sources,
         ])
     }
 

--- a/apps/ios/SoloCompass/Services/WebSearchService.swift
+++ b/apps/ios/SoloCompass/Services/WebSearchService.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// One web page returned by a live search. The chat agent summarizes the
+/// `content` snippets into a sourced answer, and the UI renders `title` + `url`
+/// as tappable source-link cards (Perplexity-style provenance).
+public struct WebSearchResult: Codable, Equatable, Identifiable, Sendable {
+    /// Stable identity for SwiftUI lists — the URL is unique within a result set
+    /// (the Edge Function dedupes by URL).
+    public var id: String { url }
+    public let title: String
+    public let url: String
+    /// Extracted page snippet. Bounded server-side so a chatty page can't blow
+    /// the model's context budget.
+    public let content: String
+
+    public init(title: String, url: String, content: String) {
+        self.title = title
+        self.url = url
+        self.content = content
+    }
+
+    /// Human-facing host label for a source card ("example.com"), stripped of a
+    /// leading "www.". Falls back to the raw URL when it won't parse.
+    public var host: String {
+        guard let host = URL(string: url)?.host else { return url }
+        return host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
+    }
+}
+
+/// Live web search for the in-chat agent, fronting the `tavily-search` Edge
+/// Function so the Tavily key stays server-side.
+///
+/// This is the real thing the old `AIService.sendWebSearchQuery` only pretended
+/// to be: that path just asked the model what it already knew from training and
+/// never touched the network. Here the query reaches Tavily, and the agent gets
+/// back actual pages — titles, URLs, and extracted snippets — to ground its
+/// answer in current, citable sources.
+///
+/// Best-effort by contract: every failure mode (backend off, not signed in,
+/// quota exhausted, provider error) resolves to an empty result array rather
+/// than throwing, so the agent degrades to its own knowledge instead of the
+/// turn erroring out.
+@MainActor
+public final class WebSearchService {
+    public static let shared = WebSearchService()
+
+    private let client: SupabaseClientProtocol
+
+    public init(client: SupabaseClientProtocol = SupabaseClient.shared) {
+        self.client = client
+    }
+
+    /// Topic hint passed to Tavily. `.news` biases toward recent, time-sensitive
+    /// pages (events, "what's on now"); `.general` is the default.
+    public enum Topic: String, Sendable {
+        case general
+        case news
+    }
+
+    /// Run a live web search. Returns up to a handful of deduped pages, or an
+    /// empty array on any failure (never throws — see the type doc).
+    ///
+    /// - Parameters:
+    ///   - query: The natural-language search string.
+    ///   - topic: `.news` for time-sensitive queries, else `.general`.
+    ///   - days: For `.news`, how far back to look (ignored otherwise).
+    public func search(
+        query: String,
+        topic: Topic = .general,
+        days: Int? = nil
+    ) async -> [WebSearchResult] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        var payload: [String: Any] = [
+            "query": trimmed,
+            "topic": topic.rawValue,
+        ]
+        if topic == .news, let days { payload["days"] = days }
+
+        guard let body = try? JSONSerialization.data(withJSONObject: payload) else {
+            return []
+        }
+
+        let result = await client.invoke(function: "tavily-search", body: body)
+        guard case .success(let data) = result, !data.isEmpty else { return [] }
+
+        struct Envelope: Decodable {
+            let results: [WebSearchResult]?
+        }
+        let decoded = try? JSONDecoder().decode(Envelope.self, from: data)
+        return decoded?.results ?? []
+    }
+}

--- a/apps/ios/SoloCompass/Tests/MapKitSearchTests.swift
+++ b/apps/ios/SoloCompass/Tests/MapKitSearchTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+import CoreLocation
+@testable import SoloCompass
+
+// MARK: - MapKit free-text POI search
+
+/// The search entry point the Nearby box escalates to when its local card
+/// filter comes up empty. Network-dependent paths aren't exercised here (unit
+/// tests stay offline); what's guaranteed is the input contract: an empty or
+/// whitespace query never wastes a network round-trip and returns no pins.
+@MainActor
+final class MapKitSearchTests: XCTestCase {
+
+    private let sf = CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194)
+
+    func testEmptyQueryShortCircuits() async throws {
+        let service = MapKitPOIService()
+        let results = try await service.search(query: "", near: sf)
+        XCTAssertTrue(results.isEmpty)
+        XCTAssertFalse(service.isFetching)
+    }
+
+    func testWhitespaceQueryShortCircuits() async throws {
+        let service = MapKitPOIService()
+        let results = try await service.search(query: "   \n\t ", near: sf)
+        XCTAssertTrue(results.isEmpty)
+        XCTAssertFalse(service.isFetching)
+    }
+}

--- a/apps/ios/SoloCompass/Tests/RecompileProgressStoreTests.swift
+++ b/apps/ios/SoloCompass/Tests/RecompileProgressStoreTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import SoloCompass
+
+// MARK: - Deep cross-compile live feed
+
+/// The feed store is the contract between the enrichment agent loop and the
+/// sheet: it must present *immediately* on begin, accumulate every stage the
+/// agent emits (including failures, which used to be silent no-ops), and reach
+/// exactly one terminal state that says whether the card was upgraded.
+@MainActor
+final class RecompileProgressStoreTests: XCTestCase {
+
+    func testBeginSeedsRunningStartEvent() {
+        let store = RecompileProgressStore()
+        store.begin(placeName: "Giang Cafe")
+
+        XCTAssertEqual(store.placeName, "Giang Cafe")
+        XCTAssertTrue(store.isRunning)
+        XCTAssertNil(store.didUpgrade)
+        // A start row exists at once so the sheet is never blank on present.
+        XCTAssertEqual(store.events.count, 1)
+        XCTAssertEqual(store.events.first?.stage, .start)
+        XCTAssertEqual(store.events.first?.status, .running)
+    }
+
+    func testEmitAppendsInOrder() {
+        let store = RecompileProgressStore()
+        store.begin(placeName: "Test")
+        store.emit(.amap, .running)
+        store.emit(.amap, .success, "12 places found")
+        store.emit(.foursquare, .skipped, "No API key")
+
+        XCTAssertEqual(store.events.map(\.stage), [.start, .amap, .amap, .foursquare])
+        XCTAssertEqual(store.events.last?.status, .skipped)
+        XCTAssertEqual(store.events.last?.detail, "No API key")
+    }
+
+    func testFinishUpgradedFlipsStartAndAppendsDone() {
+        let store = RecompileProgressStore()
+        store.begin(placeName: "Test")
+        store.emit(.synthesis, .success)
+        store.finish(upgraded: true, detail: "Upgraded")
+
+        XCTAssertFalse(store.isRunning)
+        XCTAssertEqual(store.didUpgrade, true)
+        // The leading running spinner must resolve so no orphan spinner remains.
+        XCTAssertEqual(store.events.first?.status, .success)
+        XCTAssertEqual(store.events.last?.stage, .done)
+        XCTAssertEqual(store.events.last?.status, .success)
+    }
+
+    func testFinishNoUpgradeIsAFailureTerminal() {
+        let store = RecompileProgressStore()
+        store.begin(placeName: "Test")
+        // The old silent path: a rejected adopt produced no feedback at all.
+        store.emit(.adopt, .failure, "Different venue")
+        store.finish(upgraded: false, detail: "Nothing richer found")
+
+        XCTAssertFalse(store.isRunning)
+        XCTAssertEqual(store.didUpgrade, false)
+        XCTAssertEqual(store.events.last?.stage, .failed)
+        XCTAssertEqual(store.events.last?.status, .failure)
+        // The failing stage line survives so the user sees WHY, not just "done".
+        XCTAssertTrue(store.events.contains { $0.stage == .adopt && $0.status == .failure })
+    }
+
+    func testBeginResetsPriorFeed() {
+        let store = RecompileProgressStore()
+        store.begin(placeName: "First")
+        store.emit(.amap, .success)
+        store.finish(upgraded: true)
+
+        store.begin(placeName: "Second")
+        XCTAssertEqual(store.placeName, "Second")
+        XCTAssertEqual(store.events.count, 1)
+        XCTAssertTrue(store.isRunning)
+        XCTAssertNil(store.didUpgrade)
+    }
+}

--- a/apps/ios/SoloCompass/Tests/WebSearchServiceTests.swift
+++ b/apps/ios/SoloCompass/Tests/WebSearchServiceTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import SoloCompass
+
+/// `WebSearchService` fronts the `tavily-search` Edge Function. These tests pin
+/// the input contract (empty query never calls the network), the decode path
+/// (envelope → results), the best-effort failure contract (any error → empty),
+/// and the `WebSearchResult.host` display helper.
+@MainActor
+final class WebSearchServiceTests: XCTestCase {
+
+    /// Records the last invoked function + body and returns canned data, so the
+    /// service's request shaping and response decoding can be driven in isolation.
+    private final class StubClient: SupabaseClientProtocol {
+        var responseJSON: String = #"{"results":[]}"#
+        var returnsEmptyData = false
+        var failure: SupabaseClient.SupabaseError?
+        private(set) var invokeCount = 0
+        private(set) var lastFunction: String?
+        private(set) var lastBody: Data?
+
+        var currentSession: SupabaseClient.Session? {
+            SupabaseClient.Session(
+                userId: "u", accessToken: "at", refreshToken: "rt",
+                expiresAt: Date().addingTimeInterval(3600)
+            )
+        }
+
+        func invoke(function: String, body: Data) async -> Result<Data, SupabaseClient.SupabaseError> {
+            invokeCount += 1
+            lastFunction = function
+            lastBody = body
+            if let failure { return .failure(failure) }
+            if returnsEmptyData { return .success(Data()) }
+            return .success(Data(responseJSON.utf8))
+        }
+
+        func get(table: String, query: [URLQueryItem]) async -> Result<Data, SupabaseClient.SupabaseError> { .success(Data()) }
+        func signInAnonymously() async -> Result<SupabaseClient.Session, SupabaseClient.SupabaseError> { .failure(.notSignedIn) }
+        func refreshSession() async -> Result<SupabaseClient.Session, SupabaseClient.SupabaseError> { .failure(.notSignedIn) }
+        func linkAppleIdentity(identityToken: String, nonce: String) async -> Result<SupabaseClient.Session, SupabaseClient.SupabaseError> { .failure(.notSignedIn) }
+        var isAnonymous: Bool { get async { false } }
+        func post(table: String, body: Data) async -> Result<Data, SupabaseClient.SupabaseError> { .success(Data()) }
+        func delete(table: String, id: String) async -> Result<Void, SupabaseClient.SupabaseError> { .success(()) }
+    }
+
+    func testEmptyQueryNeverCallsNetwork() async {
+        let stub = StubClient()
+        let service = WebSearchService(client: stub)
+        let results = await service.search(query: "   ")
+        XCTAssertTrue(results.isEmpty)
+        XCTAssertEqual(stub.invokeCount, 0, "empty query must short-circuit before invoke")
+    }
+
+    func testDecodesResultsFromEnvelope() async {
+        let stub = StubClient()
+        stub.responseJSON = """
+        {"query":"coffee","results":[
+          {"title":"Best Cafes","url":"https://example.com/cafes","content":"A list of cafes."},
+          {"title":"More Coffee","url":"https://blog.example.org/coffee","content":"Even more."}
+        ]}
+        """
+        let service = WebSearchService(client: stub)
+        let results = await service.search(query: "coffee")
+
+        XCTAssertEqual(stub.lastFunction, "tavily-search")
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results.first?.title, "Best Cafes")
+        XCTAssertEqual(results.first?.url, "https://example.com/cafes")
+    }
+
+    func testEmptyDataDegradesToEmptyResults() async {
+        let stub = StubClient()
+        stub.returnsEmptyData = true
+        let service = WebSearchService(client: stub)
+        let results = await service.search(query: "anything")
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testFailureDegradesToEmptyResults() async {
+        let stub = StubClient()
+        stub.failure = .notSignedIn
+        let service = WebSearchService(client: stub)
+        let results = await service.search(query: "anything")
+        XCTAssertTrue(results.isEmpty, "any client failure must degrade to empty, never throw")
+    }
+
+    func testNewsTopicSendsDaysInBody() async {
+        let stub = StubClient()
+        let service = WebSearchService(client: stub)
+        _ = await service.search(query: "exhibitions", topic: .news, days: 7)
+
+        let body = try? JSONSerialization.jsonObject(with: stub.lastBody ?? Data()) as? [String: Any]
+        XCTAssertEqual(body?["topic"] as? String, "news")
+        XCTAssertEqual(body?["days"] as? Int, 7)
+    }
+
+    func testHostStripsWww() {
+        let r = WebSearchResult(title: "T", url: "https://www.example.com/path?q=1", content: "")
+        XCTAssertEqual(r.host, "example.com")
+    }
+
+    func testHostFallsBackToRawURLWhenUnparseable() {
+        let r = WebSearchResult(title: "T", url: "not a url", content: "")
+        // No host component → returns the raw string rather than crashing.
+        XCTAssertEqual(r.host, "not a url")
+    }
+}

--- a/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
+++ b/apps/ios/SoloCompass/ViewModels/MapViewModel.swift
@@ -78,6 +78,21 @@ public final class MapViewModel {
     /// change, no cost on paths that never trigger a hydrate, still injectable.
     @ObservationIgnored
     private lazy var cityExperienceFetcher = CityExperienceFetcher()
+
+    /// MapKit-backed free-text POI search. Separate instance from the one inside
+    /// `enrichmentAgent` — `MKLocalSearch` is stateless, so sharing buys nothing,
+    /// and keeping it here avoids widening the agent's surface. `lazy` so tests
+    /// and non-search sessions never allocate it.
+    @ObservationIgnored
+    private lazy var searchMapKitService = MapKitPOIService()
+
+    /// True while a web POI search is in flight — drives the search bar spinner.
+    public var isSearchingWeb = false
+
+    /// Result of the last web search, surfaced to the user: the query and how
+    /// many new pins it dropped. `nil` until a search runs. Lets the empty-state
+    /// button turn into "Found N places" feedback instead of silently reloading.
+    public var lastWebSearchResult: (query: String, added: Int)?
     /// Cities already hydrated from the backend this session, so a repeated
     /// `selectCity` (e.g. GPS re-follow) fires at most one network read per city.
     @ObservationIgnored
@@ -314,6 +329,16 @@ public final class MapViewModel {
     /// when idle. Drives the per-card spinner so the rest of the UI stays live.
     public var recompilingExperienceId: String?
 
+    /// Live feed backing the deep cross-compile sheet. A manual recompile
+    /// resets and drives this so the user watches the agent loop run instead of
+    /// a bare spinner; the background auto-upgrade path leaves it untouched.
+    public let recompileProgress = RecompileProgressStore()
+
+    /// Drives presentation of the cross-compile feed sheet. Set true the instant
+    /// the user taps "deep cross-compile" — the sheet appears immediately, before
+    /// any network call, so the tap always has a visible response.
+    public var isShowingRecompileFeed = false
+
     /// Ids re-compiled (or auto-upgraded) this session, so the on-demand
     /// auto-upgrade (Approach C) never spends quota on the same card twice.
     /// Manual re-compile (Approach A) bypasses this — the user asked for it.
@@ -366,6 +391,61 @@ public final class MapViewModel {
         await runRecompile(experience, manual: false)
     }
 
+    // MARK: - Web POI Search
+
+    /// Free-text POI search that reaches the live map providers instead of only
+    /// filtering the cards already on screen.
+    ///
+    /// The Nearby search box filters `experiences` locally — so a query for a
+    /// place that hasn't been explored yet always comes up empty. This drops
+    /// that ceiling: it asks Apple MapKit (free, key-less, no Pro gate) for POIs
+    /// matching the query near the reference point, converts each hit into a
+    /// skeleton `Experience`, and appends them to the map. The user can then tap
+    /// any new pin and run the (Pro) deep cross-compile to enrich it.
+    ///
+    /// Deliberately lightweight: no paywall, no consent gate, no AI quota spend.
+    /// Discovery should be instant and free; enrichment is the paid step.
+    ///
+    /// - Parameters:
+    ///   - query: The user-typed search string. Empty/whitespace is a no-op.
+    ///   - coordinate: Center to bias results toward (map center or user fix).
+    @discardableResult
+    public func webSearchPOIs(
+        query: String,
+        near coordinate: CLLocationCoordinate2D
+    ) async -> Int {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !isSearchingWeb else { return 0 }
+
+        isSearchingWeb = true
+        defer { isSearchingWeb = false }
+
+        let pois: [OverpassService.POI]
+        do {
+            pois = try await searchMapKitService.search(query: trimmed, near: coordinate)
+        } catch {
+            lastWebSearchResult = (trimmed, 0)
+            return 0
+        }
+
+        guard !pois.isEmpty else {
+            lastWebSearchResult = (trimmed, 0)
+            return 0
+        }
+
+        // Skeleton conversion mirrors the free/Overpass explore path — name +
+        // coords + generic tagline, honestly attributed to MapKit. Enrichment is
+        // the user's next (optional, Pro) step via deep cross-compile.
+        let cityCode = selectedCity ?? ""
+        let skeletons = pois.map { AIService.skeletonExperience(from: $0, cityCode: cityCode) }
+        let added = experienceService.appendGenerated(skeletons)
+        lastWebSearchResult = (trimmed, added)
+        if added > 0 {
+            Haptics.notify(.success)
+        }
+        return added
+    }
+
     /// Shared re-compile body for both manual (A) and auto (C) paths. Stamps
     /// the session cache, drives the spinner, calls the agent, and swaps the
     /// upgraded content in place. `aiService.isProTier` is synced so the
@@ -376,12 +456,36 @@ public final class MapViewModel {
         recompilingExperienceId = experience.id
         defer { recompilingExperienceId = nil }
 
+        // Manual taps drive the visible feed sheet: reset the store and present
+        // it NOW, before the first network call, so the tap always responds and
+        // the user watches each stage of the agent loop resolve. The silent
+        // background auto-upgrade path leaves the store and sheet untouched.
+        let progressHandler: EnrichmentAgent.ProgressHandler?
+        if manual {
+            recompileProgress.begin(placeName: experience.shortName)
+            isShowingRecompileFeed = true
+            progressHandler = { [weak self] stage, status, detail in
+                self?.recompileProgress.emit(stage, status, detail)
+            }
+        } else {
+            progressHandler = nil
+        }
+
         guard let upgraded = await enrichmentAgent.recompile(
             experience: experience,
-            locale: LanguageService.shared.effectiveLocale
+            locale: LanguageService.shared.effectiveLocale,
+            onProgress: progressHandler
         ) else {
-            // Manual taps deserve feedback when nothing richer was found.
+            // Manual taps deserve feedback when nothing richer was found — the
+            // feed's terminal line now carries the reason, so no silent spinner.
             if manual {
+                recompileProgress.finish(
+                    upgraded: false,
+                    detail: NSLocalizedString(
+                        "recompile.feed.noChange",
+                        comment: "Terminal feed line when nothing richer was found"
+                    )
+                )
                 lastExploreToast = NSLocalizedString(
                     "recompile.toast.noChange",
                     comment: "Shown when a manual deep re-compile found nothing richer"
@@ -396,6 +500,13 @@ public final class MapViewModel {
             selectedExperience = upgraded
         }
         if manual {
+            recompileProgress.finish(
+                upgraded: true,
+                detail: NSLocalizedString(
+                    "recompile.feed.upgraded",
+                    comment: "Terminal feed line when the card was upgraded"
+                )
+            )
             lastExploreToast = NSLocalizedString(
                 "recompile.toast.success",
                 comment: "Shown after a manual deep re-compile upgrades a card"

--- a/apps/ios/SoloCompass/Views/Chat/ChatCardStack.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatCardStack.swift
@@ -27,6 +27,8 @@ struct ChatCardStack: View {
     /// Wired to `orchestrator.undoCard(id:)` at the ChatSheet layer.
     var onUndoCard: ((UUID) -> Void)? = nil
 
+    @Environment(\.openURL) private var openURL
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             ForEach(Array(cards.enumerated()), id: \.element.id) { index, card in
@@ -55,6 +57,8 @@ struct ChatCardStack: View {
                 )
             case let .events(_, list):
                 eventResults(list)
+            case let .webSources(_, list):
+                webSourceResults(list)
             }
         }
         // Slice B: overlay the undo pill only while the entry is
@@ -92,6 +96,30 @@ struct ChatCardStack: View {
             ForEach(list) { event in
                 ChatEventCard(event: event) { tapped in
                     onShowEventOnMap?(tapped)
+                }
+            }
+        }
+    }
+
+    /// Perplexity-style provenance: the live web pages the agent cited via
+    /// `web_search`. A small "Sources" header plus one tappable row per page
+    /// (title + host) — tapping opens the URL in the system browser.
+    @ViewBuilder
+    private func webSourceResults(_ list: [WebSearchResult]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "globe")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(CT.sunGoldDeep)
+                Text(NSLocalizedString("chat.sources.title", comment: "Web sources card header — Sources"))
+                    .font(.caption2.weight(.semibold))
+                    .textCase(.uppercase)
+                    .tracking(0.6)
+                    .foregroundStyle(CT.sunGoldDeep)
+            }
+            ForEach(Array(list.enumerated()), id: \.element.id) { index, source in
+                ChatWebSourceCard(index: index + 1, source: source) {
+                    if let url = URL(string: source.url) { openURL(url) }
                 }
             }
         }

--- a/apps/ios/SoloCompass/Views/Chat/ChatCardViews.swift
+++ b/apps/ios/SoloCompass/Views/Chat/ChatCardViews.swift
@@ -361,6 +361,77 @@ struct ChatEventCard: View {
     }
 }
 
+// MARK: - ChatWebSourceCard (live web search provenance)
+
+/// One tappable source-link row beneath a web-search-grounded answer. Shows a
+/// numbered citation, the page title, and its host — the same shape a reader
+/// expects from a "sources" footnote. Tapping opens the URL.
+///
+/// Kept deliberately compact (single row, host-only) so a stack of 6 sources
+/// reads as a citation list, not six full cards competing with the answer.
+@MainActor
+struct ChatWebSourceCard: View {
+    /// 1-based citation index, matching how the answer may cite "(1)", "(2)".
+    let index: Int
+    let source: WebSearchResult
+    let onTap: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Button(action: {
+            Haptics.impact(.light)
+            onTap()
+        }) {
+            HStack(alignment: .top, spacing: 10) {
+                Text("\(index)")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(CT.accent)
+                    .frame(width: 18, height: 18)
+                    .background(Circle().fill(CT.accentSoft))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(source.title.isEmpty ? source.host : source.title)
+                        .font(.subheadline)
+                        .foregroundStyle(CT.textPrimaryAdaptive)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                    HStack(spacing: 4) {
+                        Image(systemName: "link")
+                            .font(.system(size: 9, weight: .semibold))
+                        Text(source.host)
+                            .font(.caption2)
+                            .lineLimit(1)
+                    }
+                    .foregroundStyle(CT.textMutedAdaptive)
+                }
+                Spacer(minLength: 0)
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(CT.fgSubtle)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(colorScheme == .dark ? CT.warmCardDark : CT.surfaceWhite)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .strokeBorder(CT.borderAdaptive, lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text(
+            String(
+                format: NSLocalizedString("chat.sources.a11y", comment: "Source N: title, host"),
+                index, source.title.isEmpty ? source.host : source.title, source.host
+            )
+        ))
+    }
+}
+
 private extension Optional where Wrapped == String {
     var isNilOrEmpty: Bool {
         switch self {

--- a/apps/ios/SoloCompass/Views/Experience/RecompileFeedSheet.swift
+++ b/apps/ios/SoloCompass/Views/Experience/RecompileFeedSheet.swift
@@ -1,0 +1,202 @@
+import SwiftUI
+
+/// Live feed for the deep cross-compile agent loop.
+///
+/// Before this existed, tapping "deep cross-compile" swapped the ··· glyph for a
+/// spinner and ran the whole multi-provider enrichment loop behind it — a tap
+/// that found nothing looked identical to one still working, and the failure
+/// modes (no AI key, no matching venue, quality downgrade) all resolved to a
+/// silent no-op. This sheet appears the instant the user taps, then streams each
+/// stage of the loop as it resolves: which source is queried, how many signals
+/// it returned, and a green ✓ / muted dash / red ✗ per stage. The terminal card
+/// states plainly whether the place was upgraded and why.
+struct RecompileFeedSheet: View {
+    /// The live feed. `@Bindable` so appended events re-render the list.
+    @Bindable var store: RecompileProgressStore
+    let onClose: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        NavigationStack {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 10) {
+                        header
+                        ForEach(store.events) { event in
+                            FeedRow(event: event)
+                                .id(event.id)
+                        }
+                        if store.isRunning {
+                            runningTail
+                        } else {
+                            terminalCard
+                        }
+                    }
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 16)
+                }
+                .background(CT.pageAdaptive.ignoresSafeArea())
+                // Follow the tail as new stages stream in.
+                .onChange(of: store.events.count) { _, _ in
+                    guard let last = store.events.last else { return }
+                    withAnimation(.easeOut(duration: 0.25)) {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+            .navigationTitle(Text(NSLocalizedString("recompile.feed.title", comment: "Deep cross-compile sheet title")))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(action: onClose) {
+                        Text(NSLocalizedString(
+                            store.isRunning ? "action.hide" : "action.done",
+                            comment: "Dismiss the cross-compile feed"
+                        ))
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 7) {
+                Image(systemName: "sparkle.magnifyingglass")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(CT.accent)
+                Text(store.placeName)
+                    .font(.headline)
+                    .foregroundStyle(CT.textPrimaryAdaptive)
+                    .lineLimit(1)
+            }
+            Text(NSLocalizedString("recompile.feed.subtitle", comment: "Cross-referencing multiple sources"))
+                .font(.caption)
+                .foregroundStyle(CT.textMutedAdaptive)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.bottom, 4)
+    }
+
+    // MARK: - Running tail
+
+    private var runningTail: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text(NSLocalizedString("recompile.feed.working", comment: "Still working line"))
+                .font(.caption)
+                .foregroundStyle(CT.textMutedAdaptive)
+        }
+        .padding(.top, 2)
+        .transition(.opacity)
+    }
+
+    // MARK: - Terminal card
+
+    @ViewBuilder
+    private var terminalCard: some View {
+        if let upgraded = store.didUpgrade {
+            HStack(spacing: 10) {
+                Image(systemName: upgraded ? "checkmark.seal.fill" : "info.circle.fill")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(upgraded ? CT.verifiedGreen : CT.warningTextStrong)
+                Text(NSLocalizedString(
+                    upgraded ? "recompile.feed.upgraded" : "recompile.feed.noChange",
+                    comment: "Terminal feed card message"
+                ))
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(CT.textPrimaryAdaptive)
+                .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 0)
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(upgraded ? CT.successSoft : CT.warningSoft)
+            )
+            .transition(.opacity)
+        }
+    }
+}
+
+/// One line in the feed: an icon reflecting the stage's status, the stage's
+/// human label, and any specific detail (a count, a skip reason).
+private struct FeedRow: View {
+    let event: CompileProgressEvent
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            statusGlyph
+                .frame(width: 18)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(Self.label(for: event.stage))
+                    .font(.subheadline)
+                    .foregroundStyle(CT.textPrimaryAdaptive)
+                if !event.detail.isEmpty {
+                    Text(event.detail)
+                        .font(.caption)
+                        .foregroundStyle(detailTint)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .transition(.opacity)
+    }
+
+    @ViewBuilder
+    private var statusGlyph: some View {
+        switch event.status {
+        case .running:
+            ProgressView().controlSize(.small)
+        case .success:
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(CT.verifiedGreen)
+        case .skipped:
+            Image(systemName: "minus.circle")
+                .font(.system(size: 15, weight: .regular))
+                .foregroundStyle(CT.fgSubtle)
+        case .failure:
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(CT.bannerError)
+        }
+    }
+
+    private var detailTint: Color {
+        switch event.status {
+        case .failure: return CT.bannerError
+        case .skipped: return CT.fgSubtle
+        default:       return CT.textMutedAdaptive
+        }
+    }
+
+    /// Human label per stage. The stage supplies the verb; the event's `detail`
+    /// carries specifics (counts, reasons).
+    static func label(for stage: CompileProgressEvent.Stage) -> String {
+        let key: String
+        switch stage {
+        case .start:      key = "recompile.stage.start"
+        case .amap:       key = "recompile.stage.amap"
+        case .mapKit:     key = "recompile.stage.mapKit"
+        case .overpass:   key = "recompile.stage.overpass"
+        case .foursquare: key = "recompile.stage.foursquare"
+        case .ranking:    key = "recompile.stage.ranking"
+        case .address:    key = "recompile.stage.address"
+        case .synthesis:  key = "recompile.stage.synthesis"
+        case .webVerify:  key = "recompile.stage.webVerify"
+        case .adopt:      key = "recompile.stage.adopt"
+        case .done:       key = "recompile.stage.done"
+        case .failed:     key = "recompile.stage.failed"
+        }
+        return NSLocalizedString(key, comment: "Cross-compile stage label")
+    }
+}

--- a/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
+++ b/apps/ios/SoloCompass/Views/Map/CompassMapView.swift
@@ -1196,6 +1196,15 @@ struct CompassMapContentView: View {
             // dropped this line, leaving the bottom-left settings FAB inert — its
             // `isShowingSettings = true` had no presenter to observe it.
             .sheet(isPresented: settingsSheetBinding) { settingsSheetContent }
+            // Deep cross-compile live feed: presented the instant the user taps
+            // "deep cross-compile" (before any network call), streaming each
+            // stage of the enrichment agent loop instead of a silent spinner.
+            .sheet(isPresented: recompileFeedSheetBinding) {
+                RecompileFeedSheet(
+                    store: viewModel.recompileProgress,
+                    onClose: { viewModel.isShowingRecompileFeed = false }
+                )
+            }
             // One sheet for both route flows (detail + create), driven by the
             // `routeSheet` enum. Hosted here on the outer `mapContent` chain — not
             // on the inner BottomInfoSheet ZStack — so SwiftUI arbitrates it
@@ -1579,6 +1588,7 @@ struct CompassMapContentView: View {
                                     showsSectionDivider: viewModel.isNowFilter,
                                     isLoading: viewModel.isFetchingPOIs,
                                     isNowFilter: viewModel.isNowFilter,
+                                    isSearchingWeb: viewModel.isSearchingWeb,
                                     onExploreElsewhere: {
                                         // Zoom the map out one step by doubling the visible span,
                                         // capped at ±90° lat / ±180° lon, so out-of-range
@@ -1596,6 +1606,15 @@ struct CompassMapContentView: View {
                                     suggestedCityName: viewModel.suggestedCityName,
                                     onSwitchToSuggestedCity: viewModel.suggestedCityCode.map { code in
                                         { viewModel.selectCity(code) }
+                                    },
+                                    onWebSearch: { query in
+                                        // Escalate a local-filter miss to a live MapKit
+                                        // POI search around the same reference point the
+                                        // list uses. Free, no Pro gate — new pins land
+                                        // and become deep-cross-compile candidates.
+                                        let center = locationService.currentLocation?.coordinate
+                                            ?? viewModel.defaultCenterForSelectedCity
+                                        Task { await viewModel.webSearchPOIs(query: query, near: center) }
                                     },
                                     onSelectExperience: { exp in
                                         // Tap → jump straight to the detail sheet.
@@ -1846,6 +1865,13 @@ struct CompassMapContentView: View {
         Binding(
             get: { viewModel.isShowingSettings },
             set: { if !$0 { viewModel.isShowingSettings = false } }
+        )
+    }
+
+    private var recompileFeedSheetBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.isShowingRecompileFeed },
+            set: { if !$0 { viewModel.isShowingRecompileFeed = false } }
         )
     }
 

--- a/apps/ios/SoloCompass/Views/Map/NearbySectionView.swift
+++ b/apps/ios/SoloCompass/Views/Map/NearbySectionView.swift
@@ -29,6 +29,13 @@ struct NearbySection: View {
     let suggestedCityName: String?
     let onSwitchToSuggestedCity: (() -> Void)?
     let isNowFilter: Bool
+    /// Escalates a local-filter miss to a live MapKit POI search. When nil, the
+    /// empty-search state stays passive (callers that can't reach the map's
+    /// search action, e.g. previews). Given the raw query string.
+    let onWebSearch: ((String) -> Void)?
+    /// True while a `onWebSearch` call is in flight — swaps the button for a
+    /// spinner so a slow network search still reads as "working".
+    let isSearchingWeb: Bool
 
     @Environment(BestNowClock.self) private var clock
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -44,9 +51,11 @@ struct NearbySection: View {
         showsSectionDivider: Bool = false,
         isLoading: Bool = false,
         isNowFilter: Bool = false,
+        isSearchingWeb: Bool = false,
         onExploreElsewhere: (() -> Void)? = nil,
         suggestedCityName: String? = nil,
         onSwitchToSuggestedCity: (() -> Void)? = nil,
+        onWebSearch: ((String) -> Void)? = nil,
         onSelectExperience: @escaping (Experience) -> Void,
         onLongPressExperience: ((Experience) -> Void)? = nil,
         onAskSoloExperience: ((Experience) -> Void)? = nil
@@ -58,9 +67,11 @@ struct NearbySection: View {
         self.showsSectionDivider = showsSectionDivider
         self.isLoading = isLoading
         self.isNowFilter = isNowFilter
+        self.isSearchingWeb = isSearchingWeb
         self.onExploreElsewhere = onExploreElsewhere
         self.suggestedCityName = suggestedCityName
         self.onSwitchToSuggestedCity = onSwitchToSuggestedCity
+        self.onWebSearch = onWebSearch
         self.onSelectExperience = onSelectExperience
         self.onLongPressExperience = onLongPressExperience
         self.onAskSoloExperience = onAskSoloExperience
@@ -125,9 +136,13 @@ struct NearbySection: View {
                 .padding(.top, 10)
                 .padding(.bottom, 8)
             } else if !searchText.isEmpty {
-                SearchEmptyView(query: searchText)
-                    .padding(.horizontal, 16)
-                    .padding(.top, 12)
+                SearchEmptyView(
+                    query: searchText,
+                    isSearchingWeb: isSearchingWeb,
+                    onWebSearch: onWebSearch.map { handler in { handler(searchText) } }
+                )
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
             }
         }
         .padding(.top, 8)
@@ -591,9 +606,14 @@ private struct ExperienceSearchBar: View {
 
 private struct SearchEmptyView: View {
     let query: String
+    /// True while a live web search triggered from here is in flight.
+    var isSearchingWeb: Bool = false
+    /// When set, renders a "search the web for <query>" button that escalates
+    /// past the local-only card filter to live MapKit results. Nil hides it.
+    var onWebSearch: (() -> Void)?
 
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 12) {
             Image(systemName: "magnifyingglass")
                 .font(.title2)
                 .foregroundStyle(.secondary)
@@ -604,6 +624,37 @@ private struct SearchEmptyView: View {
             .font(.subheadline)
             .foregroundStyle(.secondary)
             .multilineTextAlignment(.center)
+
+            // The local filter only sees cards already on the map. Offer to
+            // reach the live providers so a first-time query isn't a dead end.
+            if let onWebSearch {
+                Button {
+                    Haptics.impact(.light)
+                    onWebSearch()
+                } label: {
+                    HStack(spacing: 6) {
+                        if isSearchingWeb {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Image(systemName: "globe")
+                                .font(.system(size: 13, weight: .semibold))
+                        }
+                        Text(String(
+                            format: NSLocalizedString("search.web.cta", comment: "Search live map providers for query"),
+                            query
+                        ))
+                        .font(.subheadline.weight(.medium))
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 9)
+                    .background(
+                        Capsule().fill(CT.accentSoft)
+                    )
+                    .foregroundStyle(CT.accent)
+                }
+                .buttonStyle(.plain)
+                .disabled(isSearchingWeb)
+            }
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 32)

--- a/infra/supabase/functions/tavily-search/index.ts
+++ b/infra/supabase/functions/tavily-search/index.ts
@@ -134,7 +134,10 @@ Deno.serve(async (req: Request) => {
   }
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    return json({ error: "search provider error", status: res.status, detail: text.slice(0, 500) }, 502);
+    return json(
+      { error: "search provider error", status: res.status, detail: text.slice(0, 500) },
+      502,
+    );
   }
 
   const data = (await res.json().catch(() => ({}))) as { results?: TavilyResult[] };

--- a/infra/supabase/functions/tavily-search/index.ts
+++ b/infra/supabase/functions/tavily-search/index.ts
@@ -1,0 +1,176 @@
+// Edge Function: tavily-search
+//
+// Real-time web search for the in-chat "Ask Solo" agent. The iOS app has no
+// live search of its own — its `sendWebSearchQuery` only ever asked the model
+// what it already knew from training. This function gives the chat agent a real
+// web-search tool: it forwards a query to Tavily (the same provider the
+// city-brief compiler already uses) and returns normalized results the model
+// then summarizes into a sourced answer.
+//
+// The Tavily key stays server-side (TAVILY_API_KEY), never shipped in the app
+// bundle — the app authenticates with its Supabase JWT and this function holds
+// the provider secret, mirroring how chat-proxy fronts the LLM key.
+//
+// Flow:
+//   1. Verify Supabase JWT; extract user_id.
+//   2. Rate-limit via sc_function_calls (shared daily accounting table).
+//   3. Call Tavily /search (advanced depth); normalize to {title,url,content}.
+//
+// Deliberately NOT Pro-gated: discovery/search should be broadly available;
+// the daily rate-limit is the only guard against abuse. Enrichment (the paid AI
+// synthesis) remains gated elsewhere.
+//
+// Deploy: `supabase functions deploy tavily-search`
+// Required secret: TAVILY_API_KEY (SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY are
+// auto-injected by the Edge runtime).
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const TAVILY_URL = "https://api.tavily.com/search";
+const TAVILY_MAX_RESULTS = 6;
+const TAVILY_SEARCH_DEPTH = "advanced";
+const FUNCTION_NAME = "tavily-search";
+// Generous vs. the AI-synthesis quota — search is cheap and the point is that
+// the agent can lean on it freely. Still bounded so a runaway loop can't bill.
+const DAILY_QUOTA = 100;
+// Hard cap on the per-result snippet the model sees, so a chatty page can't
+// blow the context budget.
+const MAX_CONTENT_CHARS = 1_500;
+
+interface RequestBody {
+  query: string;
+  // Tavily topic: "general" (default) or "news" for time-sensitive queries.
+  topic?: "general" | "news";
+  // Only meaningful for topic:"news" — how many days back to search.
+  days?: number;
+  // Optional caller override, clamped to a sane range.
+  maxResults?: number;
+}
+
+interface TavilyResult {
+  title?: string;
+  url?: string;
+  content?: string;
+}
+
+interface NormalizedResult {
+  title: string;
+  url: string;
+  content: string;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  // 1. Auth.
+  const authHeader = req.headers.get("Authorization") ?? "";
+  const jwt = authHeader.replace(/^Bearer /i, "");
+  if (!jwt) return json({ error: "missing bearer token" }, 401);
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const tavilyKey = Deno.env.get("TAVILY_API_KEY");
+  if (!tavilyKey) return json({ error: "server misconfigured" }, 500);
+
+  const admin = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false },
+  });
+
+  const { data: userData, error: userErr } = await admin.auth.getUser(jwt);
+  if (userErr || !userData.user) return json({ error: "invalid jwt" }, 401);
+  const userId = userData.user.id;
+
+  // 2. Rate-limit: today's call count (shared accounting table).
+  const dayStart = new Date();
+  dayStart.setUTCHours(0, 0, 0, 0);
+  const { count } = await admin
+    .from("sc_function_calls")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", userId)
+    .eq("function_name", FUNCTION_NAME)
+    .gte("called_at", dayStart.toISOString());
+  if ((count ?? 0) >= DAILY_QUOTA) {
+    return json({ error: "daily quota exceeded", quota: DAILY_QUOTA }, 429);
+  }
+
+  // 3. Parse.
+  let body: RequestBody;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "invalid json" }, 400);
+  }
+  const query = (body.query ?? "").trim();
+  if (!query) return json({ error: "query required" }, 400);
+
+  const topic = body.topic === "news" ? "news" : "general";
+  const maxResults = clampInt(body.maxResults ?? TAVILY_MAX_RESULTS, 1, 10);
+
+  // 4. Call Tavily.
+  const payload: Record<string, unknown> = {
+    query,
+    search_depth: TAVILY_SEARCH_DEPTH,
+    max_results: maxResults,
+    topic,
+  };
+  if (topic === "news" && typeof body.days === "number") {
+    payload.days = clampInt(body.days, 1, 30);
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(TAVILY_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${tavilyKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch (e) {
+    return json({ error: "search provider unreachable", detail: String(e) }, 502);
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    return json({ error: "search provider error", status: res.status, detail: text.slice(0, 500) }, 502);
+  }
+
+  const data = (await res.json().catch(() => ({}))) as { results?: TavilyResult[] };
+
+  // 5. Normalize + dedupe by URL.
+  const seen = new Set<string>();
+  const results: NormalizedResult[] = [];
+  for (const r of data.results ?? []) {
+    const url = (r.url ?? "").trim();
+    if (!url || seen.has(url)) continue;
+    seen.add(url);
+    results.push({
+      title: (r.title ?? "").trim(),
+      url,
+      content: (r.content ?? "").slice(0, MAX_CONTENT_CHARS),
+    });
+  }
+
+  // 6. Record the call for rate-limiting (best-effort; a failed insert must not
+  //    fail the search the user is waiting on).
+  await admin
+    .from("sc_function_calls")
+    .insert({ user_id: userId, function_name: FUNCTION_NAME })
+    .then(undefined, () => {});
+
+  return json({ query, results });
+});
+
+function clampInt(n: number, lo: number, hi: number): number {
+  const i = Math.floor(Number.isFinite(n) ? n : lo);
+  return Math.min(hi, Math.max(lo, i));
+}
+
+function json(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}


### PR DESCRIPTION
三个原本看起来像「死功能」的搜索/交叉编译缺口,一次补齐。

## 1. 深度交叉编译 feed 流弹窗
交叉编译的 agent loop 是真的,但全程只有一个 spinner——「转一圈没反应」就是这个:无 AI key→骨架、无匹配、质量降级等失败全部**静默 no-op**。
- 新 `CompileProgressEvent` + `RecompileProgressStore` + `RecompileFeedSheet`
- `EnrichmentAgent.enrich/recompile` 每步 emit 进度(**失败标红**)
- 点击**立即弹窗**,先于任何网络调用

## 2. 联网 POI 搜索
Nearby 搜索框原来只过滤已在图上的卡片,搜没探索过的地方永远空。
- `MapKitPOIService.search`(MKLocalSearch naturalLanguageQuery)+ `MapViewModel.webSearchPOIs`
- 结果落成骨架 pin,**免费无 Pro 门**;深化(交叉编译)才付费
- `SearchEmptyView` 加「在地图上搜索」升级按钮

## 3. 问 Solo 里的真联网搜索(Tavily)
`AIService.sendWebSearchQuery` 原来只问 AI 训练知识、**零联网**。
- 真 `web_search` agent 工具,fronting 新 `tavily-search` Edge Function(**key 留服务端**)
- AI 自主决定何时联网搜时效性信息并**引用来源**
- 来源链接卡片(Perplexity 式)via `ChatCard.webSources` + `ChatWebSourceCard`

## 测试
`RecompileProgressStoreTests` / `MapKitSearchTests` / `WebSearchServiceTests` —— 14 测试全绿。BUILD SUCCEEDED（iPhone 17 / iOS 26.1）。

## ⚠️ 部署前提
联网搜索端到端跑通前需:
\`\`\`
supabase functions deploy tavily-search
\`\`\`
并在 Supabase 侧设 secret `TAVILY_API_KEY`(值已在 .env）。web 搜索走后端,需 app 已登录 + backend sync 开;未登录优雅降级为 AI 自身知识。

https://claude.ai/code/session_01A9yc2UDrmYN3aSUT5MQJjM