### PR TITLE
fix: trust only default-branch changelog code

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -36,7 +36,11 @@ jobs:
   update_changelog:
     name: Update TestFlight changelog
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event.workflow_run.conclusion == 'success' &&
+           github.event.workflow_run.head_repository.full_name == github.repository &&
+           github.event.workflow_run.head_branch == 'main') }}
     timeout-minutes: 70
 
     steps:
@@ -52,27 +56,39 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_run" ]; then
-            echo "ref=$WR_HEAD_SHA"      >> "$GITHUB_OUTPUT"
+            echo "deployed_sha=$WR_HEAD_SHA" >> "$GITHUB_OUTPUT"
             echo "run_id=$WR_RUN_ID"     >> "$GITHUB_OUTPUT"
             echo "manual_tag="           >> "$GITHUB_OUTPUT"
             echo "Triggered by deploy run $WR_RUN_ID on branch=$WR_HEAD_BR sha=$WR_HEAD_SHA"
           else
-            echo "ref=$INPUT_TAG"        >> "$GITHUB_OUTPUT"
+            if [[ ! "$INPUT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::release_tag must match vMAJOR.MINOR.PATCH"
+              exit 1
+            fi
+            if [[ ! "$INPUT_RUN" =~ ^[0-9]+$ ]]; then
+              echo "::error::run_id must be numeric"
+              exit 1
+            fi
+            echo "deployed_sha="          >> "$GITHUB_OUTPUT"
             echo "run_id=$INPUT_RUN"     >> "$GITHUB_OUTPUT"
             echo "manual_tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
             echo "Manual trigger for tag=$INPUT_TAG run_id=$INPUT_RUN"
           fi
 
-      - name: Checkout repository at deployed ref
+      # Always execute repository code from the trusted default branch. The
+      # deployed SHA is data used only for tag lookup below, never a checkout.
+      - name: Checkout trusted repository code
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.resolve.outputs.ref }}
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Compute build identifiers
         id: ids
         env:
           MANUAL_TAG: ${{ steps.resolve.outputs.manual_tag }}
+          DEPLOYED_SHA: ${{ steps.resolve.outputs.deployed_sha }}
           # Build number = GITHUB_RUN_NUMBER + 1000000 offset, mirroring
           # fastlane/Fastfile increment_build (same offset applied there).
           DEPLOY_RUN_NUMBER: ${{ github.event.workflow_run.run_number || github.event.inputs.run_id }}
@@ -84,7 +100,7 @@ jobs:
           if [ -n "$MANUAL_TAG" ]; then
             TAG="$MANUAL_TAG"
           else
-            TAG=$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n1 || true)
+            TAG=$(git tag --points-at "$DEPLOYED_SHA" --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n1 || true)
             if [ -z "$TAG" ]; then
               TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1 || true)
             fi


### PR DESCRIPTION
## Summary
- gate workflow-run execution to successful runs from this repository on `main`
- always execute changelog code from the trusted default branch
- treat the deployed SHA only as data for tag lookup
- validate manual tag and run-id inputs before use
- disable persisted checkout credentials

## Verification
- workflow YAML parsed successfully
- `git diff --check`
- manual input constraints cover the declared `vMAJOR.MINOR.PATCH` and numeric run-id contract

No App Store Connect secret, deploy setting, or production artifact was changed.