### PR TITLE
fix(security): close remaining CodeQL findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -31,6 +34,9 @@ jobs:
 
       - name: typecheck
         run: pnpm typecheck
+
+      - name: test
+        run: pnpm test
 
       - name: format check
         run: pnpm format:check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: production
   cancel-in-progress: false

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -10,6 +10,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -26,12 +29,12 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: '9.12.0'
+          version: "9.12.0"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -94,7 +97,7 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO 2>&1 | tee build.log
-          
+
           # Check for errors
           if grep -q "BUILD FAILED" build.log; then
             echo "❌ BUILD FAILED"
@@ -114,7 +117,7 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO 2>&1 | tee test.log
-          
+
           if grep -q "TEST FAILED" test.log; then
             echo "❌ TESTS FAILED"
             grep "failed" test.log | head -20
@@ -139,7 +142,7 @@ jobs:
   lint:
     name: SwiftLint
     runs-on: macos-latest
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -167,7 +170,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/feat/ios-mvp'
     runs-on: macos-latest
     needs: [build-and-test]
-    
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
+    "test": "tsx --test src/lib/markdown.test.ts",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist .turbo"
   },

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -19,6 +19,7 @@ import type { Experience } from "@solo-compass/core";
 import { DEMO_EXPERIENCES } from "./demo-experiences.js";
 import { getSession, resetSession } from "./session.js";
 import { track, optOut, isOptedOut } from "./lib/analytics.js";
+import { escapeMarkdown } from "./lib/markdown.js";
 import { captureException } from "./lib/sentry.js";
 
 // ─── Config ────────────────────────────────────────────────────────────────────
@@ -54,10 +55,6 @@ function localHour(): number {
   // Demo data is Chiang Mai — UTC+7 fixed for now.
   const utcHour = new Date().getUTCHours();
   return (utcHour + 7) % 24;
-}
-
-function escapeMarkdown(text: string): string {
-  return text.replace(/([_*[\]()~`>#+\-=|{}.!])/g, "\\$1");
 }
 
 function firstSourceLink(exp: Experience): string | undefined {

--- a/apps/bot/src/lib/markdown.test.ts
+++ b/apps/bot/src/lib/markdown.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { escapeMarkdown } from "./markdown.js";
+
+test("escapes every Telegram MarkdownV2 control character", () => {
+  for (const character of "\\_*[]()~`>#+-=|{}.!") {
+    assert.equal(escapeMarkdown(character), `\\${character}`);
+  }
+});
+
+test("preserves ordinary text", () => {
+  assert.equal(escapeMarkdown("Chiang Mai 123"), "Chiang Mai 123");
+});

--- a/apps/bot/src/lib/markdown.ts
+++ b/apps/bot/src/lib/markdown.ts
@@ -1,0 +1,4 @@
+/** Escape every Telegram MarkdownV2 control character, including backslash. */
+export function escapeMarkdown(text: string): string {
+  return text.replace(/([_*[\]()~`>#+\-=|{}.!\\])/g, "\\$1");
+}

--- a/infra/supabase/functions/tavily-search/index.ts
+++ b/infra/supabase/functions/tavily-search/index.ts
@@ -129,8 +129,9 @@ Deno.serve(async (req: Request) => {
       },
       body: JSON.stringify(payload),
     });
-  } catch (e) {
-    return json({ error: "search provider unreachable", detail: String(e) }, 502);
+  } catch {
+    // Do not expose network exception text or stack details to the caller.
+    return json({ error: "search provider unreachable" }, 502);
   }
   if (!res.ok) {
     const text = await res.text().catch(() => "");

--- a/packages/ai/src/parse-intent.test.ts
+++ b/packages/ai/src/parse-intent.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { parseIntent } from "./parse-intent";
+
+describe("parseIntent budget parsing", () => {
+  it("parses generic USD amounts and leaves baht to the currency conversion", () => {
+    expect(parseIntent("something under 25").budgetMax).toBe(25);
+    expect(parseIntent("less than 19.5 please").budgetMax).toBe(20);
+    expect(parseIntent("under 330 baht").budgetMax).toBe(10);
+  });
+
+  it("handles an adversarial numeric input in linear time", () => {
+    const startedAt = performance.now();
+    const result = parseIntent(`under ${"9".repeat(100_000)}x`);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(result.budgetMax).toBeUndefined();
+    expect(result.rawText).toHaveLength(100_007);
+    expect(elapsedMs).toBeLessThan(1_000);
+  });
+});

--- a/packages/ai/src/parse-intent.ts
+++ b/packages/ai/src/parse-intent.ts
@@ -18,6 +18,10 @@ export interface IntentFilters {
   rawText: string;
 }
 
+// Telegram messages are capped at 4,096 characters. Keep the original text for
+// downstream context, but never run heuristic regexes over an unbounded string.
+const MAX_INTENT_PARSE_CHARS = 4_096;
+
 // ─── Duration ─────────────────────────────────────────────────────────────────
 
 interface DurationRule {
@@ -144,13 +148,55 @@ function parseBudget(text: string): number | undefined {
     return Math.round(parseFloat(usdMatch[1]));
   }
 
-  // "under NNN" / "less than NNN" when followed by no currency → assume USD
-  const genericMatch = text.match(/(?:under|less\s+than)\s+(\d+(?:\.\d+)?)\b(?!\s*baht)/i);
-  if (genericMatch?.[1]) {
-    return Math.round(parseFloat(genericMatch[1]));
+  // "under NNN" / "less than NNN" when followed by no currency → assume USD.
+  // Parse the numeric span with a linear scan: a backtracking decimal regex plus
+  // a negative currency lookahead becomes polynomial on very long digit input.
+  const genericPrefix = text.match(/\b(?:under|less\s+than)\s+/i);
+  if (genericPrefix?.index !== undefined) {
+    const numberStart = genericPrefix.index + genericPrefix[0].length;
+    const amount = scanDecimal(text, numberStart);
+    if (amount && !isAsciiWord(text[amount.end])) {
+      const suffix = text.slice(amount.end).trimStart().toLowerCase();
+      if (!suffix.startsWith("baht") || isAsciiWord(suffix[4])) {
+        return Math.round(amount.value);
+      }
+    }
   }
 
   return undefined;
+}
+
+interface ScannedDecimal {
+  value: number;
+  end: number;
+}
+
+function scanDecimal(text: string, start: number): ScannedDecimal | undefined {
+  let cursor = start;
+  while (isAsciiDigit(text[cursor])) cursor += 1;
+  if (cursor === start) return undefined;
+
+  if (text[cursor] === "." && isAsciiDigit(text[cursor + 1])) {
+    cursor += 1;
+    while (isAsciiDigit(text[cursor])) cursor += 1;
+  }
+
+  const value = Number(text.slice(start, cursor));
+  return Number.isFinite(value) ? { value, end: cursor } : undefined;
+}
+
+function isAsciiDigit(character: string | undefined): boolean {
+  return character !== undefined && character >= "0" && character <= "9";
+}
+
+function isAsciiWord(character: string | undefined): boolean {
+  return (
+    isAsciiDigit(character) ||
+    (character !== undefined &&
+      ((character >= "a" && character <= "z") ||
+        (character >= "A" && character <= "Z") ||
+        character === "_"))
+  );
 }
 
 // ─── indoorOutdoor ────────────────────────────────────────────────────────────
@@ -166,10 +212,11 @@ function deriveIndoorOutdoor(vibes: string[]): "indoor" | "outdoor" | "either" {
 // ─── Main export ──────────────────────────────────────────────────────────────
 
 export function parseIntent(text: string): IntentFilters {
-  const durationMinMax = parseDuration(text);
-  const vibes = parseVibes(text);
-  const timeOfDayHour = parseTimeOfDay(text);
-  const budgetMax = parseBudget(text);
+  const parseableText = text.slice(0, MAX_INTENT_PARSE_CHARS);
+  const durationMinMax = parseDuration(parseableText);
+  const vibes = parseVibes(parseableText);
+  const timeOfDayHour = parseTimeOfDay(parseableText);
+  const budgetMax = parseBudget(parseableText);
   const indoorOutdoor = deriveIndoorOutdoor(vibes);
 
   const filters: IntentFilters = { rawText: text };


### PR DESCRIPTION
## Summary

- escape every Telegram MarkdownV2 control character, including backslash, with a focused regression test
- replace the vulnerable generic-budget decimal regex with a linear scanner and cap heuristic parsing to 4,096 characters while preserving raw input
- stop returning provider exception text from the Tavily edge function
- set explicit least-privilege workflow permissions and run the full test suite in CI

## Verification

- `pnpm test` (all workspace test tasks; 76 AI tests plus bot and source/core suites)
- `pnpm typecheck` (10 packages)
- `pnpm format:check`
- `pnpm tsx scripts/anti-pattern-lint.ts`
- `pnpm tsx scripts/schema-dryrun.ts`
- `pnpm parity:check`
- workflow YAML parse and `git diff --check`

The adversarial 100,000-digit intent regression completes in ~33 ms locally; the original implementation took ~15.2 s.